### PR TITLE
[css-images-4] Mandate support for PNG and SVG in <image>

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -20,6 +20,23 @@ Link Defaults: css21 (property) display, css21 (dfn) stacking context
 Images Values: the <<image>> type {#image-values}
 =================================================
 
+Image File Formats {#image-file-formats}
+----------------------------------------
+
+At minimum, the UA must support the following image file formats
+when referenced from an <<image>> value,
+for all the properties in which using <<image>> is valid:
+<ul>
+	<li>PNG, as specified in [[!PNG]]
+	<li>SVG, as specified in [[!SVG]],
+	using the <a href="http://www.w3.org/TR/svg-integration/#secure-static-mode">secure static mode</a> (See [[!SVG-INTEGRATION]])
+	<li>If the UA supports animated <<image>>s,
+	SVG, as specified in [[!SVG]],
+	using the <a href="http://www.w3.org/TR/svg-integration/#secure-animated-mode">secure animated mode</a> (See [[!SVG-INTEGRATION]])
+</ul>
+
+The UA may support other file formats as well.
+
 Image Fallbacks and Annotations: the ''image()'' notation {#image-notation}
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
As resolved during the 'cursor' discussions, mandate support for PNG and SVG in <image>.