### PR TITLE
[css-pseudo] only propagate ::first-line to ancestors in BFC

### DIFF
--- a/css-pseudo/Overview.bs
+++ b/css-pseudo/Overview.bs
@@ -152,7 +152,7 @@ Finding the First Formatted Line</h4>
     (assuming that both <code>P</code> and <code>DIV</code> are blocks).
   </div>
 
-  The first line of a table-cell or inline-block
+  The first line of a <a>block container</a> which does not participate in a <a>block formatting context</a>
   cannot be the first formatted line of an ancestor element.
   Thus, in <code>&lt;DIV&gt;&lt;P STYLE="display: inline-block"&gt;Hello&lt;BR&gt;Goodbye&lt;/P&gt; etcetera&lt;/DIV&gt;</code>
   the first formatted line of the <code>DIV</code> is not the line "Hello".


### PR DESCRIPTION
The current text was copied from CSS2.1, but nowadays there are block containers which do not participate in a BFC other than table-cell and inline-block, e.g. flex items and grid items.

This is a minor fix, I think the whole algorithm should be replaced with something like #1158.