### PR TITLE
NL workshop errata and wording changes

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -148,7 +148,7 @@ Background and Motivation</h3>
 	</figure>
 
 	As websites evolved from simple documents into complex, interactive applications,
-	tools for document layout, e.g. floats,
+	techniques for document layout, e.g. floats,
 	were not necessarily well suited for application layout.
 	By using a combination of tables, JavaScript, or careful measurements on floated elements,
 	authors discovered workarounds to achieve desired layouts.
@@ -180,7 +180,7 @@ Adapting Layouts to Available Space</h3>
 	</figure>
 
 	Grid layout can be used to intelligently reflow elements within a webpage.
-	Figure 2 represents a game with five major components in the layout:
+	Figure 2 and 3 represents a game with five major components in the layout:
 	the game title, stats area, game board, score area, and control area.
 	The author's intent is to divide the space for the game such that:
 
@@ -192,34 +192,35 @@ Adapting Layouts to Available Space</h3>
 		<li>
 			The top of the game title and the game board should always align.
 		<li>
-			The bottom of the game board and the stats area align when the game has reached its minimum height,
-			but otherwise the game board will stretch to take advantage of all the screen real-estate available to it.
+			The bottom of the game board and bottom of the stats area align when the game has reached its minimum height.
+			In all other cases the game board will stretch to take advantage of all the space available to it.
+                <li>
+			The controls are centered under the game board.
 		<li>
-			The score area should align into the column created by the game and stats area,
-			while the controls are centered under the board.
+			The top of the score area is aligned to the top of the controls area.
+		<li>
+			The score area is beneath the stats area.
+		<li>
+			The score area is aligned to the controls beneath the stats are.
 	</ul>
 
-	As an alternative to using script to control the absolute position, width, and height of all elements,
-	the author can use grid layout,
-	as shown in Figure 3.
 	The following example shows how an author might achieve all the sizing, placement, and alignment rules declaratively.
 
-	Note that there are multiple ways to specify the structure of the grid
-	and to position and size <a>grid items</a>,
-	each optimized for different scenarios.
-	This example illustrates one that an author may use to define the position and space for each <a>grid item</a>
-	using the 'grid-template-rows' and 'grid-template-columns' properties on the <a>grid container</a>,
-	and the 'grid-row' and 'grid-column' properties on each <a>grid item</a>.
 
 	<div class="example">
 		<pre class="lang-css">
+		/**
+		 * This example illustrates one that an author may use to define the position and space for each <a>grid item</a>
+		 * using the 'grid-template-rows' and 'grid-template-columns' properties on the <a>grid container</a>,
+		 * and the 'grid-row' and 'grid-column' properties on each <a>grid item</a>.
+		 */
 		#grid {
 			/**
 			 * Two columns:
 			 *  1. the first sized to content,
 			 *  2. the second receives the remaining space
 			 *     (but is never smaller than the minimum size of the board
-			 *     or the game controls, which occupy this column [3])
+			 *     or the game controls, which occupy this column [Figure 3])
 			 *
 			 * Three rows:
 			 *  3. the first sized to content,
@@ -238,10 +239,10 @@ Adapting Layouts to Available Space</h3>
 				/* 5 */ auto;
 		}
 
-		/* Each part of the game is positioned between grid lines by
+		/* Each part of the game is positioned between grid lines. It's achieved by
 		 * referencing the starting grid line and then specifying, if more
 		 * than one, the number of rows or columns spanned to determine
-		 * the ending grid line, which establishes bounds for the part. */
+		 * the ending grid line, which establishes bounds for the area. */
 		#title    { grid-column: 1; grid-row: 1; }
 		#score    { grid-column: 1; grid-row: 3; }
 		#stats    { grid-column: 1; grid-row: 2; align-self: start; }
@@ -260,6 +261,10 @@ Adapting Layouts to Available Space</h3>
 		</pre>
 	</div>
 
+	Note: There are multiple ways to specify the structure of the grid
+	and to position and size <a>grid items</a>,
+	each optimized for different scenarios.
+
 <h3 id='source-independence'>
 Source-Order Independence</h3>
 
@@ -276,14 +281,14 @@ Source-Order Independence</h3>
 	</figure>
 
 	Continuing the prior example,
-	the author also wants the game to adapt to the space available on traditional computer monitors, handheld devices, or tablet computers.
+	the author also wants the game to adapt to different devices.
 	Also, the game should optimize the placement of the components when viewed either in portrait or landscape orientation (Figures 4 and 5).
 	By combining grid layout with media queries,
 	the author is able to use the same semantic markup,
 	but rearrange the layout of elements independent of their source order,
 	to achieve the desired layout in both orientations.
 
