### PR TITLE
[css-counter-styles] Exclude 'none' from <counter-style-name>

### DIFF
--- a/css-counter-styles/Overview.bs
+++ b/css-counter-styles/Overview.bs
@@ -152,10 +152,12 @@ Defining Custom Counter Styles: the ''@counter-style'' rule</h2>
 
 	<pre>@counter-style <<counter-style-name>> { <<declaration-list>> }</pre>
 
-	where <dfn>&lt;counter-style-name></dfn> is a <<custom-ident>>.
+	<dfn>&lt;counter-style-name></dfn> is a <<custom-ident>>
+	that is not an <a>ASCII case-insensitive</a> match for "none".
 
-	If a counter style's name is an <a>ASCII case-insensitive</a> match for "decimal" or "none",
-	the ''@counter-style'' rule is invalid.
+	Additionally, in the context of the prelude of an ''@counter-style'' rule,
+	an <a>ASCII case-insensitive</a> match for "decimal" is also an invalid <<counter-style-name>>
+	and makes the ''@counter-style'' rule invalid.
 
 	Note: Note that <<custom-ident>> also automatically excludes the <a spec=css-values>CSS-wide keywords</a>.
 	In addition, some names, like ''inside'',


### PR DESCRIPTION
… in all contexts, not just `@counter-style` rules.

Fix #1295.