### PR TITLE
Alignment container for justify-self and justify-items In Grid Layout must be the grid area instead of the grid cell.

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -704,7 +704,7 @@ Inline/Main-Axis Alignment: the 'justify-self' property</h3>
 		<dd>
 			The 'justify-self' property applies along the grid's <a>row axis</a>.
 
-			The <a>alignment container</a> is the <a>grid cell</a>.
+			The <a>alignment container</a> is the <a>grid area</a>.
 			The <a>alignment subject</a> is the <a>grid item</a>’s margin box.
 			The default <a>overflow alignment</a> is ''true''.
 	</dl>
@@ -798,7 +798,7 @@ Block/Cross-Axis Alignment: the 'align-self' property</h3>
 		<dd>
 			The 'align-self' property applies along the grid's <a>column axis</a>.
 
-			The <a>alignment container</a> is the <a>grid cell</a>.
+			The <a>alignment container</a> is the <a>grid area</a>.
 			The <a>alignment subject</a> is the <a>grid item</a>’s margin box.
 			The default <a>overflow alignment</a> is ''true''.
 	</dl>


### PR DESCRIPTION
Grid items might fill more than one grid cell, hence alignment container must be the grid area they are located in, instead of single grid cell.