### PR TITLE
[css-color-4] correct blend() adjuster calculation

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2607,8 +2607,8 @@ Color Blending: the ''blend'' and ''blenda'' adjusters</h3>
 			interpret the |base color| and the given color in the appropriate color space
 			(RGB, HSL, or HWB).
 			Linearly interpolate each of the channels of the colors according to the given <<percentage>>,
-			where ''0%'' produces the specified <<color>>
-			and ''100%'' produces the |base color|.
+			where ''100%'' produces the specified <<color>>
+			and ''0%'' produces the |base color|.
 
 			If the color space is ''hsl'' or ''hwb'',
 			interpolate the hue channel either clockwise or counterclockwise,


### PR DESCRIPTION
Correct the `blend()` adjuster calculation so that a base color does not change when a specified color is 0% blended in.

This will consequently correct `tint()` and `shade()` adjusters, as they rely on the behavior of `blend()`.

Resolves #2195