### PR TITLE
[css-position] typo/spelling corrections

### DIFF
--- a/css-position/Overview.bs
+++ b/css-position/Overview.bs
@@ -570,7 +570,7 @@ Sticky positioning</h3>
   contained in the <em>sticky-constraint rectangle</em>.
 </ol>
 
-  When computing containement of the stickily positioned element within its
+  When computing containment of the stickily positioned element within its
   containing block, margins on the stickily positioned element are taken into
   account.
 
@@ -578,7 +578,7 @@ Sticky positioning</h3>
     Say what happens if it already overflows the containing block
   </p>
   <p class="issue">
-    Do marins collapse between the stickily positioned element and its containing
+    Do margins collapse between the stickily positioned element and its containing
     block element?
   </p>
 
@@ -985,7 +985,7 @@ Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-s
   Logical offset properties allow for offseting positioned boxes based on the
   'writing-mode' and 'direction' properties. When both the physical property and
   equivalent logical property (based on 'writing-mode' and 'direction') are
-  specified the physical property computes to the computed value of the coresponding
+  specified the physical property computes to the computed value of the corresponding
   logical property.
 
   Positioned elements generate positioned boxes, and may be laid out according to
@@ -1004,8 +1004,8 @@ Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-s
     Computed value: For ''position: relative'', see Relative positioning.<br/> For ''position: sticky'', see Sticky positioning.<br/> For ''position: static'', ''top/auto''.<br/> Otherwise: if specified as a <<length>>, the corresponding absolute length; if specified as a <<percentage>>, the specified value; otherwise, ''top/auto''.
   </pre>
 
-  For an absolutely positioned box this property specifies how far the coresponding
-  margin edge is offset from the coresponding physical reference edge of the box’s
+  For an absolutely positioned box this property specifies how far the corresponding
+  margin edge is offset from the corresponding physical reference edge of the box’s
   <a>containing block</a>.
 
   The partiucular physical reference edge that is used when offsetting is based
@@ -1082,14 +1082,14 @@ Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-s
   <p class="issue">The logical property definitions should move to the Logical Properties module.</p>
 
   For relatively positioned boxes, the offset is with respect to the property’s
