### PR TITLE
[cssom][css-conditional][css-images] Switch `CSS` to use IDL namespace

### DIFF
--- a/css-conditional/Overview.bs
+++ b/css-conditional/Overview.bs
@@ -997,9 +997,9 @@ The <code>CSS</code> interface, and the <code title=''>supports()</code> functio
 The {{CSS}} interface holds useful CSS-related functions that do not belong elsewhere.
 
 <pre class='idl'>
-partial interface CSS {
-  static boolean supports(DOMString property, DOMString value);
-  static boolean supports(DOMString conditionText);
+partial namespace CSS {
+  boolean supports(DOMString property, DOMString value);
+  boolean supports(DOMString conditionText);
 };
 </pre>
 

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -401,10 +401,12 @@ Using Out-Of-Document Sources: the <code>ElementSources</code> interface</h4>
 	The <a idl>elementSources</a> Map object provides this.
 
 	<pre class='idl'>
-		partial interface CSS {
-			[SameObject] readonly attribute Map elementSources;
+		partial namespace CSS {
+			// [SameObject] readonly attribute Map elementSources;
 		};
 	</pre>
+
+	Issue(428): IDL namespaces don't support attributes yet.
 
 	Any entries in the <a idl>elementSources</a> map with a string key
 	and a value that is an object providing a <a>paint source</a>
@@ -573,7 +575,7 @@ Gradients</h2>
 <h3 id='conic-gradients'>
 Conic Gradients: the ''conic-gradient()'' notation</h3>
 
-	
+
 
 	A conic gradient starts by specifying the center of a circle,
 	similar to radial gradients,
@@ -729,7 +731,7 @@ Conic Gradient Examples</h4>
 	</div>
 
 	<div class=example>
-		A conic gradient used to draw a simple pie chart. 
+		A conic gradient used to draw a simple pie chart.
 		The ''0deg'' color stop positions will be fixed up to be equal to the position of the color stop before them.
 		This will produce infinitesimal (invisible) transitions between the color stops with different colors,
 		effectively producing solid color segments.
@@ -768,7 +770,7 @@ Repeating Gradients: the ''repeating-linear-gradient()'', ''repeating-radial-gra
 		Basic repeating conic gradient:
 
 		<pre>background: repeating-conic-gradient(gold, #f06 20deg);</pre>
-		
+
 		<img src="images/repeating-conic1.png" alt="">
 	</div>
 
@@ -780,13 +782,13 @@ Repeating Gradients: the ''repeating-linear-gradient()'', ''repeating-radial-gra
 		                    hsla(0,0%,100%,.2) 0deg 15deg,
 		                    hsla(0,0%,100%,0) 0deg 30deg
 		                ) #0ac;</pre>
-		
+
 		<img src="images/repeating-conic2.png" alt="">
 	</div>
 
 	<div class=example>
 		Here repeating color stops with abrupt transitions are used to create a checkerboard:
-		
+
 		<pre>
 			background: repeating-conic-gradient(black 0deg 25%, white 0deg 50%);
 			background-size: 60px 60px;
@@ -845,7 +847,7 @@ Gradient Color-Stops</h3>
 			T: ,
 		N: <color-stop>
 	</pre>
-	
+
 	<p class='issue'>
 		Are lengths useful in <<angular-color-stop>>, for a given gradient circle?
 

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -2629,15 +2629,15 @@ Utility APIs {#utility-apis}
 The <code>CSS.escape()</code> Method {#the-css.escape()-method}
 ------------------------------------------------------
 
-The <code>CSS</code> interface holds useful CSS-related functions that do not belong elsewhere.
+The <code>CSS</code> namespace holds useful CSS-related functions that do not belong elsewhere.
 
 <pre class=idl>
-interface CSS {
-  static DOMString escape(DOMString ident);
+namespace CSS {
+  DOMString escape(DOMString ident);
 };
 </pre>
 
-The <dfn method for=CSS>escape(<var>ident</var>)</dfn> method must return the result of invoking <a>serialize an identifier</a> of
+The <dfn method for=CSS>escape(<var>ident</var>)</dfn> operation must return the result of invoking <a>serialize an identifier</a> of
 <var>ident</var>.
 
 <div class=example>
@@ -2651,7 +2651,7 @@ The <dfn method for=CSS>escape(<var>ident</var>)</dfn> method must return the re
  <pre>var element = document.querySelector('a[href="#' + CSS.escape(fragment) + '"]');</pre>
 </div>
 
-Specifications that define static functions on the {{CSS}} interface and want to
+Specifications that define operations on the {{CSS}} namespace and want to
 store some state should store the state on the <a spec=html>current global
 object</a>'s <a spec=html>associated <code>Document</code></a>.
 <!-- https://github.com/w3c/csswg-drafts/issues/180 -->


### PR DESCRIPTION
Web IDL added support for namespaces in
https://github.com/heycam/webidl/pull/121

`elementSources` in css-images-4 is commented out for now because
IDL namespaces don't support attributes yet, see #428.

Fixes part of https://www.w3.org/Bugs/Public/show_bug.cgi?id=29623

---

cc @bzbarsky @domenic @tabatkins @dbaron 
