### PR TITLE
animations override !important

### DIFF
--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -77,7 +77,7 @@ Animations</h2>
 	adding a specified value to the CSS cascade ([[!CSS3CASCADE]]) (at the
 	level for CSS Animations) that will produce the correct computed value
 	for the current state of the animation. As defined in [[!CSS3CASCADE]],
-	animations override all normal rules, but are overridden by !important
+	animations override all normal rules, including !important
 	rules.
 
 	If at one point in time there are multiple animations specifying behavior


### PR DESCRIPTION
My understanding is that animation property values are more important than non-animation property values, even with !important
Changed As defined in [CSS3CASCADE], animations override all normal rules, but are overridden by !important rules.
to remove the overridden statement, as all modern browsers except FF support this, and conversations in #css IRC indicate that all browsers with the exception of FF have implemented as intended.

http://codepen.io/estelle/pen/iDvBz shows green border in all browsers (IE11, Safari, Chrome and Opera) except Firefox.