### PR TITLE
[css-position] Fix some minor typos and grammatical issues

### DIFF
--- a/css-position/Overview.bs
+++ b/css-position/Overview.bs
@@ -435,7 +435,7 @@ Relative positioning</h3>
   A relatively positioned box keeps its <a>normal flow</a> size, including
   line breaks and the space originally reserved for it.
 
-  A relatively positioned box establishes a new a new <a>containing block</a> for
+  A relatively positioned box establishes a new <a>containing block</a> for
   absolutely positioned descendants. (This is a common use of relatively positioned
   boxes.) The section on <a>containing blocks</a>
   explains when a relatively positioned box establishes a new <a>containing block</a>.
@@ -516,7 +516,7 @@ Sticky positioning</h3>
   A stickily positioned box keeps its <a>normal flow</a> size, including  line
   breaks and the space originally reserved for it.
 
-  A stickily positioned box establishes a new a new <a>containing block</a> for
+  A stickily positioned box establishes a new <a>containing block</a> for
   absolutely positioned descendants, just as relative positioning does. The section
   on <a>containing blocks</a> explains when a
   stickily positioned box establishes a new <a>containing block</a>.
@@ -618,11 +618,6 @@ Sticky positioning</h3>
     to "flow root," since that's the closest thing currently specced somewhere,
     but this is not optimal.
   </p>
-<div class=example>
-  The following example is the same as the previous one, but now it is explained:
-
-  <pre>EM { font-style: italic }</pre>
-</div>
 <!-- End section: Sticky positioning  -->
 
 <h3 id="abs-pos">
@@ -767,7 +762,7 @@ Choosing a positioning scheme: 'position' property</h3>
       <li>
       table-row-group, table-header-group, table-footer-group and table-row offset
       relative to its normal position within the table. If table-cells span
-      multiple rows, only the cells originating in the <a>relative positioned</a> row is
+      multiple rows, only the cells originating in the <a>relative positioned</a> row are
       offset.
 
       <li>
@@ -989,7 +984,7 @@ Box offsets: 'top', 'right', 'bottom', 'left'</h3>
 <h3 id="logical-box-offsets-beaso">
 Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-start'</h3>
 
-  Logical offset properties allow for offseting positioned boxes based on the
+  Logical offset properties allow for offsetting positioned boxes based on the
   'writing-mode' and 'direction' properties. When both the physical property and
   equivalent logical property (based on 'writing-mode' and 'direction') are
   specified the physical property computes to the computed value of the corresponding
@@ -1015,10 +1010,10 @@ Logical box offsets: 'offset-before', 'offset-end', 'offset-after' and 'offset-s
   margin edge is offset from the corresponding physical reference edge of the box’s
   <a>containing block</a>.
 
-  The partiucular physical reference edge that is used when offsetting is based
+  The particular physical reference edge that is used when offsetting is based
   on the 'writing-mode' and 'direction' properties.
 
-  The combination of the 'writing-mode' and 'direction' properties determine the
+  The combination of the 'writing-mode' and 'direction' properties determines the
   appropriate physical reference edge for offsetting.
 
   The table below shows logical offset properties (per 'writing-mode' and


### PR DESCRIPTION
This fixes some minor spelling mistakes, duplicated phrases and singular/plural grammatical nitpicks in the css-position spec. It also removes a dummy "example" section that appears to have been left over from the bikeshed template.

As a side comment, I found some parts of the spec difficult to read/comprehend properly. I have some ideas of improvements that can be made, but given that css-position is a new draft spec, I wasn't sure how far through the writing process it was.
What's the etiquette here? Create separate pull requests with suggested changes, or just raise an issue or two? (Or leave it be until the spec is further advanced?)