-  coresponding physical reference edge of the box itself (i.e., the box is given a
+  corresponding physical reference edge of the box itself (i.e., the box is given a
   position in the <a>normal flow</a>, and then offset from that position according
   to the property).
 
   <p class="issue">This needs to be defined for sticky positioning.</p>
 
   For absolutely positioned elements whose <a>containing block</a>
-  is based on a block-level element, this property is an offset from the coresponding
+  is based on a block-level element, this property is an offset from the corresponding
   padding edge of that element.
 
   <p class="note">

--- a/css-position/Overview.html
+++ b/css-position/Overview.html
@@ -812,11 +812,11 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
   rectangle</em>, the stickily positioned element is moved left until it is fully
   contained in the <em>sticky-constraint rectangle</em>. 
    </ol>
-   <p>When computing containement of the stickily positioned element within its
+   <p>When computing containment of the stickily positioned element within its
   containing block, margins on the stickily positioned element are taken into
   account.</p>
    <p class="issue" id="issue-09e98f99"><a class="self-link" href="#issue-09e98f99"></a> Say what happens if it already overflows the containing block </p>
-   <p class="issue" id="issue-e6070342"><a class="self-link" href="#issue-e6070342"></a> Do marins collapse between the stickily positioned element and its containing
+   <p class="issue" id="issue-e6070342"><a class="self-link" href="#issue-e6070342"></a> Do margins collapse between the stickily positioned element and its containing
     block element? </p>
    <p>Intersection between the stickily positioned element and the bottom of the <em>sticky-constraint rectangle</em> limits movement in any direction, so the
   offset never pushes the stickily positioned element outside of its containing
@@ -1211,7 +1211,7 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
    <h3 class="heading settled" data-level="6.7" id="logical-box-offsets-beaso"><span class="secno">6.7. </span><span class="content"> Logical box offsets: <a class="property" data-link-type="propdesc" href="#propdef-offset-before" id="ref-for-propdef-offset-before-1">offset-before</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-end" id="ref-for-propdef-offset-end-1">offset-end</a>, <a class="property" data-link-type="propdesc" href="#propdef-offset-after" id="ref-for-propdef-offset-after-1">offset-after</a> and <a class="property" data-link-type="propdesc" href="#propdef-offset-start" id="ref-for-propdef-offset-start-1">offset-start</a></span><a class="self-link" href="#logical-box-offsets-beaso"></a></h3>
    <p>Logical offset properties allow for offseting positioned boxes based on the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">direction</a> properties. When both the physical property and
   equivalent logical property (based on <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">direction</a>) are
-  specified the physical property computes to the computed value of the coresponding
+  specified the physical property computes to the computed value of the corresponding
   logical property.</p>
    <p>Positioned elements generate positioned boxes, and may be laid out according to
   the following four logical properties taking into account the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">direction</a> of the <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block-26">containing block</a>:</p>
@@ -1245,8 +1245,8 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
       <th>Animatable:
       <td>&lt;length>, &lt;percentage>
    </table>
-   <p>For an absolutely positioned box this property specifies how far the coresponding
-  margin edge is offset from the coresponding physical reference edge of the box’s <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block-28">containing block</a>.</p>
+   <p>For an absolutely positioned box this property specifies how far the corresponding
+  margin edge is offset from the corresponding physical reference edge of the box’s <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block-28">containing block</a>.</p>
    <p>The partiucular physical reference edge that is used when offsetting is based
   on the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">direction</a> properties.</p>
    <p>The combination of the <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-writing-mode">writing-mode</a> and <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">direction</a> properties determine the
@@ -1305,11 +1305,11 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
    </div>
    <p class="issue" id="issue-f0660eeb"><a class="self-link" href="#issue-f0660eeb"></a>The logical property definitions should move to the Logical Properties module.</p>
    <p>For relatively positioned boxes, the offset is with respect to the property’s
-  coresponding physical reference edge of the box itself (i.e., the box is given a
+  corresponding physical reference edge of the box itself (i.e., the box is given a
   position in the <a data-link-type="dfn" href="#normal-flow" id="ref-for-normal-flow-19">normal flow</a>, and then offset from that position according
   to the property).</p>
    <p class="issue" id="issue-40a62b16"><a class="self-link" href="#issue-40a62b16"></a>This needs to be defined for sticky positioning.</p>
-   <p>For absolutely positioned elements whose <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block-29">containing block</a> is based on a block-level element, this property is an offset from the coresponding
+   <p>For absolutely positioned elements whose <a data-link-type="dfn" href="#containing-block" id="ref-for-containing-block-29">containing block</a> is based on a block-level element, this property is an offset from the corresponding
   padding edge of that element.</p>
    <p class="note" role="note"> Note, for fixed positioned elements using large values or
     negative values may easily move elements outside the <a data-link-type="dfn" href="#viewport" id="ref-for-viewport-7">viewport</a> and make the
@@ -2504,7 +2504,7 @@ div.a8 { position: relative; direction: ltr; left: -1em; right: 5em }
    <div class="issue"> Describe which element font-size-relative units are resolved against <a href="#issue-86601ab4"> ↵ </a></div>
    <div class="issue"> Say what happens if this rectangle is empty <a href="#issue-6be9cee7"> ↵ </a></div>
    <div class="issue"> Say what happens if it already overflows the containing block <a href="#issue-09e98f99"> ↵ </a></div>
-   <div class="issue"> Do marins collapse between the stickily positioned element and its containing
+   <div class="issue"> Do margins collapse between the stickily positioned element and its containing
     block element? <a href="#issue-e6070342"> ↵ </a></div>
    <div class="issue"> Does the margin on the stickily positioned element affect its distance from
     the flow root edge? <a href="#issue-0a53b8c3"> ↵ </a></div>


### PR DESCRIPTION
Correct some spelling errors/typos:

"coresponding" -> "corresponding"
"marins" -> "margins"
"containement" -> "containment"