### PR TITLE
[css2] Linkify a mention of the 'height' property

### DIFF
--- a/css2/visudet.src
+++ b/css2/visudet.src
@@ -299,7 +299,7 @@ value of <span class="propinst-width">'width'</span> is:
 
 <blockquote><p>(used height) * (intrinsic ratio)</blockquote>
 
-<p>If 'height' and <span class="propinst-width">'width'</span> both
+<p>If <span class="propinst-height">'height'</span> and <span class="propinst-width">'width'</span> both
 have computed values of 'auto' and the element has an intrinsic ratio
 but no intrinsic height or width, then the used value of 'width' is
 undefined in CSS&nbsp;2.2.


### PR DESCRIPTION
In section CSS2 10.3.2, there are a series of paragraphs that start out "If 'height' and 'width' ..." with both properties linkified.  One of them neglects to linkify 'height'. This pull request fixes that.