### PR TITLE
[css-page-floats] map left/right to line-left/right for inline elements and clarify position of anchor

### DIFF
--- a/css-page-floats/Overview.bs
+++ b/css-page-floats/Overview.bs
@@ -60,8 +60,8 @@ Terminology</h2>
     <dt><dfn>Float anchor</dfn>
     <dd>
       The float anchor is the point in the flow where the float had appeared had
-      it not been a float and instead had been a zero-width and zero-height
-      inline element with no margins, borders or padding.
+      it not been a float and instead had been an empty inline element with no
+      margins, borders or padding.
     <dt><dfn>Float containing block formatting context</dfn>
     <dd>
       The block formatting context inside of which the float is embedded.

--- a/css-page-floats/Overview.bs
+++ b/css-page-floats/Overview.bs
@@ -60,7 +60,8 @@ Terminology</h2>
     <dt><dfn>Float anchor</dfn>
     <dd>
       The float anchor is the point in the flow where the float had appeared had
-      it not been a float.
+      it not been a float and instead had been a zero-width and zero-height
+      inline element with no margins, borders or padding.
     <dt><dfn>Float containing block formatting context</dfn>
     <dd>
       The block formatting context inside of which the float is embedded.
@@ -334,13 +335,19 @@ And some more text&lt;/p>
   <dt><dfn>left</dfn>
 
   <dd>
-    Behave like block-end, inline-start or inline-end depending on the float
+    If the <a>float reference</a> is a line box, behaves like inline-start or
+    inline-end, whichever corresponds to line-left for the float reference.
+
+    Otherwise, behaves like block-end, inline-start or inline-end depending on the float
     containing block’s 'direction' and 'writing-mode'.
 
   <dt><dfn>right</dfn>
 
   <dd>
-    Behave like block-start, inline-start or inline-end depending on the float
+    If the <a>float reference</a> is a line box, behaves like inline-start or
+    inline-end, whichever corresponds to line-right for the float reference.
+
+    Otherwise, behaves like block-start, inline-start or inline-end depending on the float
     containing block’s 'direction' and 'writing-mode'.
 
   <dt><dfn>top</dfn>


### PR DESCRIPTION
After Shinyu's comments ( https://lists.w3.org/Archives/Public/www-style/2015May/0233.html ) and explanations of usage of line-right/left by fantasai at CSSWG F2F.