### PR TITLE
Fix typo in definition of inline-list-item

### DIFF
--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -198,7 +198,7 @@ Box Layout Modes: the 'display' property</h2>
 				<td><a>block box</a>
 				    with additional <a href="https://www.w3.org/TR/CSS2/generate.html#lists">marker box</a>
 			<tr>
-				<td>''inline list-item''
+				<td>''inline-list-item''
 				<td>''list-item inline flow''
 				<td><a>inline box</a>
 				    with additional <a href="https://www.w3.org/TR/CSS2/generate.html#lists">marker box</a>


### PR DESCRIPTION
This threw me off when investigating [this Gecko bug](https://bugzilla.mozilla.org/show_bug.cgi?id=25291) as search wasn't finding a definition for "inline-list-item".