### PR TITLE
[cssom-view] Fix #159 update offsetParent spec for Shadow DOM

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1352,11 +1352,14 @@ The <dfn attribute for=HTMLElement>offsetParent</dfn> attribute must return the 
     * The element is the root element.
     * The element is <a>the HTML <code>body</code> element</a>.
     * The element's computed value of the 'position' property is ''position/fixed''.
-1. Return the nearest ancestor <a lt="unclosed node">unclosed</a> element of the element for which at least one of the following is true and terminate this algorithm if such an ancestor is found: [[!DOM]]
-    * The computed value of the 'position' property is not ''static''.
-    * It is <a>the HTML <code>body</code> element</a>.
-    * The computed value of the 'position' property of the element is ''static'' and the ancestor is one of the following <a>HTML elements</a>: <code>td</code>, <code>th</code>, or <code>table</code>.
-1. Return null.
+1. Let <var>ancestor</var> be the parent of the element and repeat these substeps:
+    1. If <var>ancestor</var> is not an <a lt="unclosed node">unclosed</a> element of the element and its computed value of the 'position' property is ''position/fixed'', terminate this algorithm and return null.
+    1. If <var>ancestor</var> is an <a lt="unclosed node">unclosed</a> element of the element and satisfies at least one of the following, terminate this algorithm and return <var>ancestor</var>.
+        * The computed value of the 'position' property is not ''static''.
+        * It is <a>the HTML <code>body</code> element</a>.
+        * The computed value of the 'position' property of the element is ''static'' and the ancestor is one of the following <a>HTML elements</a>: <code>td</code>, <code>th</code>, or <code>table</code>.
+    1. If there is no more parent of <var>ancestor</var>, terminate this algorithm and return null.
+    1. Let <var>ancestor</var> be the parent of <var>ancestor</var>.
 
 The <dfn attribute for=HTMLElement>offsetTop</dfn> attribute must return the result of running these steps:
 

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1352,14 +1352,14 @@ The <dfn attribute for=HTMLElement>offsetParent</dfn> attribute must return the 
     * The element is the root element.
     * The element is <a>the HTML <code>body</code> element</a>.
     * The element's computed value of the 'position' property is ''position/fixed''.
-1. Let <var>ancestor</var> be the parent of the element and repeat these substeps:
+1. Let <var>ancestor</var> be the parent of the element in the <a>flat tree</a> and repeat these substeps:
     1. If <var>ancestor</var> is not an <a lt="unclosed node">unclosed</a> element of the element and its computed value of the 'position' property is ''position/fixed'', terminate this algorithm and return null.
     1. If <var>ancestor</var> is an <a lt="unclosed node">unclosed</a> element of the element and satisfies at least one of the following, terminate this algorithm and return <var>ancestor</var>.
         * The computed value of the 'position' property is not ''static''.
         * It is <a>the HTML <code>body</code> element</a>.
         * The computed value of the 'position' property of the element is ''static'' and the ancestor is one of the following <a>HTML elements</a>: <code>td</code>, <code>th</code>, or <code>table</code>.
-    1. If there is no more parent of <var>ancestor</var>, terminate this algorithm and return null.
-    1. Let <var>ancestor</var> be the parent of <var>ancestor</var>.
+    1. If there is no more parent of <var>ancestor</var> in the <a>flat tree</a>, terminate this algorithm and return null.
+    1. Let <var>ancestor</var> be the parent of <var>ancestor</var> in the <a>flat tree</a>.
 
 The <dfn attribute for=HTMLElement>offsetTop</dfn> attribute must return the result of running these steps:
 


### PR DESCRIPTION
[The previous attempt ](https://github.com/w3c/csswg-drafts/pull/169)to update offsetParent to fix #159 was incomplete:
when the real offsetParent in the closed shadow tree has
'position:fixed', offsetParent should return null, instead
of continue searching for unclosed ancestor.