### PR TITLE
[css-display] Missing 'flex' in section title

### DIFF
--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -302,7 +302,7 @@ Outer Display Roles for Flow Layout: the ''block'', ''inline'', and ''run-in'' k
 	the element's <a>inner display type</a> defaults to ''flow''.
 
 <h3 id="inner-model">
-Inner Display Layout Models: the ''flow'', ''flow-root'', ''table'', ''grid'', and ''ruby'' keywords</h3>
+Inner Display Layout Models: the ''flow'', ''flow-root'', ''table'', ''flex'', ''grid'', and ''ruby'' keywords</h3>
 
 	The <<display-inside>> keywords specify the element's <a>inner display type</a>,
 	which defines the type of formatting context that lays out its contents


### PR DESCRIPTION
[Flex layout](https://drafts.csswg.org/css-display-3/#valdef-display-flex) is missing from the title of its section:

> [§ 2.2. Inner Display Layout Models: the flow, flow-root, table, grid, and ruby keywords](https://drafts.csswg.org/css-display-3/#inner-model)

It should be

> [§ 2.2. Inner Display Layout Models: the flow, flow-root, table, **flex**, grid, and ruby keywords](https://drafts.csswg.org/css-display-3/#inner-model)