### PR TITLE
[css-display] Link "replaced element" to CSS Display instead of CSS2

### DIFF
--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -131,9 +131,9 @@ Box Layout Modes: the 'display' property</h2>
 	which consists of the two basic qualities of how an element generates boxes:
 
 	* the <dfn export local-lt="inner">inner display type</dfn>,
-		which defines (if it is a <a href="https://www.w3.org/TR/CSS2/conform.html#replaced-element">non-replaced element</a>) the kind of <a>formatting context</a> it generates,
+		which defines (if it is a <a lt="replaced element">non-replaced element</a>) the kind of <a>formatting context</a> it generates,
 		dictating how its descendant boxes are laid out.
-		(The inner display of a <a href="https://www.w3.org/TR/CSS2/conform.html#replaced-element">replaced element</a> is outside the scope of CSS.)
+		(The inner display of a <a>replaced element</a> is outside the scope of CSS.)
 	* the <dfn export local-lt="outer">outer display type</dfn>,
 		which dictates how the box participates in its parent formatting context.
 
@@ -308,7 +308,7 @@ Inner Display Layout Models: the ''flow'', ''flow-root'', ''table'', ''flex'', '
 
 	The <<display-inside>> keywords specify the element's <a>inner display type</a>,
 	which defines the type of formatting context that lays out its contents
-	(assuming it is a <a href="https://www.w3.org/TR/CSS2/conform.html#replaced-element">non-replaced</a> element).
+	(assuming it is a <a lt="replaced element">non-replaced element</a>).
 	They are defined as follows:
 
 	<dl dfn-type="value" dfn-for="display, <display-inside>">


### PR DESCRIPTION
CSS Display defines "replaced element" in the same spec, so there is no need to link CSS2.