### PR TITLE
[mediaqueries-5] remove level from shortname metadata

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: Media Queries Level 5
 Group: csswg
-Shortname: mediaqueries-5
+Shortname: mediaqueries
 Level: 5
 Status: ED
 Status Text: Once complete, this specification will include and extend <cite>Media Queries Level&nbsp;4.</cite> [[MEDIAQUERIES-4]]


### PR DESCRIPTION
This causes the GitHub Issues link to point to https://github.com/w3c/csswg-drafts/labels/mediaqueries-5-5 (instead of https://github.com/w3c/csswg-drafts/labels/mediaqueries-5).