### PR TITLE
[css-color-4] correct gray() example

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1752,7 +1752,7 @@ Specifying Grays: the ''gray()'' functional notation</h2>
 	Grays are fully desaturated colors.
 	The ''gray()'' functional notation simplifies specifying this common set of colors,
 	so that only a single numerical parameter is required,
-	and so that gray(50%) is a visual mid-gray
+	and so that gray(50) is a visual mid-gray
 	(perceptually equidistant between black and white).
 
 	<pre class='prod'>


### PR DESCRIPTION
This corrects an example of `gray()` in the spec that is using a percentage (`50%`), while the syntax for `gray()` should only use a number (`50`).

https://github.com/w3c/csswg-drafts/pull/2231/files

The correct syntax is:

```
gray() = gray( <number>  [ / <alpha-value> ]? )
```

This is clarified in the description of its arguments:

> The first argument specifies the shade of gray, equal to the **CIE Lightness**...

And it is further clarified directly below the description:

> In other words, `gray(a / b)` is equal to `lab(a 0 0 / b)`.