### PR TITLE
Use CSS Syntax tokens for attr()

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -1881,7 +1881,7 @@ Ian's proposal:
 
 		<dt>''color''
 		<dd>
-			The attribute value must parse as a HASH or IDENT CSS token,
+			The attribute value must parse as a <<hash-token>> or <<ident-token>>,
 			and be successfully interpreted as a <<color>>.
 			The default is ''currentcolor''.
 
@@ -1897,7 +1897,7 @@ Ian's proposal:
 
 		<dt>''integer''
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and be successfully interpreted as an <<integer>>.
 			The default is ''0'',
 			or else the property's minimum value if ''0'' is not valid for the property.
@@ -1907,7 +1907,7 @@ Ian's proposal:
 
 		<dt>''number''
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and is interpreted as an <<number>>.
 			The default is ''0'',
 			or else the property's minimum value if ''0'' is not valid for the property.
@@ -1920,7 +1920,7 @@ Ian's proposal:
 		<dt>''time''
 		<dt>''frequency''
 		<dd>
-			The attribute value must parse as a DIMENSION CSS token,
+			The attribute value must parse as a <<dimension-token>>,
 			and be successfully interpreted as the specified type.
 			The default is ''0'' in the relevant units,
 			or else the property's minimum value if ''0'' in the relevant units is not valid for the property.
@@ -1933,7 +1933,7 @@ Ian's proposal:
 		<dt>''%''
 		<dt>A keyword matching one of the <<length>>, <<angle>>, <<time>>, or <<frequency>> units
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and is interpreted as a <a>dimension</a> with the specified unit.
 			The default is ''0'' in the relevant units,
 			or else the property's minimum value if ''0'' in the relevant units is not valid for the property.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2249,7 +2249,7 @@ Ian's proposal:
 
 		<dt><dfn>color</dfn>
 		<dd>
-			The attribute value must parse as a HASH or IDENT CSS token,
+			The attribute value must parse as a <<hash-token>> or <<ident-token>>,
 			and be successfully interpreted as a <<color>>.
 			The default is ''currentcolor''.
 
@@ -2265,7 +2265,7 @@ Ian's proposal:
 
 		<dt><dfn>integer</dfn>
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and be successfully interpreted as an <<integer>>.
 			The default is ''0'',
 			or else the property's minimum value if ''0'' is not valid for the property.
@@ -2275,7 +2275,7 @@ Ian's proposal:
 
 		<dt><dfn>number</dfn>
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and is interpreted as an <<number>>.
 			The default is ''0'',
 			or else the property's minimum value if ''0'' is not valid for the property.
@@ -2288,7 +2288,7 @@ Ian's proposal:
 		<dt><dfn>time</dfn>
 		<dt><dfn>frequency</dfn>
 		<dd>
-			The attribute value must parse as a DIMENSION CSS token,
+			The attribute value must parse as a <<dimension-token>>,
 			and be successfully interpreted as the specified type.
 			The default is ''0'' in the relevant units,
 			or else the property's minimum value if ''0'' in the relevant units is not valid for the property.
@@ -2301,7 +2301,7 @@ Ian's proposal:
 		<dt><dfn>%</dfn>
 		<dt>A keyword matching one of the <<length>>, <<angle>>, <<time>>, or <<frequency>> units
 		<dd>
-			The attribute value must parse as a NUMBER CSS token,
+			The attribute value must parse as a <<number-token>>,
 			and is interpreted as a <a>dimension</a> with the specified unit.
 			The default is ''0'' in the relevant units,
 			or else the property's minimum value if ''0'' in the relevant units is not valid for the property.


### PR DESCRIPTION
The definition of attr() used CSS 2.1 tokens (e.g. NUMBER) to describe parsing instead of CSS Syntax tokens (e.g. <number-token>). Update the text to use the tokens described in CSS Syntax.