### PR TITLE
[mediaqueries-4] More explicit clarification for when any-* 'none' evaluates to true

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -1759,10 +1759,41 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 
 	The 'any-pointer' and 'any-hover' media features are identical to the 'pointer' and 'hover' media features,
 	but they correspond to the union of capabilities of all the pointing devices available to the user.
-	More than one of their values can match,
+	In the case of 'any-pointer', more than one of the values can match,
 	if different pointing devices have different characteristics.
-	They must only match ''none'' if <em>all</em> of the pointing devices would match ''none'' for the corresponding query,
+
+	'any-pointer' and 'any-hover' must only match ''none'' if <em>all</em> of the pointing devices would match ''none'' for the corresponding query,
 	or there are no pointing devices at all.
+
+	<div class="note">
+	'any-pointer' is used to query the presence and accuracy of pointing devices.
+	It does not take into account any additional non-pointing device inputs,
+	and can not be used to test for the presence of other input mechanisms,
+	such as d-pads or keyboard-only controls,
+	that don't move an on-screen pointer.
+	'any-pointer:none' will only evaluate to true if there are no pointing devices at all present.
+	</div>
+
+	<div class="example">
+	On a traditional desktop environment with a mouse and keyboard,
+	'any-pointer:none' will be false (due to the presence of the mouse),
+	even though a non-pointer input (the keyboard) is also present.
+	</div>
+
+	<div class="note">
+	'any-hover:none' will only evaluate to true if there are no pointing devices,
+	or if all the pointing devices present lack hover capabilities.
+	As such, it should not be understood as a query to test if any hover-capable pointing devices are present,
+	rather than whether or not any of the pointing devices is not hover-capable.
+	The latter scenario can currently not be determined using 'any-hover' or any other interaction media feature.
+	</div>
+
+	<div class="example">
+	On a touch-enabled laptop with a mouse and a touchscreen,
+	'any-hover:none' will evaluate to false (due to the presence of the hover-capable mouse),
+	even though a non-hover-capable pointing device (the touchscreen) is also present.
+	It is currently not possible to provide different styles for cases where different pointing devices have different hover capabilities.
+	</div>
 
 	<div class="note">
 	While 'pointer' and 'hover' can be used to design the main style and interaction


### PR DESCRIPTION
Adds more explicit clarification about the possibly non-intuitive way in
which `any-pointer:none`/`any-hover:none` work.

Splits out the initial mention (that "ALL pointing devices need to
match") into its own line, and provides two sets of notes/examples that
clarify scenarios where this may not be completely obvious.

Additionally, this explicitly highlights the situation that currently
cannot be detected: having more than one pointing device where at least
one is non-hover-capable (as touched on in
https://github.com/w3c/csswg-drafts/issues/737#issuecomment-269348418 )