### PR TITLE
[mediaqueries-4] expand/change emphasis of advice for use of pointer/hover/any-pointer/any-hover 

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1607,7 +1607,7 @@ Pointing Device Quality: the 'pointer' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'pointer' media feature is used to query about the presence and accuracy of a pointing device such as a mouse.
+	The 'pointer' media feature is used to query the presence and accuracy of a pointing device such as a mouse.
 	If a device has multiple input mechanisms,
 	the 'pointer' media feature must reflect the characteristics of the “primary” input mechanism,
 	as determined by the user agent.

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1747,17 +1747,17 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	or there are no pointing devices at all.
 
 	<div class="note">
-	These two media features are best suited to provide refinements over 'hover' and 'pointer',
-	and it is rarely appropriate to use them
-	without having first designed the main style and interaction mode of the page
-	to suit the primary input mechanism.
-	Once that has been taken into account, 'any-hover' and 'any-pointer' can be used
-	to see if some extra conveniences or non essential controls
-	can be offered to users who have additional ways to interact.
+	While 'pointer' and 'hover' can be used to design the main style and interaction
+	mode of the page to suit the primary input mechanism, 'any-pointer' and 'any-hover'
+	can be used to potentially take into account all possible types of pointers
+	that have been detected.
 
 	Designing a page that relies on hovering or accurate pointing
-	only because 'any-hover' or 'any-pointer' indicate that an input mechanism with these capabilities is available,
-	is likely to result in a poor experience.
+	only because 'any-hover' or 'any-pointer' indicate that at least one of the available
+	input mechanisms has these capabilities	is likely to result in a poor experience.
+	However, authors may use this information to inform their decision about the style and
+	functionality they wish to provide based on additional input mechanisms that
+	are available to the user.
 	</div>
 
 	<div class="example">

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1723,7 +1723,7 @@ Hover Capability: the 'hover' feature</h3>
 	</div>
 
 <h3 id='any-input'>
-Rare Interaction Capabilities: the 'any-pointer' and 'any-hover' features</h3>
+All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' features</h3>
 
 	<pre class='descdef mq'>
 	Name: any-pointer

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1646,6 +1646,10 @@ Pointing Device Quality: the 'pointer' feature</h3>
 	even on devices whose pointing device can be described as ''fine'',
 	the UA may give a value of ''coarse'' or ''pointer/none'' to this media query,
 	to indicate that the user has difficulties manipulating the pointing device accurately or at all.
+	In addition, even if the primary input mechanism has ''fine'' pointing accuracy,
+	there may be additional ''coarse'' input mechanisms available to the user. Authors may
+	wish to query the 'any-pointer' media feature to take these other ''coarse'' potential
+	input mechanisms into account.
 
 	<div class="example">
 		<pre>
@@ -1709,6 +1713,8 @@ Hover Capability: the 'hover' feature</h3>
 	For accessibility reasons, even on devices that do support hovering,
 	the UA may give a value of ''hover: none'' to this media query,
 	to opt into layouts that work well without hovering.
+	Note that even if the primary input mechanism has 'hover: hover' capability,
+	there may be additional input mechanisms available to the user that do not provide hover capabilities.
 
 	<div class="example">
 		<pre>


### PR DESCRIPTION
Related to the discussion in https://github.com/w3c/csswg-drafts/issues/690 this is an initial expansion/change to the current advice given for `pointer`/`hover`/`any-pointer`/`any-hover`.

[edit: copying the relevant description from the individual commits here, for completeness]

* Change "rare" to "all available": "rare" is a loaded term, unnecessarily implying (without much foundation) the likelihood/frequency that a user may use inputs deemed "not primary" by the OS/UA. In addition, as `any-*` also include the pointer that is deemed primary, the "rare" moniker is even more inappropriate, as by definition the "primary" is not "rare".

* Reword the note about pointer/hover vs any-*: Change the emphasis of the note, away from making the `any-*` features sound like a nice-to-have, and more towards aknowledging that these can be useful in making a page/app adapt better/preemptively to all available input methods.

* Add new example for any-hover usage: Include the common touchscreen laptop scenario, and show how `any-hover` can be used to make two completely different judgement calls on the part of the author (one inclusive, one exclusive)

* Add additional any-* consideration note to pointer/hover: The rationale given in any-pointer/any-hover about not relying exclusively on any-* is equally valid in reverse here. This does not imply that authors must design for "lowest common denominator", but simply opens up the possibility that they may wish to keep non-primary inputs in mind when deciding on their layout/functionality.

* Soften/expand the advice in the modified note for any-*: Reworded to remove the implication that authors should "ensure" that "ideally" they take any-* into account...turning it into a "may", which explains more about the rationale for the existence of these `any-*` features without seemingly mandating that authors must follow a specific style/design decision.

While I'm still not a fan of the "primary" concept, this PR would be a compromise I could (currently) live with (in which case this PR could close the relate issue)