### PR TITLE
[css-flexbox] Correct typo in `flex` shorthand initial value

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -1491,7 +1491,7 @@ The 'flex' Shorthand</h3>
 	<pre class='propdef shorthand'>
 	Name: flex
 	Value: none | [ <<'flex-grow'>> <<'flex-shrink'>>? || <<'flex-basis'>> ]
-	Initial: 1 0 auto
+	Initial: 0 1 auto
 	Applies to: <a>flex items</a>
 	Inherited: no
 	Media: visual


### PR DESCRIPTION
This fixes #183 -- the initial value of the `flex` shorthand is `0 1 auto`, not `1 0 auto`.