### PR TITLE
Fix wording in parsing a media query list

### DIFF
--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -266,7 +266,7 @@ Parsing Media Queries {#parsing-media-queries}
 
 To <dfn export>parse a media query list</dfn> for a
 given string <var>s</var> into a media query list is defined in
-the Media Queries specification. Return the list of one or more media
+the Media Queries specification. Return the list of media
 queries that the algorithm defined there gives. <!-- XXX ref -->
 
 Note: A media query that ends up being "ignored" will turn


### PR DESCRIPTION
A media query list can contain no media query at all, so "the list of one or more media queries" is incorrect.