### PR TITLE
[css-display] Fix the 'Changes' section

### DIFF
--- a/css-display/Overview.bs
+++ b/css-display/Overview.bs
@@ -1117,7 +1117,7 @@ Changes</h2>
 	<ul>
 		<li>Deferred the <css>box-suppress/display-or-not</css> property to the next level of Display,
 		in order to provide time for futher discussion of use cases.
-		<li>Specified that ''display: contents'' computes to ''display: inline'' on replaced elements and form controls.
+		<li>Specified the effects of ''display: contents'' on unusual elements such as replaced elements and form controls.
 		<li>Clarified that an element’s ''::before'' and ''::after'' pseudo-elements still exist if its own box is not generated due to ''display: contents''.
 		<li>Clarified that event bubbling is not affected by ''display: contents''.
 		<li>Clarified interaction of run-ins with out-of-flow elements and ''::first-letter''.


### PR DESCRIPTION
The 'Changes' section still stated that `display:contents` on replaced elements etc. computed to `inline`, although the spec has been updated with more detailed rules for such elements with `display:none` as a general rule. This PR aims to fix it.