### PR TITLE
[cssom][all] Add CSSOMString and replace DOMString usage with it

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -540,7 +540,7 @@ the {{AnimationEvent}}.
 
 <pre class="idl">
 interface CSSAnimation : Animation {
-  readonly attribute DOMString animationName;
+  readonly attribute CSSOMString animationName;
 };
 </pre>
 
@@ -559,13 +559,13 @@ Perhaps something like the following:
 
 <pre class="idl">
 [Constructor (Animatable? target,
-              DOMString animationName,
+              CSSOMString animationName,
               optional (unrestricted double or KeyframeEffectOptions) options,
-              optional DOMString defaultEasing = "ease"),
+              optional CSSOMString defaultEasing = "ease"),
  Constructor (Animatable? target,
-              DOMString animationName,
+              CSSOMString animationName,
               (unrestricted double or KeyframeEffectOptions) options,
-              DOMString defaultEasing,
+              CSSOMString defaultEasing,
               AnimationTimeline? timeline)]
 partial interface CSSAnimation { };
 </pre>
@@ -580,10 +580,10 @@ updating the set of keyframes returned by
 Something like,
 
 <pre class="idl">
-[Constructor (DOMString keyframesName, DOMString defaultEasing)]
+[Constructor (CSSOMString keyframesName, CSSOMString defaultEasing)]
 interface CSSKeyframeEffectReadOnly : KeyframeEffectReadOnly {
-  readonly attribute DOMString keyframesName;
-  readonly attribute DOMString defaultEasing;
+  readonly attribute CSSOMString keyframesName;
+  readonly attribute CSSOMString defaultEasing;
 };
 </pre>
 

--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -909,16 +909,16 @@ The <code>AnimationEvent</code> Interface</h3>
 IDL Definition</h4>
 
 	<pre class="idl">
-		[Constructor(DOMString type, optional AnimationEventInit animationEventInitDict)]
+		[Constructor(CSSOMString type, optional AnimationEventInit animationEventInitDict)]
 		interface AnimationEvent : Event {
-		  readonly attribute DOMString animationName;
+		  readonly attribute CSSOMString animationName;
 		  readonly attribute float elapsedTime;
-		  readonly attribute DOMString pseudoElement;
+		  readonly attribute CSSOMString pseudoElement;
 		};
 		dictionary AnimationEventInit : EventInit {
-		  DOMString animationName = "";
+		  CSSOMString animationName = "";
 		  float elapsedTime = 0.0;
-		  DOMString pseudoElement = "";
+		  CSSOMString pseudoElement = "";
 		};
 	</pre>
 
@@ -926,7 +926,7 @@ IDL Definition</h4>
 Attributes</h4>
 
 	<dl dfn-type=attribute dfn-for=AnimationEvent>
-		<dt><dfn>animationName</dfn>, of type <a interface>DOMString</a>, readonly
+		<dt><dfn>animationName</dfn>, of type <a interface>CSSOMString</a>, readonly
 		<dd>
 			The value of the 'animation-name' property of the animation that fired the event.
 		<dt><dfn>elapsedTime</dfn>, of type float, readonly
@@ -934,7 +934,7 @@ Attributes</h4>
 			The amount of time the animation has been running, in seconds, when this event fired,
 			excluding any time the animation was paused. The precise calculation for
 			of this member is defined along with each event type.
