### PR TITLE
Change "line feed" to "segment break" in 4.1.2

### DIFF
--- a/css-text/Overview.bs
+++ b/css-text/Overview.bs
@@ -659,7 +659,8 @@ Languages and Typesetting</h4>
           break is the zero-width space character (U+200B), then the break
           is removed, leaving behind the zero-width space.
         <li>Otherwise, if the <a>East Asian Width property</a> [[!UAX11]] of both
-          the character before and after the line feed is <code>F</code>, <code>W</code>, or <code>H</code> (not <code>A</code>),
+          the character before and after the segment break is <code>F</code>,
+          <code>W</code>, or <code>H</code> (not <code>A</code>),
           and neither side is Hangul, then the segment break is removed.
         <li>Otherwise, the segment break is converted to a space (U+0020).
       </ul>


### PR DESCRIPTION
It doesn't seem to me there is any reason we need to distinguish between "line feed" and the other two types of "segment break", so I suppose this is probably a typo, which could be misleading.