### PR TITLE
replace undefined 'escaped' by serializations

### DIFF
--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -229,7 +229,7 @@ are always serialized with '"' (U+0022).
 
 To <dfn export>serialize a URL</dfn> means to create a string represented by
 "<code>url(</code>", followed by the
-<a lt="serialize a string">string escaped</a> value of the given
+<a lt="serialize a string">serialization</a> of the URL as a
 string, followed by "<code>)</code>".
 
 To <dfn export>serialize a comma-separated list</dfn> concatenate all items of
@@ -301,8 +301,8 @@ finally return <var>s</var>:
  <li>If the media query is negated append "<code>not</code>", followed
  by a single SPACE (U+0020), to <var>s</var>.
 
- <li>Let <var>type</var> be the media type of the media query,
- <a lt="serialize an identifier">escaped</a> and
+ <li>Let <var>type</var> be the <a lt="serialize an identifier">serialization
+ as an identifier</a> of the media type of the media query,
  <a>converted to ASCII lowercase</a>.
 
  <li>If the media query does not contain media features append
@@ -526,8 +526,8 @@ To
 <dfn export>serialize a group of selectors</dfn>
 <a lt="serialize a selector">serialize</a> each selector in the
 group of selectors and then
-<a lt="serialize a comma-separated list">serialize</a> the
-group.
+<a lt="serialize a comma-separated list">serialize</a> a
+comma-separated list of these serializations.
 
 To <dfn export>serialize a selector</dfn> let
 <var>s</var> be the empty string, run the steps below for each
@@ -579,9 +579,9 @@ finally return <var>s</var>:
    <li>If the <a>namespace prefix</a> maps to a namespace that is
    not the <a>default namespace</a> and is not the
    null namespace (not in a namespace) append the
-   <a lt="serialize an identifier">escaped</a>
-   <a>namespace prefix</a>, followed by a "<code>|</code>" (U+007C)
-   to <var>s</var>.
+   <a lt="serialize an identifier">serialization</a> of the
+   <a>namespace prefix</a> as an identifier, followed by a
+   "<code>|</code>" (U+007C) to <var>s</var>.
 
    <li>If the <a>namespace prefix</a> maps to a namespace that is
    the null namespace (not in a namespace) append
@@ -589,8 +589,8 @@ finally return <var>s</var>:
    <!-- This includes |* -->
 
    <li>If this is a type selector append the
-   <a lt="serialize an identifier">escaped</a> element name to
-   <var>s</var>.
+   <a lt="serialize an identifier">serialization</a> of the element name
+   as an identifier to <var>s</var>.
 
    <li>If this is a universal selector append "<code>*</code>" (U+002A)
    to <var>s</var>.
@@ -605,12 +605,12 @@ finally return <var>s</var>:
 
    <li>If the <a>namespace prefix</a> maps to a namespace that is
    not the null namespace (not in a namespace) append the
-   <a lt="serialize an identifier">escaped</a>
-   <a>namespace prefix</a>, followed by a "<code>|</code>" (U+007C)
-   to <var>s</var>.
+   <a lt="serialize an identifier">serialization</a> of the
+   <a>namespace prefix</a> as an identifier, followed by a
+   "<code>|</code>" (U+007C) to <var>s</var>.
 
-   <li>Append the <a lt="serialize an identifier">escaped</a>
-   attribute name to <var>s</var>.
+   <li>Append the <a lt="serialize an identifier">serialization</a>
+   of the attribute name as an identifier to <var>s</var>.
 
    <li>If there is an attribute value specified, append
    "<code>=</code>",
@@ -620,8 +620,8 @@ finally return <var>s</var>:
    "<code>$=</code>", or
    "<code>*=</code>"
    as appropriate (depending on the type of attribute selector), followed
-   by the <a lt="serialize a string">string escaped</a>
-   attribute value, to <var>s</var>.
+   by the <a lt="serialize a string">serialization</a> of the
+   attribute value as a string, to <var>s</var>.
 
    <li>If the attribute selector has the case-sensitivity flag present,
    append "<code> i</code>" (U+0020 U+0069) to <var>s</var>.
