### PR TITLE
[css-ui] Avoid unnecessary cascading in default HTML stylesheet

### DIFF
--- a/css-ui/Overview.bs
+++ b/css-ui/Overview.bs
@@ -1630,6 +1630,18 @@ input[type=password],
 input[type=image]
 {
  display: inline-block;
+}
+
+input[type=button],
+input[type=reset],
+input[type=submit],
+input[type=checkbox],
+input[type=radio],
+input,
+input[type=text],
+input[type=password],
+input[type=image]
+{
  white-space: nowrap;
 }
 


### PR DESCRIPTION
Stop defining a `white-space` on `button` and `textarea`, only to immediately override it with a different value.

See:
* https://github.com/w3c/csswg-drafts/blob/cb0c4d3eb1c8b7095591e20549d89708fbc15e14/css-ui/Overview.bs#L1636-L1640
* https://github.com/w3c/csswg-drafts/blob/cb0c4d3eb1c8b7095591e20549d89708fbc15e14/css-ui/Overview.bs#L1664-L1667