### PR TITLE
[css-multicol][css-display][css-contain] Becomes a formatting context

### DIFF
--- a/css-contain/Overview.bs
+++ b/css-contain/Overview.bs
@@ -309,15 +309,6 @@ Paint Containment</h3>
 	3. Because they are guaranteed to be stacking contexts,
 		scrolling elements can be painted into a single GPU layer.
 
-<h2 id="becoming-formatting-context">Becoming a formatting context</h2>
-
-When required by <a>layout containment</a> and <a>paint containment</a>,
-an element may need to <dfn lt='become a formatting context|becomes a formatting context'>become a <a>formatting context</a></dfn>.
-If the element already establishes a <a>formatting context</a> of any kind,
-this condition is satisfied.
-Otherwise, it is made to establish a <a>BFC</a> by changing its <a>inner display type</a> to ''flow-root''.
-
-
 Privacy and Security Considerations {#privsec}
 ==============================================
 

--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -735,6 +735,17 @@ Run-In Layout</h2>
 
 	Note: This run-in model is slightly different from the one proposed in earlier revisions of [[!CSS2]].
 
+<h2 id="becoming-formatting-context">Becoming a formatting context</h2>
+
+In some circumstances (See [[CSS-CONTAIN-1]] or [[CSS3-MULTICOL]] for examples),
+an element may need to <dfn export lt='become a formatting context|becomes a formatting context|becoming a formatting context'>become a <a>formatting context</a></dfn>.
+If the element already establishes a <a>formatting context</a> of any kind,
+this condition is satisfied.
+Otherwise, it is made to establish a <a>BFC</a> by changing its <a>inner display type</a> to ''flow-root''.
+This change happens at <a>used value</a> time,
+and does not affect the <a>computed value</a> of the 'display' property.
+
+
 <h2 id='glossary' class=no-num>
 Appendix A: Glossary</h2>
 
@@ -1088,6 +1099,7 @@ Changes</h2>
 		<li>Clarified interaction of run-ins with out-of-flow elements and ''::first-letter''.
 		<li>Switched ''table-caption'' and ''table-cell'' to use ''flow-root'' as their <a>inner display type</a>, since they always form a formatting context root.
 		<li>Closed off remaining issues and added at-risk list.
+		<li>Added the definition of <a>becoming a formatting context</a>
 	</ul>
 
 	Changes since the <a href="https://www.w3.org/TR/2015/WD-css-display-3-20150721/">21 July 2015 Working Draft</a> include:

--- a/css-multicol/Overview.bs
+++ b/css-multicol/Overview.bs
@@ -944,8 +944,8 @@ Spanning columns</h2>
 			ancestor in the same block formatting context. The element spans
 			across all columns. Content in the normal flow that appears before the
 			element is automatically balanced across all columns before the
-			element appears. The element establishes a new block formatting
-			context.
+			element appears.
+			The element <a>becomes a formatting context</a>.
 
 			Note: The element establishing a formatting content does not
 			depend of whether the element is a descendent of a multicol or not.
@@ -1724,6 +1724,7 @@ This appendix describes changes from the
 <ul>
 	<li>TBD
 	<li>Clarify that column-span causes the element to become a formatting context even if it is not in a multicol
+	<li>Column spanners do not always establish a <em>block</em> formatting context, but instead <a>become a formatting context</a>.
 </ul>
 
 <h2 class=no-num id=acknowledgments>


### PR DESCRIPTION
Moves a terminology definition from css-contain to css-display so that it can be reused more broadly, and reuse it in multicol to solve #1071