### PR TITLE
[css-break] Remove <i> autolinks

### DIFF
--- a/css-break/Overview.bs
+++ b/css-break/Overview.bs
@@ -58,7 +58,7 @@ Module Interactions</h3>
 <h3 id="values">
 Values</h3>
 
-  This specification follows the <a href="https://www.w3.org/TR/CSS21/about.html#property-defs">CSS property definition conventions</a> from [[!CSS2]].
+  This specification follows the <a href="https://www.w3.org/TR/CSS21/about.html#property-defs">CSS property definition conventions</a> from [[!CSS21]].
   Value types not defined in this specification are defined in CSS Values & Units [[!CSS-VALUES-3]].
   Other CSS modules may expand the definitions of these value types.
 

--- a/css-break/Overview.bs
+++ b/css-break/Overview.bs
@@ -16,7 +16,6 @@ Abstract:  This module describes the fragmentation model that partitions a flow 
 Abstract:  It builds on the Page model module and introduces and defines the fragmentation model.
 Abstract:  It adds functionality for pagination, breaking variable fragment size and orientation, widows and orphans.
 Ignored Terms: background positioning area, region chain, … message topic …, reference box
-Use <i> Autolinks: yes
 At Risk: the ''region'' and ''break-after/avoid-region'' values of 'break-*'
 </pre>
 
@@ -40,8 +39,8 @@ Introduction</h2>
     and <a href="https://www.w3.org/TR/css3-multicol/">multi-column layout</a>
     [[CSS3COL]] create a similarly fragmented environment.
     The generic term for breaking content across containers is
-    <i>fragmentation</i>.
-    This module explains how content breaks across <i>fragmentation containers</i> (<i>fragmentainers</i>)
+    <a>fragmentation</a>.
+    This module explains how content breaks across <a>fragmentation containers</a> (<a>fragmentainers</a>)
     such as pages and columns and how such breaks can be
     <a href="#breaking-controls">controlled by the author</a>.
   </p>
@@ -75,43 +74,43 @@ Fragmentation Model and Terminology</h2>
     <dt><dfn>fragmentation container</dfn> (<dfn>fragmentainer</dfn>)</dt>
     <dd>
       A box&mdash;such as a page box, column box, or region&mdash;that contains
-      a portion (or all) of a <i>fragmented flow</i>.
+      a portion (or all) of a <a>fragmented flow</a>.
       Fragmentainers can be pre-defined, or generated as needed.
       When breakable content would overflow a fragmentainer in the block dimension,
-      it breaks into the next container in its <i>fragmentation context</i>
+      it breaks into the next container in its <a>fragmentation context</a>
       instead.
     </dd>
     <dt><dfn>fragmentation context</dfn></dt>
     <dd>
-      An ordered series of <i>fragmentainers</i>,
+      An ordered series of <a>fragmentainers</a>,
       such as created by a <a href="https://www.w3.org/TR/css3-multicol/">multi-column element</a>,
       a chain of <a href="https://www.w3.org/TR/css3-regions">CSS regions</a>,
       or a <a href="https://www.w3.org/TR/css3-page/">paged media display</a>.
       A given fragmentation context can only have one block flow direction
-      across all its <i>fragmentainers</i>.
-      (Descendants of the <i>fragmentation root</i> may have other block flow directions,
-      but fragmentation proceeds according to the block flow direction applied to the <i>fragmentation root</i>.)
+      across all its <a>fragmentainers</a>.
+      (Descendants of the <a>fragmentation root</a> may have other block flow directions,
+      but fragmentation proceeds according to the block flow direction applied to the <a>fragmentation root</a>.)
     </dd>
     <dt><dfn>fragmented flow</dfn></dt>
     <dd>
-      Content that is being laid out in a <i>fragmentation context</i>.
-      The <i>fragmented flow</i> consists of the content of a (possibly anonymous) box
+      Content that is being laid out in a <a>fragmentation context</a>.
+      The <a>fragmented flow</a> consists of the content of a (possibly anonymous) box
       called the <dfn>fragmentation root</dfn>.
     </dd>
     <dt><dfn>fragmentation direction</dfn></dt>
     <dd>
-      The block flow direction of the <i>fragmentation context</i>,
+      The block flow direction of the <a>fragmentation context</a>,
       i.e. the direction in which content is fragmented.
       (In this level of CSS, content only fragments in one dimension.)
     </dd>
     <dt><dfn>fragmentation</dfn></dt>
     <dd>
