### PR TITLE
[css-flexbox][css-grid] Removed redundant exclusion of column-* properties from applying to flex and grid containers

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -28,7 +28,7 @@ Former Editor: Neil Deakin, Mozilla Corporation, enndeakin@gmail.com
 Former Editor: Ian Hickson, formerly of Opera Software, ian@hixie.ch
 Former Editor: David Hyatt, formerly of Netscape Corporation, hyatt@apple.com
 !Issues List: <a href="https://drafts.csswg.org/css-flexbox-1/issues">https://drafts.csswg.org/css-flexbox-1/issues</a>
-Ignored Terms: column-*, auto, first formatted line, first letter, static position
+Ignored Terms: auto, first formatted line, first letter, static position
 Ignored Vars: item’s own max-content, maximum min-content among all items
 </pre>
 
@@ -523,7 +523,6 @@ Flex Containers: the ''flex'' and ''inline-flex'' 'display' values</h2>
 	and so some properties that were designed with the assumption of block layout don't apply in the context of flex layout.
 	In particular:
 
-		* the 'column-*' properties in the Multi-column Layout module [[!CSS3COL]] have no effect on a flex container.
 		* 'float' and 'clear' do not create floating or clearance of <a>flex item</a>,
 			and do not take it out-of-flow.
 		* 'vertical-align' has no effect on a flex item.

--- a/css-grid/Overview.bs
+++ b/css-grid/Overview.bs
@@ -843,9 +843,6 @@ Establishing Grid Containers: the ''display/grid'' and ''inline-grid'' 'display'
 
 	<ul>
 		<li>
-			the 'column-*' properties in the Multi-column Layout module [[!CSS3COL]] have no effect on a grid container.
-
-		<li>
 			'float' and 'clear' have no effect on a <a>grid item</a>.
 			However, the 'float' property still affects the computed value of 'display' on children of a grid container,
 			as this occurs <em>before</em> <a>grid items</a> are determined.


### PR DESCRIPTION
Removes the [now redundant](https://github.com/w3c/csswg-drafts/commit/52ebb10453232307562a4e2c69e82565da9fd39b) exclusion of `column-*` properties from applying to flex and grid containers.

Sebastian