### PR TITLE
[css-flexbox] Replace 'Animatable' descriptions with 'Animation type'

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -51,6 +51,13 @@ spec: css-writing-modes-3; type: dfn;
 	text: end
 </pre>
 
+<pre class='anchors'>
+urlPrefix: https://drafts.csswg.org/css-transitions/#animtype-; type: dfn; spec: css-transitions
+    text: integer animation type; url: integer
+    text: number animation type; url: number
+    text: length, percentage, or calc animation type; url: lpcalc
+</pre>
+
 <style>
   #axis-mapping-table [rowspan=8] { writing-mode: sideways-lr; }
   #axis-mapping-table a { white-space: nowrap; }
@@ -1200,7 +1207,7 @@ Display Order: the 'order' property</h3>
 	Inherited: no
 	Computed value: specified value
 	Media: visual
-	Animatable: yes
+	Animation type: <a lt="integer animation type">integer</a>
 	</pre>
 
 	The 'order' property controls the order in which
@@ -1481,7 +1488,7 @@ Flexibility</h2>
 <h3 id='flex-property'>
 The 'flex' Shorthand</h3>
 
-	<pre class='propdef'>
+	<pre class='propdef shorthand'>
 	Name: flex
 	Value: none | [ <<'flex-grow'>> <<'flex-shrink'>>? || <<'flex-basis'>> ]
 	Initial: see individual properties
@@ -1661,7 +1668,7 @@ The 'flex-grow' property</h4>
 	Inherited: no
 	Computed value: specified value
 	Media: visual
-	Animatable: yes
+	Animation type: <a lt="number animation type">number</a>
 	</pre>
 
 	Advisement: Authors are encouraged to control flexibility using the 'flex' shorthand
@@ -1684,7 +1691,7 @@ The 'flex-shrink' property</h4>
 	Inherited: no
 	Computed value: specified value
 	Media: visual
-	Animatable: yes
+	Animation type: <a lt="number animation type">number</a>
 	</pre>
 
 	Advisement: Authors are encouraged to control flexibility using the 'flex' shorthand
@@ -1708,7 +1715,8 @@ The 'flex-basis' property</h4>
 	Computed value: as specified, with lengths made absolute
 	Percentages: relative to the <a>flex container's</a> inner <a>main size</a>
 	Media: visual
-	Animatable: as 'width'
+	Animation type: <a lt="length, percentage, or calc animation type">length,
+	percentage, or calc</a>
 	</pre>
 
 	Advisement: Authors are encouraged to control flexibility using the 'flex' shorthand


### PR DESCRIPTION
With regards to 'flex-basis', I wasn't sure if "Animation type: length,
percentage, or calc; otherwise discrete" was more clear about the case
when the value is 'content'. However, we should probably just make sure
the general wording for resolving animation types covers this case, i.e.
"if you can't stuff the value in the animation type, it's discrete".

Note that this needs https://github.com/tabatkins/bikeshed/pull/709 (the corresponding bikeshed support for Animation type) to be merged first.