### PR TITLE
Adding periods at the end figure's descriptions.

### DIFF
--- a/css-round-display/Overview.html
+++ b/css-round-display/Overview.html
@@ -238,7 +238,7 @@ on screen, on paper, in speech, etc.
       </div>
      </div>
      <div style="width: 700px">
-      <p class="caption">Devices where the <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature is not applicable</p>
+      <p class="caption">Devices where the <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature is not applicable.</p>
      </div>
       On the other hand, the example below shows how the <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature works in the different shapes of displays. This is the same as the code above except of media queries usage. The <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature can be used as follows: 
 <pre>&lt;!-- index.html -->
@@ -270,7 +270,7 @@ on screen, on paper, in speech, etc.
       </div>
      </div>
      <div style="width: 700px">
-      <p class="caption">Devices where the <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature is applicable</p>
+      <p class="caption">Devices where the <a class="property" data-link-type="propdesc" href="#descdef-media-device-radius">device-radius</a> media feature is applicable.</p>
      </div>
     </div>
     <p class="note" role="note">Note: If the shapes of displays are various, such as polygons, we need to extend the media features more with additional parameters. The current features have limitations to support the diversity beyond round shapes. How can we express star-shaped polygons? (e.g. SVG syntax, etc.) Of course, there is a trade-off between simplicity and expressiveness. </p>
@@ -341,14 +341,14 @@ on screen, on paper, in speech, etc.
       </div>
      </div>
      <div style="width: 500px">
-      <p class="caption">Align the content along the display border</p>
+      <p class="caption">Align the content along the display border.</p>
      </div>
     </div>
     <p> Even though the shape of the rounded display could be described by circle() or ellipse() as <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-shapes-2/#typedef-basic-shape">&lt;basic-shape></a>, 'shape-inside: display' is useful that authors make contents to be aligned within the display edge conveniently. In case of complicated shaped displays like curved, stelliform, or polygonal shape, the availability of 'shape-inside: display' is more increased in comparison with a simple shaped display (e.g. regular rounded display). </p>
     <p> When a containing block is placed on one end of the display and the containing block has 'shape-inside: display', the descendant blocks of the containing block are basically put on the overlapping region between the containing block and the display area. The overlapping region’s shape is mostly complicated shape, so it’s difficult to define the shape using previous method like basic-shape. The figure 4 describes these circumstances as follows. </p>
     <div style="width: 500px;">
       <img alt="An image of two examples to show the principle of shape-inside: display" src="images/shape_inside_a.png" style="width: 500px"> 
-     <p class="caption">Align a part of the content along the display border</p>
+     <p class="caption">Align a part of the content along the display border.</p>
     </div>
     <p class="issue" id="issue-8d78506c"><a class="self-link" href="#issue-8d78506c"></a> What if content overflows? Clipping or scrolling? </p>
     <h2 class="heading settled" data-level="5" id="drawing-borders"><span class="secno">5. </span><span class="content">Drawing borders around the display border</span><a class="self-link" href="#drawing-borders"></a></h2>
@@ -419,7 +419,7 @@ on screen, on paper, in speech, etc.
       </div>
      </div>
      <div style="width: 600px">
-      <p class="caption">Align the content along the display border</p>
+      <p class="caption">Align the content along the display border.</p>
      </div>
     </div>
     <p class="note" role="note">Note: If the value of <a class="property" data-link-type="propdesc" href="#propdef-border-boundary">border-boundary</a> is parent or display, border lines of the element are actually just a visual effect. It triggers a layout for rendering in a general way, but in the above cases (border-boundary: parent|display), the layout doesn’t occur and it only draws the border lines inward from the containing block’s borders. With this situation, the borders might hide contents around the display edge. </p>
@@ -491,7 +491,7 @@ on screen, on paper, in speech, etc.
       </div>
      </div>
      <div style="width: 700px">
-      <p class="caption">Positioning elements in conventional coordinate system and polar coordinate system</p>
+      <p class="caption">Positioning elements in conventional coordinate system and polar coordinate system.</p>
      </div>
     </div>
     <h3 class="heading settled" data-level="6.2" id="polar-angle-property"><span class="secno">6.2. </span><span class="content">The <a class="property" data-link-type="propdesc" href="#propdef-polar-angle">polar-angle</a> property</span><a class="self-link" href="#polar-angle-property"></a></h3>
@@ -568,7 +568,7 @@ on screen, on paper, in speech, etc.
 </pre>
      <div style="width: 400px; text-align: center">
        <img alt="An image of three elements positioned to polar coordinates" src="images/polar_a.png" style="width: 200px; border: 1px #AAA solid; text-align: center"> 
-      <p class="caption">An example of polar positioning</p>
+      <p class="caption">An example of polar positioning.</p>
      </div>
     </div>
     <p class="issue" id="issue-5df272e7"><a class="self-link" href="#issue-5df272e7"></a> How to rotate the element itself with an axis from the element position to the central point of containing block? Is new property needed to support that at one time in polar coordinate system? </p>
@@ -663,7 +663,7 @@ on screen, on paper, in speech, etc.
 </pre>
      <div style="width: 400px; text-align: center">
        <img alt="An image of four elements with different anchor points positioned in a containing block" src="images/polar_anchor.png" style="width: 300px; text-align: center"> 
-      <p class="caption">An example of <a class="property" data-link-type="propdesc" href="#propdef-polar-anchor">polar-anchor</a></p>
+      <p class="caption">An example of <a class="property" data-link-type="propdesc" href="#propdef-polar-anchor">polar-anchor.</a></p>
      </div>
     </div>
     <p class="issue" id="issue-43dc3773"><a class="self-link" href="#issue-43dc3773"></a> Is '<code>auto</code>' needed for value of <a class="property" data-link-type="propdesc" href="#propdef-polar-anchor">polar-anchor</a>? </p>


### PR DESCRIPTION
Other specs (e.g. http://www.w3.org/TR/css3-background/#the-border-radius) include a period at the end of text describing figures. This patch includes the missing periods for all figures.