-      The process of splitting a content flow across the <i>fragmentainers</i>
-      that form a <i>fragmentation context</i>.
+      The process of splitting a content flow across the <a>fragmentainers</a>
+      that form a <a>fragmentation context</a>.
     </dd>
     <dt><dfn>box fragment</dfn> or <dfn>fragment</dfn></dt>
     <dd>
-      The portion of a box that belongs to exactly one <i>fragmentainer</i>.
+      The portion of a box that belongs to exactly one <a>fragmentainer</a>.
       A box in continuous flow always consists of only one fragment.
       A box in a fragmented flow consists of one or more fragments.
       Each fragment has its own share of the box’s border, padding, and margin,
@@ -123,16 +122,16 @@ Fragmentation Model and Terminology</h2>
       (See 'box-decoration-break', which controls how these are affected by fragmentation.)
     <dt><dfn>remaining fragmentainer extent</dfn></dt>
     <dd>
-      The remaining <i>block-axis</i> space in the <i>fragmentainer</i> available to a given element,
-      i.e. between the end of preceding content in <i>fragmentainer</i>
-      and the edge of the <i>fragmentainer</i>.
+      The remaining <a>block-axis</a> space in the <a>fragmentainer</a> available to a given element,
+      i.e. between the end of preceding content in <a>fragmentainer</a>
+      and the edge of the <a>fragmentainer</a>.
   </dl>
 
   <p>
     Each <dfn>fragmentation break</dfn> (hereafter, <dfn>break</dfn>)
-    ends layout of the fragmented box in the current <i>fragmentainer</i>
-    and causes the remaining content to be laid out in the next <i>fragmentainer</i>,
-    in some cases causing a new <i>fragmentainer</i> to be generated
+    ends layout of the fragmented box in the current <a>fragmentainer</a>
+    and causes the remaining content to be laid out in the next <a>fragmentainer</a>,
+    in some cases causing a new <a>fragmentainer</a> to be generated
     to hold the deferred content.
   </p>
 
@@ -178,24 +177,24 @@ Parallel Fragmentation Flows</h3>
     Content overflowing the content edge of a fixed-size box
     is considered parallel to the content after the fixed-size box
     and follows the normal fragmentation rules.
-    Although overflowing content doesn't affect the size of the <i>fragmentation root</i> box,
-    it does increase the length of the <i>fragmented flow</i>,
-    spilling into or generating additional <i>fragmentainers</i> as necessary.
+    Although overflowing content doesn't affect the size of the <a>fragmentation root</a> box,
+    it does increase the length of the <a>fragmented flow</a>,
+    spilling into or generating additional <a>fragmentainers</a> as necessary.
   </p>
 
 <h3 id="nested-flows">
 Nested Fragmentation Flows</h3>
 
   <p>
-    Breaking a <i>fragmentainer</i> <var>F</var> effectively splits the <i>fragmentainer</i>
-    into two <i>fragmentainers</i> (<var>F<sub>1</sub></var> and <var>F<sub>2</sub></var>).
+    Breaking a <a>fragmentainer</a> <var>F</var> effectively splits the <a>fragmentainer</a>
+    into two <a>fragmentainers</a> (<var>F<sub>1</sub></var> and <var>F<sub>2</sub></var>).
     The only difference is that,
-    with regards to the content of <i>fragmentainer</i> <var>F</var>,
+    with regards to the content of <a>fragmentainer</a> <var>F</var>,
     the type of break
     between the two pieces <var>F<sub>1</sub></var> and <var>F<sub>2</sub></var>
     is the <a href="#break-types">type of break</a> created
-    by the <i>fragmentation context</i> that split <var>F</var>,
-    not the type of break normally created by <var>F</var>’s own <i>fragmentation context</i>.
+    by the <a>fragmentation context</a> that split <var>F</var>,
+    not the type of break normally created by <var>F</var>’s own <a>fragmentation context</a>.
   </p>
 
   <div class="example">
@@ -215,7 +214,7 @@ Nested Fragmentation Flows</h3>
 Controlling Breaks</h2>
 
   <p>
-    The following sections explain how breaks are controlled in a <i>fragmented flow</i>.
+    The following sections explain how breaks are controlled in a <a>fragmented flow</a>.
     A page/column/region break opportunity between two boxes
     is under the influence of
     the containing block's 'break-inside' property,
