### PR TITLE
[css-flexbox] Fix animation type of 'flex-basis'

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -1715,7 +1715,7 @@ The 'flex-basis' property</h4>
 	Computed value: as specified, with lengths made absolute
 	Percentages: relative to the <a>flex container's</a> inner <a>main size</a>
 	Media: visual
-	Animation type: as 'width'
+	Animation type: length, percentage, or calc
 	</pre>
 
 	Advisement: Authors are encouraged to control flexibility using the 'flex' shorthand


### PR DESCRIPTION
'width' is not an animation type and quoting width like this links to the width property.