### PR TITLE
Added example to grid-gap section

### DIFF
--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -3430,8 +3430,10 @@ Gutters: the 'grid-column-gap', 'grid-row-gap', and 'grid-gap' properties</h3>
 			<img src="images/gutters-gaps.svg" alt="A diagram showing how margins and padding add to the visible gutter size" width="500" height="616">
 		</figure>
 
-		Note: The 'grid-gap' property is only one component of the gutter or alley created between grid areas. Margins, padding, or the use of distributed alignment may increase the visible gutter size. Therefore a direct mapping between grid-gap and visual gutter is only possible if the author has ensured no other properties can add to the specified grid-gap.
-
+		Note: The 'grid-gap' property is only one component of the visible “gutter” or “alley” created between grid areas. 
+		Margins, padding, or the use of distributed alignment 
+		may increase the visible separation between grid items
+		beyond what is specified in 'grid-gap'. 
 	</div>
 
 <h3 id='auto-margins'>

--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -3425,6 +3425,15 @@ Gutters: the 'grid-column-gap', 'grid-row-gap', and 'grid-gap' properties</h3>
 	If <<'grid-column-gap'>> is omitted,
 	it's set to the same value as <<'grid-row-gap'>>.
 
+	<div class='example'>
+		<figure>
+			<img src="images/gutters-gaps.svg" alt="A diagram showing how margins and padding add to the visible gutter size" width="500" height="616">
+		</figure>
+
+		Note: The 'grid-gap' property is only one component of the gutter or alley created between grid areas. Margins, padding, or the use of distributed alignment may increase the visible gutter size. Therefore a direct mapping between grid-gap and visual gutter is only possible if the author has ensured no other properties can add to the specified grid-gap.
+
+	</div>
+
 <h3 id='auto-margins'>
 Aligning with <a value for="margin">auto</a> margins</h3>
 

