### PR TITLE
Spelling & grammar markers

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -450,6 +450,13 @@ Selecting Highlighted Content: the ''::selection'',  ''::inactive-selection'', '
       a portion of text that has been flagged by the user agent as grammatically incorrect.
   </dl>
 
+
+    The following addition is made to the default UA stylesheet:
+	<pre><code class="lang-css">
+		::spelling-error { text-decoration-line: spelling-error; }
+		::grammar-error { text-decoration-line: grammar-error; }
+	</code></pre>
+
   Note: A future level of CSS may introduce ways to create
   custom highlight pseudo-elements.
 
@@ -915,6 +922,7 @@ Changes</h2>
     <li>Defined handling of text decorations on ''::selection'' to match IE's more sensible behavior.
     <li>Links to pseudo-element OM design discussions.
     <li>Various minor clarifications.
+    <li>Use ''spelling-error'' and ''grammar-error'' with ''::spelling-error'' and ''::grammar-error'' in the UA stylesheet.
   </ul>
 
 <h2 class="no-num" id="acknowledgements">

--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -18,6 +18,7 @@ Abstract: This module contains the features of CSS relating to text decoration, 
 At Risk: The 'text-decoration-skip' property.
 At Risk: The line positioning rules.
 At Risk: The ability to place both emphasis marks and ruby on the same base text.
+At Risk: The ''spelling-error'' and ''grammar-error'' values of the 'text-decoration-line' property.
 Link Defaults: css-color-3 (property) color
 Use <i> Autolinks: yes
 </pre>
@@ -179,7 +180,7 @@ Text Decoration Lines: the 'text-decoration-line' property</h3>
 
   <pre class="propdef">
   Name: text-decoration-line
-  Value: none | [ underline || overline || line-through || blink ]
+  Value: none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error
   Initial: none
   Inherited: no (but see prose, above)
   </pre>
@@ -203,7 +204,26 @@ Text Decoration Lines: the 'text-decoration-line' property</h3>
         Conforming user agents may simply not blink the text.
         Note that not blinking the text is one technique to satisfy <a href="https://www.w3.org/TR/UAAG/guidelines.html#tech-on-off-blinking-text">checkpoint 3.3 of WAI-UAAG</a>.
         This value is <strong>deprecated</strong> in favor of Animations [[CSS3-ANIMATIONS]].
+    <dt><dfn value for="text-tecoration-line">spelling-error</dfn>
+      <dd>This values indicates the type of text decoration used by the User Agent
+          to highlight spelling mistakes.
+	  It's appearance is UA defined.
+	  <span class=note>It is often rendered as a red wavy underline.</span>
+    <dt><dfn value for="text-decoration-line">grammar-error</dfn>
+      <dd>This values indicates the type of text decoration used by the User Agent
+          to highlight grammar mistakes.
+	  It's appearance is UA defined.
+	  <span class=note>It is often rendered as a green wavy underline.</span>
   </dl>
+
+    When the value of 'text-decoration-line' is either ''spelling-error'' or ''grammar-error'',
+    the UA may disregard the values of the other <a>sub-properties</a> of 'text-decoration',
+    as well as those of other properties affecting the appearance of the text-decoration such as 'text-underline-position'.
+    To the extent that honoring these properties would be meaningful and practical given the UA's chosen rendering,
+    the UA should apply them, but is not required to.
+
+    Note: The ''spelling-error'' and ''grammar-error'' values are at risk.
+
 
 <h3 id="text-decoration-color-property">
 Text Decoration Color: the 'text-decoration-color' property</h3>
@@ -974,4 +994,5 @@ Changes</h2>
         (<a href="https://drafts.csswg.org/css-text-decor-3/issues-cr-2013#issue-11">Issue 11</a>, <a href="https://drafts.csswg.org/css-text-decor-3/issues-cr-2013#issue-18">Issue 18</a>, <a href="https://drafts.csswg.org/css-text-decor-3/issues-cr-2013#issue-19">Issue 19</a>)
     <li>Added rule to apply ''font-variant-east-asian/ruby'' to emphasis marks' font.
         (<a href="https://drafts.csswg.org/css-text-decor-3/issues-cr-2013#issue-13">Issue 13</a>)
+    <li>Added the ''spelling-error'' and ''grammar-error' values to 'text-decoration' (marked at risk).
   </ul>

--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -205,14 +205,14 @@ Text Decoration Lines: the 'text-decoration-line' property</h3>
         Note that not blinking the text is one technique to satisfy <a href="https://www.w3.org/TR/UAAG/guidelines.html#tech-on-off-blinking-text">checkpoint 3.3 of WAI-UAAG</a>.
         This value is <strong>deprecated</strong> in favor of Animations [[CSS3-ANIMATIONS]].
     <dt><dfn value for="text-tecoration-line">spelling-error</dfn>
-      <dd>This values indicates the type of text decoration used by the User Agent
+      <dd>This value indicates the type of text decoration used by the User Agent
           to highlight spelling mistakes.
-	  It's appearance is UA defined.
+	  Its appearance is UA defined.
 	  <span class=note>It is often rendered as a red wavy underline.</span>
     <dt><dfn value for="text-decoration-line">grammar-error</dfn>
-      <dd>This values indicates the type of text decoration used by the User Agent
+      <dd>This value indicates the type of text decoration used by the User Agent
           to highlight grammar mistakes.
-	  It's appearance is UA defined.
+	  Its appearance is UA defined.
 	  <span class=note>It is often rendered as a green wavy underline.</span>
   </dl>
 

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -228,6 +228,10 @@ Text Underline Offset: the 'text-underline-offset' property</h3>
 			<span class="issue">Should this be removed?</span>
 	</ul>
 
+	When the value of the 'text-decoration-line' property is either
+	''spelling-error'' or ''grammar-error'',
+	the UA may ignore the value of 'text-underline-position'.
+
 <h3 id="text-decoration-skip-property">
 Text Decoration Line Continuity: the 'text-decoration-skip' property</h3>
 
@@ -336,6 +340,10 @@ Text Decoration Line Continuity: the 'text-decoration-skip' property</h3>
 	<pre><code class="lang-css">
 		ins, del { text-decoration-skip: none; }
 	</code></pre>
+
+	When the value of the 'text-decoration-line' property is either
+	''spelling-error'' or ''grammar-error'',
+	the UA may ignore the value of 'text-decoration-skip'.
 
 <h2 id=temp>Rescued L3 Brainstorming: Ignore For Now</h2>
 


### PR DESCRIPTION
This pull requests is an attempt to solve https://github.com/w3c/csswg-drafts/issues/1828, based on what I think we were converging towards in during the [conf call](https://github.com/w3c/csswg-drafts/issues/1828#issuecomment-334319887).

A possible variant of this would be to add the two new values to `text-decoration-style` instead of `text-decoration-line`. Arguably, if UAs wanted to allow it, `text-decoration: overline spelling-error` is slightly more likely to be a meaningful combination than `text-decoration: solid spelling-error`.

However, neither are motivated by real use cases, and the syntax I chose in this PR means the feature can be activated with just `text-decoration: spelling-error` or `text-decoration-line: spelling-error`, rather than having to specify `text-decoration: spelling-error underline`, expecting the underline part to be ignored, in order to avoid the longhand expansion to `text-decoration-line: none; text-decoration-style: spelling-error;` that would happen if it were left out.