@@ -633,13 +633,13 @@ finally return <var>s</var>:
 
  <dt>class selector
  <dd>Append a "<code>.</code>" (U+002E), followed by the
- <a lt="serialize an identifier">escaped</a> class name to
- <var>s</var>.
+ <a lt="serialize an identifier">serialization</a> of the class name
+ as an identifier to <var>s</var>.
 
  <dt>ID selector
  <dd>Append a "<code>#</code>" (U+0023), followed by the
- <a lt="serialize an identifier">escaped</a> ID to
- <var>s</var>.
+ <a lt="serialize an identifier">serialization</a> of the ID
+ as an identifier to <var>s</var>.
 
  <dt>pseudo-class
  <dd>
@@ -654,9 +654,10 @@ finally return <var>s</var>:
 
   <dl class="switch">
    <dt><code>:lang()</code>
-   <dd>The value of each argument <a lt="serialize a string">string escaped</a>,
-   preserving relative order,
-   separated by "<code>, </code>" (U+002C U+0020).
+   <dd>The <a lt="serialize a comma-separated list">serialization of a
+   comma-separated list</a> of each argument's
+   <a lt="serialize a string">serialization as a string</a>, preserving
+   relative order.
 
    <dt><code>:nth-child()</code>
    <dt><code>:nth-last-child()</code>
@@ -1458,11 +1459,11 @@ To <dfn>serialize a CSS rule</dfn>, perform one of the following in accordance w
 
  <dt>{{CSSNamespaceRule}}
  <dd>The literal string "<code>@namespace</code>", followed by a single SPACE
- (U+0020), followed by the
- <a lt="serialize an identifier">identifier escaped</a> value of the
+ (U+0020), followed by the 
+ <a lt="serialize an identifier">serialization as an identifier</a> of the
  {{CSSNamespaceRule/prefix}} attribute (if
  any), followed by a single SPACE (U+0020) if there is a prefix, followed by the
- <a lt="serialize a URL">URL escaped</a> value of the
+ <a lt="serialize a URL">serialization as URL</a> of the
  {{CSSNamespaceRule/namespaceURI}}
  attribute, followed the character "<code>;</code>" (U+003B).
 </dl>
@@ -2400,7 +2401,7 @@ depends on the component, as follows:
 
  <dt>&lt;identifier>
  <dd>The identifier
- <a lt="serialize an identifier">escaped</a>.
+ <a lt="serialize an identifier">serialized as an identifier</a>.
 
  <dt>&lt;integer>
  <dd>A base-ten integer using digits 0-9 (U+0030 to U+0039) in the
@@ -2457,7 +2458,7 @@ depends on the component, as follows:
  <dt>&lt;family-name>
  <dt>&lt;specific-voice>
  <dd>The string
- <a lt="serialize a string">string escaped</a>.
+ <a lt="serialize a string">serialized as a string</a>.
 
  <dt>&lt;time>
  <dd>The time in seconds serialized as per &lt;number> followed by
@@ -2465,7 +2466,7 @@ depends on the component, as follows:
 
  <dt>&lt;uri>
  <dd>The <a>absolute URL</a>
- <a lt="serialize a URL">URL escaped</a>.
+ <a lt="serialize a URL">serialized as URL</a>.
 </dl>
 
 
@@ -2635,7 +2636,7 @@ The <dfn method for=CSS>escape(<var>ident</var>)</dfn> method must return the re
 <var>ident</var>.
 
 <div class=example>
- For example, to escape a string for use as part of a selector, the {{CSS/escape()}} method can be used:
+ For example, to serialize a string for use as part of a selector, the {{CSS/escape()}} method can be used:
  <pre>var element = document.querySelector('#' + CSS.escape(id) + ' > img');</pre>
 </div>
 


### PR DESCRIPTION
This PR is about https://lists.w3.org/Archives/Public/www-style/2016Mar/0235.html and is ready to merge if the CSSWG agrees on the change later today.