### PR TITLE
[css-flexbox] Clarify implied minimum size definition

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -904,6 +904,8 @@ Implied Minimum Size of Flex Items</h3>
 	However, if the box has an aspect ratio and no <a>specified size</a>,
 	its <a>automatic minimum size</a>
 	is the smaller of its <a>content size</a> and its <a>transferred size</a>.
+	If the box has neither a <a>specified size</a> nor an <a>aspect ratio</a>, 
+	its <a>automatic minimum size</a> is the <a>content size</a>.
 
 	The <a>content size</a>, <a>specified size</a>, and <a>transferred size</a>
 	used in this calculation account for the relevant min/max/preferred size properties


### PR DESCRIPTION
Fixes #671. In the [old version](https://hg.csswg.org/drafts/rev/25641c92d33f) this case was specified, but dropped while changing from a table to a paragraph.

r? @dbaron