### PR TITLE
[css-animations][css-conditional][css-font-loading][cssom-view][cssom][mediaqueries] IDL: Use [Exposed] consistently

### DIFF
--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -906,7 +906,8 @@ The <code>AnimationEvent</code> Interface</h3>
 IDL Definition</h4>
 
 	<pre class="idl">
-		[Constructor(CSSOMString type, optional AnimationEventInit animationEventInitDict)]
+		[Exposed=Window,
+		 Constructor(CSSOMString type, optional AnimationEventInit animationEventInitDict)]
 		interface AnimationEvent : Event {
 		  readonly attribute CSSOMString animationName;
 		  readonly attribute float elapsedTime;
@@ -1087,6 +1088,7 @@ The <code>CSSKeyframeRule</code> Interface</h3>
 IDL Definition</h4>
 
 	<pre class="idl">
+ [Exposed=Window]
 	interface CSSKeyframeRule : CSSRule {
     attribute CSSOMString keyText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
@@ -1139,6 +1141,7 @@ The <code>CSSKeyframesRule</code> Interface</h3>
 IDL Definition</h4>
 
 	<pre class="idl">
+	[Exposed=Window]
 	interface CSSKeyframesRule : CSSRule {
 	           attribute CSSOMString name;
 	  readonly attribute CSSRuleList cssRules;

--- a/css-animations/Overview.bs
+++ b/css-animations/Overview.bs
@@ -1088,7 +1088,7 @@ The <code>CSSKeyframeRule</code> Interface</h3>
 IDL Definition</h4>
 
 	<pre class="idl">
- [Exposed=Window]
+	[Exposed=Window]
 	interface CSSKeyframeRule : CSSRule {
     attribute CSSOMString keyText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;

--- a/css-conditional/Overview.bs
+++ b/css-conditional/Overview.bs
@@ -832,6 +832,7 @@ The <code>CSSGroupingRule</code> interface</h3>
 <p>The {{CSSGroupingRule}} interface represents an at-rule that contains other rules nested inside itself.
 
 <pre class='idl'>
+[Exposed=Window]
 interface CSSGroupingRule : CSSRule {
     readonly attribute <a href="https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRuleList">CSSRuleList</a> cssRules;
     unsigned long insertRule (CSSOMString rule, unsigned long index);
@@ -889,6 +890,7 @@ all the &ldquo;conditional&rdquo; at-rules,
   which consist of a condition and a statement block.
 
 <pre class='idl' export>
+[Exposed=Window]
 interface CSSConditionRule : CSSGroupingRule {
     attribute CSSOMString conditionText;
 };
@@ -930,6 +932,7 @@ The <code>CSSMediaRule</code> interface</h3>
 <p>The {{CSSMediaRule}} interface represents a ''@media'' at-rule:
 
 <pre class='idl'>
+[Exposed=Window]
 interface CSSMediaRule : CSSConditionRule {
     [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
 };
@@ -955,6 +958,7 @@ The <code>CSSSupportsRule</code> interface</h3>
 <p>The {{CSSSupportsRule}} interface represents a ''@supports'' rule.</p>
 
 <pre class='idl'>
+[Exposed=Window]
 interface CSSSupportsRule : CSSConditionRule {
 };
 </pre>
@@ -985,6 +989,7 @@ The <code>CSSDocumentRule</code> interface</h3>
 <p>The {{CSSDocumentRule}} interface represents a ''@document'' rule.</p>
 
 <pre class='idl'>
+[Exposed=Window]
 interface CSSDocumentRule : CSSConditionRule {
 };
 </pre>

--- a/css-font-loading/Overview.bs
+++ b/css-font-loading/Overview.bs
@@ -93,7 +93,7 @@ The <code>FontFace</code> Interface</h2>
 
 		[Constructor(CSSOMString family, (CSSOMString or BinaryData) source,
 		             optional FontFaceDescriptors descriptors),
-		 Exposed=Window,Worker]
+		 Exposed=(Window,Worker)]
 		interface FontFace {
 			attribute CSSOMString family;
 			attribute CSSOMString style;
@@ -444,7 +444,7 @@ The <code>FontFaceSet</code> Interface</h2>
 		};
 
 		[Constructor(CSSOMString type, optional FontFaceSetLoadEventInit eventInitDict),
-		 Exposed=Window,Worker]
+		 Exposed=(Window,Worker)]
 		interface FontFaceSetLoadEvent : Event {
 			[SameObject] readonly attribute FrozenArray&lt;FontFace> fontfaces;
 		};
@@ -453,7 +453,7 @@ The <code>FontFaceSet</code> Interface</h2>
 
 		callback ForEachCallback = void (FontFace font, long index, FontFaceSet self);
 
-		[Exposed=Window,Worker,
+		[Exposed=(Window,Worker),
 		 Constructor(sequence&lt;FontFace> initialFaces)]
 		interface FontFaceSet : EventTarget {
 			// FontFaceSet is Set-like!

--- a/css-font-loading/Overview.bs
+++ b/css-font-loading/Overview.bs
@@ -1001,7 +1001,8 @@ Interaction with CSS Font Loading and Matching</h3>
 The <code>FontFaceSource</code> interface</h2>
 
 	<pre class='idl'>
-		[NoInterfaceObject]
+		[Exposed=(Window,Worker)
+		 NoInterfaceObject]
 		interface FontFaceSource {
 			readonly attribute FontFaceSet fonts;
 		};

--- a/css-regions/Overview.bs
+++ b/css-regions/Overview.bs
@@ -1224,7 +1224,8 @@ The Region interface</h3>
 	such as <a href="https://drafts.csswg.org/css3-page-template/#templates-and-slots">slots</a>) in an implementation which can be <a>CSS Regions</a>.
 
 	<pre class="idl">
-		[NoInterfaceObject]
+		[Exposed=Window,
+		 NoInterfaceObject]
 		interface Region {
 			readonly attribute CSSOMString regionOverset;
 			sequence&lt;Range&gt;? getRegionFlowRanges();

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -781,6 +781,7 @@ When asked to <dfn>evaluate media queries and report changes</dfn> for a {{Docum
 </div>
 
 <pre class=idl>
+[Exposed=Window]
 interface MediaQueryList : EventTarget {
   readonly attribute CSSOMString media;
   readonly attribute boolean matches;
@@ -836,7 +837,8 @@ as <a>event handler IDL attributes</a>, by all objects implementing the {{MediaQ
 </table>
 
 <pre class=idl>
-[Constructor(CSSOMString type, optional MediaQueryListEventInit eventInitDict)]
+[Exposed=Window,
+ Constructor(CSSOMString type, optional MediaQueryListEventInit eventInitDict)]
 interface MediaQueryListEvent : Event {
   readonly attribute CSSOMString media;
   readonly attribute boolean matches;
@@ -877,6 +879,7 @@ The <dfn attribute for=MediaQueryListEvent>matches</dfn> attribute must return t
 As its name suggests, the {{Screen}} interface represents information about the screen of the output device.
 
 <pre class=idl>
+[Exposed=Window]
 interface Screen {
   readonly attribute long availWidth;
   readonly attribute long availHeight;
@@ -1043,6 +1046,7 @@ A <dfn>caret position</dfn> gives the position of a text insertion point indicat
 <dfn>caret node</dfn>, <dfn>caret offset</dfn>, and <dfn>caret range</dfn>. It is represented by a {{CaretPosition}} object.
 
 <pre class=idl>
+[Exposed=Window]
 interface CaretPosition {
   readonly attribute Node offsetNode;
   readonly attribute unsigned long offset;

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1590,7 +1590,8 @@ dictionary ConvertCoordinateOptions {
   CSSBoxType toBox = "border";
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface GeometryUtils {
   sequence&lt;DOMQuad> getBoxQuads(optional BoxQuadOptions options);
   DOMQuad convertQuadFromNode(DOMQuadInit quad, GeometryNode from, optional ConvertCoordinateOptions options);

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -501,7 +501,8 @@ The {{MediaList}} Interface {#the-medialist-interface}
 An object that implements the <code>MediaList</code> interface has an associated <dfn export for=MediaList>collection of media queries</dfn>.
 
 <pre class=idl>
-[LegacyArrayClass]
+[Exposed=Window,
+ LegacyArrayClass]
 interface MediaList {
   stringifier attribute [TreatNullAs=EmptyString] CSSOMString mediaText;
   readonly attribute unsigned long length;
@@ -856,6 +857,7 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
 The {{StyleSheet}} interface represents an abstract, base style sheet.
 
 <pre class=idl>
+[Exposed=Window]
 interface StyleSheet {
   readonly attribute CSSOMString type;
   readonly attribute USVString? href;
@@ -893,6 +895,7 @@ is set, or false otherwise. On setting, the {{StyleSheet/disabled}} attribute mu
 The {{CSSStyleSheet}} interface represents a <a>CSS style sheet</a>.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSStyleSheet : StyleSheet {
   readonly attribute CSSRule? ownerRule;
   [SameObject] readonly attribute CSSRuleList cssRules;
@@ -1118,7 +1121,8 @@ value of the header.
 The {{StyleSheetList}} interface represents an ordered collection of <a>CSS style sheets</a>.
 
 <pre class=idl>
-[LegacyArrayClass]
+[Exposed=Window,
+ LegacyArrayClass]
 interface StyleSheetList {
   getter StyleSheet? item(unsigned long index);
   readonly attribute unsigned long length;
@@ -1635,7 +1639,8 @@ To <dfn export>remove a CSS rule</dfn> from a CSS rule list <var>list</var> at i
 The {{CSSRuleList}} interface represents an ordered collection of CSS style rules.
 
 <pre class=idl>
-[LegacyArrayClass]
+[Exposed=Window,
+ LegacyArrayClass]
 interface CSSRuleList {
   getter CSSRule? item(unsigned long index);
   readonly attribute unsigned long length;
@@ -1659,6 +1664,7 @@ distinct CSS style rule type is represented by a distinct interface that
 inherits from this interface.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSRule {
   const unsigned short STYLE_RULE = 1;
   const unsigned short CHARSET_RULE = 2; // historical
@@ -1724,6 +1730,7 @@ unreachable.
 The <code>CSSStyleRule</code> interface represents a style rule.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSStyleRule : CSSRule {
   attribute CSSOMString selectorText;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
@@ -1762,6 +1769,7 @@ one with greatest cascading order must be represented, at the same relative posi
 The <code>CSSImportRule</code> interface represents an <code>@import</code> at-rule.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSImportRule : CSSRule {
   readonly attribute USVString href;
   [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
@@ -1789,6 +1797,7 @@ list is simply empty, i.e., an <code>@import</code> at-rule always has an associ
 The <code>CSSGroupingRule</code> interface represents an at-rule that contains other rules nested inside itself.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSGroupingRule : CSSRule {
   [SameObject] readonly attribute CSSRuleList cssRules;
   unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
@@ -1822,6 +1831,7 @@ Issue: Need to define the rules for
 <dfn>serialize a list of CSS page selectors</dfn>.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSPageRule : CSSGroupingRule {
            attribute CSSOMString selectorText;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
@@ -1857,6 +1867,7 @@ The <code>CSSMarginRule</code> interface represents a margin at-rule (e.g. <code
 [[!CSS3PAGE]]
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSMarginRule : CSSRule {
   readonly attribute CSSOMString name;
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
@@ -1885,6 +1896,7 @@ margin at-rule, with the following properties:
 The <code>CSSNamespaceRule</code> interface represents an <code>@namespace</code> at-rule.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSNamespaceRule : CSSRule {
   readonly attribute CSSOMString namespaceURI;
   readonly attribute CSSOMString prefix;
@@ -2037,6 +2049,7 @@ The <code>CSSStyleDeclaration</code> interface represents a <a>CSS declaration b
 underlying state depends upon the source of the <code>CSSStyleDeclaration</Code> instance.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSStyleDeclaration {
   [CEReactions] attribute CSSOMString cssText;
   readonly attribute unsigned long length;
@@ -2756,6 +2769,7 @@ The <code>CSS.escape()</code> Method {#the-css.escape()-method}
 The <code>CSS</code> interface holds useful CSS-related functions that do not belong elsewhere.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSS {
   static CSSOMString escape(CSSOMString ident);
 };

--- a/cssom/Overview.bs
+++ b/cssom/Overview.bs
@@ -1201,7 +1201,8 @@ The <dfn>associated CSS style sheet</dfn> of a node is the <a>CSS style sheet</a
 interface.
 
 <pre class=idl>
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface LinkStyle {
   readonly attribute StyleSheet? sheet;
 };
@@ -2670,7 +2671,8 @@ The {{ElementCSSInlineStyle}} Interface {#the-elementcssinlinestyle-interface}
 The <code>ElementCSSInlineStyle</code> interface provides access to inline style properties of an element.
 
 <pre class=idl>
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface ElementCSSInlineStyle {
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };

--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -359,6 +359,7 @@ CSSOM</h2>
 	The <a interface>CSSCustomMediaRule</a> interface represents a ''@custom-media'' rule.
 
 	<pre class="idl">
+	[Exposed=Window]
 	interface CSSCustomMediaRule : CSSRule {
 		attribute CSSOMString name;
 		[SameObject, PutForwards=mediaText] readonly attribute MediaList media;


### PR DESCRIPTION
This is necessary for https://github.com/heycam/webidl/issues/365.

---

cc @annevk @tobie