### PR TITLE
[css-color-4] Clarify required precision and rounding behavior for color channels

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -272,9 +272,9 @@ The RGB functions: ''rgb()'' and ''rgba()''</h3>
 	but ''255'' represents the maximum.
 	These values come from the fact that many graphics engines store the color channels internally as a single byte,
 	which can hold integers between 0 and 255.
-	However, the CSS syntax allows full <<number>>s,
-	not just <<integer>>s,
-	for authoring convenience.
+	Implementations should honor the precision of the channel as authored wherever possible.
+	If this is not possible, the channel should be rounded to the closest value,
+	rounding up if two values are equally close.
 
 	The final argument, the <<alpha-value>>, specifies the alpha of the color.
 	If given as a <<number>>, the useful range of the value is ''0''


### PR DESCRIPTION
Helps to address #1983 as to the importance of honoring authored numbers, and the required rounding behavior if the precision as authored is not honored.