### PR TITLE
Drop blank line, to fix straggling "At Risk" bullet

### DIFF
--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -35,7 +35,6 @@ Former Editor: Sylvain Galineau, Adobe, galineau@adobe.com
 Abstract: This CSS module describes a way for authors to animate the values of CSS properties over time, using keyframes. The behavior of these keyframe animations can be controlled by specifying their duration, number of repeats, and repeating behavior.
 
 At Risk: the <code>pseudoElement</code> property of the ''AnimationEvent'' interface
-
 Link Defaults: css-values-3 (type) <time>, cssom-1 (interface) cssstyledeclaration, dom-core-ls (interface) event, webidl (type) SyntaxError, css-position-3 (property) left
 Ignored Terms: domstring, float, animationeventinit, event, eventinit, eventtarget, document
 </pre>


### PR DESCRIPTION
Right now the CSS Animations spec has a straggling bullet in its "At Risk" section -- it says:
> The following features are at-risk, and may be dropped during the CR period:
> * the pseudoElement property of the AnimationEvent interface
> * 
>
> “At-risk” is a W3C Process term-of-art, [...]

From local testing with Bikeshed, I've confirmed that the stray bullet is caused by the blank line after "At Risk". If I delete that blank line (as in this pull request), the stray bullet goes away.