### PR TITLE
[css-namespaces] Restore Terminology section

### DIFF
--- a/css-namespaces/Overview.bs
+++ b/css-namespaces/Overview.bs
@@ -61,6 +61,34 @@ Introduction</h2>
 	rather than possibly match them incorrectly.
 
 
+<h3 id="terminology">
+Terminology</h3>
+
+	Besides terms introduced by this specification,
+	CSS Namespaces uses the terminology defined in Namespaces in XML 1.0. [[!XML-NAMES]]
+	However, the syntax defined here is not restricted to representing XML element and attribute names
+	and may represent other kinds of namespaces as defined by the host language.
+
+	In CSS Namespaces a namespace name consisting of the empty string
+	is taken to represent the null namespace
+	or lack of a namespace.
+
+	<div class="example">
+		For example, given the namespace declarations:
+
+		<pre>
+			@namespace empty "";
+			@namespace "";
+		</pre>
+
+		The <a>type selectors</a>
+		<code>elem</code>,
+		<code>|elem</code>,
+		and <code>empty|elem</code>
+		are equivalent.
+	</div>
+
+
 <h2 id="declaration">Declaring namespaces: the ''@namespace'' rule</h2>
 
 	The ''@namespace'' <a>at-rule</a> declares a namespace prefix


### PR DESCRIPTION
It was removed in https://github.com/w3c/csswg-drafts/commit/23f06fe37e7185bd44e8408cd533b2f5110ad586, presumably accidentally.

It includes a normative statements that was missing for the ED:

> In CSS Namespaces a namespace name consisting of the empty string is taken to represent the null namespace or lack of a namespace.