### PR TITLE
Clarify that the after-change style does not include updates to CSS Animations

### DIFF
--- a/css-transitions/Overview.bs
+++ b/css-transitions/Overview.bs
@@ -567,7 +567,7 @@ Starting of transitions {#starting}
         implementations must start transitions based on
         the <a>computed values</a> that changed in that event.
         If an element is not in the document during that
-        style change even or was not in the document during
+        style change event or was not in the document during
         the previous style change event,
         then transitions are not started for that element
         in that style change event.
@@ -584,9 +584,14 @@ Starting of transitions {#starting}
         the <a>computed values</a> of all properties
         on the element based on the information
         known at the start of that <a>style change event</a>,
-        but excluding any styles from CSS Transitions in the computation,
+        but using the computed values of the 'animation-*' properties from the
+        <a>before-change style</a>,
+        excluding any styles from CSS Transitions in the computation,
         and inheriting from
         the <a>after-change style</a> of the parent.
+        Note that this means the <a>after-change style</a> does not differ from
+        the <a>before-change style</a> due to newly created or cancelled CSS
+        Animations.
       </p>
 
       <div class="note">


### PR DESCRIPTION
This addresses issue #679.