### PR TITLE
Change anchor for high-dpi devices to pixel

### DIFF
--- a/css-values/Overview.bs
+++ b/css-values/Overview.bs
@@ -1133,10 +1133,10 @@ Absolute lengths: the ''cm'', ''mm'', ''q'', ''in'', ''pt'', ''pc'', ''px'' unit
 		<li>by relating the <a value>pixel unit</a> to the <a>reference pixel</a>.
 	</ol>
 
-	For print media and similar high-resolution devices,
+	For print media,
 	the anchor unit should be one of the standard physical units (inches, centimeters, etc).
-	For lower-resolution devices,
-	and devices with unusual viewing distances,
+	For screen media (including high-resolution devices, lower-resolution devices,
+	and devices with unusual viewing distances),
 	it is recommended instead that the anchor unit be the pixel unit.
 	For such devices it is recommended that the pixel unit
 	refer to the whole number of device pixels that best approximates the reference pixel.


### PR DESCRIPTION
Make the spec match reality, as most (all?) high-dpi screen devices
currently also anchor on pixel unit, and not any physical unit.

Closes https://github.com/w3c/csswg-drafts/issues/708