### PR TITLE
[cssom-view] Check computed value for overflow-x/y in potentially scrollable

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -132,8 +132,8 @@ An element is <dfn>potentially scrollable</dfn> if all of the following conditio
 
 * The element has an associated <a>CSS layout box</a>.
 * The element is not <a>the HTML <code>body</code> element</a>, or it is and
-    the root element's used value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
-* The element's used value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
+    the root element's computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
+* The element's computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
 
 Note: An element that is <a>potentially scrollable</a> might not have a <a>scrolling box</a>.
 For instance, it could have 'overflow' set to ''overflow/auto'' but not have its content overflowing its content area.


### PR DESCRIPTION
Fixes #1538.

---

I think this is already tested by http://w3c-test.org/cssom-view/scrollingElement.html