### PR TITLE
Fix typo: s/interpretead/interpreted/

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -851,7 +851,7 @@ Inline/Main-Axis Alignment: the 'justify-self' property</h3>
 	the box's outer edges are aligned within its <a>alignment container</a>
 	<a href="#alignment-values">as described by its alignment value</a>.
 
-	The <dfn value for="justify-self">auto</dfn> keyword is interpretead as
+	The <dfn value for="justify-self">auto</dfn> keyword is interpreted as
 	''justify-self/normal'' if the box is absolutely positioned or has no parent,
 	and as the computed value of 'justify-items' on the parent
 	(minus any ''legacy'' keywords)
@@ -1055,7 +1055,7 @@ Block/Cross-Axis Alignment: the 'align-self' property</h3>
 	the box's outer edges are aligned within its <a>alignment container</a>
 	<a href="#alignment-values">as described by its alignment value</a>.
 
-	The <dfn value for="align-self">auto</dfn> keyword is interpretead as
+	The <dfn value for="align-self">auto</dfn> keyword is interpreted as
 	''align-self/normal'' if the box is absolutely positioned or has no parent,
 	and as the computed value of 'align-items' on the parent
 	otherwise.


### PR DESCRIPTION
This fixes a minor spelling typo that was introduced in f5d582671f7fd3ff935e45c0675aca9f52e23483