### PR TITLE
[selectors] Remove scoped <style> element

### DIFF
--- a/selectors/Overview.bs
+++ b/selectors/Overview.bs
@@ -1927,8 +1927,7 @@ The Reference Element Pseudo-class: '':scope''</h3>
 	In some contexts, selectors can be matched with an explicit set of <dfn dfn export lt=":scope element">:scope elements</dfn>.
 	This is is a (potentially empty) set of elements
 	that provide a reference point for selectors to match against,
-	such as that specified by the <code>querySelector()</code> call in [[DOM]],
-	or the parent element of a <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#the-style-element">scoped <code>&lt;style></code> element</a> in [[HTML5]].
+	such as that specified by the <code>querySelector()</code> call in [[DOM]].
 
 	The <dfn id='scope-pseudo'>:scope</dfn> pseudo-class represents any element that is a <a>:scope element</a>.
 	If the <a>:scope elements</a> are not explicitly specified,


### PR DESCRIPTION
Scoped style was removed from WHATWG HTML. See whatwg/html#552.