### PR TITLE
Added note for :link and :visited pseudo classes

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1936,6 +1936,10 @@ The Link History Pseudo-classes: '':link'' and '':visited''</h3>
 	or implement other measures to preserve the user's privacy
 	while rendering visited and unvisited links differently.
 
+	Note: UAs may display chosen colors for :visited and :link elements,
+	but only return the :link colors from getComputedStyle().
+	For non-color properties, UAs may treat all links as unvisited.
+
 <h3 id="the-target-pseudo">
 The Target Pseudo-class: '':target''</h3>
 


### PR DESCRIPTION
UAs may display chosen colors for :visited and :link elements, but only
return the :link colors from getComputedStyle(). For non-color
properties, UAs may treat all links as unvisited.

fixes #2037