### PR TITLE
Use Web IDL's new-ish interface mixins concept

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1201,9 +1201,7 @@ The <dfn>associated CSS style sheet</dfn> of a node is the <a>CSS style sheet</a
 interface.
 
 <pre class=idl>
-[Exposed=Window,
- NoInterfaceObject]
-interface LinkStyle {
+interface mixin LinkStyle {
   readonly attribute StyleSheet? sheet;
 };
 </pre>
@@ -1248,7 +1246,7 @@ must also define when a <a>CSS style sheet</a> is
 
 <!-- XXX load/error events -->
 
-<pre class="idl">ProcessingInstruction implements LinkStyle;</pre>
+<pre class="idl">ProcessingInstruction includes LinkStyle;</pre>
 
 The <dfn>prolog</dfn> refers to <a>nodes</a> that are children of the
 <a>document</a> and are not <a>following</a> the
@@ -2671,9 +2669,7 @@ The {{ElementCSSInlineStyle}} Interface {#the-elementcssinlinestyle-interface}
 The <code>ElementCSSInlineStyle</code> interface provides access to inline style properties of an element.
 
 <pre class=idl>
-[Exposed=Window,
- NoInterfaceObject]
-interface ElementCSSInlineStyle {
+interface mixin ElementCSSInlineStyle {
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 </pre>
@@ -2700,13 +2696,13 @@ properties:
 If the user agent supports HTML, the following IDL applies: [[HTML]]
 
 <pre class=idl>
-HTMLElement implements ElementCSSInlineStyle;
+HTMLElement includes ElementCSSInlineStyle;
 </pre>
 
 If the user agent supports SVG, the following IDL applies: [[SVG11]]
 
 <pre class=idl>
-SVGElement implements ElementCSSInlineStyle;
+SVGElement includes ElementCSSInlineStyle;
 </pre>
 
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1592,19 +1592,17 @@ dictionary ConvertCoordinateOptions {
   CSSBoxType toBox = "border";
 };
 
-[Exposed=Window,
- NoInterfaceObject]
-interface GeometryUtils {
+interface mixin GeometryUtils {
   sequence&lt;DOMQuad> getBoxQuads(optional BoxQuadOptions options);
   DOMQuad convertQuadFromNode(DOMQuadInit quad, GeometryNode from, optional ConvertCoordinateOptions options);
   DOMQuad convertRectFromNode(DOMRectReadOnly rect, GeometryNode from, optional ConvertCoordinateOptions options);
   DOMPoint convertPointFromNode(DOMPointInit point, GeometryNode from, optional ConvertCoordinateOptions options); // XXX z,w turns into 0
 };
 
-Text implements GeometryUtils; // like Range
-Element implements GeometryUtils;
-CSSPseudoElement implements GeometryUtils;
-Document implements GeometryUtils;
+Text includes GeometryUtils; // like Range
+Element includes GeometryUtils;
+CSSPseudoElement includes GeometryUtils;
+Document includes GeometryUtils;
 
 typedef (Text or Element or CSSPseudoElement or Document) GeometryNode;
 </pre>


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins [1]. This
replaces the existing [NoInterfaceObject] and "implements" syntax with
"interface mixin" and "includes" in the appropriate places.

This fixes #1931, #1932 issues.

Test: https://github.com/w3c/web-platform-tests/pull/8772

[1] https://github.com/heycam/webidl/commit/45e8173d40ddff8dcf81697326e094bcf8b92920