@@ -268,7 +267,7 @@ Breaks Between Boxes: the 'break-before' and 'break-after' properties</h3>
 
   <p>
     Values for 'break-before' and 'break-after' are defined in the sub-sections below.
-    User Agents must apply these properties to boxes in the normal flow of the <i>fragmentation root</i>.
+    User Agents must apply these properties to boxes in the normal flow of the <a>fragmentation root</a>.
     User agents should also apply these properties to floated boxes
     whose containing block is in the normal flow of the root fragmented element.
     User agents may also apply these properties to other boxes.
@@ -320,13 +319,13 @@ Page Break Values</h4>
     <dd>
       Force one or two page breaks before/after the <a href="https://www.w3.org/TR/CSS21/visuren.html#block-boxes">principal box</a> so that
       the next page is formatted as either a left page or a right page,
-      whichever is second (according to the <i>page progression</i>) in a page spread.
+      whichever is second (according to the <a>page progression</a>) in a page spread.
     </dd>
     <dt><dfn>verso</dfn>
     <dd>
       Force one or two page breaks before/after the <a href="https://www.w3.org/TR/CSS21/visuren.html#block-boxes">principal box</a> so that
       the next page is formatted as either a left page or a right page,
-      whichever is first (according to the <i>page progression</i>) in a page spread.
+      whichever is first (according to the <a>page progression</a>) in a page spread.
     </dd>
   </dl>
 
@@ -420,10 +419,10 @@ Breaks Between Lines: 'orphans', 'widows'</h3>
   <p>
     The 'orphans' property specifies the minimum number
     of line boxes in a block container
-    that must be left in a <i>fragment</i> <em>before</em> a fragmentation break.
+    that must be left in a <a>fragment</a> <em>before</em> a fragmentation break.
     The 'widows' property specifies the minimum number
     of line boxes of a block container
-    that must be left in a <i>fragment</i> <em>after</em> a break.
+    that must be left in a <a>fragment</a> <em>after</em> a break.
     Examples of how they are used to control fragmentation breaks are given
     <a href="#widows-orphans-example">below</a>.
   </p>
@@ -474,7 +473,7 @@ Rules for Breaking</h2>
 
   <p>
 	To guarantee progress, fragmentainers are assumed to have a minimum
-	<i>block size</i> of 1px regardless of their used size.
+	<a>block size</a> of 1px regardless of their used size.
 
 <h3 id="possible-breaks">
 Possible Break Points</h3>
@@ -544,7 +543,7 @@ Possible Break Points</h3>
 
   <p>
     In addition to any content which is not generally fragmentable,
-    UAs may consider as <i>monolithic</i> any elements with
+    UAs may consider as <a>monolithic</a> any elements with
     'overflow' set to ''overflow/auto'' or ''overflow/scroll'' and
     any elements with ''overflow: hidden'' and a non-''height/auto''
     <a href="https://www.w3.org/TR/css3-writing-modes/#block-size">logical height</a>
@@ -580,16 +579,16 @@ Types of Breaks</h3>
     <dd>
       A break between two <a href="https://www.w3.org/TR/css3-multicol/#column-box">column boxes</a>.
       Note that if the column boxes are on different pages, then the break is
-      also a <i>page break</i>.
+      also a <a>page break</a>.
       Similarly, if the column boxes are in different regions,
-      then the break is also a <i>region break</i>.
+      then the break is also a <a>region break</a>.
       [[!CSS3COL]]
     </dd>
     <dt><dfn>region break</dfn></dt>
     <dd>
       A break between two <a href="https://www.w3.org/TR/css3-regions/#regions">regions</a>.
       Note that if the region boxes are on different pages, then the break is
-      also a <i>page break</i>.
+      also a <a>page break</a>.
       [[!CSS3-REGIONS]]
     </dd>
   </dl>
@@ -604,15 +603,15 @@ Forced Breaks</h3>
 
   <p>
     A <dfn>forced break</dfn> is one explicitly indicated by the style sheet author.
-    A <i>forced break</i> occurs at a <a href="#btw-blocks">class A break point</a> if,
+    A <a>forced break</a> occurs at a <a href="#btw-blocks">class A break point</a> if,
     among the 'break-after' properties specified on or propagated to the earlier sibling box
     and the 'break-before' properties specified on or propagated to the later sibling box
