### PR TITLE
[cssom-1] Record mutation for changes to CSSStyleDeclaration.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2157,6 +2157,7 @@ The <dfn method for=CSSStyleDeclaration>setProperty(<var>property</var>, <var>va
   Note: <var>value</var> can not include "<code>!important</code>".
 
  <li>If <var>component value list</var> is null terminate these steps.
+ <li><a>Queue a mutation record for declarations change</a> with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration">set the CSS declaration</a> <var>longhand</var> with the appropriate value(s) from <var>component value
  list</var>, with the <i>important</i> flag set if <var>priority</var> is not the empty string, and unset otherwise, and with the list of declarations being the
@@ -2179,6 +2180,16 @@ a list of declarations <var>declarations</var>, follow these steps:
  Otherwise, unset <var>declaration</var>'s <a for="CSS declaration">important flag</a>.
 </ol>
 
+To <dfn>queue a mutation record for declarations change</dfn> for a list of declarations <var>declarations</var>, follow these steps:
+
+<ol>
+ <li>Let <var>owner node</var> be <var>declarations</var>'s <a for="CSSStyleDeclaration">owner node</a>.
+ <li>If <var>owner node</var> is null, terminate these steps.
+ <li>Let <var>oldValue</var> be the result of <a lt="serialize a CSS declaration block">serializing</a> <var>declarations</var>.
+ <li><a>queue a mutation record</a> of "<code>attributes</code>" for <var>owner node</var> with name "<code>style</code>",
+ namespace <var>owner node</var>'s <a for=Element>namespace</a>, and oldValue <var>oldValue</var>.
+</ol>
+
 The <dfn method for=CSSStyleDeclaration>setPropertyValue(<var>property</var>, <var>value</var>)</dfn> method must run these
 steps:
 <ol>
@@ -2197,6 +2208,7 @@ steps:
   Note: <var>value</var> can not include "<code>!important</code>".
 
  <li>If <var>component value list</var> is null terminate these steps.
+ <li><a>Queue a mutation record for declarations change</a> with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration value">set the CSS declaration value</a> <var>longhand</var> to the appropriate value(s) from <var>component
  value list</var>, and with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
@@ -2227,6 +2239,7 @@ these steps:
   </ol>
  <li>If <var>priority</var> is not the empty string and is not an <a>ASCII case-insensitive</a> match for the string
  "<code>important</code>", terminate this algorithm.
+ <li><a>Queue a mutation record for declarations change</a> with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration priority">set the CSS declaration priority</a> <var>longhand</var> with the <i>important</i> flag set if
  <var>priority</var> is not the empty string, and unset otherwise, and with the list of declarations being the
@@ -2255,11 +2268,25 @@ The <dfn method for=CSSStyleDeclaration>removeProperty(<var>property</var>)</dfn
  let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
  <li>Let <var>value</var> be the return value of invoking {{CSSStyleDeclaration/getPropertyValue()}}
  with <var>property</var> as argument.
- <li>If <var>property</var> is a shorthand property, for each longhand property <var>longhand</var> that <var>property</var> maps to, invoke
- {{CSSStyleDeclaration/removeProperty()}} with <var>longhand</var> as argument.
- <li>Otherwise, if <var>property</var> is a <a>case-sensitive</a> match for a
+ <li>If <var>property</var> is a shorthand property, follow these substeps:
+  <ol>
+   <li>Set <var>queued mutation record</var> to false.
+   <li>For each longhand property <var>longhand</var> that <var>property</var> maps to:
+    <ol>
+     <li>If <var>longhand</var> is not the <a for="CSS declaration">property name</a> of a <a>CSS declaration</a>
+     in the <a for="CSSStyleDeclaration">declarations</a>, <a for=iteration>continue</a>.
+     <li>If <var>queued mutation record</var> is false, set <var>queued mutation record</var> to true, and
+     <a>queue a mutation record for declarations change</a> with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
+     <li>Remove that <a>CSS declaration</a>.
+    </ol>
+  </ol>
+ <li>Otherwise, if <var>property</var> is a <a>case-sensitive</a> match for the
  <a for="CSS declaration">property name</a> of a <a>CSS declaration</a> in the
- <a for="CSSStyleDeclaration">declarations</a>, remove that <a>CSS declaration</a>.
+ <a for="CSSStyleDeclaration">declarations</a>, follow these substeps:
+  <ol>
+   <li><a>Queue a mutation record for declarations change</a> with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
+   <li>Remove that <a>CSS declaration</a>.
+  </ol>
  <li>Return <var>value</var>.
 </ol>
 


### PR DESCRIPTION
To ensure that we record the mutation to style attribute for MutationObserver.

Most of this should match what browsers currently do, at least it seems to match what Blink does. Gecko's behavior on `removeProperty` is a bit inconsistent in this case, and we want to fix it.