### PR TITLE
Clarification for an example

### DIFF
--- a/css-pseudo/Overview.bs
+++ b/css-pseudo/Overview.bs
@@ -127,6 +127,8 @@ The ::first-line pseudo-element</h3>
       will be treated as ordinary lines in the
       paragraph.&lt;/P&gt;
     </pre>
+    
+    However, the span element is not in fact broken in two for the purposes of styling.
   </div>
 
 <h4 id="first-text-line">


### PR DESCRIPTION
However, the span element is not in fact broken in two for the purposes of styling.

If the span had a border or background image, and the browser acted as if the element were closed and reopened, a no-repeat background image would be displayed twice. or, if a border were present, the border would be closed and reopened.