-	The following example leverages grid layout’s ability to name the space which will be occupied by a <a>grid item</a>.
+	The following example uses grid layout’s ability to name the space which will be occupied by a <a>grid item</a>.
 	This allows the author to avoid rewriting rules for <a>grid items</a>
 	as the grid’s definition changes.
 
@@ -294,18 +299,17 @@ Source-Order Independence</h3>
 				display: grid;
 
 				/* The rows, columns and areas of the grid are defined visually
-				* using the grid-template-areas property.  Each string is a row,
-				* and each word an area.  The number of words in a string
-				* determines the number of columns. Note the number of words
-				* in each string must be identical. */
+				 * using the grid-template-areas property.  Each string is a row,
+				 * and each word an area.  The number of words in a string
+				 * determines the number of columns. Note the number of words
+				 * in each string must be identical. */
 				grid-template-areas: "title stats"
 				                     "score stats"
 				                     "board board"
 				                     "ctrls ctrls";
 
-				/* Columns and rows created with the template property can be
-				* assigned a sizing function with the grid-template-columns
-				* and grid-template-rows properties. */
+				/* The way to size columns and rows can be assigned with the
+				 * grid-template-columns and grid-template-rows properties. */
 				grid-template-columns: auto 1fr;
 				grid-template-rows: auto auto 1fr auto;
 			}
@@ -316,8 +320,8 @@ Source-Order Independence</h3>
 				display: grid;
 
 				/* Again the template property defines areas of the same name,
-				* but this time positioned differently to better suit a
-				* landscape orientation. */
+				 * but this time positioned differently to better suit a
+				 * landscape orientation. */
 				grid-template-areas: "title board"
 				                     "stats board"
 				                     "score ctrls";
@@ -328,7 +332,7 @@ Source-Order Independence</h3>
 		}
 
 		/* The grid-area property places a grid item into a named
-		* region (area) of the grid. */
+		 * area of the grid. */
 		#title    { grid-area: title }
 		#score    { grid-area: score }
 		#stats    { grid-area: stats }
@@ -368,20 +372,25 @@ Grid Layering of Elements</h3>
 
 	In the example shown in Figure 6,
 	the author is creating a custom slider control.
-	The control has six parts.
-	The lower-limit and upper-limit labels align to the left and right edges of the control.
-	The track of the slider spans the area between the labels.
-	The lower-range and upper-range fill parts touch beneath the thumb,
-	and the thumb is a fixed width and height that can be moved along the track
-	by updating the two flex-sized columns.
+	<ul>
+		<li>
+			The control has six parts.
+		<li>
+			The lower-limit and upper-limit labels align to the left and right edges of the control.
+		<li>
+			The track of the slider spans the area between the labels.
+		<li>
+			The lower-fill and upper-fill parts touch beneath the thumb.
+		<li>
+			The thumb is a fixed width and height that can be moved along the track
+			by updating the two flex-sized columns.
+		<li>
+			The thumb,
+			snaps to various positions along the track
+			as the 'grid-template-columns' property of the <a>grid container</a> is updated.
+	</ul>
 
-	Prior to the introduction of grid layout,
-	the author would have likely used absolute positioning to control the top and left coordinates,
-	along with the width and height of each HTML element that comprises the control.
-	By leveraging grid layout,
-	the author can instead limit script usage to handling mouse events on the thumb,
-	which snaps to various positions along the track
-	as the 'grid-template-columns' property of the <a>grid container</a> is updated.
+
 
 	<div class="example">
 		<pre class="lang-css">
@@ -459,9 +468,9 @@ Grid Layout Concepts and Terminology</h2>
 	into which <a>grid items</a> (representing the <a>grid container</a>’s content) can be placed.
 	There are two sets of <a>grid lines</a>:
 	one set defining <dfn export lt="grid column | column">columns</dfn>
-	that run along the <a href="https://www.w3.org/TR/css3-writing-modes/#block-axis-">block axis</a> (the <dfn export>column axis</dfn>),
+	that run along the <a href="https://www.w3.org/TR/css3-writing-modes/#block-axis">block axis</a> (the <dfn export>column axis</dfn>),
 	and an orthogonal set defining <dfn export lt="grid row | row">rows</dfn>
