### PR TITLE
[css-align-3] Add left|right to *-position grammar

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -349,7 +349,7 @@ Positional Alignment: the ''center'', ''start'', ''end'', ''self-start'', ''self
 			(to specify default values for 'justify-self' and 'align-self').
 			<pre class='prod'>
 				<dfn>&lt;self-position></dfn> = center | start | end | self-start | self-end |
-								flex-start | flex-end;
+								flex-start | flex-end | left | right;
 			</pre>
 		<dt><<content-position>>
 		<dd>
@@ -357,7 +357,8 @@ Positional Alignment: the ''center'', ''start'', ''end'', ''self-start'', ''self
 			to align the box's contents within itself.
 
 			<pre class='prod'>
-				<dfn>&lt;content-position></dfn> = center | start | end | flex-start | flex-end;
+				<dfn>&lt;content-position></dfn> = center | start | end | flex-start | flex-end |
+								left | right;
 			</pre>
 	</dl>
 
@@ -864,7 +865,7 @@ The 'justify-content' And 'align-content' Properties</h3>
 
 	<pre class="propdef">
 	Name: justify-content
-	Value: normal | <<content-distribution>> | <<overflow-position>>? [ <<content-position>> | left | right ]
+	Value: normal | <<content-distribution>> | <<overflow-position>>? [ <<content-position>> ]
 	Initial: normal
 	Applies to: multicol containers, flex containers, and grid containers
 	Inherited: no
@@ -1148,7 +1149,7 @@ Inline/Main-Axis Alignment: the 'justify-self' property</h3>
 
 	<pre class="propdef">
 	Name: justify-self
-	Value: auto | normal | stretch | <<baseline-position>> | <<overflow-position>>? [ <<self-position>> | left | right ]
+	Value: auto | normal | stretch | <<baseline-position>> | <<overflow-position>>? [ <<self-position>> ]
 	Initial: auto
 	Applies to: block-level boxes, absolutely-positioned boxes, and grid items
 	Inherited: no


### PR DESCRIPTION
This change adds the `left` and `right` keywords to the grammar terms
`<self-position>` and `<content-position>`.

That addition to the grammar brings it into sync with the existing spec prose,
which already includes `left` and `right` among the *positional alignment*
keywords collection, and states, “Two grammar terms are used to denote this
collection of values: `<self-position>` [and] `<content-position>`”.