### PR TITLE
Estelle

### DIFF
--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -174,7 +174,7 @@ Keyframes</h2>
 
 	Keyframes are used to specify the values for the animating properties at various points
 	during the animation. The keyframes specify the behavior of one cycle of the animation;
-	the animation may iterate one or more times.
+	the animation may iterate zero or more times.
 
 	Keyframes are specified using a specialized CSS at-rule. A <dfn>@keyframes</dfn> rule consists of the
 	keyword "@keyframes", followed by an identifier giving a name for the animation (which will
@@ -256,10 +256,9 @@ Keyframes</h2>
 	by time. The rules within the @keyframes rule then cascade; the properties of a keyframe may thus derive
 	from more than one @keyframes rule with the same selector value.
 
-	If a property is not specified for a keyframe, or is specified but invalid, the animation of that
-	property proceeds as if that keyframe did not exist. Conceptually, it is as if a set of keyframes is
-	constructed for each property that is present in any of the keyframes, and an animation is run
-	independently for each property.
+	Conceptually, it is as if a set of keyframes is constructed for each property that is present in any of the keyframes, and an animation is run
+	independently for each property. If a property is not specified for a keyframe, or is specified but invalid, the animation of that
+	property proceeds as if that keyframe did not exist. 
 
 	<div class='example'>
 		<pre>

--- a/css-animations/Overview.html
+++ b/css-animations/Overview.html
@@ -417,7 +417,7 @@ Animations</span><a class="self-link" href="#animations"></a></h2>
 
    <p>The end of the animation is defined by the combination of the
 	<a class="property" data-link-type="propdesc" href="#propdef-animation-duration">animation-duration</a>, <a class="property" data-link-type="propdesc" href="#propdef-animation-iteration-count">animation-iteration-count</a> and <a class="property" data-link-type="propdesc" href="#propdef-animation-fill-mode">animation-fill-mode</a>
-	properties.</p>
+	properties, and <a class="property" data-link-type="propdesc" href="#propdef-animation-delay">animation-delay</a>, if negative.</p>
 
 	
    <div class="example" id="example-dee38741"><a class="self-link" href="#example-dee38741"></a>

--- a/css-animations/Overview.html
+++ b/css-animations/Overview.html
@@ -571,10 +571,10 @@ Keyframes</span><a class="self-link" href="#keyframes"></a></h2>
 	from more than one @keyframes rule with the same selector value.</p>
 
 
-   <p>If a property is not specified for a keyframe, or is specified but invalid, the animation of that
-	property proceeds as if that keyframe did not exist. Conceptually, it is as if a set of keyframes is
-	constructed for each property that is present in any of the keyframes, and an animation is run
-	independently for each property.</p>
+   <p>Conceptually, it is as if a set of keyframes is
+  constructed for each property that is present in any of the keyframes, and an animation is run
+  independently for each property. If a property is not specified for a keyframe, or is specified but invalid, the animation of that
+	property proceeds as if that keyframe did not exist. </p>
 
 	
    <div class="example" id="example-25879023"><a class="self-link" href="#example-25879023"></a>

--- a/css-animations/Overview.html
+++ b/css-animations/Overview.html
@@ -477,7 +477,7 @@ Keyframes</span><a class="self-link" href="#keyframes"></a></h2>
 
    <p>Keyframes are used to specify the values for the animating properties at various points
 	during the animation. The keyframes specify the behavior of one cycle of the animation;
-	the animation may iterate one or more times.</p>
+	the animation may iterate zero or more times.</p>
 
 
    <p>Keyframes are specified using a specialized CSS at-rule. A <dfn class="css" data-dfn-type="at-rule" data-export="" id="at-ruledef-keyframes">@keyframes<a class="self-link" href="#at-ruledef-keyframes"></a></dfn> rule consists of the


### PR DESCRIPTION
edit to overview.bs. Edits to overview.html should be automagically overwritten.

1) The animation may iterate less than one time. 0.25 and 0 are valid iteration counts
2) reordered the two sentences because in the original order it made it sound like keyframes, not property values, are ignored.
What does that paragraph mean? When we animate multiple properties, in the end it's as if a separate animation was created for each property. That is why switching the animation-timing-function during a keyframe only impacts the property/value pairs within that keyframe.