### PR TITLE
[mediaqueries-4] Clarify hover:none refers to primary pointing device

### DIFF
--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -702,7 +702,7 @@ Combining Media Features {#media-conditions}
 		by placing ''or'' between them.
 		For example, ''(update: slow) or (hover: none)''
 		matches if the device is slow to update the screen (such as an e-reader)
-		<em>or</em> the device has no hover capability,
+		<em>or</em> the device's primary pointing device has no hover capability,
 		perhaps indicating that one should use a layout that displays more information
 		rather than compactly hiding it until the user hovers.
 


### PR DESCRIPTION
Minor copy change to clarify what `hover:none` refers to. Uses the
"primary pointing device" wording now used consistently in the
Interaction Media Features section