### PR TITLE
[selectors] Single form for descendant combinator

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -446,10 +446,10 @@ Selectors Overview</h2>
 				<td>3
 		<tbody>
 			<tr>
-				<td><code>E F</code> <em>or</em> <code>E >> F</code>
+				<td><code>E F</code>
 				<td>an F element descendant of an E element
 				<td>[[#descendant-combinators]]
-				<td>1 <em>or</em> 4
+				<td>1
 			<tr>
 				<td><code>E > F</code>
 				<td>an F element child of an E element
@@ -2964,19 +2964,16 @@ Typed Child-indexed Pseudo-classes</h3>
 Combinators</h2>
 
 <h3 id="descendant-combinators">
-Descendant combinator (<code> </code>) <em>or</em> (<code>>></code>)</h3>
+Descendant combinator (<code> </code>)</h3>
 
 	At times, authors may want selectors to describe an element that is
 	the descendant of another element in the document tree (e.g., "an
 	<a element>em</a> element that is contained within an <a element>H1</a> element").
 	The <dfn export>descendant combinator</dfn> expresses such a relationship.
-	It has two syntactic forms:
-	<ol>
-	  <li><a href="#whitespace">whitespace</a> that separates two <a>compound selectors</a> <em>or</em>
-	  <li>A doubled child selector (<dfn selector id=selectordef-descendant>>></dfn>)
-	</ol>
 
-	A selector of the form ''A B'' or ''A >> B''' represents an element <code>B</code> that is an
+	A descendant combinator is whitespace that separates two <a>compound selectors</a>.
+
+	A selector of the form ''A B'' represents an element <code>B</code> that is an
 	arbitrary descendant of some ancestor element <code>A</code>.
 
 	<div class="example">
@@ -3011,12 +3008,6 @@ Descendant combinator (<code> </code>) <em>or</em> (<code>>></code>)</h3>
 
 		<pre>div p *[href]</pre>
 	</div>
-
-	Note: Note that the whitespace form has existed since CSS Level 1,
-	whereas the <code>>></code> form is introduced in Level 4.
-	It was introduced to give the descendant combinator a visible, non-whitespace form
-	and to bridge the gap between the <a>child combinator</a> (<code>></code>)
-	and the shadow-piercing descendant combinator (<code>>>></code>) [[CSS-SCOPING-1]].
 
 <h3 id="child-combinators">
 Child combinator (<code>></code>)</h3>
@@ -3311,7 +3302,7 @@ Grammar</h2>
 	<dfn>&lt;simple-selector></dfn> = <<type-selector>> | <<subclass-selector>>
 
 
-	<dfn>&lt;combinator></dfn> = '>>' | '>' | '+' | '~' | [ '||' ]
+	<dfn>&lt;combinator></dfn> = '>' | '+' | '~' | [ '||' ]
 
 	<dfn>&lt;type-selector></dfn> = <<wq-name>> | <<ns-prefix>>? '*'
 
@@ -3720,7 +3711,6 @@ Changes</h2>
 	Significant changes since the <a href="https://www.w3.org/TR/2013/WD-selectors4-20130502/">2 May 2013 Working Draft</a> include:
 
 	<ul>
-		<li>Added the ''>>'' notation for the descendant selector.
 		<li>Added the '':target-within'', '':focus-within'', '':focus-visible'', '':playing'', and  '':paused'' pseudo-classes.
 		<li>Added a zero-specificity '':matches()''-type pseudo-class, with name TBD.
 		<li>Replaced subject indicator (''!'') feature with '':has()''.


### PR DESCRIPTION
CSS Selectors 4 previously allowed >> as an alternative
for whitespace. This has been removed.

resolves #641