### PR TITLE
[selectors-4] Clarifying :nth-child and friends

### DIFF
--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -2543,9 +2543,8 @@ Child-indexed Pseudo-classes</h3>
 '':nth-child()'' pseudo-class</h4>
 
 	The <dfn id='nth-child-pseudo' lt=":nth-child()">:nth-child(<var>An+B</var> [of <var>S</var>]? )</dfn>
-	pseudo-class notation represents the <var>An+B</var>th element
-	that matches the <a>selector list</a> <var>S</var>
-	among its <a>inclusive siblings</a>.
+	pseudo-class notation represents an element among its <var>An+B</var>th <a>inclusive siblings</a>
+	that match the <a>selector list</a> <var>S</var>.
 
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
 	If <var>S</var> is omitted,
@@ -2619,9 +2618,8 @@ Child-indexed Pseudo-classes</h3>
 '':nth-last-child()'' pseudo-class</h4>
 
 	The <dfn id='nth-last-child-pseudo' lt=":nth-last-child()">:nth-last-child(<var>An+B</var> [of <var>S</var>]? )</dfn>
-	pseudo-class notation represents the <var>An+B</var>th element
-	that matches the <a>selector list</a> <var>S</var>
-	among its <a>inclusive siblings</a>,
+	pseudo-class notation represents an element among its <var>An+B</var>th <a>inclusive siblings</a>
+	that match the <a>selector list</a> <var>S</var>,
 	counting backwards from the end.
 
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
@@ -2716,9 +2714,8 @@ Typed Child-indexed Pseudo-classes</h3>
 '':nth-of-type()'' pseudo-class</h4>
 
 	The <dfn id='nth-of-type-pseudo' lt=":nth-of-type()">:nth-of-type(<var>An+B</var>)</dfn> pseudo-class notation
-	represents the <var>An+B</var>th element
-	with the same <a section href="#type-nmsp">namespace</a> and <a section href="#type-selectors">type</a>
-	among its <a>inclusive siblings</a>.
+	represents an element among its <var>An+B</var>th <a>inclusive siblings</a>
+	with the same <a section href="#type-nmsp">namespace</a> and <a section href="#type-selectors">type</a>.
 
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
 
@@ -2742,9 +2739,8 @@ Typed Child-indexed Pseudo-classes</h3>
 '':nth-last-of-type()'' pseudo-class</h4>
 
 	The <dfn id='nth-last-of-type' lt=":nth-last-of-type()">:nth-last-of-type(<var>An+B</var>)</dfn> pseudo-class notation
-	represents the <var>An+B</var>th element
-	with the same <a section href="#type-nmsp">namespace</a> and <a section href="#type-selectors">type</a>
-	among its <a>inclusive siblings</a>,
+	represents an element among its <var>An+B</var>th <a>inclusive siblings</a>
+	with the same <a section href="#type-nmsp">namespace</a> and <a section href="#type-selectors">type</a>,
 	counting backwards from the end.
 
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.


### PR DESCRIPTION
It was not completely clear what “the An+Bth element” meant, because according to CSS Syntax, this notation represents a list of elements. Fixes #1292