--- a/css-grid/images/gutters-gaps.svg
+++ b/css-grid/images/gutters-gaps.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="692" height="852" viewBox="0 0 692 852" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <path id="a" d="M0 25h580v200H0z"/>
+    <mask id="q" width="580" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#a"/>
+    </mask>
+    <path id="b" d="M0 25h260v200H0z"/>
+    <mask id="r" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#b"/>
+    </mask>
+    <path id="c" d="M320 25h260v200H320z"/>
+    <mask id="s" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#c"/>
+    </mask>
+    <path id="d" d="M0 316h580v200H0z"/>
+    <mask id="t" width="580" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#d"/>
+    </mask>
+    <path id="e" d="M0 316h260v200H0z"/>
+    <mask id="u" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#e"/>
+    </mask>
+    <path id="f" d="M320 316h260v200H320z"/>
+    <mask id="v" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#f"/>
+    </mask>
+    <path id="g" d="M20 336h220v160H20z"/>
+    <mask id="w" width="220" height="160" x="0" y="0" fill="#fff">
+      <use xlink:href="#g"/>
+    </mask>
+    <path id="h" d="M0 610h580v200H0z"/>
+    <mask id="x" width="580" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#h"/>
+    </mask>
+    <path id="i" d="M320 316h260v200H320z"/>
+    <mask id="y" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#i"/>
+    </mask>
+    <path id="j" d="M320 610h260v200H320z"/>
+    <mask id="z" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#j"/>
+    </mask>
+    <path id="k" d="M0 610h260v200H0z"/>
+    <mask id="A" width="260" height="200" x="0" y="0" fill="#fff">
+      <use xlink:href="#k"/>
+    </mask>
+    <path id="l" d="M20 630h220v160H20z"/>
+    <mask id="B" width="220" height="160" x="0" y="0" fill="#fff">
+      <use xlink:href="#l"/>
+    </mask>
+    <path id="m" d="M40 650h180v120H40z"/>
+    <mask id="C" width="180" height="120" x="0" y="0" fill="#fff">
+      <use xlink:href="#m"/>
+    </mask>
+    <path id="n" d="M340 630h220v160H340z"/>
+    <mask id="D" width="220" height="160" x="0" y="0" fill="#fff">
+      <use xlink:href="#n"/>
+    </mask>
+    <path id="o" d="M340 336h220v160H340z"/>
+    <mask id="E" width="220" height="160" x="0" y="0" fill="#fff">
+      <use xlink:href="#o"/>
+    </mask>
+    <path id="p" d="M360 650h180v120H360z"/>
+    <mask id="F" width="180" height="120" x="0" y="0" fill="#fff">
+      <use xlink:href="#p"/>
+    </mask>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <use fill="#FFF" stroke="#979797" stroke-width="2" mask="url(#q)" xlink:href="#a"/>
+    <use fill="#EDEDED" stroke="#979797" stroke-width="2" mask="url(#r)" xlink:href="#b"/>
+    <use fill="#EDEDED" stroke="#979797" stroke-width="2" mask="url(#s)" xlink:href="#c"/>
+    <path stroke="#979797" d="M386.5 124.5h-63m0 0l10.8 3v-6l-10.8 3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="394" y="128">Content width 260px </tspan>
+    </text>
+    <path stroke="#979797" d="M516.5 124.5h60m0 0l-10.8-3v6l10.8-3z" stroke-linecap="square"/>
+    <use fill="#FFF" stroke="#979797" stroke-width="2" mask="url(#t)" xlink:href="#d"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#u)" stroke-dasharray="2 1" xlink:href="#e"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#v)" stroke-dasharray="2" xlink:href="#f"/>
+    <use fill="#EDEDED" stroke="#666" stroke-width="2" mask="url(#w)" xlink:href="#g"/>
+    <use fill="#FFF" stroke="#979797" stroke-width="2" mask="url(#x)" xlink:href="#h"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#y)" stroke-dasharray="2" xlink:href="#i"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#z)" stroke-dasharray="2" xlink:href="#j"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#A)" stroke-dasharray="2" xlink:href="#k"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#B)" stroke-dasharray="2 1" xlink:href="#l"/>
+    <use fill="#EDEDED" stroke="#979797" stroke-width="2" mask="url(#C)" xlink:href="#m"/>
+    <use stroke="#979797" stroke-width="2" mask="url(#D)" stroke-dasharray="2" xlink:href="#n"/>
+    <use fill="#EDEDED" stroke="#666" stroke-width="2" mask="url(#E)" xlink:href="#o"/>
+    <use fill="#EDEDED" stroke="#979797" stroke-width="2" mask="url(#F)" xlink:href="#p"/>
+    <path stroke="#979797" d="M388.5 709.5h-22m0 0l10.8 3v-6l-10.8 3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="395" y="419">Content width 220px </tspan>
+    </text>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="275" y="11">580px</tspan>
+    </text>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="245" y="259">Visible gap 60px</tspan>
+    </text>
+    <path stroke="#979797" d="M324.5 7.5h255m0 0l-10.8-3v6l10.8-3zm-321-1H2.5m0 0l10.8 3v-6l-10.8 3zm282 236h33m0 0l-10.8-3v6l10.8-3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="393" y="713">Content width 180px </tspan>
+    </text>
+    <path stroke="#979797" d="M283.5 242.5h-22m0 0l10.8 3v-6l-10.8 3zm248 174h47m0 0l-10.8-3v6l10.8-3zm-166-2h-46m0 0l10.8 3v-6l-10.8 3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="241" y="553">Visible gap 100px</tspan>
+    </text>
+    <path stroke="#979797" d="M281.5 534.5h59m0 0l-10.8-3v6l10.8-3zm-58 0h-37m0 0l10.8 3v-6l-10.8 3zm260 176h30m0 0l-10.8-3v6l10.8-3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="242" y="849">Visible gap 140px</tspan>
+    </text>
+    <path stroke="#979797" d="M295.5 829.5h63m0 0l-10.8-3v6l10.8-3zm-58 0h-79m0 0l10.8 3v-6l-10.8 3z" stroke-linecap="square"/>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="614" y="339">margin: 20px;</tspan>
+    </text>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="613" y="633">margin: 20px;</tspan>
+    </text>
+    <text fill="#000" font-family="Helvetica" font-size="12">
+      <tspan x="613" y="667">padding: 20px;</tspan>
+    </text>
+    <path stroke="#979797" d="M608.5 335.5h-42m0 0l10.8 3v-6l-10.8 3zm41 293h-42m0 0l10.8 3v-6l-10.8 3zm42 36h-56m0 0l10.8 3v-6l-10.8 3z" stroke-linecap="square"/>
+  </g>
+</svg>


### PR DESCRIPTION
Example for grid-gap section demonstrating difference between grid-gap and visible gutter.

Re: Issue 452 https://github.com/w3c/csswg-drafts/issues/452