### PR TITLE
Florian/pre wrap auto trim

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -109,7 +109,7 @@ White Space Trimming: the 'text-space-trim' property</h3>
 	<pre class="propdef">
 	Name: text-space-trim
 	Value: none | trim-inner || discard-before || discard-after
-	Initial: collapse
+	Initial: none
 	Applies to: all elements
 	Inherited: no
 	Percentages: n/a

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -12,6 +12,7 @@ Editor: Koji Ishii, Invited Expert, kojiishi@gluesoft.co.jp
 Editor: Alan Stearns, Adobe Systems, stearns@adobe.com
 Abstract: This module defines properties for text manipulation and specifies their processing model. It covers line breaking, justification and alignment, white space handling, and text transformation.
 Ignored terms: segment break, segment breaks
+At Risk: The ''preserve-trim'' of the 'text-space-collapse' property
 </pre>
 
 <h2 id="intro">
@@ -84,6 +85,13 @@ White Space Collapsing: the 'text-space-collapse' property</h3>
 			However, the UA <em>must</em> visually collapse to 0
 			the advance widths of all preserved white space
 			that occur at the end of a line.
+
+			Note: the ''preserve-trim'' value is at risk.
+
+			Issue: The CSSWG would appreciate feedback
+			on the use cases for this value,
+			to evaluate whether trimming leading spaces
+			could be needed as well.
 
 		<dt><dfn>preserve-breaks</dfn>
 		<dd>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -36,7 +36,7 @@ White Space Collapsing: the 'text-space-collapse' property</h3>
 
 	<pre class="propdef">
 	Name: text-space-collapse
-	Value: collapse | discard | preserve | preserve-breaks | preserve-spaces 
+	Value: collapse | discard | preserve | preserve-auto | preserve-trim | preserve-breaks | preserve-spaces
 	Initial: collapse
 	Applies to: all elements
 	Inherited: yes
@@ -64,6 +64,26 @@ White Space Collapsing: the 'text-space-collapse' property</h3>
 			This value prevents user agents
 			from collapsing sequences of white space.
 			<a>Segment breaks</a> are preserved as forced line breaks.
+
+		<dt><dfn>preserve-auto</dfn>
+		<dd>
+			This value preserves white space and <a>segment breaks</a> as for ''preserve''.
+			However, the UA <em>may</em> visually collapse
+			the advance widths of preserved white space
+			that occur at the end of a line.
+
+			If 'text-wrap' is ''text-wrap/normal'' or ''text-wrap/balance'',
+			whether or not there are soft wrap opportunities
+			in preserved sequences of white space,
+			and if yes where and under what condition,
+			is UA defined.
+
+		<dt><dfn>preserve-trim</dfn>
+		<dd>
+			This value preserves white space and <a>segment breaks</a> as for ''preserve''.
+			However, the UA <em>must</em> visually collapse to 0
+			the advance widths of all preserved white space
+			that occur at the end of a line.
 
 		<dt><dfn>preserve-breaks</dfn>
 		<dd>
@@ -449,6 +469,52 @@ Shorthand for White Space and Wrapping: the 'white-space' property</h2>
 
 	Note: This shorthand combines both inheritable and non-inheritable properties.
 	If this is a problem, please inform the CSSWG.
+
+	The following table gives the mapping of the values of the shorthand to its longhands.
+
+	<table class="data">
+		<colgroup class="header"></colgroup>
+		<colgroup span=3></colgroup>
+		<thead>
+			<tr>
+				<th>'white-space'
+				<th>'text-space-collapse'
+				<th>'text-wrap'
+				<th>'text-space-trim'
+		</thead>
+		<tbody>
+		<tr>
+			<th>''white-space/normal''
+			<td>''text-space-collapse/collapse''
+			<td>''text-wrap/normal''
+			<td>''text-space-trim/none''
+		<tr>
+			<th>''pre''
+			<td>''text-space-collapse/preserve''
+			<td>''text-wrap/nowrap''
+			<td>''text-space-trim/none''
+		<tr>
+			<th>''nowrap''
+			<td>''text-space-collapse/collapse''
+			<td>''text-wrap/nowrap''
+			<td>''text-space-trim/none''
+		<tr>
+			<th>''pre-wrap''
+			<td>''text-space-collapse/preserve''
+			<td>''text-wrap/normal''
+			<td>''text-space-trim/none''
+		<tr>
+			<th>''pre-wrap-auto''
+			<td>''text-space-collapse/preserve-auto''
+			<td>''text-wrap/normal''
+			<td>''text-space-trim/none''
+		<tr>
+			<th>''pre-line''
+			<td>''text-space-collapse/preserve-breaks''
+			<td>''text-wrap/normal''
+			<td>''text-space-trim/none''
+		</tbody>
+	</table>
 
 	Issue: Add details from level 3
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -79,6 +79,10 @@ White Space Collapsing: the 'text-space-collapse' property</h3>
 			and if yes where and under what condition,
 			is UA defined.
 
+			Both with regards to collapsing
+			and to soft wrap opportunities,
+			the UA should follow platform conventions.
+
 		<dt><dfn>preserve-trim</dfn>
 		<dd>
 			This value preserves white space and <a>segment breaks</a> as for ''preserve''.


### PR DESCRIPTION
This adds text-space-collapse: preserve-auto and text-space-collapse: preserve-trim to css-text-4, and explains white-space: pre-wrap-auto in terms of the former.

Also includes a small bug fix.