### PR TITLE
[css-multicol] Revert part of a change about formatting contexts

### DIFF
--- a/css-multicol/Overview.bs
+++ b/css-multicol/Overview.bs
@@ -952,7 +952,7 @@ Spanning columns</h2>
 			Content in the normal flow that appears before the
 			element is automatically balanced across all columns before the
 			element appears.
-			The element establishes a new <a>formatting context</a>.
+			The element <a>becomes a formatting context</a>.
 
 			Note: Whether the element establishes a new <a>formatting context</a>
 			does not depend on whether the element is a descendent of a multicol or not.


### PR DESCRIPTION
Stating that the element establishes a new formatting context, without
saying what kind of formatting context it needs to establish is not
specific enough. Also, saying that it must establish a "new" formatting
context is ambiguous or misleading for elements that would establish one
anyway.

The current definition of "becomes a formatting context" is
problematic (see https://github.com/w3c/csswg-drafts/issues/1457), so we
need to fix it, but it is precisely aimed at solving this: defining what
kind of formatting context to establish for the boxes that wouldn't
otherwise, and being clear about which boxes are fine as is and don't
need to be changed.