### PR TITLE
[css-align] Fixes Example 1 behavior in Firefox

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -564,14 +564,14 @@ Overflow Alignment: the ''safe'' and ''unsafe'' keywords</h3>
 				<div style="display:table-cell; padding-right: 50px;" class='cross-auto-figure'>
 					<div>
 						<div>About</div>
-						<div>Authoritarianism</div>
+						<div style="white-space: nowrap;">Authoritarianism</div>
 						<div>Blog</div>
 					</div>
 				</div>
 				<div style="display:table-cell; padding-left: 50px;" class='cross-auto-figure'>
 					<div>
 						<div>About</div>
-						<div style="margin-left: -31px;">Authoritarianism</div>
+						<div style="white-space: nowrap; margin-left: -31px;">Authoritarianism</div>
 						<div>Blog</div>
 					</div>
 				</div>


### PR DESCRIPTION
Currently, Firefox wraps the word "Authoritarianism" in the Example 1, making it hard to understand the difference between unsafe and safe centering. Setting `white-space:nowrap` to it makes it more clear.