### PR TITLE
Point out case-insensitivity of i in [foo=bar i]

### DIFF
--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -1464,6 +1464,9 @@ Case-sensitivity</h3>
 	identifier <code>i</code> before the closing bracket (<code>]</code>).
 	When this flag is present, UAs must match the attribute's value
 	case-insensitively within the ASCII range.
+	Like the rest of Selectors syntax, 
+	the <code>i</code> identifier is <a href="#case-sensitive">case-insensitive</a>
+	within the ASCII range.
 
 	<div class="example">
 		The following rule will style the <code>frame</code> attribute when it


### PR DESCRIPTION
https://lists.w3.org/Archives/Public/www-style/2016Jan/0166.html shows that it’s easy to miss.

How does this look, @tabatkins?