### PR TITLE
[css-color][mediaqueries] Editorial: use space in "Rec. 2020"

### DIFF
--- a/css-color/Overview.bs
+++ b/css-color/Overview.bs
@@ -1678,7 +1678,7 @@ Profiled, Device-dependent Colors</h2>
 	CSS provides two predefined RGB color spaces:
 	DCI P3 [[!DCI-P3]],
 	which is a wide gamut space typical of current wide-gamut monitors,
-	and Rec.2020 [[[!Rec.2020]],
+	and Rec. 2020 [[[!Rec.2020]],
 	which is a ultra-wide gamut space capable of representing almost all visible real-world colors.
 	Both are broadcast industry standards.
 
@@ -2843,10 +2843,10 @@ function XYZ_to_lin_P3(XYZ) {
 	return math.multiply(M, XYZ).valueOf();
 }
 
-//Rec.2020-related functions
+//Rec. 2020-related functions
 
 function lin_2020(RGB) {
-	// convert an array of Rec.2020 RGB values in the range 0.0 - 1.0
+	// convert an array of Rec. 2020 RGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
 	const α = 1.09929682680944 ;
 	const β = 0.018053968510807;
@@ -2862,7 +2862,7 @@ function lin_2020(RGB) {
 //check with standard this really is 2.4 and 1/2.4, not 0.45 was wikipedia claims
 
 function gam_2020(RGB) {
-	// convert an array of linear-light Rec.2020 RGB  in the range 0.0-1.0
+	// convert an array of linear-light Rec. 2020 RGB  in the range 0.0-1.0
 	// to gamma corrected form
 	const α = 1.09929682680944 ;
 	const β = 0.018053968510807;
@@ -2877,7 +2877,7 @@ function gam_2020(RGB) {
 }
 
 function lin_2020_to_XYZ(rgb) {
-	// convert an array of linear-light rec.2020 values to CIE XYZ
+	// convert an array of linear-light Rec. 2020 values to CIE XYZ
 	// using  D65 (no chromatic adaptation)
 	// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
 	var M = math.matrix([
@@ -2891,7 +2891,7 @@ function lin_2020_to_XYZ(rgb) {
 }
 
 function XYZ_to_lin_2020(XYZ) {
-	// convert XYZ to linear-light rec.2020
+	// convert XYZ to linear-light Rec. 2020
 	var M = math.matrix([
 		[1.7166511879712674,   -0.35567078377639233, -0.25336628137365974],
 		[-0.6666843518324892,   1.6164812366349395,   0.01576854581391113],

--- a/css-color/conversions.js
+++ b/css-color/conversions.js
@@ -1,14 +1,14 @@
 // sRGB-related functions
 
 function lin_sRGB(RGB) {
-	// convert an array of sRGB values in the range 0.0 - 1.0 
+	// convert an array of sRGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
 	// https://en.wikipedia.org/wiki/SRGB
 	return RGB.map(function (val) {
 		if (val < 0.04045) {
 			return val / 12.92;
 		}
-		
+
 		return Math.pow((val + 0.055) / 1.055, 2.4);
 	});
 }
@@ -21,11 +21,11 @@ function gam_sRGB(RGB) {
 		if (val > 0.0031308) {
 			return 1.055 * Math.pow(val, 1/2.4) - 0.055;
 		}
-		
+
 		return 12.92 * val;
 	});
 }
- 
+
 function lin_sRGB_to_XYZ(rgb) {
 	// convert an array of linear-light sRGB values to CIE XYZ
 	// using sRGB's own white, D65 (no chromatic adaptation)
@@ -35,7 +35,7 @@ function lin_sRGB_to_XYZ(rgb) {
 		[0.2126729,  0.7151522,  0.0721750],
 		[0.0193339,  0.1191920,  0.9503041]
 	]);
-	
+
 	return math.multiply(M, rgb).valueOf();
 }
 
@@ -46,7 +46,7 @@ function XYZ_to_lin_sRGB(XYZ) {
 		[-0.9692660,  1.8760108,  0.0415560],
 		[ 0.0556434, -0.2040259,  1.0572252]
 	]);
-	
+
 	return math.multiply(M, XYZ).valueOf();
 }
 
@@ -54,7 +54,7 @@ function XYZ_to_lin_sRGB(XYZ) {
 
 
 function lin_P3(RGB) {
-	// convert an array of DCI P3 RGB values in the range 0.0 - 1.0 
+	// convert an array of DCI P3 RGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
 
 	return RGB.map(function (val) {
@@ -65,23 +65,23 @@ function lin_P3(RGB) {
 function gam_P3(RGB) {
 	// convert an array of linear-light P3 RGB  in the range 0.0-1.0
 	// to gamma corrected form
-	
+
 	return RGB.map(function (val) {
 			return Math.pow(val, 1/2.6);
 	});
 }
- 
+
 function lin_P3_to_XYZ(rgb) {
 	// convert an array of linear-light P3 values to CIE XYZ
 	// using  D65 (no chromatic adaptation)
 	// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
 	var M = math.matrix([
 		[0.4865709486482162, 0.26566769316909306, 0.1982172852343625],
-		[0.2289745640697488, 0.6917385218365064,  0.079286914093745], 
+		[0.2289745640697488, 0.6917385218365064,  0.079286914093745],
 		[0.0000000000000000, 0.04511338185890264, 1.043944368900976]
 	]);
 	// 0 was computed as -3.972075516933488e-17
-	
+
 	return math.multiply(M, rgb).valueOf();
 }
 
@@ -92,45 +92,45 @@ function XYZ_to_lin_P3(XYZ) {
 		[-0.8294889695615747,   1.7626640603183463,  0.023624685841943577],
 		[ 0.03584583024378447, -0.07617238926804182, 0.9568845240076872]
 	]);
-	
+
 	return math.multiply(M, XYZ).valueOf();
 }
 
-//Rec.2020-related functions
+//Rec. 2020-related functions
 
 function lin_2020(RGB) {
-	// convert an array of Rec.2020 RGB values in the range 0.0 - 1.0 
+	// convert an array of Rec. 2020 RGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
 	const α = 1.09929682680944 ;
 	const β = 0.018053968510807;
-	
+
 	return RGB.map(function (val) {
 		if (val < β * 4.5 ) {
 			return val / 4.5;
 		}
-		
+
 		return Math.pow((val + α -1 ) / α, 2.4);
 	});
 }
 //check with standard this really is 2.4 and 1/2.4, not 0.45 was wikipedia claims
 
 function gam_2020(RGB) {
-	// convert an array of linear-light Rec.2020 RGB  in the range 0.0-1.0
+	// convert an array of linear-light Rec. 2020 RGB  in the range 0.0-1.0
 	// to gamma corrected form
 	const α = 1.09929682680944 ;
 	const β = 0.018053968510807;
-	
+
 	return RGB.map(function (val) {
 		if (val > β ) {
 			return α * Math.pow(val, 1/2.4) - (α - 1);
 		}
-		
+
 		return 4.5 * val;
 	});
 }
- 
+
 function lin_2020_to_XYZ(rgb) {
-	// convert an array of linear-light rec.2020 values to CIE XYZ
+	// convert an array of linear-light Rec. 2020 values to CIE XYZ
 	// using  D65 (no chromatic adaptation)
 	// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
 	var M = math.matrix([
@@ -139,18 +139,18 @@ function lin_2020_to_XYZ(rgb) {
 		[0.000000000000000,  0.028072693049087428, 1.060985057710791]
 	]);
 	// 0 is actually calculated as  4.994106574466076e-17
-	
+
 	return math.multiply(M, rgb).valueOf();
 }
 
 function XYZ_to_lin_2020(XYZ) {
-	// convert XYZ to linear-light rec.2020
+	// convert XYZ to linear-light Rec. 2020
 	var M = math.matrix([
 		[1.7166511879712674,   -0.35567078377639233, -0.25336628137365974],
 		[-0.6666843518324892,   1.6164812366349395,   0.01576854581391113],
 		[0.017639857445310783, -0.042770613257808524, 0.9421031212354738]
 	]);
-	
+
 	return math.multiply(M, XYZ).valueOf();
 }
 
@@ -168,7 +168,7 @@ function D65_to_D50(XYZ) {
 		[ 0.0295424,  0.9904844, -0.0170491],
 		[-0.0092345,  0.0150436,  0.7521316]
 	 ]);
-	
+
 	return math.multiply(M, XYZ).valueOf();
 }
 
@@ -179,7 +179,7 @@ function D50_to_D65(XYZ) {
 		[-0.0282895,  1.0099416,  0.0210077],
 		[ 0.0122982, -0.0204830,  1.3299098]
 	 ]);
-	 
+
 	return math.multiply(M, XYZ).valueOf();
 }
 
@@ -191,13 +191,13 @@ function XYZ_to_Lab(XYZ) {
 	var ε = 216/24389;  // 6^3/29^3
 	var κ = 24389/27;   // 29^3/3^3
 	var white = [0.9642, 1.0000, 0.8249]; // D50 reference white
-	
+
 	// compute xyz, which is XYZ scaled relative to reference white
 	var xyz = XYZ.map((value, i) => value / white[i]);
-	
+
 	// now compute f
 	var f = xyz.map(value => value > ε ? Math.cbrt(value) : (κ * value + 16)/116);
-	
+
 	return [
 		(116 * f[1]) - 16, // L
 		500 * (f[0] - f[1]), // a
@@ -212,20 +212,20 @@ function Lab_to_XYZ(Lab) {
 	var ε = 216/24389;  // 6^3/29^3
 	var white = [0.9642, 1.0000, 0.8249]; // D50 reference white
 	var f = [];
-	
+
 	// compute f, starting with the luminance-related term
 	f[1] = (Lab[0] + 16)/116;
 	f[0] = Lab[1]/500 + f[1];
 	f[2] = f[1] - Lab[2]/200;
-	
+
 	// compute xyz
 	var xyz = [
 		Math.pow(f[0],3) > ε ?   Math.pow(f[0],3)            : (116*f[0]-16)/κ,
 		Lab[0] > κ * ε ?         Math.pow((Lab[0]+16)/116,3) : Lab[0]/κ,
 		Math.pow(f[2],3)  > ε ?  Math.pow(f[2],3)            : (116*f[2]-16)/κ
 	];
-	
-	// Compute XYZ by scaling xyz by reference white  
+
+	// Compute XYZ by scaling xyz by reference white
 	return xyz.map((value, i) => value * white[i]);
 }
 
@@ -233,7 +233,7 @@ function Lab_to_LCH(Lab) {
 	// Convert to polar form
 	return [
 		Lab[0], // L is still L
-		Math.sqrt(Math.pow(Lab[1], 2) + Math.pow(Lab[2], 2)), // Chroma 
+		Math.sqrt(Math.pow(Lab[1], 2) + Math.pow(Lab[2], 2)), // Chroma
 		Math.atan2(Lab[2], Lab[1]) * 180 / Math.PI // Hue, in degrees
 	];
 }

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1477,7 +1477,7 @@ Color Display Quality: the 'color-gamut' feature</h3>
 
 	Note: The query uses approximate ranges for a few reasons.
 	Firstly, there are a lot of differences in display hardware.
-	For example, a device might claim to support "Rec.2020",
+	For example, a device might claim to support "Rec. 2020",
 	but actually renders a significantly lower range of the full gamut.
 	Secondly, there are a lot of different color ranges that different devices support,
 	and enumerating them all would be tedious.


### PR DESCRIPTION
Ref. https://github.com/w3c/csswg-drafts/commit/b7e9438393033fad1e390f41a4558cb735b3507c#commitcomment-18147194

---

My text editor also trimmed trailing whitespace.

@grorg @svgeesus @tabatkins 