### PR TITLE
[mediaqueries-4] Change when any-* evaluate to 'none'

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1746,11 +1746,9 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	</pre>
 
 	The 'any-pointer' and 'any-hover' media features are identical to the 'pointer' and 'hover' media features,
-	but they correspond to the union of capabilities of all the pointing devices available to the user.
+	but they correspond to the capabilities of all the pointing devices available to the user.
 	More than one of their values can match,
 	if different pointing devices have different characteristics.
-	They must only match ''none'' if <em>all</em> of the pointing devices would match ''none'' for the corresponding query,
-	or there are no pointing devices at all.
 
 	<div class="note">
 	While 'pointer' and 'hover' can be used to design the main style and interaction

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1792,6 +1792,28 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 		or to hide them altogether to reduce visual clutter if ''(any-pointer: fine)'' is false.
 	</div>
 
+	<div class="example">
+		A browser on a web-enabled game console provides a motion controller to move an
+		on-screen cursor. This input mechanism is considered primary, and matches ''(pointer: coarse)''.
+		In addition, the controller also provides a "d-pad" which allows the user to
+		(sequentially, or with a "spatial navigation" model) move a focus/caret across
+		all focusable elements on the page. This secondary input mechanism
+		matches ''(any-pointer: none)''. Based on this, an author
+		may decide to provide additional styles or functionality to cater for sequential/spatial
+		focus navigation, such as ensuring that all relevant elements are explicitly focusable and
+		provide relevant `:focus` styles.
+	</div>
+
+	<div class="example">
+		On a touchscreen laptop, the built-in trackpad is usually treated as the primary
+		input mechanism. As such, ''(hover: hover)'' is true. However, due to the presence of the
+		touchscreen, ''(any-hover: none)'' is also true. An author may decide that in this case,
+		the page should not rely on hover capabilities, as a user may choose to
+		use the non-hover-capable input mechanism. On the other hand, an author may decide that
+		use of the hover capability is essential for their page, and display a notification
+		reminding users to only use their mouse/trackpad.
+	</div>
+
 <!--
  ██████   ██████  ████████  ████ ████████  ████████ ████ ██    ██  ██████
 ██    ██ ██    ██ ██     ██  ██  ██     ██    ██     ██  ███   ██ ██    ██


### PR DESCRIPTION
Currently, `any-pointer: none` and `any-hover: none` only evaluate to true when they apply to ALL pointers/input mechanisms. There are situations, however, where it would be useful if these evaluated to true if ANY pointers/input mechanisms had those characteristics. See the examples in this PR for use cases where this would be the case. This would clearly be a substantive change to the spec, but one that I feel would open up some more granular possibilities for authors.

(this issue is a continuation of #715 which in turn came out of this isse #690)

Closes https://github.com/w3c/csswg-drafts/issues/737