### PR TITLE
[cssom-view] Move tokenizing of window.open's features arg to HTML

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -664,8 +664,8 @@ The <var ignore>features</var> argument to the {{Window/open()}} method {#the-fe
 HTML defines the {{Window/open()}} method. This section defines behavior for position and size given
 in the <var ignore>features</var> argument. [[!HTML]]
 
-To <dfn export>set up window size and position</dfn> for a browsing context <var>target</var> given
-a <a>map</a> <var>tokenizedFeatures</var>:
+To <dfn export>set up browsing context features</dfn> for a browsing context <var>target</var> given a
+<a>map</a> <var>tokenizedFeatures</var>:
 
 1. Let <var>x</var> be null.
 1. Let <var>y</var> be null.

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -13,7 +13,7 @@ Status: ED
 Work Status: Revising
 Shortname: cssom-view
 Level: 1
-Editor: Simon Pieters, Opera Software ASA http://www.opera.com, simonp@opera.com
+Editor: Simon Pieters, Opera Software AS http://www.opera.com, simonp@opera.com
 Former Editor: Glenn Adams, Cox Communications&#44; Inc. http://www.cox.com, glenn.adams@cos.com, http://www.w3.org/wiki/User:Gadams
 Former Editor: Anne van Kesteren, Opera Software ASA http://www.opera.com, annevk@annevk.nl, https://annevankesteren.nl/
 !Legacy issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=CSS&amp;component=CSSOM%20View&amp;resolution=---">Bugzilla</a>
@@ -377,6 +377,9 @@ The <dfn export>Web-exposed available screen area</dfn> is one of the following:
 Common Infrastructure {#common-infrastructure}
 ==============================================
 
+This specification depends on the WHATWG Infra standard. [[!INFRA]]
+
+
 Scrolling {#scrolling}
 ----------------------
 
@@ -655,56 +658,61 @@ The <dfn attribute for=Window>devicePixelRatio</dfn> attribute must return the r
 1. Return the result of dividing <var>CSS pixel size</var> by <var>device pixel size</var>.
 
 
-The <var>features</var> argument to the {{Window/open()}} method {#the-features-argument-to-the-open()-method}
+The <var ignore>features</var> argument to the {{Window/open()}} method {#the-features-argument-to-the-open()-method}
 --------------------------------------------------------------------------------------------------------------
 
-HTML defines the {{Window/open()}} method but has no defined effect for the third argument, <var>features</var>.
-[[!HTML]]
+HTML defines the {{Window/open()}} method. This section defines behavior for position and size given
+in the <var ignore>features</var> argument. [[!HTML]]
 
-This specification defines the effect of the <var>features</var> argument for user agents that do not opt to ignore it, as follows:
+To <dfn export>set up window size and position</dfn> for a browsing context <var>target</var> given
+a <a>map</a> <var>tokenizedFeatures</var>:
 
-1. If the method does not result in a new <a>auxiliary browsing context</a> being created, terminate these steps.
-1. Let <var>target</var> be the new <a>auxiliary browsing context</a>.
-1. Let <var>tokens</var> be the result of <a lt="split a string on commas">splitting <var>features</var> on commas</a>.
-1. Let <var>parsed features</var> be a new empty dictionary.
-1. <i>Token loop</i>: For each token <var>token</var> in <var>tokens</var>, follow these substeps:
-    1. Let <var>input</var> be <var>token</var>.
-    1. Let <var>position</var> point at the first character of <var>input</var>.
-    1. <a>Skip whitespace</a>.
-    1. <a>Collect a sequence of characters</a> that are not <a>space characters</a> nor "<code>=</code>" (U+003D).
-        Let <var>name</var> be the collected characters, <a>converted to ASCII lowercase</a>.
-    1. If <var>name</var> is in <var>parsed features</var> or if <var>name</var> is not a <a>supported <code>open()</code> feature name</a>,
-        continue <i>token loop</i>.
-    1. <a>Skip whitespace</a>.
-    1. If the character at <var>position</var> is not "<code>=</code>" (U+003D), continue <i>token loop</i>.
-    1. Advance <var>position</var> by one.
-    1. If <var>position</var> is past the end of <var>input</var>, continue <i>token loop</i>.
-    1. <a>Collect a sequence of characters</a> that are any characters. Let <var>raw value</var> be the collected characters.
-    1. Let <var>value</var> be the result of invoking the <a>rules for parsing integers</a> on <var>raw value</var>.
-    1. If <var>value</var> is an error, continue <i>token loop</i>.
-    1. Set <var>name</var> in <var>parsed features</var> to <var>value</var>.
-1. If <a for="supported open() feature name">left</a> is present in <var>parsed features</var>, follow these substeps:
-    1. Let <var>x</var> be the value of <a for="supported open() feature name">left</a>.
-    1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not move outside the available space.
-    1. Optionally, move <var>target</var>'s window such that the window's left edge is at the horizontal coordinate <var>x</var> relative to the left edge of
-        the output device, measured in CSS pixels of <var>target</var>. The positive axis is rightward.
-1. If <a for="supported open() feature name">top</a> is present in <var>parsed features</var>, follow these substeps:
-    1. Let <var>y</var> be the value of <a for="supported open() feature name">top</a>.
-    1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not move outside the available space.
-    1. Optionally, move <var>target</var>'s window such that the window's top edge is at the vertical coordinate <var>y</var> relative to the top edge of
-        the output device, measured in CSS pixels of <var>target</var>. The positive axis is downward.
-1. If <a for="supported open() feature name">width</a> is present in <var>parsed features</var>, follow these substeps:
-    1. Let <var>x</var> be the value of <a for="supported open() feature name">width</a>.
-    1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not get too small or bigger than the available space.
-    1. Optionally, size <var>target</var>'s window by moving its right edge such that the distance between the left and right edges of the viewport are
-        <var>x</var> CSS pixels of <var>target</var>.
-    1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does not grow outside the available space.
-1. If <a for="supported open() feature name">height</a> is present in <var>parsed features</var>, follow these substeps:
-    1. Let <var>y</var> be the value of <a for="supported open() feature name">height</a>.
-    1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not get too small or bigger than the available space.
-    1. Optionally, size <var>target</var>'s window by moving its bottom edge such that the distance between the top and bottom edges of the viewport are
-        <var>y</var> CSS pixels of <var>target</var>.
-    1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does not grow outside the available space.
+1. Let <var>x</var> be null.
+1. Let <var>y</var> be null.
+1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">left</a>"]
+    <a for=map>exists</a>:
+    1. Set <var>x</var> to the result of invoking the <a>rules for parsing integers</a> on
+        <var>tokenizedFeatures</var>["<a for="supported open() feature name">left</a>"].
+    1. If <var>x</var> is an error, set <var>x</var> to 0.
+    1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not
+        move outside the available space.
+    1. Optionally, move <var>target</var>'s window such that the window's left edge is at the
+        horizontal coordinate <var>x</var> relative to the left edge of the output device, measured
+        in CSS pixels of <var>target</var>. The positive axis is rightward.
+1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">top</a>"]
+    <a for=map>exists</a>:
+    1. Set <var>y</var> to the result of invoking the <a>rules for parsing integers</a> on
+        <var>tokenizedFeatures</var>["<a for="supported open() feature name">top</a>"].
+    1. If <var>y</var> is an error, set <var>y</var> to 0.
+    1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not
+        move outside the available space.
+    1. Optionally, move <var>target</var>'s window such that the window's top edge is at the
+        vertical coordinate <var>y</var> relative to the top edge of the output device, measured in
+        CSS pixels of <var>target</var>. The positive axis is downward.
+1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">width</a>"]
+    <a for=map>exists</a>:
+    1. Set <var>x</var> to the result of invoking the <a>rules for parsing integers</a> on
+        <var>tokenizedFeatures</var>["<a for="supported open() feature name">width</a>"].
+    1. If <var>x</var> is an error, set <var>x</var> to 0.
+    1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not get
+        too small or bigger than the available space.
+    1. Optionally, size <var>target</var>'s window by moving its right edge such that the distance
+        between the left and right edges of the viewport are <var>x</var> CSS pixels of
+        <var>target</var>.
+    1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does
+        not grow outside the available space.
+1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">height</a>"]
+    <a for=map>exists</a>:
+    1. Set <var>y</var> to the result of invoking the <a>rules for parsing integers</a> on
+        <var>tokenizedFeatures</var>["<a for="supported open() feature name">height</a>"].
+    1. If <var>y</var> is an error, set <var>y</var> to 0.
+    1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not get
+        too small or bigger than the available space.
+    1. Optionally, size <var>target</var>'s window by moving its bottom edge such that the distance
+        between the top and bottom edges of the viewport are <var>y</var> CSS pixels of
+        <var>target</var>.
+    1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does
+        not grow outside the available space.
 
 A <dfn export>supported <code>open()</code> feature name</dfn> is one of the following:
 

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -11,7 +11,7 @@ Status: ED
 Work Status: Exploring
 Shortname: cssom
 Level: 1
-Editor: Simon Pieters, Opera Software ASA http://www.opera.com, simonp@opera.com
+Editor: Simon Pieters, Opera Software AS http://www.opera.com, simonp@opera.com
 Editor: Daniel Glazman, Disruptive Innovations http://disruptive-innovations.com/, daniel.glazman@disruptive-innovations.com
 Former Editor: Glenn Adams, Cox Communications&#44; Inc. http://www.cox.com, glenn.adams@cos.com, http://www.w3.org/wiki/User:Gadams
 Former Editor: Anne van Kesteren, Opera Software ASA http://www.opera.com, annevk@annevk.nl, https://annevankesteren.nl/


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/2476

Also change the behavior for left=foo to act as if left=0 to align
with the behavior of at least WebKit and Chromium.