### PR TITLE
[css-scroll-snap] 'snap window' -> 'snapport'

### DIFF
--- a/css-scroll-snap/Overview.bs
+++ b/css-scroll-snap/Overview.bs
@@ -395,7 +395,7 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#snap-type}
 ██        ██     ██ ████████  ████████  ████ ██    ██  ██████
 -->
 
-Scroll Snapping Window: the 'scroll-snap-padding' property {#snap-padding}
+Scroll Snapport: the 'scroll-snap-padding' property {#snap-padding}
 -----------------------
 
 	<pre class="propdef">


### PR DESCRIPTION
@fantasai I think this was just overlooked in the rebranding, right?