### PR TITLE
[mediaqueries-4] Can't have 'not', 'and' and 'or' at the same level

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -679,15 +679,14 @@ Combining Media Features {#media-conditions}
 
 	* <a>Media conditions</a> can be grouped by wrapping them in parentheses ''()''
 		which can then be nested within a condition the same as a single media query.
-		For example, ''not (color) or (hover)''
+		For example, ''(not (color)) or (hover)''
 		is true on devices that are monochrome
-		and/or that have hover capabilities,
-		because the ''not'' only applies to the immediately following ''(color)'' feature.
+		and/or that have hover capabilities.
 		If one instead wanted to query for a device that was monochrome and <em>didn't</em> have hover capabilities,
 		it must instead be written as ''not ((color) or (hover))''
-		(or, equivalently, as ''not (color) and not (hover)'').
+		(or, equivalently, as ''(not (color)) and (not (hover))'').
 
-	It is <em>invalid</em> to mix ''and'' and ''or'' at the same “level” of a media query.
+	It is <em>invalid</em> to mix ''and'' and ''or'' and ''not'' at the same “level” of a media query.
 	For example, ''(color) and (pointer) or (hover)'' is illegal,
 	as it's unclear what was meant.
 	Instead, parentheses can be used to group things using a particular joining keyword,


### PR DESCRIPTION
This fixes a mistake introduced in https://github.com/w3c/csswg-drafts/commit/2f37630466463a8653832584ad3c80fd6f2e01be

Not only can you not have `or` and `and` at the same level, but `not` is handled the same as well, and also needs extra parentheses.