### PR TITLE
[css-color] Bikeshed fix

### DIFF
--- a/css-color/Overview.bs
+++ b/css-color/Overview.bs
@@ -2039,7 +2039,7 @@ Specifying a color profile: the ''color-profile'' at-rule</h3>
 	Initial: n/a
 	</pre>
 
-	The 'src' descriptor specifies the URL to retrieve the color-profile information from.
+	The '@color-profile/src' descriptor specifies the URL to retrieve the color-profile information from.
 
 	Issue: Same-origin and CORS for src.
 


### PR DESCRIPTION
To disambiguate the '@color-profile/src' descriptor.