### PR TITLE
[css-cascade] typo. Fixes #154

### DIFF
--- a/css-cascade-3/Overview.bs
+++ b/css-cascade-3/Overview.bs
@@ -319,7 +319,7 @@ Cascaded Values</h3>
 <h3 id="specified">
 Specified Values</h3>
 
-	The <dfn export>specified value</dfn> the value of a given property that the style sheet authors intended for that element.
+	The <dfn export>specified value</dfn> is the value of a given property that the style sheet authors intended for that element.
 	It is the result of putting the <a>cascaded value</a> through the <a href="#defaulting">defaulting</a> processes,
 	guaranteeing that a <a>specified value</a> exists for every property on every element.
 

--- a/css-cascade/Overview.bs
+++ b/css-cascade/Overview.bs
@@ -387,7 +387,7 @@ Cascaded Values</h3>
 <h3 id="specified">
 Specified Values</h3>
 
-	The <dfn export>specified value</dfn> the value of a given property that the style sheet authors intended for that element.
+	The <dfn export>specified value</dfn> is the value of a given property that the style sheet authors intended for that element.
 	It is the result of putting the <a>cascaded value</a> through the <a href="#defaulting">defaulting</a> processes,
 	guaranteeing that a <a>specified value</a> exists for every property on every element.
 


### PR DESCRIPTION
Simple typo fix. Added the missing verb "is"