### PR TITLE
[css-background] Add missed "internal" into "applies to" for <'border-image-width'>

### DIFF
--- a/css-backgrounds/Overview.html
+++ b/css-backgrounds/Overview.html
@@ -3431,7 +3431,7 @@ DIV {
     <tr>
      <th>Applies to:
 
-     <td>All elements, except table elements when ‘<code
+     <td>All elements, except internal table elements when ‘<code
       class=property>border-collapse</code>’ is ‘<code
       class=css>collapse</code>’
 

--- a/css-backgrounds/Overview.src.html
+++ b/css-backgrounds/Overview.src.html
@@ -2459,7 +2459,7 @@ with no <i>specified size</i> and the <i>border image area</i> as the <i>default
     <td>1
   <tr>
     <th>Applies to:
-    <td>All elements, except table elements when 'border-collapse' is
+    <td>All elements, except internal table elements when 'border-collapse' is
     ''collapse''
   <tr>
     <th>Inherited:


### PR DESCRIPTION
There is no reasons for `border-image-width` to differ from other `border-image-*` properties. I suppose "internal" was missed by accident when [splitting `border-image` into multiple properties](https://github.com/w3c/csswg-drafts/commit/eb4c769e78568e37b8fad92f99d6ebd49f484371)