### PR TITLE
[cssom-view] Make window.open's features use Web-exposed screen area 

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -675,44 +675,44 @@ To <dfn export>set up browsing context features</dfn> for a browsing context <va
         <var>tokenizedFeatures</var>["<a for="supported open() feature name">left</a>"].
     1. If <var>x</var> is an error, set <var>x</var> to 0.
     1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not
-        move outside the available space.
+        move outside the <a>Web-exposed available screen area</a>.
     1. Optionally, move <var>target</var>'s window such that the window's left edge is at the
-        horizontal coordinate <var>x</var> relative to the left edge of the output device, measured
-        in CSS pixels of <var>target</var>. The positive axis is rightward.
+        horizontal coordinate <var>x</var> relative to the left edge of the <a>Web-exposed screen
+        area</a>, measured in CSS pixels of <var>target</var>. The positive axis is rightward.
 1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">top</a>"]
     <a for=map>exists</a>:
     1. Set <var>y</var> to the result of invoking the <a>rules for parsing integers</a> on
         <var>tokenizedFeatures</var>["<a for="supported open() feature name">top</a>"].
     1. If <var>y</var> is an error, set <var>y</var> to 0.
     1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not
-        move outside the available space.
+        move outside the <a>Web-exposed available screen area</a>.
     1. Optionally, move <var>target</var>'s window such that the window's top edge is at the
-        vertical coordinate <var>y</var> relative to the top edge of the output device, measured in
-        CSS pixels of <var>target</var>. The positive axis is downward.
+        vertical coordinate <var>y</var> relative to the top edge of the <a>Web-exposed screen
+        area</a>, measured in CSS pixels of <var>target</var>. The positive axis is downward.
 1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">width</a>"]
     <a for=map>exists</a>:
     1. Set <var>x</var> to the result of invoking the <a>rules for parsing integers</a> on
         <var>tokenizedFeatures</var>["<a for="supported open() feature name">width</a>"].
     1. If <var>x</var> is an error, set <var>x</var> to 0.
     1. Optionally, clamp <var>x</var> in a user-agent-defined manner so that the window does not get
-        too small or bigger than the available space.
+        too small or bigger than the <a>Web-exposed available screen area</a>.
     1. Optionally, size <var>target</var>'s window by moving its right edge such that the distance
         between the left and right edges of the viewport are <var>x</var> CSS pixels of
         <var>target</var>.
     1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does
-        not grow outside the available space.
+        not grow outside the <a>Web-exposed available screen area</a>.
 1. If <var>tokenizedFeatures</var>["<a for="supported open() feature name">height</a>"]
     <a for=map>exists</a>:
     1. Set <var>y</var> to the result of invoking the <a>rules for parsing integers</a> on
         <var>tokenizedFeatures</var>["<a for="supported open() feature name">height</a>"].
     1. If <var>y</var> is an error, set <var>y</var> to 0.
     1. Optionally, clamp <var>y</var> in a user-agent-defined manner so that the window does not get
-        too small or bigger than the available space.
+        too small or bigger than the <a>Web-exposed available screen area</a>.
     1. Optionally, size <var>target</var>'s window by moving its bottom edge such that the distance
         between the top and bottom edges of the viewport are <var>y</var> CSS pixels of
         <var>target</var>.
     1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does
-        not grow outside the available space.
+        not grow outside the <a>Web-exposed available screen area</a>.
 
 A <dfn export>supported <code>open()</code> feature name</dfn> is one of the following:
 


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/2476#issuecomment-290339738

---

This is on top of https://github.com/w3c/csswg-drafts/pull/1138