### PR TITLE
[css-scoping] fixed typo in slotted-pseudo fixes #167

### DIFF
--- a/css-scoping/Overview.bs
+++ b/css-scoping/Overview.bs
@@ -552,7 +552,7 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 				&lt;"shadow tree">
 					&lt;div id="five">...&lt;/div>
 					&lt;div id="six">...&lt;/div>
-					&lt;slot name="foo">&lt;/content>
+					&lt;slot name="foo">&lt;/slot>
 				&lt;/"shadow tree">
 			&lt;/x-foo>
 		</pre>


### PR DESCRIPTION
change /content => /slot (in the example)