### PR TITLE
[css-transforms-2] Individual transform properties animate with none

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -590,6 +590,9 @@ while all other values
 create a stacking context and containing block,
 per usual for transforms.
 
+When 'translate', 'rotate' or 'scale' are animating or transitioning, and the from value or to
+value (but not both) is ''none'', the value ''none'' is replaced by the equivalent identity
+value (''0px'' for translate, ''0deg'' for rotate, ''1'' for scale).
 
 Current Transformation Matrix {#ctm}
 ====================================


### PR DESCRIPTION
When 'translate', 'rotate' or 'scale' are animating or transitioning, and
the from value or to value (but not both) is none, the value none is
replaced by the equivalent identity value (0px for translate, 0deg for
rotate, 1 for scale).

resolves #968