-	along the <a href="https://www.w3.org/TR/css3-writing-modes/#inline-axis-">inline axis</a> (the <dfn export>row axis</dfn>).
+	along the <a href="https://www.w3.org/TR/css3-writing-modes/#inline-axis">inline axis</a> (the <dfn export>row axis</dfn>).
 	[[!CSS3-WRITING-MODES]]
 
 <!--
@@ -490,7 +499,7 @@ Grid Lines</h3>
 		The following two examples both create three column <a>grid lines</a> and four row <a>grid lines</a>.
 
 		This first example demonstrates how an author would position a <a>grid item</a> using <a>grid line</a> numbers:
-		<pre>
+		<pre class="lang-css">
 			#grid {
 				display: grid;
 				grid-template-columns: 150px 1fr;
@@ -503,7 +512,7 @@ Grid Lines</h3>
 
 		This second example uses explicitly named <a>grid lines</a>:
 
-		<pre>
+		<pre class="lang-css">
 			/* equivalent layout to the prior example, but using named lines */
 			#grid {
 				display: grid;
@@ -526,7 +535,7 @@ Grid Tracks and Cells</h3>
 	Each <a>grid track</a> is assigned a sizing function,
 	which controls how wide or tall the column or row may grow,
 	and thus how far apart its bounding <a>grid lines</a> are.
-	Adjacent <a>grid tracks</a> can be separated by <a href="#gutters">gutters</a> or <a href="#grid-align">alignment spacing</a>,
+	Adjacent <a>grid tracks</a> can be separated by <a href="#gutters">gutters</a>
 	but are otherwise packed tightly.
 
 	A <dfn export>grid cell</dfn> is the intersection of a grid row and a grid column.
@@ -535,9 +544,9 @@ Grid Tracks and Cells</h3>
 	<div class="example">
 		In the following example there are two columns and three rows.
 		The first column is fixed at 150px.
-		The second column uses flexible sizing, which is a function of the unassigned space in the Grid,
+		The second column uses flexible sizing, which is a function of the unassigned space in the grid,
 		and thus will vary as the width of the <a>grid container</a> changes.
-		If the used width of the <a>grid container</a> is 200px, then the second column 50px wide.
+		If the used width of the <a>grid container</a> is 200px, then the second column is 50px wide.
 		If the used width of the <a>grid container</a> is 100px, then the second column is 0px
 		and any content positioned in the column will overflow the <a>grid container</a>.
 
@@ -554,6 +563,7 @@ Grid Tracks and Cells</h3>
 Grid Areas</h3>
 
 	A <dfn export>grid area</dfn> is the logical space used to lay out one or more <a>grid items</a>.
+	A <a>grid area</a> consists of one or more adjecent <a>grid cells</a>.
 	It is bound by four <a>grid lines</a>, one on each side of the <a>grid area</a>,
 	and participates in the sizing of the <a>grid tracks</a> it intersects.
 	A <a>grid area</a> can be named explicitly using the 'grid-template-areas' property of the <a>grid container</a>,
@@ -577,8 +587,8 @@ Grid Areas</h3>
 			#item2 { grid-area: b }
 			#item3 { grid-area: b }
 
-			/* Align items 2 and 3 at different points in the Grid Area "b".  */
-			/* By default, Grid Items are stretched to fit their Grid Area    */
+			/* Align items 2 and 3 at different points in the grid area "b".  */
+			/* By default, grid items are stretched to fit their grid area    */
 			/* and these items would layer one over the other. */
 			#item2 { align-self: start; }
 			#item3 { justify-self: end; align-self: end; }
@@ -766,8 +776,8 @@ Establishing Grid Containers: the ''display/grid'', ''inline-grid'', and ''subgr
 
 		<li>
 			'float' and 'clear' have no effect on a <a>grid item</a>.
-			(However, the 'float' property still affects the computed value of 'display' on children of a grid container,
-			as this occurs <em>before</em> <a>grid items</a> are determined.)
+			However, the 'float' property still affects the computed value of 'display' on children of a grid container,
+			as this occurs <em>before</em> <a>grid items</a> are determined.
 
 		<li>
 			'vertical-align' has no effect on a grid item.
@@ -788,15 +798,24 @@ Establishing Grid Containers: the ''display/grid'', ''inline-grid'', and ''subgr
 <h3 id='intrinsic-sizes'>
 Sizing Grid Containers</h3>
 
+	Note see [[!CSS3-SIZING]] for a definition of the terms in this section.
+
 	A <a>grid container</a> is sized
