### PR TITLE
[css-values] Values serialize as lower case

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -1131,6 +1131,8 @@ Absolute lengths: the ''cm'', ''mm'', ''Q'', ''in'', ''pt'', ''pc'', ''px'' unit
 	(This change was made because too much existing content relies on the assumption of 96dpi,
 	and breaking that assumption broke the content.)
 
+	Note: Values are case-insensitive and serialize as lower case, for example 1Q serializes as 1q.
+
 	The <dfn export>reference pixel</dfn> is the visual angle of one pixel on a device with a pixel density of 96dpi
 	and a distance from the reader of an arm's length.
 	For a nominal arm's length of 28 inches,
@@ -1300,6 +1302,8 @@ Frequency Units: the <<frequency>> type and ''Hz'', ''kHz'' units</h3>
 
 	All <<frequency>> units are <a>compatible</a>,
 	and ''hz'' is their <a>canonical unit</a>.
+
+	Note: Values are case-insensitive and serialize as lower case, for example 1Hz serializes as 1hz.
 
 <!--
 ████████  ████████  ██████   ███████

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1228,6 +1228,8 @@ Absolute lengths: the ''cm'', ''mm'', ''Q'', ''in'', ''pt'', ''pc'', ''px'' unit
 	(This change was made because too much existing content relies on the assumption of 96dpi,
 	and breaking that assumption broke the content.)
 
+	Note: Values are case-insensitive and serialize as lower case, for example 1Q serializes as 1q.
+
 	The <dfn export>reference pixel</dfn> is the visual angle of one pixel on a device with a pixel density of 96dpi
 	and a distance from the reader of an arm's length.
 	For a nominal arm's length of 28 inches,
@@ -1397,6 +1399,8 @@ Frequency Units: the <<frequency>> type and ''Hz'', ''kHz'' units</h3>
 
 	All <<frequency>> units are <a>compatible</a>,
 	and ''hz'' is their <a>canonical unit</a>.
+
+	Note: Values are case-insensitive and serialize as lower case, for example 1Hz serializes as 1hz.
 
 <!--
 ████████  ████████  ██████   ███████


### PR DESCRIPTION
Add note that CSS values such as 1Q and 1Hz serialize as lower case.

Note requested in teleconference
https://lists.w3.org/Archives/Public/www-style/2017Oct/0025.html