### PR TITLE
[css-fonts] Fix references to <integer> and <number> types

### DIFF
--- a/css-fonts-3/Fonts.html
+++ b/css-fonts-3/Fonts.html
@@ -4978,9 +4978,9 @@ h2:first-letter { font-variant-alternates: swash(flowing); }
    href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>IDENT</i></a> <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* ':' <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a
-   href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> [ <a
+   href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> [ <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a
-   href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> ]*
+   href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> ]*
   ;
 </pre>
 

--- a/css-fonts-3/Fonts.src.html
+++ b/css-fonts-3/Fonts.src.html
@@ -3668,7 +3668,7 @@ features defined for a given font.</p>
   ;
 
 <dfn>feature_value_definition</dfn>
-  : <a href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>IDENT</i></a> <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* ':' <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> [ <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> ]*
+  : <a href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>IDENT</i></a> <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* ':' <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> [ <a href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> ]*
   ;
 </pre>
 

--- a/css-fonts-3/Overview.html
+++ b/css-fonts-3/Overview.html
@@ -4978,9 +4978,9 @@ h2:first-letter { font-variant-alternates: swash(flowing); }
    href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>IDENT</i></a> <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* ':' <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a
-   href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> [ <a
+   href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> [ <a
    href="https://www.w3.org/TR/CSS21/grammar.html#scanner"><i>S</i></a>* <a
-   href="https://www.w3.org/TR/CSS21/syndata.html#tokenization"><i>&lt;integer&gt;</i></a> ]*
+   href="https://www.w3.org/TR/css3-values/#integer-value"><i>&lt;integer&gt;</i></a> ]*
   ;
 </pre>
 

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -335,19 +335,19 @@ Inherited: yes
 Percentages: n/a
 Computed value: numeric weight value (see description)
 Media: visual
-Animatable: As <<integer>>
+Animatable: As <<number>>
 </pre>
 
 The 'font-weight' property specifies the weight of glyphs in the font, their degree of blackness or stroke thickness.
 
 This property accepts values of the following:
 
-<pre class="prod"><dfn id="font-weight-absolute-values">&lt;font-weight-absolute&gt;</dfn> = [normal | bold | <<integer>>]</pre>
+<pre class="prod"><dfn id="font-weight-absolute-values">&lt;font-weight-absolute&gt;</dfn> = [normal | bold | <<number>>]</pre>
 
 Values have the following meanings:
 
 <dl dfn-for=font-weight dfn-type=value>
-	<dt id="font-weight-numeric-values"><dfn><<integer>></dfn>
+	<dt id="font-weight-numeric-values"><dfn><<number>></dfn>
 	<dd>
 		These values form an ordered sequence, where each number indicates a weight that is
 		at least as dark as its predecessor. Only values greater than or equal to 1, and less than or equal to 1000, are valid, and all other values are treated as parse errors. Certain numeric values correspond to the commonly used weight names below (Note that a font might internally provide its own mappings, but those mappings within the font are disregarded):
@@ -467,7 +467,7 @@ Inherited: yes
 Percentages: Not resolved.
 Computed value: As specified
 Media: visual
-Animatable: As <<integer>>
+Animatable: As <<number>>
 </pre>
 
 The 'font-stretch' property selects a normal,
@@ -785,14 +785,14 @@ Relative sizing: the 'font-size-adjust' property</h3>
 
 <pre class="propdef">
 Name: font-size-adjust
-Value: none | <<integer>>
+Value: none | <<number>>
 Initial: none
 Applies to: all elements
 Inherited: yes
 Percentages: N/A
 Computed value: as specified
 Media: visual
-Animatable: as <<integer>>
+Animatable: as <<number>>
 </pre>
 
 For any given font size, the apparent size and legibility of text
@@ -1953,7 +1953,7 @@ For: @font-face
 
 <pre class='descdef'>
 Name: font-variation-settings
-Value: normal | [ <<string>> <<integer>>] #
+Value: normal | [ <<string>> <<number>>] #
 Initial: normal
 For: @font-face
 </pre>
@@ -3045,7 +3045,7 @@ Low-level font variation settings control: the 'font-variation-settings' propert
 
 <pre class="propdef">
 Name: font-variation-settings
-Value: normal | [ <<string>> <<integer>>] #
+Value: normal | [ <<string>> <<number>>] #
 Initial: normal
 Applies to: all elements
 Inherited: yes


### PR DESCRIPTION
After #1127, `<number>` was mistakenly changed to `<integer>` in Fonts 4. Revert this commit. Also change the links for `<integer>` to point to Values 3, as CSS 2.1 does not define the `<integer>` type.