### PR TITLE
[css-content] Fix syntaxes according to CSS Values and Units grammar

### DIFF
--- a/css-content/Overview.bs
+++ b/css-content/Overview.bs
@@ -164,7 +164,7 @@ Inserting and replacing content with the 'content' property</h2>
 			Equal to:
 
 			<pre class=prod>
-			[ <<string>> | contents | <<image>> | <<quote>> | <<target>> | ''leader()'' ]+
+			[ <<string>> | contents | <<image>> | <<quote>> | <<target>> | <<leader()>> ]+
 			</pre>
 
 			Replaces the element's contents with one or more anonymous inline boxes
@@ -378,7 +378,7 @@ Specifying quotes with the 'quotes' property</h4>
 
 	<pre class='propdef'>
 		Name: quotes
-		Value: [ <<string>> <<string>> ]+ | none
+		Value: none | [ <<string>> <<string>> ]+
 		Initial: depends on user agent
 		Applies To: all elements
 		Inherited: yes
@@ -422,7 +422,7 @@ Specifying quotes with the 'quotes' property</h4>
 The *-quote values of the content property</h4>
 
 	<pre class="prod">
-		<dfn><<quote>></dfn> = [open-quote | close-quote | no-open-quote | no-close-quote]
+		<dfn><<quote>></dfn> = open-quote | close-quote | no-open-quote | no-close-quote
 	</pre>
 
 	<dl dfn-for="content, <content-list>, <quote>" dfn-type=value>
@@ -601,7 +601,8 @@ The ''leader()'' function</h4>
 	</dl>
 
 	<pre class="prod">
-		<dfn><<leader-type>></dfn> = leader( dotted | solid | space | <<string>>);
+		<dfn><<leader()>></dfn> = leader( <<leader-type>> )
+		<dfn><<leader-type>></dfn> = dotted | solid | space | <<string>>
 	</pre>
 
 	Three keywords are shorthand values for common strings:
@@ -758,7 +759,7 @@ Cross references and the target-* functions</h3>
 	Each of these displays information obtained from the target end of a link.
 
 	<pre class="prod">
-		<dfn><<target>></dfn> = [ ''target-counter()'' | ''target-counters()'' | ''target-text()'' ]
+		<dfn><<target>></dfn> = <<target-counter()>> | <<target-counters()>> | <<target-text()>>
 	</pre>
 
 	See sections below for details on each of these.
@@ -769,7 +770,7 @@ Cross references and the target-* functions</h3>
 The ''target-counter()'' function</h4>
 
 	<pre class="prod">
-		<dfn>target-counter()</dfn> = target-counter( [ <<string>> | <<url>> ] , <<custom-ident>> [ , <<counter-style>> ]? )
+		<dfn><<target-counter()>></dfn> = target-counter( [ <<string>> | <<url>> ] , <<custom-ident>> , <<counter-style>>? )
 	</pre>
 
 	The ''target-counter()'' function retrieves the value
@@ -851,7 +852,7 @@ The ''target-counters()'' function
 	and formats them by inserting a given string between the value of each nested counter.
 
 	<pre class="prod">
-		<dfn>target-counters()</dfn> = target-counter( [ <<string>> | <<url>> ] , <<custom-ident>> , <<string>> [ , <<counter-style>> ]? )
+		<dfn><<target-counters()>></dfn> = target-counters( [ <<string>> | <<url>> ] , <<custom-ident>> , <<string>> , <<counter-style>>? )
 	</pre>
 
 	<div class="example">
@@ -871,7 +872,7 @@ The ''target-text()'' function</h4>
 	using the same values as the 'string-set' property above.
 
 	<pre class="prod">
-		<dfn id="target-text-function">target-text()</dfn> = target-text( [ <<string>> | <<url>> ] [ , [ content | before | after | first-letter] ]? )
+		<dfn id="target-text-function"><<target-text()>></dfn> = target-text( [ <<string>> | <<url>> ] , [ content | before | after | first-letter ]? )
 	</pre>
 
 
@@ -938,7 +939,7 @@ The string-set property</h4>
 
 	<pre class="propdef">
 	Name: string-set
