### PR TITLE
Minor fixes of the example for `grid-auto-flow` section

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -1878,7 +1878,7 @@ Sizing Auto-generated Rows and Columns: the 'grid-auto-rows' and 'grid-auto-colu
 				/* Define three columns, all content-sized,
 				   and name the corresponding lines. */
 				grid-template-columns: [labels] auto [controls] auto [oversized] auto;
-				grid-auto-flow: row;
+				grid-auto-flow: row dense;
 			}
 			form > label {
 				/* Place all labels in the "labels" column and
@@ -1893,7 +1893,7 @@ Sizing Auto-generated Rows and Columns: the 'grid-auto-rows' and 'grid-auto-colu
 				grid-row: auto;
 			}
 
-			#department {
+			#department-block {
 				/* Auto place this item in the "oversized" column
 				   in the first row where an area that spans three rows
 				   won't overlap other explicitly placed items or areas
@@ -1931,7 +1931,7 @@ Sizing Auto-generated Rows and Columns: the 'grid-auto-rows' and 'grid-auto-colu
 				&lt;label for="zip">Zip:&lt;/label>
 				&lt;input type="text" id="zip" name="zip" />
 
-				&lt;div id="department">
+				&lt;div id="department-block">
 					&lt;label for="department">Department:&lt;/label>
 					&lt;select id="department" name="department" multiple>
 						&lt;option value="finance">Finance&lt;/option>


### PR DESCRIPTION
Two fixes of the example in the `grid-auto-flow` section of the spec:

1. Markup correction — making IDs unique
2. Updating the CSS to match the example rendering (without adding `dense`, the departments block will render in the last row, not in the first, at least by my understanding and the current Blink experimental implementation: http://codepen.io/SelenIT/pen/JdmKMK)