### PR TITLE
[css-transforms-2] Transform properties create containing block

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -93,10 +93,10 @@ All three properties accept
 the value <dfn value for="translate, rotate, scale">none</dfn>,
 which produces no transform at all.
 In particular,
-this value does <em>not</em> trigger the creation of a stacking context,
+this value does <em>not</em> trigger the creation of a stacking context or containing block,
 while all other values
 (including identity transforms like ''translate: 0px'')
-create a stacking context,
+create a stacking context and containing block,
 per usual for transforms.
 
 


### PR DESCRIPTION
The individual transform properties create a containing block, just
like the transform property does.

fixes #582
