### PR TITLE
Remove text-orientation references from css-logical-props 

### DIFF
--- a/css-logical-props/Overview.bs
+++ b/css-logical-props/Overview.bs
@@ -145,7 +145,7 @@ Logical Box Model Properties
   but the logical and physical properties share computed values.
   Which pairs of properties share computed values
   depends on the computed values of
-  'writing-mode', 'text-orientation', and 'direction'.
+  'writing-mode' and 'direction'.
   For a summary of these dependencies, see
   <a href="https://drafts.csswg.org/css-writing-modes/#logical-to-physical">Abstract-to-Physical Mappings</a>
   in [[!CSS3-WRITING-MODES]].
@@ -254,8 +254,8 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'margin-top', 'margin-bottom',
   'margin-left', and 'margin-right' properties.
-  The mapping depends on the element's 'writing-mode',
-  'direction', and 'text-orientation'.
+  The mapping depends on the element's 'writing-mode' and
+  'direction'.
 
   <pre class="propdef">
   Name: offset-block-start, offset-block-end, offset-inline-start, offset-inline-end
@@ -270,7 +270,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'top', 'bottom', 'left', and 'right'
   properties. The mapping depends on the <em>parent element's</em>
-  'writing-mode', 'direction', and 'text-orientation'.
+  'writing-mode' and 'direction'.
 
 <h3 id="border-padding">
   Logical Padding and Border: the padding- and border-<var>*</var>-
@@ -289,7 +289,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'padding-top', 'padding-bottom',
   'padding-left', and 'padding-right' properties. The mapping depends on the
-  element's 'writing-mode', 'direction', and 'text-orientation'.
+  element's 'writing-mode' and 'direction'.
 
   <pre class="propdef">
   Name: border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width
@@ -304,7 +304,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'border-top-width', 'border-bottom-width',
   'border-left-width', and 'border-right-width' properties. The mapping depends
-  on the element's 'writing-mode', 'direction', and 'text-orientation'.
+  on the element's 'writing-mode' and 'direction'.
 
   <pre class="propdef">
   Name: border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style
@@ -319,7 +319,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'border-top-style', 'border-bottom-style',
   'border-left-style', and 'border-right-style' properties. The mapping depends
-  on the element's 'writing-mode', 'direction', and 'text-orientation'.
+  on the element's 'writing-mode' and 'direction'.
 
   <pre class="propdef">
   Name: border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color
@@ -334,7 +334,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'border-top-color', 'border-bottom-color',
   'border-left-color', and 'border-right-color' properties. The mapping depends
-  on the element's 'writing-mode', 'direction', and 'text-orientation'.
+  on the element's 'writing-mode' and 'direction'.
 
   <pre class="propdef">
   Name: border-block-start, border-block-end, border-inline-start, border-inline-end
@@ -349,7 +349,7 @@ the margin- and offset- block-start/block-end/inline-start/inline-end properties
 
   These properties correspond to the 'border-top', 'border-bottom',
   'border-left', and 'border-right' properties. The mapping depends on the
-  element's 'writing-mode', 'direction', and 'text-orientation'.
+  element's 'writing-mode' and 'direction'.
 
 <h3 id="logical-shorthand-keyword">
 Shorthand Properties with <css>logical</css> Keyword</h3>


### PR DESCRIPTION
(fixes #691)

r? @fantasai @heycam @kojiishi