### PR TITLE
[cssom-view] Fix #159. Do not leak a closed node via offsetParent

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1352,7 +1352,7 @@ The <dfn attribute for=HTMLElement>offsetParent</dfn> attribute must return the 
     * The element is the root element.
     * The element is <a>the HTML <code>body</code> element</a>.
     * The element's computed value of the 'position' property is ''position/fixed''.
-1. Return the nearest ancestor element of the element for which at least one of the following is true and terminate this algorithm if such an ancestor is found:
+1. Return the nearest ancestor <a lt="unclosed node">unclosed</a> element of the element for which at least one of the following is true and terminate this algorithm if such an ancestor is found: [[!DOM]]
     * The computed value of the 'position' property is not ''static''.
     * It is <a>the HTML <code>body</code> element</a>.
     * The computed value of the 'position' property of the element is ''static'' and the ancestor is one of the following <a>HTML elements</a>: <code>td</code>, <code>th</code>, or <code>table</code>.


### PR DESCRIPTION
My attempt to fix https://github.com/w3c/csswg-drafts/issues/159.

@tabatkins , could you review this?

> Return the nearest ancestor <a>unclosed node</a> element of the element

"unclosed node element of the element" can be acceptable?