-	using the rules of the formatting context in which it participates.
-	As a block-level box in a <a>block formatting context</a>,
-	it is sized like a block box that establishes a formatting context,
-	with an ''auto'' inline size calculated as for in-flow block boxes.
-	As an inline-level box in an inline formatting context,
-	it is sized as an atomic inline-level box (such as an inline-block).
+	using the rules of the formatting context in which it participates:
+
+	<ul>
+		<li>
+			As a block-level box in a <a>block formatting context</a>,
+			it is sized like a block box that establishes a formatting context,
+			with an ''auto'' <a>inline size</a> calculated as for in-flow block boxes.
+		<li>
+			As an inline-level box in an <a>inline formatting context</a>,
+			it is sized as an atomic inline-level box (such as an inline-block).
+	</ul>
+
 	In both inline and block formatting contexts,
-	the <a>grid container</a>’s ''auto'' block size is its max-content size.
+	the <a>grid container</a>’s ''auto'' <a>block size</a> is its max-content size.
+	<span class="issue">The block layout spec should define this?</span>
 
 	The <a>max-content size</a> of a <a>grid container</a> is
 	the sum of the <a>grid container’s</a> track sizes in the appropriate axis,
@@ -806,7 +825,6 @@ Sizing Grid Containers</h3>
 	the sum of the <a>grid container’s</a> track sizes in the appropriate axis,
 	when the grid is sized under a <a>min-content constraint</a>.
 
-	See [[!CSS3-SIZING]] for a definition of the terms in this section.
 
 <!--
  ██████  ██          ███    ██     ██ ████████  ████ ██    ██  ██████
@@ -819,19 +837,19 @@ Sizing Grid Containers</h3>
 -->
 
 <h3 id="overlarge-grids">
-Clamping Overlarge Grids</h3>
+Clamping Overly Large Grids</h3>
 
-	Since memory is not infinite,
+	Since memory is limited,
 	UAs may clamp the possible size of the <a>grid</a>
-	to within a UA-defined limit,
+	to be within a UA-defined limit,
 	dropping all lines outside that limit.
 	If a grid item is placed outside this limit,
 	its grid area must be <a>clamped</a> to within this limited grid.
 
 	To <dfn local-lt=clamp>clamp a grid area</dfn>:
-	* If the <a>grid area</a> would span outside the limited grid,
+	* If the <a>grid area</a> would <a>span</a> outside the limited grid,
 		its span is clamped to the last line of the limited <a>grid</a>.
-	* If the <a>grid area</a> would be placed completely outside the limited grid
+	* If the <a>grid area</a> would be placed completely outside the limited grid,
 		its span must be truncated to 1
 		and the area repositioned into the last <a>grid track</a> on that side of the grid.
 
@@ -872,8 +890,9 @@ Grid Items</h2>
 	Loosely speaking, the <dfn export id="grid-item" lt="grid item">grid items</dfn> of a <a>grid container</a>
 	are boxes representing its in-flow contents:
 	each in-flow child of a <a>grid container</a>
-	becomes a <a>grid item</a>,
-	and each contiguous run of text that is directly contained inside a <a>grid container</a>
+	becomes a <a>grid item</a>.
+
+	Each contiguous run of text that is directly contained inside a <a>grid container</a>
 	is wrapped in an anonymous <a>grid item</a>.
 	However, an anonymous grid item that contains only
 	<a href="https://www.w3.org/TR/css-text/#white-space-processing">white space</a>
@@ -922,32 +941,23 @@ Grid Items</h2>
 			</a>
 		</figure>
 
-		Note that the inter-element white space disappears:
-		it does not become its own grid item,
-		even though the inter-element text <em>does</em> get wrapped in an anonymous grid item.
-
-		Note also that the anonymous item's box is unstyleable,
-		since there is no element to assign style rules to.
-		Its contents will however inherit styles (such as font settings) from the grid container.
 	</div>
 
+	Note: inter-element white space disappears:
+	it does not become its own grid item,
+	even though inter-element text <em>does</em> get wrapped in an anonymous grid item.
+
+	Note: The box of a anonymous item is unstyleable,
+	since there is no element to assign style rules to.
+	Its contents will however inherit styles (such as font settings) from the grid container.
+
+<h3 id="grid-item-display">
+	Grid item display</h3>
 	A <a>grid item</a> establishes a new formatting context for its contents.
 	The type of this formatting context is determined by its 'display' value, as usual.
 	However, grid items are <dfn>grid-level</dfn> boxes, not block-level boxes:
 	they participate in their container's <a>grid formatting context</a>,
 	not in a block formatting context.
