### PR TITLE
[selectors-4] Make :active :hover and :focus-within work on the flat tree

### DIFF
--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -1989,7 +1989,10 @@ The Pointer Hover Pseudo-class: '':hover''</h3>
 	(e.g., a pen device that does not detect hovering)
 	are still conforming.
 
-	An element also matches '':hover'' if one of its <a>shadow-including descendants</a> matches '':hover''.
+	An element also matches '':hover''
+	if one of its descendants in the <a>flat tree</a>
+	(including non-element nodes, such as text nodes)
+	matches the above conditions.
 
 	Document languages may define additional ways in which an element can match '':hover''.
 	For example, [[HTML5]] defines a labeled control element as <a href="http://www.whatwg.org/html/selectors.html#selector-hover">matching <code>:hover</code></a>
@@ -2016,7 +2019,9 @@ The Activation Pseudo-class: '':active''</h3>
 	which elements can become '':active''.
 	For example, [[HTML5]] defines a <a href="http://www.whatwg.org/html/selectors.html#selector-active">list of activatable elements</a>.
 
-	An element also matches '':active'' if one of its <a>shadow-including descendants</a> matches '':active''.
+	An element also matches '':active''
+	if one of its descendants in the <a>flat tree</a>
+	matches the above conditions.
 
 	Document languages may define additional ways in which an element can match '':active''.
 
@@ -2105,7 +2110,9 @@ The Generalized Input Focus Pseudo-class: '':focus-within''</h3>
 
 	The <dfn id='focus-within-pseudo'>:focus-within</dfn> pseudo-class applies to elements for which the '':focus'' pseudo class applies.
 
-	An element also matches '':focus-within'' if one of its <a>shadow-including descendants</a> matches '':focus''.
+	An element also matches '':focus-within''
+	if one of its descendants in the <a>flat tree</a>
+	matches the above condition.
 
 <h3 id="drag-pseudos">
 The Drag-and-Drop Pseudo-class: '':drop'' and '':drop()''</h3>


### PR DESCRIPTION
They were incorrectly defined as applying to shadow-including descendants,
while the intent was for them to work on flat tree descendants

Closes #1135