### PR TITLE
[css-values-4] Remove redundant text

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1039,8 +1039,6 @@ Font-relative lengths: the ''em'', ''ex'', ''cap'', ''ch'', ''ic'', ''rem'', ''l
 		<dd>
 			Equal to the computed value of 'line-height' property on the root element,
 			converted to an absolute length by measuring the height line box containing only the strut (See [[CSS2/visudet#strut]]) would have.
-			When specified on the 'font-size' or 'line-height' properties of the root element,
-			the ''rlh'' units refer to the properties' <em>initial value</em>.
 
 			Note: setting the 'height' of an element using either the ''lh'' or the ''rlh'' units
 			does not enable authors to control the actual number of lines in that element.


### PR DESCRIPTION
As far as I can tell, this bit of text is redundant with the (now improved, thanks to #2115) the last paragraph of https://drafts.csswg.org/css-values-4/#font-relative-lengths

Sending this as a PR rather than making a direct fix, in case I missed something and there's actually a good reason to be explicit here.