-
-	A <a>grid item</a> is sized within the containing block defined by its <a>grid area</a>
-	similarly to an equivalent block-level box in an equivalently-sized containing block,
-	except that ''margin/auto'' margins and the <a>box alignment properties</a>
-	have special effects. (See [[#alignment]].)
-
-	The ''min-width/auto'' value of 'min-width' and 'min-height'
-	behaves on <a>grid items</a> in the relevant axis
-	analogously to its behavior on <a>flex items</a> in the <a>main axis</a>.
-	See [[#min-size-auto]].
-
-	ISSUE: Review implications of intrinsic ratio and Grid's 2D nature.
 
 	The 'display' value of a <a>grid item</a> is <a>blockified</a>:
 	if the specified 'display' of an in-flow child of an element generating a <a>grid container</a>
@@ -963,6 +973,22 @@ Grid Items</h2>
 	For example, two contiguous <a>grid items</a> with ''display: table-cell''
 	will become two separate ''display: block'' <a>grid items</a>,
 	instead of being wrapped into a single anonymous table.
+
+<h3 id="grid-item-sizing">
+	Grid item sizing</h3>
+
+	A <a>grid item</a> is sized within the containing block defined by its <a>grid area</a>
+	similarly to an equivalent block-level box in an equivalently-sized containing block,
+	except that ''margin/auto'' margins and the <a>box alignment properties</a>
+	have special effects. (See [[#alignment]].)
+
+	Note: The ''min-width/auto'' value of 'min-width' and 'min-height'
+	behaves on <a>grid items</a> in the relevant axis
+	similar to the flexbox behavior on <a>flex items</a> in the <a>main axis</a>.
+	See [[#min-size-auto]].
+
+	ISSUE: Review implications of intrinsic ratio and Grid's 2D nature.
+
 
 <!--
 <h3 id="position-grid">
@@ -1019,7 +1045,7 @@ Grid Item Margins and Paddings</h3>
 
 	Percentage margins and paddings on <a>grid items</a> can be resolved against either:
 
-	* their own axis (left/right percentages resolve against width, top/bottom resolve against height), or,
+	* their own axis (left/right percentages resolve against width, top/bottom resolve against height)
 	* the inline axis (left/right/top/bottom percentages all resolve against width)
 
 	A User Agent must choose one of these two behaviors.
@@ -1034,7 +1060,8 @@ Grid Item Margins and Paddings</h3>
 
 	Auto margins expand to absorb extra space in the corresponding dimension,
 	and can therefore be used for alignment.
-	See <a href="#auto-margins">Aligning with <span class=css>auto</span> margins</a>.
+
+	See [[#auto-margins]]
 
 <h3 id='z-order'>
 Z-axis Ordering: the 'z-index' property</h3>
@@ -1043,7 +1070,7 @@ Z-axis Ordering: the 'z-index' property</h3>
 	or even when positioned in non-intersecting areas because of negative margins or positioning.
 	The painting order of <a>grid items</a> is exactly the same as inline blocks [[CSS21]],
 	except that <a>order-modified document order</a> is used in place of raw document order,
-	and 'z-index' values other than <a value for=z-index>auto</a> create a stacking context even if 'position' is ''static''.
+	and 'z-index' values other than <a value for=z-index>auto</a> create a stacking context.
 	Thus the 'z-index' property can easily be used to control the z-axis order of grid items.
 
 	<p class='note'>
@@ -1103,9 +1130,9 @@ Implied Minimum Size of Grid Items</h3>
 	this specification defines the effects of the 'min-width'/'min-height' ''min-width/auto'' value
 	for <a>grid items</a>.
 
-	On a <a>grid item</a> whose 'overflow' is ''overflow/visible'',
-	when ''min-width/auto'' is specified on the <a>grid item</a>,
-	it specifies an <a>automatic minimum size</a>
+	When 'min-width'/'min-height' is set to ''min-width/auto'',
+	on a <a>grid item</a> whose 'overflow' is ''overflow/visible'',
+	this causes a <a>automatic minimum size</a>
 	(just as for <a>flex items</a>).
 	[[!CSS-FLEXBOX-1]]
 
@@ -1117,10 +1144,10 @@ Implied Minimum Size of Grid Items</h3>
 		In particular, if grid layout is being used for a major content area of a document,
 		it is better to set an explicit font-relative minimum width such as ''min-width: 12em''.
 		A content-based minimum width could result in a large table or large image
-		stretching the size of the entire content area into an overflow zone,
-		and thereby making lines of text gratuitously long and hard to read.
+		stretching the size of the entire content area,
+		and thereby making lines of text needlessly long and hard to read.
 
-		Note also, when content-based sizing is used on an item with large amounts of content,
+		When content-based sizing is used on an item with large amounts of content,
 		the layout engine must traverse all of this content before finding its minimum size,
 		whereas if the author sets an explicit minimum, this is not necessary.
 		(For items with small amounts of content, however,
@@ -1147,14 +1174,15 @@ The Explicit Grid</h3>
 	together define the <dfn export local-lt="explicit">explicit grid</dfn> of a <a>grid container</a>.
 	The 'grid' property is a <a>shorthand</a> that can be used to set all three at the same time.
 	The final grid may end up larger due to <a>grid items</a> placed outside the <a>explicit grid</a>;
-	in this case, any implicit tracks are sized by the 'grid-auto-rows' and 'grid-auto-columns' properties.
+	in this case implicit tracks will be created,
+	these implicit tracks will be sized by the 'grid-auto-rows' and 'grid-auto-columns' properties.
 
 	The size of the <a>explicit grid</a> is determined by the larger of
 	the number of rows/columns defined by 'grid-template-areas'
 	and the number of rows/columns sized by 'grid-template-rows'/'grid-template-columns'.
 	Any rows/columns defined by 'grid-template-areas' but not sized by 'grid-template-rows'/'grid-template-columns'
 	take their size from the 'grid-auto-rows'/'grid-auto-columns' properties.
-	If these properties don't define <em>any</em> <a>explicit</a> tracks,
+	If these properties don't define <em>any</em> tracks
 	the <a>explicit grid</a> still contains one <a>grid line</a> in each axis.
 
 	Numeric indexes in the <a>grid-placement properties</a>
@@ -1190,8 +1218,9 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 	<dl dfn-type="value" dfn-for="grid-template-rows, grid-template-columns">
 		<dt><dfn>none</dfn>
 		<dd>
-			This value indicates that there is no <a>explicit grid</a>;
-			any rows/columns will be <a href="#implicit-grids">implicitly generated</a>,
+			This value indicates that there is no <a>explicit grid</a> created by this property;
+			(an explicit grid could still be created by a grid-template-areas)
+			In the absence or an <a>explicit grid</a> any rows/columns will be <a href="#implicit-grids">implicitly generated</a>,
 			and their size will be determined by the 'grid-auto-rows' and 'grid-auto-columns' properties.
 
 		<dt><dfn id="track-listing"><<track-list>> | <<auto-track-list>></dfn>
@@ -1635,6 +1664,10 @@ Named Areas: the 'grid-template-areas' property</h3>
 		<dt><dfn>none</dfn>
 		<dd>
 			The <a>grid container</a> doesn't define any <a>named grid areas</a>.
+			This value indicates that there is no <a>explicit grid</a> created by this property;
+			(an explicit grid could still be created by grid-template-columns or grid-template-rows)
+			In the absence or an <a>explicit grid</a> any rows/columns will be <a href="#implicit-grids">implicitly generated</a>,
+			and their size will be determined by the 'grid-auto-rows' and 'grid-auto-columns' properties.
 
 		<dt><dfn><<string>>+</dfn>
 		<dd>
@@ -1900,7 +1933,7 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 	</pre>
 
 	If a grid item is positioned into a row or column that is not explicitly sized
-	by 'grid-template-rows' or 'grid-template-columns',
+	by 'grid-template-rows', 'grid-template-columns',
 	<a>implicit grid tracks</a> are created to hold it.
 	This can happen either by explicitly positioning into a row or column that is out of range,
 	or by the <a>auto-placement algorithm</a> creating additional rows or columns.


### PR DESCRIPTION
Wording changes from NL grid meetup we had: http://gridlayout.eu/ I was just scribe others had the brains :)

(This is more of a discussion pull than an actual bit of work)

We also discovered an issue which had been mentioned to @fantasai that there was issues with explicit vs implicit grid on the `grid-template-rows`, `grid-template-columns` and `grid-template-areas` properties. Such that the definition for all 3 seems linked however their behaviour needs further explanation and work to make clear if all three properties impact the explicit grid and if not then explain the edge cases further. `grid-template-areas` mentions that it impacts the explicit grid but then it doesn't seem clear how and also contradicts with the other areas on the same topic.

Sorry this isn't clear. Losing this work seems worse than making sense in my tired state, (thanks for looking through this!)

/cc @MichielBijl