### PR TITLE
[css-align] Fix reference to unexisting justify-items: auto.

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -1489,7 +1489,7 @@ Inline/Main-Axis Alignment: the 'justify-items' property</h3>
 	Inherited: no
 	Percentages: n/a
 	Media: visual
-	Computed value: specified value, except for ''justify-items/auto'' (see prose)
+	Computed value: specified value, except for ''justify-items/legacy'' (see prose)
 	Animatable: no
 	</pre>
 


### PR DESCRIPTION
Fixes #1649.