-    there is at least one with a <i>forced break value</i>.
-    (Thus a <i>forced break value</i> effectively overrides any <i>avoid break value</i>
+    there is at least one with a <a>forced break value</a>.
+    (Thus a <a>forced break value</a> effectively overrides any <a>avoid break value</a>
     that also applies at that break point.)
   </p>
   <p>
-    When multiple <i>forced break values</i> apply to a single break point,
+    When multiple <a>forced break values</a> apply to a single break point,
     they combine such that all types of break are honored.
     When ''left'', ''right'', ''recto'', and/or ''verso'' are combined,
     the value specified on the latest element in the flow wins.
@@ -637,7 +636,7 @@ Unforced Breaks</h3>
     While <a href="#breaking-controls">breaking controls</a> can force breaks,
     they can also discourage them.
     An <dfn>unforced break</dfn> is one that is inserted automatically by the UA
-    in order to prevent content from overflowing the <i>fragmentainer</i>.
+    in order to prevent content from overflowing the <a>fragmentainer</a>.
     The following rules control whether unforced breaking
     at a <a href="#possible-breaks">possible break point</a> is allowed:
   </p>
@@ -673,7 +672,7 @@ Unforced Breaks</h3>
 
   <p>
     If the above doesn't provide enough break points to keep content from
-    overflowing the <i>fragmentainer</i>,
+    overflowing the <a>fragmentainer</a>,
     then rule 3 is dropped to provide more break points.
   </p>
 
@@ -699,7 +698,7 @@ Unforced Breaks</h3>
     and not all the content fits, the UA may break anywhere
     in order to avoid losing content off the edge of the fragmentainer.
     <span id="monolithic-breaking">
-    In such cases, the UA may also fragment the contents of <i>monolithic</i> elements
+    In such cases, the UA may also fragment the contents of <a>monolithic</a> elements
     by slicing the element's graphical representation.
     However, the UA must not break at the top of the page,
     i.e. it must place at least some content on each fragmentainer,
@@ -795,16 +794,16 @@ Breaking into Varying-size Fragmentainers</h3>
       across fragmentainers of this size. Progress is measured in percentages
       (not absolute lengths) of used/remaining fragmentainer extent and in amount of
       used/remaining content.
-      However, when laying out <i>monolithic</i> elements,
-      the UA may instead maintain a consistent <i>inline size</i> and resolved <i>block size</i>
+      However, when laying out <a>monolithic</a> elements,
+      the UA may instead maintain a consistent <a>inline size</a> and resolved <a>block size</a>
       across fragmentainers.
     </li>
     <li>
       Fragments of boxes that began on a previous fragmentainer must obey
       placement rules with the additional constraint that fragments must
-      not be positioned above the <i>block-start</i> edge of the fragmentainer.
+      not be positioned above the <a>block-start</a> edge of the fragmentainer.
       If this results in a box's continuation fragment
-      shifting away from the <i>block-start</i> edge of the fragmentainer, then
+      shifting away from the <a>block-start</a> edge of the fragmentainer, then
       ''box-decoration-break: clone'', if specified, wraps the fragment
       with the box's margin in addition to its padding and border.
       <div class="figure">
@@ -829,13 +828,13 @@ Breaking into Varying-size Fragmentainers</h3>
   <ul>
     <li>
       Boxes (including tables) fullfilling layout constraints at their
-      <i lt='stretch-fit size'>stretch-fit</i> or percentage-based size
-      may change <i>inline size</i> across pages.
+      <i lt='stretch-fit size'>stretch-fit</a> or percentage-based size
+      may change <a>inline size</a> across pages.
     </li>
     <li>
       Boxes (including tables) fulfilling layout constraints at their
-      <i lt="min-content size">min-content</i>, <i lt="max-content size">max-content</i>, or absolute-length size
-      will maintain their <i>inline size</i> across pages.
+      <i lt="min-content size">min-content</a>, <i lt="max-content size">max-content</a>, or absolute-length size
+      will maintain their <a>inline size</a> across pages.
     </li>
     <li>
       A block-level continuation fragment may be placed below the top of
@@ -889,7 +888,7 @@ Adjoining Margins at Breaks</h3>
 
   <p>
     When an unforced break occurs between block-level boxes,
-    any margins adjoining the break truncate to the <i>remaining fragmentainer extent</i> before the break,
+    any margins adjoining the break truncate to the <a>remaining fragmentainer extent</a> before the break,
     and are truncated to zero after the break.
     When a forced break occurs there, adjoining margins before the break are truncated,
     but margins after the break are preserved.
@@ -901,16 +900,16 @@ Splitting Boxes</h3>
 
   <p>
     When a box breaks,
-    its content box extends to fill any <i>remaining fragmentainer extent</i>
+    its content box extends to fill any <a>remaining fragmentainer extent</a>
     (leaving room for any margins/borders/padding applied by ''box-decoration-break: clone'')
-    before the content resumes on the next <i>fragmentainer</i>.
-    (A <i>fragmentation break</i> that pushes content to the next <i>fragmentainer</i>
-     effectively increases the <i>block size</i> of a box's contents.)
+    before the content resumes on the next <a>fragmentainer</a>.
+    (A <a>fragmentation break</a> that pushes content to the next <a>fragmentainer</a>
+     effectively increases the <a>block size</a> of a box's contents.)
 
   <p class="note">
-    The extra <i>block size</i> contributed by fragmenting the box
-    (i.e. the distance from the break point to the edge of the <i>fragmentainer</i>)
-    contributes progress towards any specified limits on the box's <i>block size</i>.
+    The extra <a>block size</a> contributed by fragmenting the box
+    (i.e. the distance from the break point to the edge of the <a>fragmentainer</a>)
+    contributes progress towards any specified limits on the box's <a>block size</a>.
 
   <div class="figure">
     <p><img
@@ -918,7 +917,7 @@ Splitting Boxes</h3>
       src="images/Remaining-Fragmentainer-Extent.svg"
       alt="Illustration: Filling remaining fragmentainer extent">
     <p class="caption">
-      Illustration of filling the <i>remaining fragmentainer extent</i>.
+      Illustration of filling the <a>remaining fragmentainer extent</a>.
     </p>
   </div>
 
@@ -939,7 +938,7 @@ Fragmented Borders and Backgrounds: the 'box-decoration-break' property</h3>
   <ul>
     <li>whether the box's margins, borders, padding, and other decorations
       wrap the broken edges of the box fragments
-    <li>how the <a href="https://www.w3.org/TR/css3-background/#background-positioning-area"><i>background positioning area</i></a> [[!CSS3BG]]
+    <li>how the <a href="https://www.w3.org/TR/css3-background/#background-positioning-area"><a>background positioning area</a></a> [[!CSS3BG]]
       (and <a>mask positioning area</a> [[!CSS-MASKING-1]],
       shape <a>reference box</a> [[!CSS-SHAPES-1]], etc.)
       is derived from or duplicated across the box fragments
@@ -1015,7 +1014,7 @@ Joining Boxes for ''slice''</h4>
     <dd>
       First, fragments on the same line are connected in visual order.
       Then, fragments on subsequent lines are ordered
-      according to the element's <i>inline base direction</i>
+      according to the element's <a>inline base direction</a>
       and aligned on the element's dominant baseline.
       For example, in a left-to-right containing block ('direction' is ''ltr''),
       the first fragment is the leftmost fragment on the first line
@@ -1028,19 +1027,19 @@ Joining Boxes for ''slice''</h4>
     <dt>For boxes broken across columns</dt>
     <dd>
       Fragments are connected as if the column boxes were glued together
-      in the <i>block flow direction</i> of the multi-column element.
+      in the <a>block flow direction</a> of the multi-column element.
     </dd>
 
     <dt>For boxes broken across pages</dt>
     <dd>
       Fragments are connected as if page content areas were glued together
-      in the <i>block flow direction</i> of the root element.
+      in the <a>block flow direction</a> of the root element.
     </dd>
 
     <dt>For boxes broken across regions</dt>
     <dd>
       Fragments are connected as if region content areas were glued together
-      in the <i>block flow direction</i> of the <i>principal writing mode</i> of the <i>region chain</i>.
+      in the <a>block flow direction</a> of the <a>principal writing mode</a> of the <a>region chain</a>.
     </dd>
   </dl>
 
@@ -1092,8 +1091,8 @@ Transforms, Positioning, and Pagination</h3>
     will fragment across fragmentainers in the same fragmentation flow as the containing block.
 
   <p>
-    UAs are not required to correctly position boxes that span a <i>fragmentation break</i>
-    and whose <i>block-start</i> edge position depends on where the box's content fragments.
+    UAs are not required to correctly position boxes that span a <a>fragmentation break</a>
+    and whose <a>block-start</a> edge position depends on where the box's content fragments.
 
   <p>
     UAs with memory constraints that prevent them from manipulating an entire document in memory


### PR DESCRIPTION
According to tabatkins/bikeshed#1042, `<i>` autolinks will be removed in the future.