-		<dt><dfn>pseudoElement</dfn>, of type <a interface>DOMString</a>, readonly
+		<dt><dfn>pseudoElement</dfn>, of type <a interface>CSSOMString</a>, readonly
 		<dd>
 			The name (beginning with two colons) of the CSS pseudo-element on which the animation
 			runs (in which case the target of the event is that pseudo-element's corresponding
@@ -1091,7 +1091,7 @@ IDL Definition</h4>
 
 	<pre class="idl">
 	interface CSSKeyframeRule : CSSRule {
-    attribute DOMString keyText;
+    attribute CSSOMString keyText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 	};
 	</pre>
@@ -1143,12 +1143,12 @@ IDL Definition</h4>
 
 	<pre class="idl">
 	interface CSSKeyframesRule : CSSRule {
-	           attribute DOMString   name;
+	           attribute CSSOMString   name;
 	  readonly attribute CSSRuleList cssRules;
 
-	  void            appendRule(DOMString rule);
-	  void            deleteRule(DOMString select);
-	  CSSKeyframeRule? findRule(DOMString select);
+	  void            appendRule(CSSOMString rule);
+	  void            deleteRule(CSSOMString select);
+	  CSSKeyframeRule? findRule(CSSOMString select);
 	};
 	</pre>
 
@@ -1181,7 +1181,7 @@ The <code>appendRule</code> method</h4>
 
 	<dl>
 
-		<dt><dfn argument for="CSSKeyframesRule/appendRule(rule)">rule</dfn> of type <a interface>DOMString</a>
+		<dt><dfn argument for="CSSKeyframesRule/appendRule(rule)">rule</dfn> of type <a interface>CSSOMString</a>
 		<dd>
 			The rule to be appended, expressed in the same syntax as one entry in the
 			''@keyframes'' rule. A valid rule is always appended e.g. even if its key(s) already
@@ -1203,7 +1203,7 @@ The <code>deleteRule</code> method</h4>
 
 	<dl>
 
-		<dt><dfn argument for="CSSKeyframesRule/deleteRule(select)">select</dfn> of type <a interface>DOMString</a>
+		<dt><dfn argument for="CSSKeyframesRule/deleteRule(select)">select</dfn> of type <a interface>CSSOMString</a>
 		<dd>
 			The keyframe selector of the rule to be deleted: a comma-separated list of percentage values between 0% and 100% or the keywords ''from'' or ''to'' which resolve to 0% and 100%, respectively.
 
@@ -1225,7 +1225,7 @@ The <code>findRule</code> method</h4>
 	Parameters:
 
 	<dl>
-		<dt><dfn argument for="CSSKeyframesRule/findRule(select)">select</dfn> of type <a interface>DOMString</a>
+		<dt><dfn argument for="CSSKeyframesRule/findRule(select)">select</dfn> of type <a interface>CSSOMString</a>
 		<dd>
 			The keyframe selector of the rule to be deleted: a comma-separated list of percentage values between 0% and 100% or the keywords ''from'' or ''to'' which resolve to 0% and 100%, respectively.
 

--- a/css-color/Overview.bs
+++ b/css-color/Overview.bs
@@ -13,7 +13,7 @@ Former Editor: L. David Baron, Mozilla Corporation, dbaron@dbaron.org
 Abstract: This specification describes CSS <<color>> values and properties for foreground color and group opacity.
 Repository: w3c/csswg-drafts
 Inline Github Issues: title
-Ignored Terms: stacking context, double, octet, DOMString
+Ignored Terms: stacking context, double, octet
 </pre>
 
 <style>

--- a/css-conditional/Overview.bs
+++ b/css-conditional/Overview.bs
@@ -834,7 +834,7 @@ The <code>CSSGroupingRule</code> interface</h3>
 <pre class='idl'>
 interface CSSGroupingRule : CSSRule {
     readonly attribute <a href="https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRuleList">CSSRuleList</a> cssRules;
-    unsigned long insertRule (DOMString rule, unsigned long index);
+    unsigned long insertRule (CSSOMString rule, unsigned long index);
     void deleteRule (unsigned long index);
 };
 </pre>
@@ -846,7 +846,7 @@ interface CSSGroupingRule : CSSRule {
 </dl>
 
 <dl class='idl-methods'>
-  <dt><code>insertRule(DOMString rule, unsigned long index)</code>, returns
+  <dt><code>insertRule(CSSOMString rule, unsigned long index)</code>, returns
     <code>unsigned long</code>
   <dd>
     The <code>insertRule</code> operation must
@@ -890,13 +890,13 @@ all the &ldquo;conditional&rdquo; at-rules,
 
 <pre class='idl' export>
 interface CSSConditionRule : CSSGroupingRule {
-    attribute DOMString conditionText;
+    attribute CSSOMString conditionText;
 };
 </pre>
 
 <dl class='idl-attributes'>
 
-  <dt><code>conditionText</code> of type <code>DOMString</code>
+  <dt><code>conditionText</code> of type <code>CSSOMString</code>
   <dd>
     <p>The <code>conditionText</code> attribute represents
     the condition of the rule.
@@ -940,7 +940,7 @@ interface CSSMediaRule : CSSConditionRule {
   <dd>The <code>media</code> attribute must return a <code>MediaList</code> object
     for the list of media queries specified with the ''@media'' rule.
 
-  <dt><code>conditionText</code> of type <code>DOMString</code> (CSSMediaRule-specific definition for attribute on CSSConditionRule)
+  <dt><code>conditionText</code> of type <code>CSSOMString</code> (CSSMediaRule-specific definition for attribute on CSSConditionRule)
   <dd>The <code>conditionText</code> attribute (defined on the <code>CSSConditionRule</code> parent rule),
     on getting, must return the value of <code>media.mediaText</code> on the rule.
 
@@ -960,7 +960,7 @@ interface CSSSupportsRule : CSSConditionRule {
 </pre>
 
 <dl class='idl-attributes'>
-  <dt><code>conditionText</code> of type <code>DOMString</code> (CSSSupportsRule-specific definition for attribute on CSSConditionRule)
+  <dt><code>conditionText</code> of type <code>CSSOMString</code> (CSSSupportsRule-specific definition for attribute on CSSConditionRule)
   <dd>The <code>conditionText</code> attribute (defined on the <code>CSSConditionRule</code> parent rule),
     on getting, must return the condition that was specified,
     without any logical simplifications,
@@ -998,15 +998,15 @@ The {{CSS}} interface holds useful CSS-related functions that do not belong else
 
 <pre class='idl'>
 partial interface CSS {
-  static boolean supports(DOMString property, DOMString value);
-  static boolean supports(DOMString conditionText);
+  static boolean supports(CSSOMString property, CSSOMString value);
+  static boolean supports(CSSOMString conditionText);
 };
 </pre>
 
 <dl class='idl-methods'>
-  <dt><code>supports(DOMString property, DOMString value)</code>,
+  <dt><code>supports(CSSOMString property, CSSOMString value)</code>,
     returns <code>boolean</code>
-  <dt><code>supports(DOMString conditionText)</code>,
+  <dt><code>supports(CSSOMString conditionText)</code>,
     returns <code>boolean</code>
   <dd>
     When the <code title=''>supports()</code> method is invoked with two arguments <var>property</var> and <var>value</var>,

--- a/css-counter-styles/Overview.bs
+++ b/css-counter-styles/Overview.bs
@@ -2480,24 +2480,24 @@ The <code>CSSCounterStyleRule</code> interface</h3>
 
 	<pre class='idl'>
 	interface CSSCounterStyleRule : CSSRule {
-	  attribute DOMString name;
-	  attribute DOMString system;
-	  attribute DOMString symbols;
-	  attribute DOMString additiveSymbols;
-	  attribute DOMString negative;
-	  attribute DOMString prefix;
-	  attribute DOMString suffix;
-	  attribute DOMString range;
-	  attribute DOMString pad;
-	  attribute DOMString speakAs;
-	  attribute DOMString fallback;
+	  attribute CSSOMString name;
+	  attribute CSSOMString system;
+	  attribute CSSOMString symbols;
+	  attribute CSSOMString additiveSymbols;
+	  attribute CSSOMString negative;
+	  attribute CSSOMString prefix;
+	  attribute CSSOMString suffix;
+	  attribute CSSOMString range;
+	  attribute CSSOMString pad;
+	  attribute CSSOMString speakAs;
+	  attribute CSSOMString fallback;
 	};
 	</pre>
 
 	<dl class='idl-attributes' >
-		<dt><a attribute>name</a> of type <code>DOMString</code>
+		<dt><a attribute>name</a> of type <code>CSSOMString</code>
 		<dd>
-			The <var>name</var> attribute on getting must return a <code>DOMString</code> object
+			The <var>name</var> attribute on getting must return a <code>CSSOMString</code> object
 			that contains the serialization of the <<counter-style-name>> defined for the associated rule.
 
 			On setting the <var>name</var> attribute, run the following steps:
@@ -2517,18 +2517,18 @@ The <code>CSSCounterStyleRule</code> interface</h3>
 				<li>Otherwise, do nothing.
 			</ol>
 
-		<dt><a attribute>system</a> of type <code>DOMString</code>
-		<dt><a attribute>symbols</a> of type <code>DOMString</code>
-		<dt><a attribute>additiveSymbols</a> of type <code>DOMString</code>
-		<dt><a attribute>negative</a> of type <code>DOMString</code>
-		<dt><a attribute attribute>prefix</a> of type <code>DOMString</code>
-		<dt><a attribute>suffix</a> of type <code>DOMString</code>
-		<dt><a attribute>range</a> of type <code>DOMString</code>
-		<dt><a attribute>pad</a> of type <code>DOMString</code>
-		<dt><a attribute>speakAs</a> of type <code>DOMString</code>
-		<dt><a attribute>fallback</a> of type <code>DOMString</code>
+		<dt><a attribute>system</a> of type <code>CSSOMString</code>
+		<dt><a attribute>symbols</a> of type <code>CSSOMString</code>
+		<dt><a attribute>additiveSymbols</a> of type <code>CSSOMString</code>
+		<dt><a attribute>negative</a> of type <code>CSSOMString</code>
+		<dt><a attribute attribute>prefix</a> of type <code>CSSOMString</code>
+		<dt><a attribute>suffix</a> of type <code>CSSOMString</code>
+		<dt><a attribute>range</a> of type <code>CSSOMString</code>
+		<dt><a attribute>pad</a> of type <code>CSSOMString</code>
+		<dt><a attribute>speakAs</a> of type <code>CSSOMString</code>
+		<dt><a attribute>fallback</a> of type <code>CSSOMString</code>
 		<dd>
-			The remaining attributes on getting must return a <code>DOMString</code> object
+			The remaining attributes on getting must return a <code>CSSOMString</code> object
 			that contains the serialization of the associated descriptor defined for the associated rule.
 			If the descriptor was not specified in the associated rule,
 			the attribute must return an empty string.

--- a/css-font-loading/Overview.bs
+++ b/css-font-loading/Overview.bs
@@ -81,27 +81,27 @@ The <code>FontFace</code> Interface</h2>
 		typedef (ArrayBuffer or ArrayBufferView) BinaryData;
 
 		dictionary FontFaceDescriptors {
-			DOMString style = "normal";
-			DOMString weight = "normal";
-			DOMString stretch = "normal";
-			DOMString unicodeRange = "U+0-10FFFF";
-			DOMString variant = "normal";
-			DOMString featureSettings = "normal";
+			CSSOMString style = "normal";
+			CSSOMString weight = "normal";
+			CSSOMString stretch = "normal";
+			CSSOMString unicodeRange = "U+0-10FFFF";
+			CSSOMString variant = "normal";
+			CSSOMString featureSettings = "normal";
 		};
 
 		enum FontFaceLoadStatus { "unloaded", "loading", "loaded", "error" };
 
-		[Constructor(DOMString family, (DOMString or BinaryData) source,
+		[Constructor(CSSOMString family, (CSSOMString or BinaryData) source,
 		             optional FontFaceDescriptors descriptors),
 		 Exposed=Window,Worker]
 		interface FontFace {
-			attribute DOMString family;
-			attribute DOMString style;
-			attribute DOMString weight;
-			attribute DOMString stretch;
-			attribute DOMString unicodeRange;
-			attribute DOMString variant;
-			attribute DOMString featureSettings;
+			attribute CSSOMString family;
+			attribute CSSOMString style;
+			attribute CSSOMString weight;
+			attribute CSSOMString stretch;
+			attribute CSSOMString unicodeRange;
+			attribute CSSOMString variant;
+			attribute CSSOMString featureSettings;
 
 			readonly attribute FontFaceLoadStatus status;
 
@@ -206,8 +206,8 @@ The Constructor</h3>
 
 	When the <dfn constructor lt='FontFace()' for=FontFace>FontFace</dfn>(
 	<span dfn-for="FontFace/FontFace(family, source, descriptors)">
-		DOMString <dfn argument>family</dfn>,
-		(DOMString or {{/BinaryData}}) <dfn argument>source</dfn>,
+		CSSOMString <dfn argument>family</dfn>,
+		(CSSOMString or {{/BinaryData}}) <dfn argument>source</dfn>,
 		{{/FontFaceDescriptors}} <dfn argument>descriptors</dfn>
 	</span>
 	)
@@ -221,7 +221,7 @@ The Constructor</h3>
 		Parse the {{family!!argument}} argument,
 		and the members of the {{descriptors!!argument}} argument,
 		according to the grammars of the corresponding descriptors of the CSS ''@font-face'' rule.
-		If the {{source!!argument}} argument is a {{DOMString}},
+		If the {{source!!argument}} argument is a {{CSSOMString}},
 		parse it according to the grammar of the CSS ''@font-face/src'' descriptor of the ''@font-face'' rule.
 		If any of them fail to parse correctly,
 		reject <var>font face's</var> {{[[FontStatusPromise]]}} with a DOMException named "SyntaxError",
@@ -251,7 +251,7 @@ The Constructor</h3>
 		otherwise,
 		complete the rest of these steps asynchronously.
 
-	2. If the {{source!!argument}} argument was a {{DOMString}},
+	2. If the {{source!!argument}} argument was a {{CSSOMString}},
 		set <var>font face's</var> internal {{[[Urls]]}} slot to the string.
 
 		If the {{source}} argument was a {{BinaryData}},
@@ -443,7 +443,7 @@ The <code>FontFaceSet</code> Interface</h2>
 			sequence&lt;FontFace> fontfaces = [];
 		};
 
-		[Constructor(DOMString type, optional FontFaceSetLoadEventInit eventInitDict),
+		[Constructor(CSSOMString type, optional FontFaceSetLoadEventInit eventInitDict),
 		 Exposed=Window,Worker]
 		interface FontFaceSetLoadEvent : Event {
 			[SameObject] readonly attribute FrozenArray&lt;FontFace> fontfaces;
@@ -469,11 +469,11 @@ The <code>FontFaceSet</code> Interface</h2>
 
 			// check and start loads if appropriate
 			// and fulfill promise when all loads complete
-			Promise&lt;sequence&lt;FontFace>> load(DOMString font, optional DOMString text = " ");
+			Promise&lt;sequence&lt;FontFace>> load(CSSOMString font, optional CSSOMString text = " ");
 
 			// return whether all fonts in the fontlist are loaded
 			// (does not initiate load if not available)
-			boolean check(DOMString font, optional DOMString text = " ");
+			boolean check(CSSOMString font, optional CSSOMString text = " ");
 
 			// async notification that font loading and layout operations are done
 			readonly attribute Promise&lt;FontFaceSet> ready;

--- a/css-fonts/Fonts.html
+++ b/css-fonts/Fonts.html
@@ -5875,14 +5875,14 @@ span.special { font-variant-ligatures: no-discretionary-ligatures; }
 
   <pre class=idl>
 interface CSSFontFaceRule : CSSRule {
-  attribute DOMString family;
-  attribute DOMString src;
-  attribute DOMString style;
-  attribute DOMString weight;
-  attribute DOMString stretch;
-  attribute DOMString unicodeRange;
-  attribute DOMString variant;
-  attribute DOMString featureSettings;
+  attribute CSSOMString family;
+  attribute CSSOMString src;
+  attribute CSSOMString style;
+  attribute CSSOMString weight;
+  attribute CSSOMString stretch;
+  attribute CSSOMString unicodeRange;
+  attribute CSSOMString variant;
+  attribute CSSOMString featureSettings;
 }</pre>
 
   <p>The DOM Level 2 Style specification <a href="#DOM-LEVEL-2-STYLE"
@@ -5906,7 +5906,7 @@ interface CSSFontFaceRule : CSSRule {
    rule.
 
   <pre class=idl>interface CSSFontFeatureValuesRule : CSSRule {
-  attribute DOMString fontFamily;
+  attribute CSSOMString fontFamily;
   readonly attribute CSSFontFeatureValuesMap annotation;
   readonly attribute CSSFontFeatureValuesMap ornaments;
   readonly attribute CSSFontFeatureValuesMap stylistic;
@@ -5915,14 +5915,14 @@ interface CSSFontFaceRule : CSSRule {
   readonly attribute CSSFontFeatureValuesMap styleset;
 }
 
-[MapClass(DOMString, sequence&lt;unsigned long&gt;)]
+[MapClass(CSSOMString, sequence&lt;unsigned long&gt;)]
 interface CSSFontFeatureValuesMap {
-  void set(DOMString featureValueName,
+  void set(CSSOMString featureValueName,
            (unsigned long or sequence&lt;unsigned long&gt;) values);
 }</pre>
 
   <dl class=idl-attributes>
-   <dt><var>fontFamily</var> of type <code>DOMString</code>
+   <dt><var>fontFamily</var> of type <code>CSSOMString</code>
 
    <dd>The list of one or more font families for which a given set of feature
     values is defined.

--- a/css-fonts/Fonts.src.html
+++ b/css-fonts/Fonts.src.html
@@ -4469,14 +4469,14 @@ the following extensions to the CSS Object Model.</p>
 
 <pre class="idl">
 interface CSSFontFaceRule : CSSRule {
-  attribute DOMString family;
-  attribute DOMString src;
-  attribute DOMString style;
-  attribute DOMString weight;
-  attribute DOMString stretch;
-  attribute DOMString unicodeRange;
-  attribute DOMString variant;
-  attribute DOMString featureSettings;
+  attribute CSSOMString family;
+  attribute CSSOMString src;
+  attribute CSSOMString style;
+  attribute CSSOMString weight;
+  attribute CSSOMString stretch;
+  attribute CSSOMString unicodeRange;
+  attribute CSSOMString variant;
+  attribute CSSOMString featureSettings;
 }</pre>
 
 <p>The DOM Level 2 Style specification [[DOM-LEVEL-2-STYLE]] defined a different variant of this rule.  This definition supercedes that one.</p>
@@ -4492,7 +4492,7 @@ interface CSSFontFaceRule : CSSRule {
 <p>The <dfn>CSSFontFeatureValuesRule</dfn> interface represents a <code>@font-feature-values</code> rule.</p>
 
 <pre class='idl'>interface CSSFontFeatureValuesRule : CSSRule {
-  attribute DOMString fontFamily;
+  attribute CSSOMString fontFamily;
   readonly attribute CSSFontFeatureValuesMap annotation;
   readonly attribute CSSFontFeatureValuesMap ornaments;
   readonly attribute CSSFontFeatureValuesMap stylistic;
@@ -4501,14 +4501,14 @@ interface CSSFontFaceRule : CSSRule {
   readonly attribute CSSFontFeatureValuesMap styleset;
 }
 
-[MapClass(DOMString, sequence&lt;unsigned long&gt;)]
+[MapClass(CSSOMString, sequence&lt;unsigned long&gt;)]
 interface CSSFontFeatureValuesMap {
-  void set(DOMString featureValueName,
+  void set(CSSOMString featureValueName,
            (unsigned long or sequence&lt;unsigned long&gt;) values);
 }</pre>
 
 <dl class='idl-attributes'>
-<dt><var>fontFamily</var> of type <code>DOMString</code>
+<dt><var>fontFamily</var> of type <code>CSSOMString</code>
 <dd>The list of one or more font families for which a given set of feature values is defined.</dd>
 <dt>value maps of type <code>CSSFontFeatureValuesMap</code>, readonly
 <dd>Maps of feature values associated with feature value names for a given 'font-variant-alternates' value type</dd>

--- a/css-fonts/Overview-wip.bs
+++ b/css-fonts/Overview-wip.bs
@@ -3688,14 +3688,14 @@ The <dfn interface>CSSFontFaceRule</dfn> interface represents a ''@font-face'' r
 
 <pre class="idl">
 interface CSSFontFaceRule : CSSRule {
-	attribute DOMString family;
-	attribute DOMString src;
-	attribute DOMString style;
-	attribute DOMString weight;
-	attribute DOMString stretch;
-	attribute DOMString unicodeRange;
-	attribute DOMString variant;
-	attribute DOMString featureSettings;
+	attribute CSSOMString family;
+	attribute CSSOMString src;
+	attribute CSSOMString style;
+	attribute CSSOMString weight;
+	attribute CSSOMString stretch;
+	attribute CSSOMString unicodeRange;
+	attribute CSSOMString variant;
+	attribute CSSOMString featureSettings;
 };
 </pre>
 
@@ -3715,7 +3715,7 @@ The <dfn interface >CSSFontFeatureValuesRule</dfn> interface represents a ''@fon
 
 <pre class='idl'>
 interface CSSFontFeatureValuesRule : CSSRule {
-	attribute DOMString fontFamily;
+	attribute CSSOMString fontFamily;
 	readonly attribute CSSFontFeatureValuesMap annotation;
 	readonly attribute CSSFontFeatureValuesMap ornaments;
 	readonly attribute CSSFontFeatureValuesMap stylistic;
@@ -3724,9 +3724,9 @@ interface CSSFontFeatureValuesRule : CSSRule {
 	readonly attribute CSSFontFeatureValuesMap styleset;
 };
 
-[MapClass(DOMString, sequence&lt;unsigned long&gt;)]
+[MapClass(CSSOMString, sequence&lt;unsigned long&gt;)]
 interface CSSFontFeatureValuesMap {
-	void set(DOMString featureValueName,
+	void set(CSSOMString featureValueName,
 	         (unsigned long or sequence&lt;unsigned long&gt;) values);
 };
 </pre>

--- a/css-module-bikeshed/Overview.bs
+++ b/css-module-bikeshed/Overview.bs
@@ -165,14 +165,14 @@ Internal display model: the 'foo' property {#the-foo-property}
 	<pre class='idl'>
 		/* Write WebIDL in a &lt;pre class="idl"> as plain text. */
 		interface Foo {
-			readonly attribute DOMString bar;
-			boolean baz(FooDict Arg1, (DOMString or Foo) Arg2);
+			readonly attribute CSSOMString bar;
+			boolean baz(FooDict Arg1, (CSSOMString or Foo) Arg2);
 		};
 
 		dictionary FooDict {
 			sequence&lt;Foo> foos;
 			boolean bar;
-			DOMString baz = "qux";
+			CSSOMString baz = "qux";
 		};
 	</pre>
 

--- a/css-pseudo/Overview.bs
+++ b/css-pseudo/Overview.bs
@@ -813,7 +813,7 @@ Interface CSSPseudoElement</h3>
 
   <pre class="idl">
     interface CSSPseudoElement {
-        readonly attribute DOMString <a href="#dom-csspseudochild-type">type</a>;
+        readonly attribute CSSOMString <a href="#dom-csspseudochild-type">type</a>;
         readonly attribute <a href="https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration">CSSStyleDeclaration</a> <a href="#dom-csspseudochild-style">style</a>;
     };
 
@@ -861,7 +861,7 @@ Interface CSSPseudoElementList</h3>
     interface CSSPseudoElementList {
         readonly attribute unsigned long <a href="#dom-csspseudochildlist-length">length</a>;
         CSSPseudoElement <a href="#dom-csspseudochildlist-item">item</a>(unsigned long index);
-        CSSPseudoElement <a href="#dom-csspseudochildlist-getbytype">getByType</a>(DOMString type);
+        CSSPseudoElement <a href="#dom-csspseudochildlist-getbytype">getByType</a>(CSSOMString type);
                          // replies null if no pseudo-element exists for
                          //     the requested type
     };
@@ -893,7 +893,7 @@ Addition to the <code>window</code> interface</h3>
   <pre class="idl">
     partial interface Window {
       CSSPseudoElementList <a href="#dom-window-getpseudochildren">getPseudoElements</a>(Element elt,
-                                           DOMString type);
+                                           CSSOMString type);
     };
   </pre>
 

--- a/css-regions/Overview.bs
+++ b/css-regions/Overview.bs
@@ -1080,11 +1080,11 @@ The NamedFlow interface</h3>
 	and is read-only.
 
 	<pre class="idl">
-		[MapClass(DOMString, NamedFlow)] interface NamedFlowMap {
-			NamedFlow? get(DOMString flowName);
-			boolean has(DOMString flowName);
-			NamedFlowMap set(DOMString flowName, NamedFlow flowValue);
-			boolean delete(DOMString flowName);
+		[MapClass(CSSOMString, NamedFlow)] interface NamedFlowMap {
+			NamedFlow? get(CSSOMString flowName);
+			boolean has(CSSOMString flowName);
+			NamedFlowMap set(CSSOMString flowName, NamedFlow flowValue);
+			boolean delete(CSSOMString flowName);
 		};
 	</pre>
 
@@ -1127,7 +1127,7 @@ The NamedFlow interface</h3>
 
 	<pre class="idl">
 		interface NamedFlow : EventTarget {
-			readonly attribute DOMString name;
+			readonly attribute CSSOMString name;
 			readonly attribute boolean overset;
 			sequence&lt;Region&gt; getRegions();
 			readonly attribute short firstEmptyRegionIndex;
@@ -1226,7 +1226,7 @@ The Region interface</h3>
 	<pre class="idl">
 		[NoInterfaceObject]
 		interface Region {
-			readonly attribute DOMString regionOverset;
+			readonly attribute CSSOMString regionOverset;
 			sequence&lt;Range&gt;? getRegionFlowRanges();
 		};
 

--- a/css-regions/region-styling.txt
+++ b/css-regions/region-styling.txt
@@ -197,7 +197,7 @@ Markup cut from the draft
 Removed from the Region interface
 
   <a href="http://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface">CSSStyleDeclaration</a> <a href="#dom-region-getComputedRegionStyle">getComputedRegionStyle</a>(Element elt);
-  <a href="http://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface">CSSStyleDeclaration</a> <a href="#dom-region-getComputedRegionStyle">getComputedRegionStyle</a>(Element elt, DOMString pseudoElt);
+  <a href="http://dev.w3.org/csswg/cssom/#the-cssstyledeclaration-interface">CSSStyleDeclaration</a> <a href="#dom-region-getComputedRegionStyle">getComputedRegionStyle</a>(Element elt, CSSOMString pseudoElt);
 
 
         <p>The <dfn id="dom-region-getComputedRegionStyle">getComputedRegionStyle</dfn> 

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -341,7 +341,7 @@ the {{TransitionEvent}}.
 
 <pre class="idl">
 interface CSSTransition : Animation {
-  readonly attribute DOMString transitionProperty;
+  readonly attribute CSSOMString transitionProperty;
 };
 </pre>
 
@@ -354,11 +354,11 @@ This interface needs a constructor. Perhaps something like the following,
 
 <pre class="idl">
 [Constructor (Animatable? target,
-              DOMString transitionProperty,
+              CSSOMString transitionProperty,
               any transitionValue,
               optional (unrestricted double or KeyframeEffectOptions) options),
  Constructor (Animatable? target,
-              DOMString transitionProperty,
+              CSSOMString transitionProperty,
               any transitionValue,
               (unrestricted double or KeyframeEffectOptions) options,
               AnimationTimeline? timeline)]

--- a/css-transitions/Overview.bs
+++ b/css-transitions/Overview.bs
@@ -1096,30 +1096,30 @@ associated with transitions.
 ### IDL Definition ### {#interface-transitionevent-idl}
 
 <pre class="idl">
-  [Constructor(DOMString type, optional TransitionEventInit transitionEventInitDict)]
+  [Constructor(CSSOMString type, optional TransitionEventInit transitionEventInitDict)]
   interface TransitionEvent : Event {
-    readonly attribute DOMString propertyName;
+    readonly attribute CSSOMString propertyName;
     readonly attribute float elapsedTime;
-    readonly attribute DOMString pseudoElement;
+    readonly attribute CSSOMString pseudoElement;
   };
 
   dictionary TransitionEventInit : EventInit {
-    DOMString propertyName = "";
+    CSSOMString propertyName = "";
     float elapsedTime = 0.0;
-    DOMString pseudoElement = "";
+    CSSOMString pseudoElement = "";
   };
 </pre>
 
 ### Attributes ### {#interface-transitionevent-attributes}
 
-:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-propertyName">propertyName</dfn></code> of type <code>DOMString</code>, readonly
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-propertyName">propertyName</dfn></code> of type <code>CSSOMString</code>, readonly
 ::  The name of the CSS property associated with the transition.
     <p class="note">Note:  This is always the name of a longhand property.  See 'transition-property' for how specifying shorthand properties causes transitions on longhands.</p>
 :   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-elapsedTime">elapsedTime</dfn></code> of type <code>float</code>, readonly
 ::  The amount of time the transition has been running, in seconds, when this
     event fired not including any time spent in the delay phase.  The precise
     calculation for of this member is defined along with each event type.
-:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-pseudoElement">pseudoElement</dfn></code> of type <code>DOMString</code>, readonly
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-pseudoElement">pseudoElement</dfn></code> of type <code>CSSOMString</code>, readonly
 ::  The name (beginning with two colons) of the CSS
     pseudo-element on which the transition occurred (in
     which case the target of the event is that

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -443,7 +443,7 @@ dictionary ScrollToOptions : ScrollOptions {
 };
 
 partial interface Window {
-    [NewObject] MediaQueryList matchMedia(DOMString query);
+    [NewObject] MediaQueryList matchMedia(CSSOMString query);
     [SameObject, Replaceable] readonly attribute Screen screen;
 
     // browsing context
@@ -782,7 +782,7 @@ When asked to <dfn>evaluate media queries and report changes</dfn> for a {{Docum
 
 <pre class=idl>
 interface MediaQueryList : EventTarget {
-  readonly attribute DOMString media;
+  readonly attribute CSSOMString media;
   readonly attribute boolean matches;
   void addListener(EventListener? listener);
   void removeListener(EventListener? listener);
@@ -836,14 +836,14 @@ as <a>event handler IDL attributes</a>, by all objects implementing the {{MediaQ
 </table>
 
 <pre class=idl>
-[Constructor(DOMString type, optional MediaQueryListEventInit eventInitDict)]
+[Constructor(CSSOMString type, optional MediaQueryListEventInit eventInitDict)]
 interface MediaQueryListEvent : Event {
-  readonly attribute DOMString media;
+  readonly attribute CSSOMString media;
   readonly attribute boolean matches;
 };
 
 dictionary MediaQueryListEventInit : EventInit {
-  DOMString media = "";
+  CSSOMString media = "";
   boolean matches = false;
 };
 </pre>

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -281,13 +281,14 @@ typedef DOMString CSSOMString;
 	This choice effectively allows implementations to do this replacement,
 	but does not require it.
 
-	This enables an implementation to use UTF-8 internally to represent strings in memory.
+	Using {{USVString}} enables an implementation
+	to use UTF-8 internally to represent strings in memory.
 	Since well-formed UTF-8 specifically disallows <a>surrogate</a> code points,
 	it effectively requires this replacement.
 
 	On the other hand,
 	implementations that internally represent strings as 16-bit <a>code units</a>
-	may prefer to avoid the cost of doing this replacement.
+	might prefer to avoid the cost of doing this replacement.
 </div>
 
 
@@ -489,11 +490,11 @@ An object that implements the <code>MediaList</code> interface has an associated
 <pre class=idl>
 [LegacyArrayClass]
 interface MediaList {
-  [TreatNullAs=EmptyString] stringifier attribute DOMString mediaText;
+  [TreatNullAs=EmptyString] stringifier attribute CSSOMString mediaText;
   readonly attribute unsigned long length;
-  getter DOMString? item(unsigned long index);
-  void appendMedium(DOMString medium);
-  void deleteMedium(DOMString medium);
+  getter CSSOMString? item(unsigned long index);
+  void appendMedium(CSSOMString medium);
+  void deleteMedium(CSSOMString medium);
 };
 </pre>
 
@@ -843,7 +844,7 @@ The {{StyleSheet}} interface represents an abstract, base style sheet.
 
 <pre class=idl>
 interface StyleSheet {
-  readonly attribute DOMString type;
+  readonly attribute CSSOMString type;
   readonly attribute USVString? href;
   readonly attribute (Element or ProcessingInstruction)? ownerNode;
   readonly attribute StyleSheet? parentStyleSheet;
@@ -882,7 +883,7 @@ The {{CSSStyleSheet}} interface represents a <a>CSS style sheet</a>.
 interface CSSStyleSheet : StyleSheet {
   readonly attribute CSSRule? ownerRule;
   [SameObject] readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
+  unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
   void deleteRule(unsigned long index);
 };
 </pre>
@@ -1591,7 +1592,7 @@ interface CSSRule {
   const unsigned short MARGIN_RULE = 9;
   const unsigned short NAMESPACE_RULE = 10;
   readonly attribute unsigned short type;
-  attribute DOMString cssText;
+  attribute CSSOMString cssText;
   readonly attribute CSSRule? parentRule;
   readonly attribute CSSStyleSheet? parentStyleSheet;
 };
@@ -1647,7 +1648,7 @@ The <code>CSSStyleRule</code> interface represents a style rule.
 
 <pre class=idl>
 interface CSSStyleRule : CSSRule {
-  attribute DOMString selectorText;
+  attribute CSSOMString selectorText;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 </pre>
@@ -1713,7 +1714,7 @@ The <code>CSSGroupingRule</code> interface represents an at-rule that contains o
 <pre class=idl>
 interface CSSGroupingRule : CSSRule {
   [SameObject] readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
+  unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
   void deleteRule(unsigned long index);
 };
 </pre>
@@ -1753,7 +1754,7 @@ Issue: Need to define the rules for
 
 <pre class=idl>
 interface CSSPageRule : CSSGroupingRule {
-           attribute DOMString selectorText;
+           attribute CSSOMString selectorText;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 </pre>
@@ -1788,7 +1789,7 @@ The <code>CSSMarginRule</code> interface represents a margin at-rule (e.g. <code
 
 <pre class=idl>
 interface CSSMarginRule : CSSRule {
-  readonly attribute DOMString name;
+  readonly attribute CSSOMString name;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 </pre>
@@ -1816,8 +1817,8 @@ The <code>CSSNamespaceRule</code> interface represents an <code>@namespace</code
 
 <pre class=idl>
 interface CSSNamespaceRule : CSSRule {
-  readonly attribute DOMString namespaceURI;
-  readonly attribute DOMString prefix;
+  readonly attribute CSSOMString namespaceURI;
+  readonly attribute CSSOMString prefix;
 };
 </pre>
 
@@ -1968,17 +1969,17 @@ underlying state depends upon the source of the <code>CSSStyleDeclaration</Code>
 
 <pre class=idl>
 interface CSSStyleDeclaration {
-  [CEReactions] attribute DOMString cssText;
+  [CEReactions] attribute CSSOMString cssText;
   readonly attribute unsigned long length;
-  getter DOMString item(unsigned long index);
-  DOMString getPropertyValue(DOMString property);
-  DOMString getPropertyPriority(DOMString property);
-  [CEReactions] void setProperty(DOMString property, [TreatNullAs=EmptyString] DOMString value, [TreatNullAs=EmptyString] optional DOMString priority = "");
-  [CEReactions] void setPropertyValue(DOMString property, [TreatNullAs=EmptyString] DOMString value);
-  [CEReactions] void setPropertyPriority(DOMString property, [TreatNullAs=EmptyString] DOMString priority);
-  [CEReactions] DOMString removeProperty(DOMString property);
+  getter CSSOMString item(unsigned long index);
+  CSSOMString getPropertyValue(CSSOMString property);
+  CSSOMString getPropertyPriority(CSSOMString property);
+  [CEReactions] void setProperty(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value, [TreatNullAs=EmptyString] optional CSSOMString priority = "");
+  [CEReactions] void setPropertyValue(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value);
+  [CEReactions] void setPropertyPriority(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString priority);
+  [CEReactions] CSSOMString removeProperty(CSSOMString property);
   readonly attribute CSSRule? parentRule;
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString cssFloat;
+  [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString cssFloat;
 };
 </pre>
 
@@ -2197,7 +2198,7 @@ is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 
 <pre class="idl extract">
 partial interface CSSStyleDeclaration {
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString _<var>camel_cased_attribute</var>;
+  [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString _<var>camel_cased_attribute</var>;
 };
 </pre>
 
@@ -2221,7 +2222,7 @@ algorithm for <var>property</var>, with the <i>lowercase first</i> flag set.
 
 <pre class="idl extract">
 partial interface CSSStyleDeclaration {
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString _<var>webkit_cased_attribute</var>;
+  [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString _<var>webkit_cased_attribute</var>;
 };
 </pre>
 
@@ -2246,7 +2247,7 @@ the following partial interface applies where <var>dashed attribute</var> is <va
 
 <pre class="idl">
 partial interface CSSStyleDeclaration {
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString _<var>dashed_attribute</var>;
+  [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString _<var>dashed_attribute</var>;
 };
 </pre>
 
@@ -2630,7 +2631,7 @@ Extensions to the {{Window}} Interface {#extensions-to-the-window-interface}
 
 <pre class=idl>
 partial interface Window {
-  [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional DOMString? pseudoElt);
+  [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
 };
 </pre>
 
@@ -2687,7 +2688,7 @@ The <code>CSS</code> interface holds useful CSS-related functions that do not be
 
 <pre class=idl>
 interface CSS {
-  static DOMString escape(DOMString ident);
+  static CSSOMString escape(CSSOMString ident);
 };
 </pre>
 

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -256,6 +256,41 @@ the last item. Unless otherwise specified, an empty list is serialized as the
 empty string.
 
 
+CSSOMString {#cssomstring-type}
+===============================
+
+Most strings in CSSOM interfaces use the <dfn>CSSOMString</dfn> type.
+Each implementation chooses to define it as either {{USVString}} or {{DOMString}}:
+
+<pre class=idl>
+typedef USVString CSSOMString;
+</pre>
+
+Or, alternatively:
+
+<pre class="def lang-webidl">
+typedef DOMString CSSOMString;
+</pre>
+
+<div class=note>
+	The difference is only observable from web content
+	when <a>surrogate</a> code units are involved.
+	{{DOMString}} would preserve them,
+	whereas {{USVString}} would replace them with U+FFFD REPLACEMENT CHARACTER.
+
+	This choice effectively allows implementations to do this replacement,
+	but does not require it.
+
+	This enables an implementation to use UTF-8 internally to represent strings in memory.
+	Since well-formed UTF-8 specifically disallows <a>surrogate</a> code points,
+	it effectively requires this replacement.
+
+	On the other hand,
+	implementations that internally represent strings as 16-bit <a>code units</a>
+	may prefer to avoid the cost of doing this replacement.
+</div>
+
+
 Media Queries {#media-queries}
 ==============================
 

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -809,7 +809,7 @@ The {{StyleSheet}} interface represents an abstract, base style sheet.
 <pre class=idl>
 interface StyleSheet {
   readonly attribute DOMString type;
-  readonly attribute DOMString? href;
+  readonly attribute USVString? href;
   readonly attribute (Element or ProcessingInstruction)? ownerNode;
   readonly attribute StyleSheet? parentStyleSheet;
   readonly attribute DOMString? title;
@@ -1650,7 +1650,7 @@ The <code>CSSImportRule</code> interface represents an <code>@import</code> at-r
 
 <pre class=idl>
 interface CSSImportRule : CSSRule {
-  readonly attribute DOMString href;
+  readonly attribute USVString href;
   [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
   [SameObject] readonly attribute CSSStyleSheet styleSheet;
 };

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -313,7 +313,7 @@ finally return <var>s</var>:
 
  <li>Let <var>type</var> be the <a lt="serialize an identifier">serialization
  as an identifier</a> of the media type of the media query,
- <a>converted to ASCII lowercase</a>.
+ <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
 
  <li>If the media query does not contain media features append
  <var>type</var>, to <var>s</var>,
@@ -331,7 +331,7 @@ finally return <var>s</var>:
 
   <ol>
    <li>Append a "<code>(</code>" (U+0028), followed by the media feature
-   name, <a>converted to ASCII lowercase</a>,
+   name, <a lt="ASCII lowercase">converted to ASCII lowercase</a>,
    to <var>s</var>.
 
    <li>If a value is given append a "<code>:</code>" (U+003A), followed
@@ -702,7 +702,7 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
  <dd>The literal string "<code>text/css</code>".
 
  <dt><dfn id=concept-css-style-sheet-location>location</dfn>
- <dd>Specified when created. The <a>absolute URL</a> of the first request of the
+ <dd>Specified when created. The <a>absolute-URL string</a> of the first request of the
  <a>CSS style sheet</a> or null if the <a>CSS style sheet</a> was
  embedded. Does not change during the lifetime of the <a>CSS style sheet</a>.
 
@@ -1118,7 +1118,7 @@ To <dfn>fetch a CSS style sheet</dfn> with parsed URL <var>parsed URL</var>, ref
 <a>request</a>), follow these steps:
 
 <ol>
- <li>Let <var>origin</var> be <var>document</var>'s <a>origin</a>.
+ <li>Let <var>origin</var> be <var>document</var>'s <a for=/>origin</a>.
 
  <li>Let <var>request</var> be a new <a>request</a>, with the
  <a for=request>url</a> <var>parsed URL</var>,
@@ -1332,7 +1332,7 @@ must be run:
 
  <li>Let <var>referrer</var> be the document's <a lt="document URL">address</a>.
 
- <li>Let <var>origin</var> be the document's <a>origin</a>.
+ <li>Let <var>origin</var> be the document's <a for=/>origin</a>.
 
  <li>Let <var>parsed URL</var> be the return value of invoking the <a>URL parser</a> with the
  string <var>input URL</var> and the base URL <var>base URL</var>.
@@ -1972,7 +1972,7 @@ The <dfn method for=CSSStyleDeclaration>getPropertyValue(<var>property</var>)</d
 <ol>
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
-   <li>Let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+   <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
    <li>If <var>property</var> is a shorthand property, then follow these substeps:
     <ol>
      <li>Let <var>list</var> be a new empty array.
@@ -2000,7 +2000,7 @@ The <dfn method for=CSSStyleDeclaration>getPropertyPriority(<var>property</var>)
 <ol>
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
-   <li>Let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+   <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
    <li>If <var>property</var> is a shorthand property, follow these substeps:
     <ol>
      <li>Let <var>list</var> be a new array.
@@ -2025,7 +2025,7 @@ The <dfn method for=CSSStyleDeclaration>setProperty(<var>property</var>, <var>va
  a {{NoModificationAllowedError}} exception and terminate these steps.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
-   <li>Let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+   <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
    <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
   </ol>
  <li>If <var>value</var> is the empty string, invoke {{CSSStyleDeclaration/removeProperty()}}
@@ -2067,7 +2067,7 @@ steps:
  a {{NoModificationAllowedError}} exception and terminate these steps.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
-   <li>Let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+   <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
    <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
   </ol>
  <li>If <var>value</var> is the empty string, invoke {{CSSStyleDeclaration/removeProperty()}}
@@ -2103,7 +2103,7 @@ these steps:
  a {{NoModificationAllowedError}} exception and terminate these steps.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
-   <li>Let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+   <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
    <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
   </ol>
  <li>If <var>priority</var> is not the empty string and is not an <a>ASCII case-insensitive</a> match for the string
@@ -2133,7 +2133,7 @@ The <dfn method for=CSSStyleDeclaration>removeProperty(<var>property</var>)</dfn
  <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
  a {{NoModificationAllowedError}} exception and terminate these steps.
  <li>If <var>property</var> is not a <a>custom property</a>,
- let <var>property</var> be <var>property</var> <a>converted to ASCII lowercase</a>.
+ let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
  <li>Let <var>value</var> be the return value of invoking {{CSSStyleDeclaration/getPropertyValue()}}
  with <var>property</var> as argument.
  <li>If <var>property</var> is a shorthand property, for each longhand property <var>longhand</var> that <var>property</var> maps to, invoke
@@ -2246,7 +2246,7 @@ The <dfn>CSS property to IDL attribute</dfn> algorithm for <var>property</var>, 
    <li>If <var>c</var> is "<code>-</code>" (U+002D), let <var>uppercase next</var> be set.
 
    <li>Otherwise, if <var>uppercase next</var> is set, let <var>uppercase next</var> be unset and append <var>c</var>
-   <a>converted to ASCII uppercase</a> to <var>output</var>.
+   <a lt="ASCII uppercase">converted to ASCII uppercase</a> to <var>output</var>.
 
    <li>Otherwise, append <var>c</var> to <var>output</var>.
   </ol>
@@ -2266,7 +2266,7 @@ The <dfn>IDL attribute to CSS property</dfn> algorithm for <var>attribute</var>,
 
   <ol>
    <li>If <var>c</var> is in the range U+0041 to U+005A (ASCII uppercase), append "<code>-</code>" (U+002D) followed by <var>c</var>
-   <a>converted to ASCII lowercase</a> to <var>output</var>.
+   <a lt="ASCII lowercase">converted to ASCII lowercase</a> to <var>output</var>.
 
    <li>Otherwise, append <var>c</var> to <var>output</var>.
   </ol>
@@ -2335,7 +2335,7 @@ depends on the component, as follows:
 <dl class="switch">
  <dt>keyword
  <dd>The keyword
- <a>converted to ASCII lowercase</a>.
+ <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
 
  <dt>&lt;angle>
  <dd>The &lt;number> component serialized as per &lt;number> followed by the unit in canonical form as defined in its respective specification.
@@ -2489,7 +2489,7 @@ depends on the component, as follows:
  the literal string "<code>s</code>".
 
  <dt>&lt;uri>
- <dd>The <a>absolute URL</a>
+ <dd>The <a>absolute-URL string</a>
  <a lt="serialize a URL">serialized as URL</a>.
 </dl>
 
@@ -2583,7 +2583,7 @@ If the user agent supports HTML, the following IDL applies: [[HTML]]
 HTMLElement implements ElementCSSInlineStyle;
 </pre>
 
-If the user agent supports SVG, the following IDL applies: [[SVG]]
+If the user agent supports SVG, the following IDL applies: [[SVG11]]
 
 <pre class=idl>
 SVGElement implements ElementCSSInlineStyle;

--- a/mediaqueries/Overview.bs
+++ b/mediaqueries/Overview.bs
@@ -17,7 +17,7 @@ Former Editor: Anne van Kesteren, Mozilla, annevk@annevk.nl
 Abstract: <a>Media Queries</a> allow authors to test and query values or features of the user agent or display device, independent of the document being rendered.  They are used in the CSS @media rule to conditionally apply styles to a document, and in various other contexts and languages, such as HTML and Javascript.
 Abstract:
 Abstract: Media Queries Level 4 describes the mechanism and syntax of media queries, media types, and media features. It extends and supersedes the features defined in Media Queries Level 3.
-Ignored Terms: min-resolution, max-resolution, none, view-mode, mediaText, DOMString
+Ignored Terms: min-resolution, max-resolution, none, view-mode, mediaText, CSSOMString
 Link Defaults: css-break-3 (property) break-inside
 Link Defaults: css-cascade-3 (at-rule) @import
 </pre>
@@ -2046,15 +2046,15 @@ CSSOM</h2>
 
 	<pre class="idl">
 	interface CSSCustomMediaRule : CSSRule {
-		attribute DOMString name;
+		attribute CSSOMString name;
 		[SameObject, PutForwards=mediaText] readonly attribute MediaList media;
 	};
 	</pre>
 
 	<dl dfn-type=attribute dfn-for=CSSCustomMediaRule>
-		<dt><dfn>name</dfn>, of type <code>DOMString</code>
+		<dt><dfn>name</dfn>, of type <code>CSSOMString</code>
 		<dd>
-			The <a attribute>name</a> attribute on getting must return a <code>DOMString</code> object
+			The <a attribute>name</a> attribute on getting must return a <code>CSSOMString</code> object
 			that contains the serialization of the <<extension-name>> defined for the associated rule.
 
 			On setting the <a attribute>name</a> attribute,


### PR DESCRIPTION
`CSSOMString` is an IDL `typedef` of either `USVString` or `DOMString`, chosen by implementations.

CSSWG resolution: https://github.com/w3c/csswg-drafts/issues/1217#issuecomment-295053842. Fixes #1217.

Each replaced occurrence is one of:

* CSS syntax
* A name (for example a property name) that also occurs in CSS syntax
* `Stylesheet::type`, which is always `text/css`.
* <s>`Stylesheet::title`, which is set from the eponymous HTML content attribute of [`<style>`](https://html.spec.whatwg.org/multipage/semantics.html#attr-style-title) and [`<link>`](https://html.spec.whatwg.org/multipage/semantics.html#attr-link-title) elements.</s>