### PR TITLE
[css-color] Link to rgb() instead of its *a() alias

### DIFF
--- a/css-color/Overview.bs
+++ b/css-color/Overview.bs
@@ -1281,7 +1281,7 @@ HWB Colors: ''hwb()'' function</h2>
 	with the same relative ratio.
 
 	The fourth argument specifies the alpha channel of the color.
-	It's interpreted identically to the fourth argument of the ''rgba()'' function.
+	It's interpreted identically to the fourth argument of the ''rgb()'' function.
 	If omitted, it defaults to ''100%''.
 
 	The resulting color can be thought of conceptually as a mixture of paint in the chosen hue,
@@ -2179,7 +2179,7 @@ Device-dependent CMYK Colors: the ''device-cmyk()'' function</h2>
 	instead, they are clamped to 0/0% or 1/100%.
 
 	The fifth argument specifies the alpha channel of the color.
-	It's interpreted identically to the fourth argument of the ''rgba()'' function.
+	It's interpreted identically to the fourth argument of the ''rgb()'' function.
 	If omitted, it defaults to ''100%''.
 
 	The sixth argument specifies the fallback color,
@@ -2798,7 +2798,7 @@ Transparency: the 'opacity' property</h2>
 		<dt><<alpha-value>>
 		<dd>
 			The opacity to be applied to the element.
-			It is interpreted identically to its definition in ''rgba()'',
+			It is interpreted identically to its definition in ''rgb()'',
 			except that the resulting opacity is applied to the entire element,
 			rather than a particular color.
 	</dl>


### PR DESCRIPTION
In https://drafts.csswg.org/css-color/#rgb-functions:

> Also for legacy reasons, an rgba() function also exists, with an identical grammar and behavior to rgb().