### PR TITLE
Add :focusring selector

### DIFF
--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -272,7 +272,7 @@ Selectors Overview</h2>
 			<tr>
 				<td><code>E:hover</code>
 				<td>an E element that is under the cursor,
-						or that has a descendant under the cursor
+					or that has a descendant under the cursor
 				<td>[[#useraction-pseudos]]
 				<td>2
 			<tr>
@@ -281,8 +281,10 @@ Selectors Overview</h2>
 				<td>[[#useraction-pseudos]]
 				<td>2
 			<tr>
-				<td><code>E:focusring</code>
-				<td>an E element where the element is currently focused and a focus ring or other indicator should be drawn for that element
+				<td><code>E:focus-ring</code>
+				<td>an E element that has user input focus, 
+					and the UA has determined that a focus ring or other indicator 
+					should be drawn for that element
 				<td>[[#useraction-pseudos]]
 				<td>4
 			<tr>
@@ -2024,9 +2026,9 @@ The Activation Pseudo-class: '':active''</h3>
 <h3 id="the-focus-pseudo">
 The Input Focus Pseudo-class: '':focus''</h3>
 
-	The <dfn id='focus-pseudo'>:focus</dfn> pseudo-class applies while an element
-	has the focus (accepts keyboard or mouse events, or other forms of
-	input).
+	The <dfn id='focus-pseudo'>:focus</dfn> pseudo-class applies 
+	while an element has the focus 
+	(accepts keyboard or mouse events, or other forms of input).
 
 	There may be document language or implementation specific limits on
 	which elements can acquire '':focus''.
@@ -2037,46 +2039,65 @@ The Input Focus Pseudo-class: '':focus''</h3>
 	except that the parent of an element that matches '':focus'' must not match '':focus''.
 
 <h3 id="the-focusring-pseudo">
-The Input Focusring Pseudo-class: '':focusring''</h3>
+The Input Focus-Ring Pseudo-class: '':focus-ring''</h3>
 
-	The <dfn id="focusring-pseudo">:focusring</dfn> pseudo-class is similar to the
-	:focus pseudo-class, but it only matches an element if the element is
-	currently focused and a focus ring or other indicator should be drawn for that
-	element. If :focusring matches, then :focus also matches, but the converse is
-	not always true - it depends on whether the user agent has focus ring drawing
-	enabled and how the element was focused. Whether the user agent has focus ring
-	drawing enabled can depend on things like the settings of the operating system
-	the user is using, so the precise behavior of this pseudo-class can vary from
-	platform to platform depending on each platform's particular focus best
-	practices (defaults) or user modified settings.
-
-	<div class="example">
-		For example, most UAs choose to display focus rings on native text fields
-		whenever they are focused, and on native buttons only when selected via
-		the keyboard.
+	The <dfn id='focus-ring-pseudo'>:focus-ring</dfn> pseudo-class applies
+	while an element matches the '':focus'' pseudo-class,
+	<em>and</em> the UA determines via heuristics
+	that the focus should be specially indicated on the element
+	(typically via a "focus ring").
+	
+	<div class=example>
+		For example, UAs typically display focus indicators on text elements
+		<em>whenever</em> they're focused,
+		to draw attention to the fact that keyboard input will affect their contents.
+		
+		On the other hand, they typically only display focus indicators on buttons
+		when they were focused by a keyboard interaction
+		(such as tabbing thru the document), 
+		because it's not always immediately obvious where the focus will move
+		after such an interaction,
+		but not when they were focused by more "obvious" interactions,
+		like clicking on the button with a mouse pointer.
 	</div>
-
-	<em>This section is non-normative, and is meant to help clarify when a
-	:focusring selector might match.</em>
-
-	A user agent might choose to use the following heuristic for deciding when to
-	match '':focusring'' on focused elements which do not have any native focus
-	ring behaviour defined:
-
-	When focusing an element:
-	*   if the element received focus via a keyboard interaction, including
-	indirectly such as triggering a dialog via pressing a button using the
-	keyboard, apply '':focusring''.
-
-	When handling a keyboard event:
-	*   if a non-native element is focused, even if it did not become focused via
-	the keyboard, apply '':focusring'' to that element.
-
-	<div class="note">
-		Authors who build non-native interactive elements that are text-field
-		like in nature should consider adding a '':focus'' rule to that element to
-		ensure a focusring is displayed whenever focussed, rather than only when the
-		heuristic matches.
+	
+	<div class=advisement>
+		Page authors should follow these guidelines
+		when deciding whether to use '':focus'' or '':focus-ring''
+		to style the focused state of an element:
+		
+		* If the element has "native" focus indicator behavior
+			(such as text fields or buttons),
+			use '':focus-ring''.
+		* Otherwise, if the element is emulating a text input,
+			or something else that is <em>intended</em> to receive keyboard interaction,
+			use '':focus''.
+		* Otherwise,
+			use '':focus-ring''.
+	</div>
+	
+	When UAs choose to specially indicate focus on an element,
+	or whether they specially indicate focus at all,
+	is UA-dependent.
+	Different UAs,
+	the same UA on different operating systems,
+	or the same UA on the same OS,
+	but with different user settings,
+	can make different choices as to when an element matches '':focus-ring''.
+	
+	<div class=example>
+		The following guidelines are suggested heuristics
+		for choosing when to apply '':focus-ring'' 
+		to elements without "native" focus ring behavior:
+		
+		* If the element received focus via a keyboard interaction,
+			including indirectly,
+			such as triggering a dialog
+			by pressing a button using the keyboard,
+			apply '':focus-ring''.
+		* If a keyboard event occurs while an element is focused,
+			even if the element wasn't focused by a keyboard interaction,
+			apply '':focus-ring''.
 	</div>
 
 <h3 id="the-focus-within-pseudo">

--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -281,6 +281,11 @@ Selectors Overview</h2>
 				<td>[[#useraction-pseudos]]
 				<td>2
 			<tr>
+				<td><code>E:focusring</code>
+				<td>an E element where the element is currently focused and a focus ring or other indicator should be drawn for that element
+				<td>[[#useraction-pseudos]]
+				<td>4
+			<tr>
 				<td><code>E:drop</code>
 				<td>an E element that can possibly receive a drop
 				<td>[[#drag-pseudos]]
@@ -2030,6 +2035,49 @@ The Input Focus Pseudo-class: '':focus''</h3>
 	If the document language has defined additional ways by which an element can match '':active'',
 	the same ways must apply to elements matching '':focus'' as well,
 	except that the parent of an element that matches '':focus'' must not match '':focus''.
+
+<h3 id="the-focusring-pseudo">
+The Input Focusring Pseudo-class: '':focusring''</h3>
+
+	The <dfn id="focusring-pseudo">:focusring</dfn> pseudo-class is similar to the
+	:focus pseudo-class, but it only matches an element if the element is
+	currently focused and a focus ring or other indicator should be drawn for that
+	element. If :focusring matches, then :focus also matches, but the converse is
+	not always true - it depends on whether the user agent has focus ring drawing
+	enabled and how the element was focused. Whether the user agent has focus ring
+	drawing enabled can depend on things like the settings of the operating system
+	the user is using, so the precise behavior of this pseudo-class can vary from
+	platform to platform depending on each platform's particular focus best
+	practices (defaults) or user modified settings.
+
+	<div class="example">
+		For example, most UAs choose to display focus rings on native text fields
+		whenever they are focused, and on native buttons only when selected via
+		the keyboard.
+	</div>
+
+	<em>This section is non-normative, and is meant to help clarify when a
+	:focusring selector might match.</em>
+
+	A user agent might choose to use the following heuristic for deciding when to
+	match '':focusring'' on focused elements which do not have any native focus
+	ring behaviour defined:
+
+	When focusing an element:
+	*   if the element received focus via a keyboard interaction, including
+	indirectly such as triggering a dialog via pressing a button using the
+	keyboard, apply '':focusring''.
+
+	When handling a keyboard event:
+	*   if a non-native element is focused, even if it did not become focused via
+	the keyboard, apply '':focusring'' to that element.
+
+	<div class="note">
+		Authors who build non-native interactive elements that are text-field
+		like in nature should consider adding a '':focus'' rule to that element to
+		ensure a focusring is displayed whenever focussed, rather than only when the
+		heuristic matches.
+	</div>
 
 <h3 id="the-focus-within-pseudo">
 The Generalized Input Focus Pseudo-class: '':focus-within''</h3>


### PR DESCRIPTION
Adds support for `:focusring`, related discussion here: https://lists.w3.org/Archives/Public/www-style/2016Mar/0250.html

`:focusring` only matches an element if the element is currently focused and a focus ring or other indicator should be drawn for that element. This is extremely useful for accessibility.

As @tabatkins explained on the mailing list:

> The main benefit of such a thing is that, today, if the default UA focus ring style does not work well with your site's theme, you're kinda screwed. You can manually write a :focus rule, but you can't predict when an element would have a focus ring drawn; you'll unfortunately start drawing focus rings when the user mouse-clicks a button. Using :focus-ring instead does the right thing automatically, triggering your styles only when the UA determines via heuristics that it should draw a focus ring.