### PR TITLE
Counter reset on ol too broad in scope

### DIFF
--- a/css2/generate.html
+++ b/css2/generate.html
@@ -647,7 +647,7 @@ result is very similar to that of setting 'display:list-item' and
 'list-style: inside' on the LI element:
 
 <pre>
-OL { counter-reset: item }
+OL>LI:first-child { counter-reset: item }
 LI { display: block }
 LI:before { content: counter(item) ". "; counter-increment: item }
 </pre>
@@ -735,7 +735,7 @@ string.
 as "1", "1.1", "1.1.1", etc.
 
 <PRE>
-OL { counter-reset: item }
+OL>LI:first-child { counter-reset: item }
 LI { display: block }
 LI:before { content: counters(item, ".") " "; counter-increment: item }
 </PRE>


### PR DESCRIPTION
Reseting counters on the “ol” element means that an ordered list which
is the descendent of a sibling element of a previous ordered list will
behave as a continuation of the previous list.
