### PR TITLE
[css-grid] Fix typo in the grid item placement algorithm

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -2331,14 +2331,14 @@ Grid Item Placement Algorithm</h3>
 
 		: “sparse” packing (omitted ''dense'' keyword)
 		::
-			Set the row-start line of its <a>placement</a>
+			Set the column-start line of its <a>placement</a>
 			to the earliest (smallest positive index) line index
 			that ensures this item’s <a>grid area</a> will not overlap any <a>occupied</a> grid cells
 			and that is past any <a>grid items</a> previously placed in this row by this step.
 
 		: “dense” packing (''dense'' specified)
 		::
-			Set the row-start line of its <a>placement</a>
+			Set the column-start line of its <a>placement</a>
 			to the earliest (smallest positive index) line index
 			that ensures this item’s <a>grid area</a> will not overlap any <a>occupied</a> grid cells.
 


### PR DESCRIPTION
In the first step, items are locked to a row, so the algorithm should
define how to determine the column-start instead of the row-start.