### PR TITLE
[cssom-1] Add missing extract class on dashed_attribute example

### DIFF
--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -2245,7 +2245,7 @@ For each CSS property <var>property</var> that is a <a>supported CSS property</a
 except for properties that have no "<code>-</code>" (U+002D) in the property name,
 the following partial interface applies where <var>dashed attribute</var> is <var>property</var>.
 
-<pre class="idl">
+<pre class="idl extract">
 partial interface CSSStyleDeclaration {
   [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString _<var>dashed_attribute</var>;
 };


### PR DESCRIPTION
https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-_dashed_attribute

```WebIDL
partial interface CSSStyleDeclaration {
  [CEReactions, TreatNullAs=EmptyString] attribute CSSOMString _dashed_attribute;
};
```

This IDL snippet does not have `extract` class attached and thus collected on IDL index, whereas other _camel_cased_attribute and _webkit_cased_attribute examples are not collected.