### PR TITLE
[css-grid] Update grid shorthand example to the new syntax

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -2292,22 +2292,22 @@ Grid Definition Shorthand: the 'grid' property</h3>
 	<div class='example'>
 		In addition to accepting the 'grid-template' shorthand syntax for setting up the <a>explicit grid</a>,
 		the 'grid' shorthand can also easily set up parameters for an auto-formatted grid.
-		For example, ''grid: row 1fr;'' is equivalent to
+		For example, ''grid: auto-flow 1fr / 100px;'' is equivalent to
 
 		<pre>
-			grid-template: none;
+			grid-template: none / 100px;
 			grid-auto-flow: row;
 			grid-auto-rows: 1fr;
-			grid-auto-columns: 1fr;
+			grid-auto-columns: auto;
 			grid-gap: 0;
 		</pre>
 
-		Similarly, ''grid: column 1fr / auto'' is equivalent to
+		Similarly, ''grid: none / auto-flow 1fr'' is equivalent to
 		<pre>
 			grid-template: none;
 			grid-auto-flow: column;
-			grid-auto-rows: 1fr;
-			grid-auto-columns: auto;
+			grid-auto-rows: auto;
+			grid-auto-columns: 1fr;
 			grid-gap: 0;
 		</pre>
 	</div>


### PR DESCRIPTION
The grid shorthand syntax was changed in commit 5fde09cd,
but the example was not updated by that time.