### PR TITLE
Allow -n in an-b, allow comments within +n and -n

### DIFF
--- a/css-syntax/Overview.bs
+++ b/css-syntax/Overview.bs
@@ -2655,23 +2655,23 @@ The <code>&lt;an+b></code> type</h3>
 		  <var>&lt;integer></var> |
 
 		  <var>&lt;n-dimension></var> |
-		  '+'?<sup><a href="#anb-plus">†</a></sup> n |
+		  ['+' | '-']?<sup><a href="#anb-plus">†</a></sup> n |
 		  -n |
 
 		  <var>&lt;ndashdigit-dimension></var> |
-		  '+'?<sup><a href="#anb-plus">†</a></sup> <var>&lt;ndashdigit-ident></var> |
+		  ['+' | '-']?<sup><a href="#anb-plus">†</a></sup> <var>&lt;ndashdigit-ident></var> |
 		  <var>&lt;dashndashdigit-ident></var> |
 
 		  <var>&lt;n-dimension></var> <var>&lt;signed-integer></var> |
-		  '+'?<sup><a href="#anb-plus">†</a></sup> n <var>&lt;signed-integer></var> |
+		  ['+' | '-']?<sup><a href="#anb-plus">†</a></sup> n <var>&lt;signed-integer></var> |
 		  -n <var>&lt;signed-integer></var> |
 
 		  <var>&lt;ndash-dimension></var> <var>&lt;signless-integer></var> |
-		  '+'?<sup><a href="#anb-plus">†</a></sup> n- <var>&lt;signless-integer></var> |
+		  ['+' | '-']?<sup><a href="#anb-plus">†</a></sup> n- <var>&lt;signless-integer></var> |
 		  -n- <var>&lt;signless-integer></var> |
 
 		  <var>&lt;n-dimension></var> ['+' | '-'] <var>&lt;signless-integer></var>
-		  '+'?<sup><a href="#anb-plus">†</a></sup> n ['+' | '-'] <var>&lt;signless-integer></var> |
+		  ['+' | '-']?<sup><a href="#anb-plus">†</a></sup> n ['+' | '-'] <var>&lt;signless-integer></var> |
 		  -n ['+' | '-'] <var>&lt;signless-integer></var>
 	</pre>
 
@@ -2689,9 +2689,9 @@ The <code>&lt;an+b></code> type</h3>
 	</ul>
 
 	<p id="anb-plus">
-		<sup>†</sup>: When a plus sign (+) precedes an ident starting with "n", as in the cases marked above,
+		<sup>†</sup>: When a plus sign (+) or a minus sign (-) precedes an ident starting with "n", as in the cases marked above,
 		there must be no whitespace between the two tokens,
-		or else the tokens do not match the above grammar.
+		or else the tokens do not match the above grammar. Comments are allowed between these tokens provided that there is no whitespace.
 		Whitespace is valid (and ignored) between any other two tokens.
 
 	The clauses of the production are interpreted as follows:


### PR DESCRIPTION
Currently the grammar doesn't allow for `-n` within `:nth-child`, it only deals with `+n`. However, `-n` (and things like `-n+5`) are accepted by browsers.

This fixes the discrepancy.

Additionally, the parsing here is a bit tricky -- while the `+`/`-` and `n` are separate tokens, the spec does not allow for spaces between them. Chrome follows this, and as of  https://bugzilla.mozilla.org/show_bug.cgi?id=1364009, firefox does too. However, both allow comments. While this is probably implicit, I'm clarifying this within the spec.



See also: https://github.com/servo/rust-cssparser/issues/153,


r? @tabatkins @SimonSapin