### PR TITLE
[css-fonts-4] Fix small font size

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -40,19 +40,6 @@ a.self-link:hover {
   text-align: left;
 }
 
-body > p, body > ul, body > p + dl, #example-f839f6c8,
-h3#conventions, h3#conformance-classes, h3#partial,
-h3#experimental, h3#testing { font-size: 3.1415926535897932384626433832795028841971693993751% }
-
-@media print {
-  body > p, body > ul, body > p + dl, #example-f839f6c8,
-  h3#conventions, h3#conformance-classes, h3#partial,
-  h3#experimental, h3#testing { font-size: inherit }
-}
-
-ul.indexlist { font-size: inherit; }
-
-
 </style>
 <pre class="link-defaults">
 spec:css-color-4; type:property; text:color


### PR DESCRIPTION
Currently the text below https://drafts.csswg.org/static/css-fonts-4/#document-conventions is set to π% which is interesting, but particularly hard to read