### PR TITLE
[css-color] Propdef table: color computed value can be currentcolor

### DIFF
--- a/css-color/Overview.bs
+++ b/css-color/Overview.bs
@@ -60,7 +60,7 @@ Foreground Color: the 'color' property</h2>
 	Inherited: yes
 	Percentages: N/A
 	Media: visual
-	Computed value: an RGBA color
+	Computed value: an RGBA color or 'currentcolor'
 	</pre>
 
 	This property describes the foreground fill color of an element's text content.


### PR DESCRIPTION
https://drafts.csswg.org/css-color/#currentcolor-color says that `currentcolor` substitution happens at used-value time.