### PR TITLE
[css-grid] Make placing examples follow `<integer> && <custom-ident>?`

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -2594,9 +2594,9 @@ Named Lines and Spans</h4>
 	<div class='example'>
 		<pre>
 			.six {
-				grid-row: text 5 / text 7;
+				grid-row: 5 text / 7 text;
 				/* Span between the 5th and 7th lines named "text". */
-				grid-row: text 5 / span text 2;
+				grid-row: 5 text / span 2 text;
 				/* Same as above - start at the 5th line named "text",
 				   then span across two more "text" lines, to the 7th. */
 			}
@@ -2813,13 +2813,13 @@ Line-based Placement: the 'grid-row-start', 'grid-column-start', 'grid-row-end',
 			grid-column-start: auto; grid-column-end: 6;
 			/* Line 5 to line 6 */
 
-			grid-column-start: C; grid-column-end: C -1;
+			grid-column-start: C; grid-column-end: -1 C;
 			/* Line 3 to line 9 */
 
 			grid-column-start: C; grid-column-end: span C;
 			/* Line 3 to line 6 */
 
-			grid-column-start: span C; grid-column-end: C -1;
+			grid-column-start: span C; grid-column-end: -1 C;
 			/* Line 6 to line 9 */
 
 			grid-column-start: span C; grid-column-end: span C;
@@ -2827,7 +2827,7 @@ Line-based Placement: the 'grid-row-start', 'grid-column-start', 'grid-row-end',
 			   item can't span to a named line.
 			   Equivalent to ''grid-column: span 1;''. */
 
-			grid-column-start: 5; grid-column-end: C -1;
+			grid-column-start: 5; grid-column-end: -1 C;
 			/* Line 5 to line 9 */
 
 			grid-column-start: 5; grid-column-end: span C;
@@ -2836,7 +2836,7 @@ Line-based Placement: the 'grid-row-start', 'grid-column-start', 'grid-row-end',
 			grid-column-start: 8; grid-column-end: 8;
 			/* Error: line 8 to line 9 */
 
-			grid-column-start: B 2; grid-column-end: span 1;
+			grid-column-start: 2 B; grid-column-end: span 1;
 			/* Line 5 to line 6 */
 		</pre>
 	</div>


### PR DESCRIPTION
I found out that Examples 33 and 37 are incompatible with `<grid-line>` definition at https://drafts.csswg.org/css-grid/#line-placement
```
<grid-line> =
  auto |
  <custom-ident> |
  [ <integer> && <custom-ident>? ] |
  [ span && [ <integer> || <custom-ident> ] ]
```
As they use:
```
grid-row: text 5 / text 7;
```
So more like `<custom-ident>? <integer>`

This PR updates examples to:
```
grid-row: 5 text / 7 text;
```