### PR TITLE
[selectors-4] :nth-*-child(n of S) selectors should be Level 3/4

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -403,13 +403,13 @@ Selectors Overview</h2>
 				<td><code>E:nth-child(<var>n</var> [of <var>S</var>]?)</code>
 				<td>an E element, the <var>n</var>-th child of its parent matching <var>S</var>
 				<td>[[#child-index]]
-				<td>3
+				<td>3/4
 			<tr>
 				<td><code>E:nth-last-child(<var>n</var> [of <var>S</var>]?)</code>
 				<td>an E element, the <var>n</var>-th child of its parent matching <var>S</var>,
 						counting from the last one
 				<td>[[#child-index]]
-				<td>3
+				<td>3/4
 			<tr>
 				<td><code>E:first-child</code>
 				<td>an E element, first child of its parent


### PR DESCRIPTION
It's true that `:nth-child(n)`/`:nth-last-child(n)` have been added in Level 3, but `of S` syntax is Level 4 addition. I believe they should be marked as Level 3/4, like the `:not()` selector (also introduced in Level 3, but extended in Level 4 with the ability to contain selector lists).