### PR TITLE
[css-transforms-2] Refer to offset, not motion

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -611,14 +611,14 @@ Current Transformation Matrix {#ctm}
 
 The <a>transformation matrix</a> computation is amended to the following:
 
-The transformation matrix is computed from the 'transform', 'transform-origin', 'translate', 'rotate', 'scale', and 'motion' properties as follows:
+The transformation matrix is computed from the 'transform', 'transform-origin', 'translate', 'rotate', 'scale', and 'offset' properties as follows:
 
 1. Start with the identity matrix.
 2. Translate by the computed X, Y, and Z values of 'transform-origin'.
 3. Translate by the computed X, Y, and Z values of 'translate'.
 4. Rotate by the computed <<angle>> about the specified axis of 'rotate'.
 5. Scale by the computed X, Y, and Z values of 'scale'.
-6. Translate and rotate by the transform specified by 'motion'.
+6. Translate and rotate by the transform specified by 'offset'.
 7. Multiply by each of the transform functions in 'transform' from left to right.
 8. Translate by the negated computed X, Y and Z values of 'transform-origin'.
 


### PR DESCRIPTION
The shorthand defined by CSS Motion Path is named
'offset', not 'motion'.
https://drafts.fxtf.org/motion-1/#propdef-offset

The 'Current Transformation Matrix' no longer refers
to the obsolete name 'motion'.