### PR TITLE
[css-color-4] Fix typo

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2385,7 +2385,7 @@ Modifying Colors: the ''color-mod()'' function</h2>
 		the color is still chromatic
 		(and the return value is ''#33f'').
 
-		On the other hand, if X is a greenish gray like ''#787'',
+		On the other hand, if X is a greenish gray like ''#708070'',
 		which is represented in HWB as ''hwb(120deg, 44%, 50%)'',
 		the first operation will boost the sum of white and black to greater than ''100%'',
 		making it an <a>achromatic</a> gray


### PR DESCRIPTION
`#787` (`#778877`) is represented in HWB as `hwb(120deg, 47%, 47%)` and next transformations not right for this color too.