### PR TITLE
[css-device-adapt] Adds motivating scenarios and rewording of intro

### DIFF
--- a/css-device-adapt/Overview.bs
+++ b/css-device-adapt/Overview.bs
@@ -28,32 +28,28 @@ CSS 2.1 [[!CSS21]] specifies an
 <a href="https://www.w3.org/TR/CSS21/visudet.html#containing-block-details">
 initial containing block</a> for continuous media that has the dimensions
 of the <a href="https://www.w3.org/TR/CSS21/visuren.html#viewport">
-viewport</a>. Mobile/handheld device browsers have a viewport that is
-generally a lot narrower than a desktop browser window at a zoom level
-that gives a CSS pixel size
+viewport</a>. Since the viewport is generally no larger than the display,
+devices with smaller displays such as phones or tablets typically present
+a smaller viewport than larger devices like desktop or laptops.
+
+Unfortunately, many documents have historically been designed against larger
+viewports and exhibit a variety of bugs when viewed in smaller viewports.
+These include unintended layout wrapping, clipped content, awkward scrollable
+bounds, and script errors. To avoid these issues, mobile browsers generally
+use a fixed initial containing block width that mimics common desktop browser
+window size (typically 980-1024px). The resulting layout is then scaled down
+to fit in the available screen space.
+
+Although this approach mitigates the issues mentioned above, the downscaling
+means the CSS pixel size will be smaller than
 <a href="https://www.w3.org/TR/CSS21/syndata.html#length-units">recommended</a>
-by CSS 2.1.
+by CSS 2.1. Users will likely need to zoom on the content to view it
+comfortably.
 
-The narrow viewport is a problem for documents designed to look good in
-desktop browsers. The result is that mobile browser vendors use a fixed
-initial containing block size that is different from the viewport size,
-and close to that of a typical desktop browser window. In addition to
-scrolling or panning, zooming is often used to change between an overview
-of the document and zoom in on particular areas of the document to read
-and interact with.
-
-Certain DOCTYPEs (for instance XHTML Mobile Profile) are used to recognize
-mobile documents which are assumed to be designed for handheld devices,
-hence using the viewport size as the initial containing block size.
-
-Additionally, an HTML <code class=html>&lt;META&gt;</code> tag has been
-introduced for allowing an author to specify the size of the initial
-containing block, and the initial zoom factor directly. It was first
-implemented by Apple for the Safari/iPhone browser, but has since been
-implemented for the Opera, Android, and Fennec browsers. These
-implementations are not fully interoperable and this specification is
-an attempt at standardizing the functionality provided by the
-viewport <code class=html>&lt;META&gt;</code> tag in CSS.
+This mitigation is unneccessary for sites that have been designed to work
+well on small viewports.  This specification describes the CSS
+<code class=css>@viewport</code> rule which allows authors to control and
+opt-out of this behavior.
 
 Issue: This specification is written from an implementation centric point of view,
 making it arguably difficult to read.
@@ -65,6 +61,65 @@ for a good discussion of these issues.
 
 Issue: Various issues about this specification and related specifications
 are listed in <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/Investigation_of_APIs_for_Level_of_detail#The_issues_on_existing_APIs">this report</a>.
+
+<h2 id="scenarios">
+Motivating Scenarios</h2>
+
+<div class="example">
+    In this example, the document can be rendered without issue with any
+    size viewport. The author indicates this using the
+    <code class=css>@viewport</code> rule.
+
+    <pre class="lang-html">
+        &lt;!doctype html>
+        &lt;html>
+        &lt;head>
+        &lt;title>My Site&lt;/title>
+        &lt;style>
+            @viewport { width: auto; }
+        &lt;/style>
+        &lt;/head>
+        &lt;body>
+            Since this document is just some simple text, it can be rendered
+            at any width without issue.  The text will just re-wrap as needed
+            when viewed in a smaller viewport.
+        &lt;/body>
+        &lt;/html>
+    </pre>
+</div>
+
+<div class="example">
+    In this example, the document can be rendered without issue for viewports
+    down to 384px, but smaller sizes would clip the diagram. The author
+    indicates this using the <code class=css>@viewport</code> rule in
+    combination with a media query. When the viewport would be smaller than
+    384px, the user agent will select 384px as the initial containing block
+    size and scale the resulting layout down to fit the available space.
+
+    <pre class="lang-html">
+        &lt;!doctype html>
+        &lt;html>
+        &lt;head>
+        &lt;style>
+            @viewport { width: auto; }
+            @media (max-width: 384px) {
+                @viewport { width: 384px; }
+            }
+            body {
+                margin: 0;
+            }
+            img {
+                min-width: 384px;
+            }
+        &lt;/style>
+        &lt;title>My Other Site&lt;/title>
+        &lt;/head>
+        &lt;body>
+            &lt;img src="diagram.png">
+        &lt;/body>
+        &lt;/html>
+    </pre>
+</div>
 
 <h2 id="values">
 Values</h2>


### PR DESCRIPTION
Addresses #326 

Intro reworded to discuss more of the "why" -- why current default behavior exists and why authors would want to opt-out.  Added 2 scenarios -- one for fully responsive using <meta> viewport and one partially responsive using @viewport and @media.  The examples use the current syntax for now, if/when syntax changes are made they can be updated at that time.