### PR TITLE
Fix typo (capitalization at start of sentence)

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -1172,7 +1172,7 @@ at least as dark as its predecessor. Only values between 1 - 999 are valid, and 
 
 	The <<string>> is a case-sensitive OpenType or TrueType variation axis name. As
 	specified in the OpenType / TrueType specifications, axis names contain four
-	ASCII characters. axis name strings longer or shorter than four characters,
+	ASCII characters. Axis name strings longer or shorter than four characters,
 	or containing characters outside the U+20&ndash;7E codepoint range are
 	invalid. Axis names need only
 	match an axis tag defined in the font, so they are not limited to


### PR DESCRIPTION
Just fixing a typo I noticed when reading this section of the spec - capitalizing a word at the start of a sentence.

(The next sentence starts with the same term & it's capitalized there, so this isn't an always-lowercase-term or anything like that.)