### PR TITLE
Fix typo

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -505,7 +505,7 @@ Aspect-ratio&ndash;controlled Gutters</h2>
 
 			Note: This value can expand gutters
 			even when there is no free space left,
-			causing oveflow.
+			causing overflow.
 
 			Specifically, an 'align-content' value of ''1'' represents
 			the amount of space (which may be zero) allocated between two adjacent


### PR DESCRIPTION
Hi, I just noticed a tiny typo in the text:: 

oveflow --> overflow