### PR TITLE
Fix typo (<var> wanted to be </var)

### DIFF
--- a/css-flexbox/Overview.bs
+++ b/css-flexbox/Overview.bs
@@ -2798,7 +2798,7 @@ Flex Container Intrinsic Main Sizes</h4>
 
 		<li>
 			For each <a>flex item</a>,
-			find its <var>max-content flex fraction<var>:
+			find its <var>max-content flex fraction</var>:
 			Subtract its outer <a>flex base size</a> from its [[#intrinsic-item-contributions|max-content contribution]] size.
 			If that result is positive,
 			divide by its <a>flex grow factor</a> floored at 1;


### PR DESCRIPTION
This fixes a typo in @fantasai's commit https://github.com/w3c/csswg-drafts/commit/1ddd3039929a92d20a63dd3ae5cbc6996b7fa702

(Without this typo-fix, a bunch of this paragraph ends up being incorrectly italicized.)