### PR TITLE
Fix comment syntax on partial CSSRule

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -819,9 +819,7 @@ Extensions to the <code>CSSRule</code> interface</h3>
 <pre class='idl'>
 partial interface CSSRule {
     const unsigned short SUPPORTS_RULE = 12;
-    <!--
-    const unsigned short DOCUMENT_RULE = 13;
-    -->
+    // const unsigned short DOCUMENT_RULE = 13;
 };
 </pre>
 


### PR DESCRIPTION
`<!-- comment -->` syntax is not supported by WebIDL so it causes #2034. This replaces it with `//` syntax. (Or should it be removed completely?)