### PR TITLE
Adding 'cap' unit to the section heading

### DIFF
--- a/css-values/Overview.bs
+++ b/css-values/Overview.bs
@@ -919,7 +919,7 @@ Relative lengths</h3>
 -->
 
 <h4 id="font-relative-lengths">
-Font-relative lengths: the ''em'', ''ex'', ''ch'', ''ic'', ''rem'', ''lh'', ''rlh'' units</h4>
+Font-relative lengths: the ''em'', ''ex'', ''cap'', ''ch'', ''ic'', ''rem'', ''lh'', ''rlh'' units</h4>
 
 	Aside from ''rem'' (which refers to the font-size of the root element)
 	and ''rlh'' (which refers to the line-height of the root element),


### PR DESCRIPTION
Adding 'cap' unit to the 'Font-relative lengths' section heading, to solve #1126