### PR TITLE
Removal of the rests of 'grid-template' references

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -1103,7 +1103,7 @@ The Explicit Grid</h2>
 
 	The three properties 'grid-template-rows', 'grid-template-columns', and 'grid-template-areas'
 	together define the <dfn export local-lt="explicit">explicit grid</dfn> of a <a>grid container</a>.
-	The 'grid-template' property is a <a>shorthand</a> that sets all three at the same time.
+	The 'grid' property is a <a>shorthand</a> that can be used to set all three at the same time.
 	The final grid may end up larger due to <a>grid items</a> placed outside the <a>explicit grid</a>;
 	in this case, any implicit tracks are sized by the 'grid-auto-rows' and 'grid-auto-columns' properties.
 
@@ -1886,7 +1886,8 @@ Implicit Named Areas</h4>
 <h2 id='implicit-grids'>
 The Implicit Grid</h2>
 
-	The 'grid-template' property and its longhands define a fixed number of tracks that form the <a>explicit grid</a>.
+	The 'grid-template-rows', 'grid-template-columns', and 'grid-template-areas' properties define a fixed number
+	of tracks that form the <a>explicit grid</a>.
 	When <a>grid items</a> are positioned outside of these bounds,
 	the <a>grid container</a> generates
 	<dfn export lt="implicit grid track|implicit grid row|implicit grid column">implicit grid tracks</dfn>
@@ -4092,6 +4093,7 @@ Changes</h2>
 	* Reduced <<auto-repeat>> syntax to accept only a single track size, for simplicity.
 	* Added information on the speech and navigation impact of reordering with grid placement or 'order'
 		vs. reordering the underlying source.
+	* Removed 'grid-template' shorthand.
 
 	A partial <a href="https://drafts.csswg.org/css-grid-1/issues-wd-20150805">Disposition of Comments</a> is available.
 


### PR DESCRIPTION
The `grid-template` shorthand property has been removed from the spec, but two references to it remained. Also, this change was not reflected in the 'Changes' section. Shouldn't we fix this?