### PR TITLE
[css-color-4] consistently name color-mod()

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2310,7 +2310,7 @@ Modifying Colors: the ''color-mod()'' function</h2>
 	Issue: Actually add the CNS thing.
 
 	<pre class='prod'>
-		<dfn>color-mod()</dfn> = color( [ <<color>> | <<hue>> ] <<color-adjuster>>* )
+		<dfn>color-mod()</dfn> = color-mod( [ <<color>> | <<hue>> ] <<color-adjuster>>* )
 		<dfn>&lt;color-adjuster></dfn> =
 		    [red( | green( | blue( | alpha( | a(] ['+' | '-']? [<<number>> | <<percentage>>] ) |
 		    [red( | green( | blue( | alpha( | a(] '*' <<percentage>> ) |
@@ -2343,7 +2343,7 @@ Modifying Colors: the ''color-mod()'' function</h2>
 	Each <<color-adjuster>> modifies the color in some way,
 	passing a new |base color| to the next <<color-adjuster>> in the list.
 	The same <<color-adjuster>> can be specified more than once in the list,
-	such as ''color(red s(- 10%) s(- 10%))'';
+	such as ''color-mod(red s(- 10%) s(- 10%))'';
 	each instance just modifies the color appropriately
 	(in this case, producing ''hsl(0deg, 80%, 50%)'').
 
@@ -2388,7 +2388,7 @@ Modifying Colors: the ''color-mod()'' function</h2>
 	<div class='example'>
 		For example, here's a possible ''color-mod()'' function that lightens and brightens the |base color|:
 
-		<pre class="lang-css">color(X w(+ 20%) s(+ 20%))</pre>
+		<pre class="lang-css">color-mod(X w(+ 20%) s(+ 20%))</pre>
 
 		If X is a color like ''blue'',
 		this works in the expected way -
@@ -2471,7 +2471,7 @@ RGBA Adjustment</h3>
 			are applied as adjustments to the |base color|.
 
 			<div class='example'>
-				For example, in ''color(red rgb(+ #004400))'',
+				For example, in ''color-mod(red rgb(+ #004400))'',
 				the |base color| is ''red'' (''#ff0000'').
 				The red and blue channels aren't adjusted at all
 				(those channels in the given color are both 0),
@@ -2540,7 +2540,7 @@ HSL/HWB Adjustment</h3>
 			and the adjuster would make the sum of whiteness and blackness less than 100%,
 			it additionally adjusts the opposite HWB channel
 			to make the sum equal to 100%.
-			(That is, ''color(white w(- 20%))'' would represent the same color as ''hwb(0, 80%, 20%)''.)
+			(That is, ''color-mod(white w(- 20%))'' would represent the same color as ''hwb(0, 80%, 20%)''.)
 	</dl>
 
 
@@ -2595,10 +2595,10 @@ Color Blending: the ''blend'' and ''blenda'' adjusters</h3>
 			then the components are blended.
 
 			<div class='example'>
-				For example, ''color(yellow blend(blue 50%))'' blends yellow (''#ffff00'') with blue (''#0000ff'') equally,
+				For example, ''color-mod(yellow blend(blue 50%))'' blends yellow (''#ffff00'') with blue (''#0000ff'') equally,
 				resulting in ''#808080'', a medium gray.
 
-				On the other hand, ''color(yellow blend(blue 50% hsl))'' blends the same colors in HSL space,
+				On the other hand, ''color-mod(yellow blend(blue 50% hsl))'' blends the same colors in HSL space,
 				where yellow is ''hsl(60, 100%, 50%)'' and blue is ''hsl(240, 100%, 50%)'',
 				which results in ''hsl(150, 100%, 50%)'', a fully-saturated shade of green.
 			</div>
@@ -2729,7 +2729,7 @@ Guaranteeing Adequate Contrast: the ''contrast'' adjuster</h3>
 
 				<li>
 					Blend the |minimum-contrast color| and |maximum-contrast color| according to the specified <<percentage>>,
-					as if ''color(|maximum-contrast color| blend(|minimum-contrast color| <<percentage>> hwb))'' were specified.
+					as if ''color-mod(|maximum-contrast color| blend(|minimum-contrast color| <<percentage>> hwb))'' were specified.
 					Return the blended color.
 			</ol>
 	</dl>


### PR DESCRIPTION
Uses the `color-mod()` function name consistently in order to avoid confusion with the `color()` function.

Resolves #868