### PR TITLE
Port HTML note on zoom/accessibility

### DIFF
--- a/css-device-adapt/Overview.bs
+++ b/css-device-adapt/Overview.bs
@@ -524,7 +524,9 @@ Computed value: auto, or a non-negative number or percentage as specified
 Specifies the largest allowed zoom factor. It is used as input to the
 <a href="#constraining-procedure">constraining procedure</a> to constrain
 non-''zoom/auto'' 'zoom' values, but also to limit the allowed zoom factor
-that can be set through user interaction. The UA should also use this
+that can be set through user interaction. The UA may choose to ignore
+this limit for accessbility/usability reasons – see the relevant note in
+the 'user-zoom' section. The UA should also use this
 value as a constraint when choosing an actual zoom factor when the
 used value of 'zoom' is ''zoom/auto''.
 
@@ -577,6 +579,22 @@ Values have the following meanings:
         The user cannot interactively change the zoom factor.
     </dd>
 </dl>
+
+<div class="note">
+    Authors should not suppress (with <code>user-zoom: fixed</code>)
+    or limit (with <code>max-zoom</code>) the ability of users to resize
+    a document, as this causes accessibility and usability issues.
+
+    There may be specific use cases where preventing users from zooming 
+    may be appropriate, such as map applications – where custom zoom 
+    functionality is handled via scripting. However, in general this 
+    practice should be avoided.
+
+    Most user agents now allow users to always zoom, regardless 
+    of any restrictions specified by web content – either by default, or 
+    as a setting/option (which may however not be immediately apparent
+    to users).
+</div>
 
 <h3 id="orientation-desc">
 The 'orientation' descriptor</h3>


### PR DESCRIPTION
Ports the note warning/note recently added to
https://w3c.github.io/html/document-metadata.html#the-meta-element about
not suppressing/limiting user's ability to zoom, and the note that UAs
can ignore these directives anyway.

Closes https://github.com/w3c/csswg-drafts/issues/704