-	Value: [ <<custom-ident>> <<string>>+ ]# | none
+	Value: none | [ <<custom-ident>> <<string>>+ ]#
 	Initial: none
 	Applies to: all elements, but not pseudo-elements
 	Inherited: no
@@ -988,7 +989,7 @@ The string-set property</h4>
 The ''string()'' function</h4>
 
 	<pre class="prod">
-		<dfn>string()</dfn> = string( <<custom-ident>> , [ first | start | last | first-except ]? )
+		<dfn><<string()>></dfn> = string( <<custom-ident>> , [ first | start | last | first-except ]? )
 	</pre>
 
 	The ''string()'' function is used to copy the value of a named string to the document,
@@ -1087,7 +1088,7 @@ The ''string()'' function</h4>
 The ''content()'' function</h4>
 
 	<pre class="prod">
-		<dfn>content()</dfn> = content( [text | before | after | first-letter | marker ]? )
+		<dfn><<content()>></dfn> = content( [ text | before | after | first-letter | marker ] )
 	</pre>
 
 	<dl dfn-type="value" dfn-for="content()">

--- a/css-content/Overview.bs
+++ b/css-content/Overview.bs
@@ -601,7 +601,7 @@ The ''leader()'' function</h4>
 	</dl>
 
 	<pre class="prod">
-		<dfn><<leader()>></dfn> = leader( <<leader-type>> )
+		<dfn>leader()</dfn> = leader( <<leader-type>> )
 		<dfn><<leader-type>></dfn> = dotted | solid | space | <<string>>
 	</pre>
 
@@ -770,7 +770,7 @@ Cross references and the target-* functions</h3>
 The ''target-counter()'' function</h4>
 
 	<pre class="prod">
-		<dfn><<target-counter()>></dfn> = target-counter( [ <<string>> | <<url>> ] , <<custom-ident>> , <<counter-style>>? )
+		<dfn>target-counter()</dfn> = target-counter( [ <<string>> | <<url>> ] , <<custom-ident>> , <<counter-style>>? )
 	</pre>
 
 	The ''target-counter()'' function retrieves the value
@@ -852,7 +852,7 @@ The ''target-counters()'' function
 	and formats them by inserting a given string between the value of each nested counter.
 
 	<pre class="prod">
-		<dfn><<target-counters()>></dfn> = target-counters( [ <<string>> | <<url>> ] , <<custom-ident>> , <<string>> , <<counter-style>>? )
+		<dfn>target-counters()</dfn> = target-counters( [ <<string>> | <<url>> ] , <<custom-ident>> , <<string>> , <<counter-style>>? )
 	</pre>
 
 	<div class="example">
@@ -872,7 +872,7 @@ The ''target-text()'' function</h4>
 	using the same values as the 'string-set' property above.
 
 	<pre class="prod">
-		<dfn id="target-text-function"><<target-text()>></dfn> = target-text( [ <<string>> | <<url>> ] , [ content | before | after | first-letter ]? )
+		<dfn id="target-text-function">target-text()</dfn> = target-text( [ <<string>> | <<url>> ] , [ content | before | after | first-letter ]? )
 	</pre>
 
 
@@ -989,7 +989,7 @@ The string-set property</h4>
 The ''string()'' function</h4>
 
 	<pre class="prod">
-		<dfn><<string()>></dfn> = string( <<custom-ident>> , [ first | start | last | first-except ]? )
+		<dfn>string()</dfn> = string( <<custom-ident>> , [ first | start | last | first-except ]? )
 	</pre>
 
 	The ''string()'' function is used to copy the value of a named string to the document,
@@ -1088,7 +1088,7 @@ The ''string()'' function</h4>
 The ''content()'' function</h4>
 
 	<pre class="prod">
-		<dfn><<content()>></dfn> = content( [ text | before | after | first-letter | marker ] )
+		<dfn>content()</dfn> = content( [ text | before | after | first-letter | marker ]? )
 	</pre>
 
 	<dl dfn-type="value" dfn-for="content()">


### PR DESCRIPTION
Fix and simplify syntaxes, see #663 for details