### PR TITLE
[cssom-view] Specify aliases for window.open feature names

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -673,6 +673,7 @@ This specification defines the effect of the <var>features</var> argument for us
     1. <a>Skip whitespace</a>.
     1. <a>Collect a sequence of characters</a> that are not <a>space characters</a> nor "<code>=</code>" (U+003D).
         Let <var>name</var> be the collected characters, <a>converted to ASCII lowercase</a>.
+    1. Set <var>name</var> to the result of <a>normalizing the feature name</a> <var>name</var>.
     1. If <var>name</var> is in <var>parsed features</var> or if <var>name</var> is not a <a>supported <code>open()</code> feature name</a>,
         continue <i>token loop</i>.
     1. <a>Skip whitespace</a>.
@@ -720,6 +721,22 @@ A <dfn export>supported <code>open()</code> feature name</dfn> is one of the fol
 
     <dt><dfn>top</dfn>
     <dd>The top position of the window.
+</dl>
+
+For legacy reasons, there are some aliases of some feature names. To <dfn lt="normalizing the
+feature name">normalize a feature name</dfn> <var>name</var>, switch on <var>name</var>:
+
+<dl class="switch">
+ <dt>"<code>screenx</code>"
+ <dd>Return "<code>left</code>".
+ <dt>"<code>screeny</code>"
+ <dd>Return "<code>top</code>".
+ <dt>"<code>innerwidth</code>"
+ <dd>Return "<code>width</code>".
+ <dt>"<code>innerheight</code>"
+ <dd>Return "<code>height</code>".
+ <dt>Anything else
+ <dd>Return <var>name</var>.
 </dl>
 
 


### PR DESCRIPTION
Add screenx, screeny, innerwidth, innerheight as aliases for left,
top, width, and height, respectively.

Part of https://github.com/whatwg/html/issues/2464