### PR TITLE
[css-backgrounds-3] Fix example 15

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -1232,7 +1232,7 @@ body {
 p {
     background-color: gray;
     background-position: 40% 50%;
-    background-size: 10em 10em;
+    background-size: 10em auto;
     background-repeat: round;
     background-clip: border-box;
     background-origin: border-box;

--- a/css-backgrounds-3/Overview.html
+++ b/css-backgrounds-3/Overview.html
@@ -1310,7 +1310,7 @@ p { background: url("chess.png") 40% / 10em gray
 <pre>p {
     background-color: gray;
     background-position: 40% 50%;
-    background-size: 10em 10em;
+    background-size: 10em auto;
     background-repeat: round;
     background-clip: border-box;
     background-origin: border-box;


### PR DESCRIPTION
# description 
"background: ... / 10em ... " is equivalent to "background-size: 10em auto", not "background-size: 10em 10em".
# picture1
![image](https://user-images.githubusercontent.com/3817366/33667482-ee4549dc-dad7-11e7-93fe-8852a3e71bb0.png)

# picture2
![image](https://user-images.githubusercontent.com/3817366/33667510-fc5e35a6-dad7-11e7-9214-7cc15a6d7c13.png)

# picture3
![image](https://user-images.githubusercontent.com/3817366/33667548-1b01f0e2-dad8-11e7-8f5a-1eea97479676.png)


