### PR TITLE
[css-box] Fixed example 26

### DIFF
--- a/css-box/Overview.html
+++ b/css-box/Overview.html
@@ -3092,13 +3092,13 @@ with an overflow parent. Style sheet: </p>
 <pre>container { position: relative; border: solid; }
 scroller { overflow: scroll; height: 5em; margin: 5em; }
 satellite { position: absolute; top: 0; }
-body { height: 10em; }
+content { height: 10em; }
 </pre>
     <p>Document fragment: </p>
 <pre>&lt;container>
  &lt;scroller>
   &lt;satellite/>
-  &lt;body/>
+  &lt;content/>
  &lt;/scroller>
 &lt;/container>
 </pre>

--- a/css-box/Overview.html
+++ b/css-box/Overview.html
@@ -3089,10 +3089,10 @@ clipped content. </p>
     <a class="self-link" href="#example-4a4023db"></a> 
     <p>Consider this case where an absolutely positioned element is mixed
 with an overflow parent. Style sheet: </p>
-<pre>container { position: relative; border: solid; }
-scroller { overflow: scroll; height: 5em; margin: 5em; }
-satellite { position: absolute; top: 0; }
-content { height: 10em; }
+<pre>#container { position: relative; border: 2px solid black; }
+#scroller { overflow: scroll; height: 5em; margin: 5em; }
+#satellite { position: absolute; top: 0; }
+#content { height: 10em; }
 </pre>
     <p>Document fragment: </p>
 <pre>&lt;div id="container">

--- a/css-box/Overview.html
+++ b/css-box/Overview.html
@@ -3095,12 +3095,14 @@ satellite { position: absolute; top: 0; }
 content { height: 10em; }
 </pre>
     <p>Document fragment: </p>
-<pre>&lt;container>
- &lt;scroller>
-  &lt;satellite/>
-  &lt;content/>
- &lt;/scroller>
-&lt;/container>
+<pre>&lt;div id="container">
+ &lt;div id="scroller">
+  &lt;div id="satellite">
+  &lt;/div>
+  &lt;div id="content">
+  &lt;/div>
+ &lt;/div>
+&lt;/div>
 </pre>
     <p>In this example, the “scroller” element will not scroll the
 “satellite” element, because the latter’s containing block is


### PR DESCRIPTION
Example 26 has lot of errors. I've replaced ambiguous 'body' with 'content'.  Also attached all the container (or boxes/ pseudo code divs) names with actual css ids and replaced pseudo code like <scroller> with actual div tags. 