### PR TITLE
[css-font-loading] Fix typo in WebIDL

### DIFF
--- a/css-font-loading/Overview.bs
+++ b/css-font-loading/Overview.bs
@@ -454,7 +454,7 @@ The <code>FontFaceSet</code> Interface</h2>
 		callback ForEachCallback = void (FontFace font, long index, FontFaceSet self);
 
 		[Exposed=Window,Worker,
-		 Constructor(sequence<FontFace> initialFaces)]
+		 Constructor(sequence&lt;FontFace> initialFaces)]
 		interface FontFaceSet : EventTarget {
 			// FontFaceSet is Set-like!
 			setlike&lt;FontFace>;


### PR DESCRIPTION
missing HTML escape