### PR TITLE
[selectors-4] edited major changes list

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -3597,7 +3597,8 @@ Changes</h2>
 					</ul>
 				</li>
 			</ul>
-		<li>Removed restriction on combinators within '':matches()'', '':not()'', '':nth-match()'', and '':nth-last-match()''.
+		<li>Removed restriction on combinators within '':matches()'' and '':not()''.
+		<li>Removed '':nth-match()'', and '':nth-last-match()''.
 
 			Issue: Do we have implementations of this? If not, maybe it's better to keep the restriction for level 4?
 		<li>Defined <a>specificity</a> of a <a>selector list</a>. (Why?)


### PR DESCRIPTION
In the css selectors 4 specification it reads under major changes since working draft: "Removed restriction on combinators within :matches(), :not(), :nth-match(), and :nth-last-match()."
:nth-match(), and :nth-last-match() are not in the current draft other than in this line, so it should likely read "Removed restriction on combinators within :matches() and not:not()"
and on another line:
"Removed :nth-match(), and :nth-last-match()"
location: https://drafts.csswg.org/selectors-4/#changes
Issue #1997