### PR TITLE
Related to #1821, the change to "check if two code points are a valid escape" makes part of "consume an escaped code point" unreachable.

### DIFF
--- a/css-syntax/Overview.bs
+++ b/css-syntax/Overview.bs
@@ -1274,7 +1274,7 @@ Consume an escaped code point</h4>
 	This section describes how to <dfn>consume an escaped code point</dfn>.
 	It assumes that the U+005C REVERSE SOLIDUS (\) has already been consumed
 	and that the next input code point has already been verified
-	to not be a <a>newline</a>.
+	to not be a <a>newline</a> or EOF.
 	It will return a <a>code point</a>.
 
 	Consume the <a>next input code point</a>.
@@ -1293,11 +1293,6 @@ Consume an escaped code point</h4>
 			or is greater than the <a>maximum allowed code point</a>,
 			return U+FFFD REPLACEMENT CHARACTER (�).
 			Otherwise, return the <a>code point</a> with that value.
-
-		<dt>EOF code point
-		<dd>
-			This is a <a>parse error</a>.
-			Return U+FFFD REPLACEMENT CHARACTER (�).
 
 		<dt>anything else
 		<dd>


### PR DESCRIPTION
@tabatkins I think this falls out of the change made earlier — there are no paths to "consume an escaped code point" which are not preceded by the check, so EOF is not possible at this juncture now.