### PR TITLE
[css-display] Run-in can be inserted in IFC root. #1228

### DIFF
--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -703,7 +703,7 @@ Run-In Layout</h2>
 	<ul>
 		<li>
 			If a <a>run-in sequence</a> is immediately followed by a block box
-			that does not establish a new <a>formatting context</a>,
+			that does not establish a new <a>block formatting context</a>,
 			it is inserted as direct children of the block box
 			after its ''::marker'' pseudo-element's boxes (if any),
 			but preceding any other boxes generates by the contents of the block


### PR DESCRIPTION
If a block box establishes a new formatting context, it can either be a block or an inline one. Run-in sequences should be allowed to be inserted into the block box in the latter case. Fixes #1228