### PR TITLE
[css-display] Remove references to <applet>.

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -902,7 +902,7 @@ Appendix A: Glossary</h2>
 		<dt><dfn lt="replaced element|replaced">replaced element</dfn>
 		<dd>
 			An element whose content is outside the scope of the CSS formatting model,
-			such as an image, embedded document, or applet.
+			such as an image or embedded document.
 			<span class=non-normative>
 				For example, the content of the HTML <{img}> element
 				is often replaced by the image that its <{img/src}> attribute designates.
@@ -1052,7 +1052,6 @@ HTML Elements {#unbox-html}
 	: <{wbr}>
 	: <{meter}>
 	: <{progress}>
-	: <{applet}>
 	: <{canvas}>
 	: <{embed}>
 	: <{object}>


### PR DESCRIPTION
Applet is no longer part of the HTML spec.