### PR TITLE
[cssom-view] Add notIfViewed to ScrollIntoViewOptions; add FocusScrollOptions

### DIFF
--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1073,14 +1073,15 @@ Note: This {{DOMRect}} object is not <a spec=html>live</a>.
 <h2 id=extension-to-the-element-interface>Extensions to the {{Element}} Interface</h2>
 
 <pre class=idl>
+enum ScrollIntoViewMode { "always", "if-needed" };
 enum ScrollLogicalPosition { "start", "center", "end", "nearest" };
 dictionary ScrollIntoViewOptions : ScrollOptions {
-  boolean notIfViewed = false;
+  ScrollIntoViewMode scroll = "always";
   ScrollLogicalPosition block = "start";
   ScrollLogicalPosition inline = "nearest";
 };
 dictionary FocusScrollOptions : ScrollOptions {
-  boolean notIfViewed = true;
+  ScrollIntoViewMode scroll = "if-needed";
   ScrollLogicalPosition block;
   ScrollLogicalPosition inline;
 };
@@ -1153,16 +1154,16 @@ The <dfn method for=Element caniuse=scrollintoview>scrollIntoView(<var>arg</var>
 1. Let <var>behavior</var> be "<code>auto</code>".
 1. Let <var>block</var> be "<code>start</code>".
 1. Let <var>inline</var> be "<code>nearest</code>".
-1. Let <var>notIfViewed</var> be false.
+1. Let <var>scrollMode</var> be "<code>always</code>".
 1. If <var>arg</var> is a {{ScrollIntoViewOptions}} dictionary, then:
     1. Set <var>behavior</var> to the {{ScrollOptions/behavior}} dictionary member of <var>options</var>.
     1. Set <var>block</var> to the {{ScrollIntoViewOptions/block}} dictionary member of <var>options</var>.
     1. Set <var>inline</var> to the {{ScrollIntoViewOptions/inline}} dictionary member of <var>options</var>.
-    1. Set <var>notIfViewed</var> to the {{ScrollIntoViewOptions/notIfViewed}} dictionary member of <var>options</var>.
+    1. Set <var>scrollMode</var> to the {{ScrollIntoViewOptions/scroll}} dictionary member of <var>options</var>.
 1. Otherwise, if <var>arg</var> is false, then set <var>block</var> to "<code>end</code>".
 1. If the element does not have any associated <a>layout box</a>, then return.
 1. <a lt='scroll an element into view'>Scroll the element into view</a>
-    with <var>behavior</var>, <var>block</var>, <var>inline</var>, and <var>notIfViewed</var>.
+    with <var>behavior</var>, <var>block</var>, <var>inline</var>, and <var>scrollMode</var>.
 1. Optionally perform some other action that brings the element to the user's attention.
 
 The <dfn method for=Element lt="scroll(options)|scroll(x, y)">scroll()</dfn> method must run these steps:
@@ -1315,7 +1316,7 @@ The <dfn attribute for=Element>clientHeight</dfn> attribute must run these steps
 
 To <dfn>scroll an element into view</dfn> <var>element</var>,
 with a scroll behavior <var>behavior</var>,
-a boolean indicating to not scroll if the element is already in view <var>notIfViewed</var>,
+a mode indicating whether to scroll if the element is already in view <var>scrollMode</var>,
 optionally a block flow direction position <var>block</var> (undefined if not given),
 and optionally an inline base direction position <var>inline</var> (undefined if not given),
 means to run these steps for each ancestor element or <a>viewport</a> that establishes
@@ -1329,7 +1330,7 @@ a <a>scrolling box</a> <var>scrolling box</var>, in order of innermost to outerm
 1. Let <var>scrolling box edge D</var> be the <a>ending edge</a> in the <a>inline base direction</a> of <var>scrolling box</var>, and let <var>element edge D</var> be <var>element bounding border box</var>'s edge on the same physical side as that of <var>scrolling box edge D</var>.
 1. Let <var>element width</var> be the distance between <var>element edge C</var> and <var>element edge D</var>.
 1. Let <var>scrolling box width</var> be the distance between <var>scrolling box edge C</var> and <var>scrolling box edge D</var>.
-1. If <var>notIfViewed</var> is true, and <var>element</var> is entirely in view already, then return.
+1. If <var>scrollMode</var> is "<code>if-needed</code>", and <var>element</var> is entirely in view already, then return.
 
         ISSUE: Define "entirely in view".
 

--- a/cssom-view/Overview.bs
+++ b/cssom-view/Overview.bs
@@ -1075,8 +1075,14 @@ Note: This {{DOMRect}} object is not <a spec=html>live</a>.
 <pre class=idl>
 enum ScrollLogicalPosition { "start", "center", "end", "nearest" };
 dictionary ScrollIntoViewOptions : ScrollOptions {
+  boolean notIfViewed = false;
   ScrollLogicalPosition block = "start";
   ScrollLogicalPosition inline = "nearest";
+};
+dictionary FocusScrollOptions : ScrollOptions {
+  boolean notIfViewed = true;
+  ScrollLogicalPosition block;
+  ScrollLogicalPosition inline;
 };
 
 partial interface Element {
@@ -1099,6 +1105,13 @@ partial interface Element {
   readonly attribute long clientHeight;
 };
 </pre>
+
+The {{ScrollIntoViewOptions}} dictionary is used by {{Element/scrollIntoView()}} and similar APIs
+that primarily scroll something into view.
+
+The {{FocusScrollOptions}} dictionary is similar to {{ScrollIntoViewOptions}}, but has different
+defaults, and is used by {{HTMLElement}}'s {{HTMLElement/focus()}} and similar APIs that primarily
+move focus to something, or equivalent, and secondarily scroll it into view.
 
 The <dfn method for=Element>getClientRects()</dfn> method, when invoked, must return the result of the following algorithm:
 
@@ -1140,14 +1153,16 @@ The <dfn method for=Element caniuse=scrollintoview>scrollIntoView(<var>arg</var>
 1. Let <var>behavior</var> be "<code>auto</code>".
 1. Let <var>block</var> be "<code>start</code>".
 1. Let <var>inline</var> be "<code>nearest</code>".
+1. Let <var>notIfViewed</var> be false.
 1. If <var>arg</var> is a {{ScrollIntoViewOptions}} dictionary, then:
     1. Set <var>behavior</var> to the {{ScrollOptions/behavior}} dictionary member of <var>options</var>.
     1. Set <var>block</var> to the {{ScrollIntoViewOptions/block}} dictionary member of <var>options</var>.
     1. Set <var>inline</var> to the {{ScrollIntoViewOptions/inline}} dictionary member of <var>options</var>.
+    1. Set <var>notIfViewed</var> to the {{ScrollIntoViewOptions/notIfViewed}} dictionary member of <var>options</var>.
 1. Otherwise, if <var>arg</var> is false, then set <var>block</var> to "<code>end</code>".
 1. If the element does not have any associated <a>layout box</a>, then return.
 1. <a lt='scroll an element into view'>Scroll the element into view</a>
-    with <var>behavior</var>, <var>block</var>, and <var>inline</var>.
+    with <var>behavior</var>, <var>block</var>, <var>inline</var>, and <var>notIfViewed</var>.
 1. Optionally perform some other action that brings the element to the user's attention.
 
 The <dfn method for=Element lt="scroll(options)|scroll(x, y)">scroll()</dfn> method must run these steps:
@@ -1300,8 +1315,9 @@ The <dfn attribute for=Element>clientHeight</dfn> attribute must run these steps
 
 To <dfn>scroll an element into view</dfn> <var>element</var>,
 with a scroll behavior <var>behavior</var>,
-a block flow direction position <var>block</var>,
-and an inline base direction position <var>inline</var>,
+a boolean indicating to not scroll if the element is already in view <var>notIfViewed</var>,
+optionally a block flow direction position <var>block</var> (undefined if not given),
+and optionally an inline base direction position <var>inline</var> (undefined if not given),
 means to run these steps for each ancestor element or <a>viewport</a> that establishes
 a <a>scrolling box</a> <var>scrolling box</var>, in order of innermost to outermost <a>scrolling box</a>:
 
@@ -1313,6 +1329,15 @@ a <a>scrolling box</a> <var>scrolling box</var>, in order of innermost to outerm
 1. Let <var>scrolling box edge D</var> be the <a>ending edge</a> in the <a>inline base direction</a> of <var>scrolling box</var>, and let <var>element edge D</var> be <var>element bounding border box</var>'s edge on the same physical side as that of <var>scrolling box edge D</var>.
 1. Let <var>element width</var> be the distance between <var>element edge C</var> and <var>element edge D</var>.
 1. Let <var>scrolling box width</var> be the distance between <var>scrolling box edge C</var> and <var>scrolling box edge D</var>.
+1. If <var>notIfViewed</var> is true, and <var>element</var> is entirely in view already, then return.
+
+        ISSUE: Define "entirely in view".
+
+1. If <var>block</var> is undefined, set <var>block</var> to a UA-defined value.
+1. If <var>inline</var> is undefined, set <var>inline</var> to a UA-defined value.
+
+        ISSUE: Define defaults for <var>block</var> and <var>inline</var> for {{FocusScrollOptions}}.
+
 1. Let <var>position</var> be the scroll position <var>scrolling box</var> would have by following these steps:
 
     1. If <var>block</var> is "<code>start</code>", then align <var>element edge A</var> with <var>scrolling box edge A</var>.


### PR DESCRIPTION
notIfViewed was originally suggested in
http://www.w3.org/mid/CAE3TfZPmNWvz1z7XPqFjtg5S+m_9BOmNNHsOZuSrR2z2AgyNHA@mail.gmail.com

Now it is needed for HTMLElement focus(options) to match the behavior
of focus() in browsers. Since the defaults for focus() is different
from the defaults for scrollIntoView(), a new dictionary
FocusScrollOptions is introduced. For now the defaults for block
and inline are UA-defined.

https://github.com/whatwg/html/pull/2787#issuecomment-328397430