### PR TITLE
[mediaqueries-4] add example of 'pointer: none' to table, add note about how UA could determine "primary" input

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1597,6 +1597,12 @@ Interaction Media Features</h2>
 		</style>
 	</div>
 
+	The 'pointer' and 'hover' features relate to the characteristics of the “primary” input mechanism, while 'any-pointer' and 'any-hover' can be used to query the properties of all potentially available input mechanisms.
+
+	<div class="note">
+		While this specification does not define how User Agents should decide what the “primary” input is, the expectation is that User Agents should make this determination by combining knowledge about the device/environment they are running on, the number and type of input mechanisms available, and a notion of which of these inputs is generally and/or currently being used. User Agents may also decide to dynamically change what type of input is deemed to be primary, in response to changes in the user environment or in the way the user is interacting with the UA.
+	</div>
+
 <h3 id="pointer">
 Pointing Device Quality: the 'pointer' feature</h3>
 

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1571,23 +1571,23 @@ Interaction Media Features</h2>
 		Typical examples of devices matching combinations of 'pointer' and 'hover':
 
 		<table class=data>
-			<col>
-			<col></col>
-			<col></col>
 			<thead>
 				<tr>
 					<td>
+					<th>''pointer: none''
 					<th>''pointer: coarse''
 					<th>''pointer: fine''
 			<tbody>
 				<tr>
 					<th scope=row>''hover: none''
+					<td>keyboard-only controls, sequential/spatial (d-pad) focus navigation
 					<td>smartphones, touch screens
-					<td>stylus-based screens (Cintiq, Wacom, etc)
+					<td>basic stylus digitizers (Cintiq, Wacom, etc)
 				<tr>
 					<th scope=row>''hover: hover''
+					<td>
 					<td>Nintendo Wii controller, Kinect
-					<td>mouse, touch pad
+					<td>mouse, touch pad, advanced stylus digitizers (Surface, Samsung Note, Wacom Intuos Pro, etc)
 		</table>
 		<style>
 			#pointer-hover-table { margin: 1em auto; text-align: center; border-collapse: collapse; max-width: 40em; }

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1597,11 +1597,17 @@ Interaction Media Features</h2>
 		</style>
 	</div>
 
-	The 'pointer' and 'hover' features relate to the characteristics of the “primary” input mechanism, while 'any-pointer' and 'any-hover' can be used to query the properties of all potentially available input mechanisms.
+	The 'pointer' and 'hover' features relate to the characteristics of the “primary” input mechanism, 
+	while 'any-pointer' and 'any-hover' can be used to query the properties of all potentially available input mechanisms.
 
-	<div class="note">
-		While this specification does not define how User Agents should decide what the “primary” input is, the expectation is that User Agents should make this determination by combining knowledge about the device/environment they are running on, the number and type of input mechanisms available, and a notion of which of these inputs is generally and/or currently being used. User Agents may also decide to dynamically change what type of input is deemed to be primary, in response to changes in the user environment or in the way the user is interacting with the UA.
-	</div>
+	Note: While this specification does not define how User Agents should decide what the “primary” input is, 
+	the expectation is that User Agents should make this determination 
+	by combining knowledge about the device/environment they are running on, 
+	the number and type of input mechanisms available, 
+	and a notion of which of these inputs is generally and/or currently being used. 
+	User Agents may also decide to dynamically change what type of input is deemed to be primary, 
+	in response to changes in the user environment 
+	or in the way the user is interacting with the UA.
 
 <h3 id="pointer">
 Pointing Device Quality: the 'pointer' feature</h3>


### PR DESCRIPTION
- expands the table https://drafts.csswg.org/mediaqueries/#mf-interaction to include an example of `pointer:none`, swaps "stylus-based screen" to "stylus digitizer" (preferred/common term), adds distinction between basic and advanced stylus (the latter does support hover)

- adds an introductory paragraph in the main "Interaction Media Features" section that introduces the concept of primary/all input mechanisms

- based on the conversation in https://github.com/w3c/csswg-drafts/issues/690#issuecomment-260941888, add a (non normative) note hinting at ways in which UAs can potentially determine what is and isn't primary (based on @frivoal's explanation to me in that thread about what the expectation for UAs seems to be...this makes it a bit more explicit)

both these changes should be editorial, rather than substantive, as they don't introduce any new normative requirements.

this addition would, as far as i'm currently concerned, close #690 