### PR TITLE
Delete stray <li> from containing block definition

### DIFF
--- a/css-position/Overview.bs
+++ b/css-position/Overview.bs
@@ -273,7 +273,6 @@ Definition of <dfn lt="containing block">containing block</dfn></h3>
         </p>
       </ol>
     </ol>
-    <li>
 
     <li>
     If there is no such ancestor, the containing block is the <a>initial


### PR DESCRIPTION
Before this change, https://drafts.csswg.org/css-position-3/#def-cb shows a stray list item (just an empty "3." in an ordered list).  This comes from two back-to-back `<li>` tags.  My change just removes one of these redundant `<li>` tags.