### PR TITLE
[css-ui] Avoid unnecessary redundancy in HTML default stylesheet

### DIFF
--- a/css-ui/Overview.bs
+++ b/css-ui/Overview.bs
@@ -1677,7 +1677,6 @@ input[type=hidden]
 
 input[type=image]
 {
- display: inline-block;
  content: attr(src,url);
  border: none;
 }

--- a/css-ui/Overview.bs
+++ b/css-ui/Overview.bs
@@ -1626,7 +1626,6 @@ input[type=radio],
 textarea,
 input,
 input[type=text],
-input[type=hidden],
 input[type=password],
 input[type=image]
 {


### PR DESCRIPTION
This removes some redundancies in the stylesheet given in "Appendix D. Default style sheet additions for HTML" of CSS Basic User Interface Module Level 3.

(Note to self: Additionally, the `white-space: nowrap` in the first section just ends up getting overridden for `button` and `textarea`, but that will be a matter for a separate issue.)