### PR TITLE
Fix #1241 by adding a number-calc microgrammar

### DIFF
--- a/css-values/Overview.bs
+++ b/css-values/Overview.bs
@@ -1646,8 +1646,11 @@ Syntax</h4>
 	<pre class='prod'>
 	<<calc()>> = calc( <<calc-sum>> )
 	<dfn>&lt;calc-sum></dfn> = <<calc-product>> [ [ '+' | '-' ] <<calc-product>> ]*
-	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ '*' <<calc-value>> | '/' <<number>> ]*
+	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ '*' <<calc-value>> | '/' <<calc-number-value>> ]*
 	<dfn>&lt;calc-value></dfn> = <<number>> | <<dimension>> | <<percentage>> | ( <<calc-sum>> )
+	<dfn>&lt;calc-number-sum></dfn> = <<calc-number-product>> [ [ '+' | '-' ] <<calc-number-product>> ]*
+	<dfn>&lt;calc-number-product></dfn> = <<calc-number-value>> [ '*' <<calc-number-value>> | '/' <<calc-number-value>> ]*
+	<dfn>&lt;calc-number-value></dfn> = <<number>> | ( <<calc-number-sum>> )
 	</pre>
 
 	In addition, <a href="https://www.w3.org/TR/css-syntax/#whitespace">white space</a>


### PR DESCRIPTION
Another option would be to allow any calc-value again, and let the prose that follows disambiguate like we do for the * products.