### PR TITLE
[css-ui] Add !important to input[type=hidden] portion of default stylesheet to align with HTML

### DIFF
--- a/css-ui/Overview.bs
+++ b/css-ui/Overview.bs
@@ -1672,7 +1672,7 @@ textarea
 input[type=hidden]
 {
 /* appearance of the HTML hidden text field in particular */
- display: none;
+ display: none !important;
 }
 
 input[type=image]


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements :
> ```css
> input[type=hidden i] { display none ! important; }
> ```