### PR TITLE
[cssom] Don't serialize shorthand if importance differs

### DIFF
--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -1980,7 +1980,9 @@ The <dfn method for=CSSStyleDeclaration>getPropertyValue(<var>property</var>)</d
        <li>If <var>declaration</var> is null, return the empty string and terminate these steps.
        <li>Append the <var>declaration</var> to <var>list</var>.
       </ol>
-     <li>Return the <a lt="serialize a CSS value">serialization</a> of <var>list</var> and terminate these steps.
+     <li>If <a lt="important flag" for="CSS declaration">important flags</a> of all declarations in <var>list</var> are same,
+     return the <a lt="serialize a CSS value">serialization</a> of <var>list</var> and terminate these steps.
+     <li>Return the empty string.
     </ol>
   </ol>
  <li>If <var>property</var> is a <a>case-sensitive</a>


### PR DESCRIPTION
For the following declarations:
```css
div {
  background: green;
  background-image: none !important;
}
```
the current spec should return something for `getPropertyValue('background')`, but all browsers (even Servo) agree on that this should return nothing because the importance of its longhands differ.

This PR fixes this issue.

It can alternatively be fixed in "serialize a CSS value" algorithm. Given that the other callsite of this algorithm with a list (which is "serialize a CSS declaration block") already handles important flag itself, I guess it is better being put in `getPropertyValue` rather than "serialize a CSS value".