### PR TITLE
[css-align] fix typo: s/baseline/last-baseline/

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -334,7 +334,7 @@ Baseline Alignment: the ''baseline'' and ''last-baseline'' keywords</h3>
 			in the shared <a>last baseline set</a>
 			of all the boxes in its <a>baseline-sharing group</a>.
 
-			The <a>fallback alignment</a> for ''baseline'' is ''end''.
+			The <a>fallback alignment</a> for ''last-baseline'' is ''end''.
 
 			Issue: Should this ''end'' fallback be ''safe'' or ''unsafe''?
 	</dl>


### PR DESCRIPTION
css-align section 4.2 currently [says](https://drafts.csswg.org/css-align/#valdef-justify-content-baseline):

> `baseline`
> [...] The fallback alignment for `baseline` is `start`.
> 
> `last-baseline`
> [... ]The fallback alignment for `baseline` is `end`.

Those "fallback alignment" sentences are contradictory (they say opposite things about the fallback alignment for `baseline`).

The latter one clearly means to be talking about `last-baseline`, not `baseline`. Here's a pull request to fix that typo.
