### PR TITLE
[css-align] gap now consistent with longhands

### DIFF
--- a/css-align/Overview.bs
+++ b/css-align/Overview.bs
@@ -1695,12 +1695,12 @@ Gap Shorthand: the 'gap' property</h3>
 	<pre class='propdef'>
 	Name: gap
 	Value: <<'row-gap'>> <<'column-gap'>>?
-	Initial: 0 0
-	Applies to: <a>grid containers</a>
+	Initial: see individual properties
+	Applies to: <a>multi-column elements</a>, <a>flex containers</a>, <a>grid containers</a>
 	Inherited: no
 	Percentages: refer to corresponding dimension of the content area
 	Media: visual
-	Computed value: as specified, with <<length>>s made absolute
+	Computed value: see individual properties
 	Animatable: as length, percentage, or calc
 	</pre>
 


### PR DESCRIPTION
We refer to the longhands for the initial value and computed
value of 'gap'.

The longhands row-gap and column-gap apply to 'multi-column elements,
flex containers, grid containers', and the gap shorthand now applies
to these same elements, instead of only 'grid containers'.

resolves #1784