### PR TITLE
[css-device-adapt] Trivial clarification of "Resolve width value" algo

### DIFF
--- a/css-device-adapt/Overview.bs
+++ b/css-device-adapt/Overview.bs
@@ -678,7 +678,7 @@ Resolve <code lt="width!!resolved">width</code> value</h4>
     </li>
 
     <li>
-        If <code lt="width!!resolved">width</code> is
+        Otherwise, if <code lt="width!!resolved">width</code> is
         ''viewport-length/auto'', set <code>width = height * (initial-width /
         initial-height)</code>, or <code>width = initial-width</code>
         if <code class="index"


### PR DESCRIPTION
Assuming I'm interpreting this correctly, the intention is that at most 1 of the branches in https://drafts.csswg.org/css-device-adapt/#resolve-width will execute. If so, I suggest tweaking the phrasing to clarify this. Thus, naive translations of the algorithm from spec-ese into actual code would result in better code (`if...else if` rather than `if...if`; there's no need to check for the 2nd case if the 1st case was true).