### PR TITLE
[css-fonts-4] Remove redundant boilerplate styles and scripts

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -12,35 +12,6 @@ Abstract: This specification defines modifications to the existing <a href="http
 Ignored Terms: font-palette, <named-palette-color>
 </pre>
 
-<script type="text/javascript" src="http://use.typekit.com/xon2bky.js"></script>
-<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-
-<style>
-
-body, th, td, h1, h2, h3, h4, h5, h6 {
-  font-family: "myriad-pro", sans-serif !important;
-}
-
-a.self-link {
-  opacity: 0.1;
-}
-
-.touch a.self-link {
-  opacity: 0.5;
-}
-
-a.self-link:hover {
-  color: black;
-  opacity: 1;
-  background-color: transparent;
-}
-
-.advisement {
-  margin-top: 4em;
-  text-align: left;
-}
-
-</style>
 <pre class="link-defaults">
 spec:css-color-4; type:property; text:color
 </pre>
@@ -1325,11 +1296,3 @@ an emoji font or not, UTR51 defines a the default behavior for a given codepoint
 	Peter Constable for assorted language fixes.
 
 	Optical sizing <a href="#optical-size-example">image</a> prepared by Nick Sherman.
-
-
-<script>
-if ('ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0) {
-  var el = document.getElementsByTagName("html")[0];
-  el.className += " touch";
-}
-</script>


### PR DESCRIPTION
I was randomly looking at the spec source of CSS fonts level 4 and found this out:

- Loading Typescript JavaScript was failing because it wasn't from a secure source
- Boilerplate styles aren't needed to display https://drafts.csswg.org/css-fonts-4/ properly
- The script adding a "touch" class to the document isn't needed