### PR TITLE
[cssom-1] Remove or replace "terminate ..."

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -344,8 +344,7 @@ To
 run these steps:
 
 <ol>
- <li>If the media query list is empty return the empty string and
- terminate these steps.
+ <li>If the media query list is empty, then return the empty string.
 
  <li><a lt="serialize a media query">Serialize</a> each media query in the list of media queries, in the same order as they appear in the list of
  media queries, and then <a lt="serialize a comma-separated list">serialize</a> the list.
@@ -353,8 +352,7 @@ run these steps:
 
 To
 <dfn export>serialize a media query</dfn> let
-<var>s</var> be the empty string, run the steps below, and
-finally return <var>s</var>:
+<var>s</var> be the empty string, run the steps below:
 
 <ol>
  <li>If the media query is negated append "<code>not</code>", followed
@@ -366,7 +364,7 @@ finally return <var>s</var>:
 
  <li>If the media query does not contain media features append
  <var>type</var>, to <var>s</var>,
- then return <var>s</var> and terminate this algorithm.
+ then return <var>s</var>.
 
  <li>If <var>type</var> is not "<code>all</code>" or if the
  media query is negated append <var>type</var>, followed by a
@@ -395,6 +393,8 @@ finally return <var>s</var>:
    followed by "<code>and</code>", followed by a single SPACE (U+0020), to
    <var>s</var>.
   </ol>
+
+ <li>Return <var>s</var>.
 
 </ol>
 
@@ -528,7 +528,7 @@ The <dfn attribute for=MediaList>mediaText</dfn> attribute, on getting, must ret
 Setting the {{MediaList/mediaText}} attribute must run these steps:
 <ol>
  <li>Empty the <a>collection of media queries</a>.
- <li>If the given value is the empty string terminate these steps.
+ <li>If the given value is the empty string, then return.
  <li>Append all the media queries as a result of <a lt="parse a media query list">parsing</a> the given
  value to the <a>collection of media queries</a>.
 </ol>
@@ -544,16 +544,16 @@ queries</a>.
 The <dfn method for=MediaList>appendMedium(<var>medium</var>)</dfn> method must run these steps:
 <ol>
  <li>Let <var>m</var> be the result of <a lt="parse a media query">parsing</a> the given value.
- <li>If <var>m</var> is null terminate these steps.
+ <li>If <var>m</var> is null, then return.
  <li>If <a lt="compare media queries">comparing</a> <var>m</var> with any of the media queries in the
- <a>collection of media queries</a> returns true terminate these steps.
+ <a>collection of media queries</a> returns true, then return.
  <li>Append <var>m</var> to the <a>collection of media queries</a>.
 </ol>
 
 The <dfn method for=MediaList>deleteMedium(<var>medium</var>)</dfn> method must run these steps:
 <ol>
  <li>Let <var>m</var> be the result of <a lt="parse a media query">parsing</a> the given value.
- <li>If <var>m</var> is null terminate these steps.
+ <li>If <var>m</var> is null, then return.
  <li>Remove any media query from the <a>collection of media queries</a> for which
  <a lt="compare media queries">comparing</a> the media query with <var>m</var> returns true.
  If nothing was removed, then <a>throw</a> a {{NotFoundError}} exception.
@@ -979,8 +979,7 @@ steps:
  remainder of these steps deal with the
  <a>disabled flag</a>.
 
- <li>If the <a>disabled flag</a> is set, terminate
- these steps.
+ <li>If the <a>disabled flag</a> is set, then return.
 
  <li>If the <a>title</a> is not the empty string, the
  <a>alternate flag</a> is unset, and
@@ -989,8 +988,8 @@ steps:
  <a>title</a>.
 
  <li>
-  If any of the following is true unset the
-  <a>disabled flag</a> and terminate these steps:
+  If any of the following is true, then unset the
+  <a>disabled flag</a> and return:
 
   <ul>
    <li>The <a>title</a> is the empty string.
@@ -1044,7 +1043,7 @@ with name <var>name</var>, run these steps:
 <ol>
  <li>If <var>name</var> is the empty string, set the
  <a>disabled flag</a> for each <a>CSS style sheet</a>
- that is in a <a>CSS style sheet set</a> and terminate these steps.
+ that is in a <a>CSS style sheet set</a> and return.
 
  <li>Unset the <a>disabled flag</a> for each
  <a>CSS style sheet</a> in a <a>CSS style sheet set</a> whose
@@ -1264,9 +1263,9 @@ must be run:
 
  <li>If <var>node</var> has an <a>associated CSS style sheet</a>, <a lt="remove a CSS style sheet">remove</a> it.
 
- <li>If <var>node</var> is not an <a>xml-stylesheet processing instruction</a>, terminate these steps.
+ <li>If <var>node</var> is not an <a>xml-stylesheet processing instruction</a>, then return.
 
- <li>If <var>node</var> does not have an <code>href</code> <a>pseudo-attribute</a>, terminate these steps.
+ <li>If <var>node</var> does not have an <code>href</code> <a>pseudo-attribute</a>, then return.
 
  <li>Let <var>title</var> be the value of the
  <code>title</code> <a>pseudo-attribute</a> or the empty string if the
@@ -1275,11 +1274,11 @@ must be run:
  <li>If there is an <code>alternate</code> <a>pseudo-attribute</a>
  whose value is a <a>case-sensitive</a> match
  for "<code>yes</code>" and <var>title</var> is the
- empty string terminate these steps.
+ empty string, then return.
 
  <li>If there is a <code>type</code> <a>pseudo-attribute</a> whose
  value is not a <a>supported styling language</a> the user agent
- may terminate these steps.
+ may return.
 
  <li>Let <var>input URL</var> be the value specified by the
  <code>href</code> <a>pseudo-attribute</a>.
@@ -1293,12 +1292,12 @@ must be run:
  <li>Let <var>parsed URL</var> be the return value of invoking the <a>URL parser</a> with the
  string <var>input URL</var> and the base URL <var>base URL</var>.
 
- <li>If <var>parsed URL</var> is failure, terminate these steps.
+ <li>If <var>parsed URL</var> is failure, then return.
 
  <li>Let <var>response</var> be the result of <a lt="fetch a CSS style sheet">fetching a CSS style sheet</a> with parsed URL <var>parsed URL</var>,
  referrer <var>referrer</var> and document <var>document</var>.
 
- <li>If <var>response</var> is an error, terminate these steps.
+ <li>If <var>response</var> is an error, then return.
 
  <li>
   <a>Create a CSS style sheet</a> with the following properties:
@@ -1374,7 +1373,7 @@ must be run:
  <li>If one of the (other) link relation types is an
  <a>ASCII case-insensitive</a> match for
  "<code>alternate</code>" and <var>title</var> is the
- empty string terminate these steps.
+ empty string, then return.
 
  <li>Let <var>input URL</var> be the value specified.
 
@@ -1391,7 +1390,7 @@ must be run:
  <li>Let <var>parsed URL</var> be the return value of invoking the <a>URL parser</a> with the
  string <var>input URL</var> and the base URL <var>base URL</var>.
 
- <li>If <var>parsed URL</var> is failure, terminate these steps.
+ <li>If <var>parsed URL</var> is failure, then return.
 
  <li>Let <var>response</var> be the result of <a lt="fetch a CSS style sheet">fetching a CSS style sheet</a> with parsed URL <var>parsed URL</var>,
  referrer <var>referrer</var> and document being the document.
@@ -2041,9 +2040,9 @@ before the first property name and no whitespace appears after the final semicol
 A <a>CSS declaration block</a> has these <a>attribute change steps</a> for its <a for="CSSStyleDeclaration">owner node</a>:
 
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, terminate these steps.
- <li>If the <a for="CSSStyleDeclaration">updating flag</a> is set, terminate these steps.
- <li>If <var>localName</var> is not "<code>style</code>", or <var>namespace</var> is not null, terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, then return.
+ <li>If the <a for="CSSStyleDeclaration">updating flag</a> is set, then return.
+ <li>If <var>localName</var> is not "<code>style</code>", or <var>namespace</var> is not null, then return.
  <li>If <var>value</var> is null, empty the <a for="CSSStyleDeclaration">declarations</a>.
  <li>Otherwise, let the <a for="CSSStyleDeclaration">declarations</a> be the result of <a>parse a CSS declaration block</a>
  from a string <var>value</var>.
@@ -2053,7 +2052,7 @@ When a <a>CSS declaration block</a> object is created, then:
 
 <ol>
  <li>Let <var>owner node</var> be the <a for="CSSStyleDeclaration">owner node</a>.
- <li>If <var>owner node</var> is null, or the <a for="CSSStyleDeclaration">readonly flag</a> is set, terminate these steps.
+ <li>If <var>owner node</var> is null, or the <a for="CSSStyleDeclaration">readonly flag</a> is set, then return.
  <li>Let <var>value</var> be the result of <a lt="get an attribute by namespace and local name">getting an attribute</a>
  given null, "<code>style</code>", and <var>owner node</var>.
  <li>If <var>value</var> is not null, let the <a for="CSSStyleDeclaration">declarations</a> be the result of
@@ -2065,7 +2064,7 @@ To <dfn>update style attribute for</dfn> <var>declaration block</var> means to r
 <ol>
  <li>Assert: <var>declaration block</var>'s <a for="CSSStyleDeclaration">readonly flag</a> is unset.
  <li>Let <var>owner node</var> be <var>declaration block</var>'s <a for="CSSStyleDeclaration">owner node</a>.
- <li>If <var>owner node</var> is null, terminate these steps.
+ <li>If <var>owner node</var> is null, then return.
  <li>Set <var>declaration block</var>'s <a for="CSSStyleDeclaration">updating flag</a>.
  <li><a>Set an attribute value</a> for <var>owner node</var> using "<code>style</code>" and the result of
  <a lt="serialize a CSS declaration block">serializing</a> <var>declaration block</var>.
@@ -2112,8 +2111,8 @@ The <dfn attribute for=CSSStyleDeclaration>cssText</dfn> attribute must return t
 <a lt="serialize a CSS declaration block">serializing</a> the <a for="CSSStyleDeclaration">declarations</a>.
 Setting the {{CSSStyleDeclaration/cssText}} attribute must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
- a {{NoModificationAllowedError}} exception and terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>Empty the <a for="CSSStyleDeclaration">declarations</a>.
  <li><a lt="Parse a CSS declaration block">Parse</a> the given value and, if the return value is not the empty list, insert the items in the list
  into the <a for="CSSStyleDeclaration">declarations</a>, in <a>specified order</a>.
@@ -2139,18 +2138,18 @@ The <dfn method for=CSSStyleDeclaration>getPropertyValue(<var>property</var>)</d
        <li>If <var>longhand</var> is a <a>case-sensitive</a> match for a <a for="CSS declaration">property
        name</a> of a <a>CSS declaration</a> in the <a for="CSSStyleDeclaration">declarations</a>, let <var>declaration</var>
        be that <a>CSS declaration</a>, or null otherwise.
-       <li>If <var>declaration</var> is null, return the empty string and terminate these steps.
+       <li>If <var>declaration</var> is null, then return the empty string.
        <li>Append the <var>declaration</var> to <var>list</var>.
       </ol>
      <li>If <a lt="important flag" for="CSS declaration">important flags</a> of all declarations in <var>list</var> are same,
-     return the <a lt="serialize a CSS value">serialization</a> of <var>list</var> and terminate these steps.
+     then return the <a lt="serialize a CSS value">serialization</a> of <var>list</var>.
      <li>Return the empty string.
     </ol>
   </ol>
  <li>If <var>property</var> is a <a>case-sensitive</a>
  match for a <a for="CSS declaration">property name</a> of a <a>CSS declaration</a> in the
- <a for="CSSStyleDeclaration">declarations</a>, return the result of invoking
- <a>serialize a CSS value</a> of that declaration and terminate these steps.
+ <a for="CSSStyleDeclaration">declarations</a>, then return the result of invoking
+ <a>serialize a CSS value</a> of that declaration.
  <li>Return the empty string.
 </ol>
 
@@ -2164,8 +2163,7 @@ The <dfn method for=CSSStyleDeclaration>getPropertyPriority(<var>property</var>)
      <li>Let <var>list</var> be a new array.
      <li>For each longhand property <var>longhand</var> that <var>property</var> maps to, append the result of invoking
      {{CSSStyleDeclaration/getPropertyPriority()}} with <var>longhand</var> as argument to <var>list</var>.
-     <li>If all items in <var>list</var> are the string "<code>important</code>", return the string "<code>important</code>" and terminate these
-     steps.
+     <li>If all items in <var>list</var> are the string "<code>important</code>", then return the string "<code>important</code>".
     </ol>
   </ol>
  <li>If <var>property</var> is a
@@ -2179,23 +2177,23 @@ value would be "<code>important</code>".</div>
 
 The <dfn method for=CSSStyleDeclaration>setProperty(<var>property</var>, <var>value</var>, <var>priority</var>)</dfn> method must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
- a {{NoModificationAllowedError}} exception and terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
    <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
-   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
+   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, then return.
   </ol>
  <li>If <var>value</var> is the empty string, invoke {{CSSStyleDeclaration/removeProperty()}}
- with <var>property</var> as argument and terminate this algorithm.
+ with <var>property</var> as argument and return.
  <li>If <var>priority</var> is not the empty string and is not an <a>ASCII case-insensitive</a> match for the string
- "<code>important</code>", terminate this algorithm.
+ "<code>important</code>", then return.
  <li>
   Let <var>component value list</var> be the result of <a lt="parse a CSS value">parsing</a> <var>value</var> for property <var>property</var>.
 
   Note: <var>value</var> can not include "<code>!important</code>".
 
- <li>If <var>component value list</var> is null terminate these steps.
+ <li>If <var>component value list</var> is null, then return.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration">set the CSS declaration</a> <var>longhand</var> with the appropriate value(s) from <var>component value
  list</var>, with the <i>important</i> flag set if <var>priority</var> is not the empty string, and unset otherwise, and with the list of declarations being the
@@ -2222,21 +2220,21 @@ a list of declarations <var>declarations</var>, follow these steps:
 The <dfn method for=CSSStyleDeclaration>setPropertyValue(<var>property</var>, <var>value</var>)</dfn> method must run these
 steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
- a {{NoModificationAllowedError}} exception and terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
    <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
-   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
+   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, then return.
   </ol>
  <li>If <var>value</var> is the empty string, invoke {{CSSStyleDeclaration/removeProperty()}}
- with <var>property</var> as argument and terminate this algorithm.
+ with <var>property</var> as argument and return.
  <li>
   Let <var>component value list</var> be the result of <a lt="parse a CSS value">parsing</a> <var>value</var> for property <var>property</var>.
 
   Note: <var>value</var> can not include "<code>!important</code>".
 
- <li>If <var>component value list</var> is null terminate these steps.
+ <li>If <var>component value list</var> is null, then return.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration value">set the CSS declaration value</a> <var>longhand</var> to the appropriate value(s) from <var>component
  value list</var>, and with the list of declarations being the <a for="CSSStyleDeclaration">declarations</a>.
@@ -2259,15 +2257,15 @@ The <dfn method for=CSSStyleDeclaration>setPropertyPriority(<var>property</var>,
 these steps:
 
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
- a {{NoModificationAllowedError}} exception and terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
    <li>Let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
-   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, terminate this algorithm.
+   <li>If <var>property</var> is not a <a>case-sensitive</a> match for a <a>supported CSS property</a>, then return.
   </ol>
  <li>If <var>priority</var> is not the empty string and is not an <a>ASCII case-insensitive</a> match for the string
- "<code>important</code>", terminate this algorithm.
+ "<code>important</code>", then return.
  <li>If <var>property</var> is a shorthand property, then for each longhand property <var>longhand</var> that <var>property</var> maps to, in canonical
  order, <a lt="set a CSS declaration priority">set the CSS declaration priority</a> <var>longhand</var> with the <i>important</i> flag set if
  <var>priority</var> is not the empty string, and unset otherwise, and with the list of declarations being the
@@ -2284,15 +2282,15 @@ To <dfn>set a CSS declaration priority</dfn> <var>property</var> optionally with
 <ol>
  <li>If <var>property</var> is a <a>case-sensitive</a> match for a <a for="CSS declaration">property
  name</a> of a <a>CSS declaration</a> in <var>declarations</var>, let <var>declaration</var> be that <a>CSS declaration</a>.
- <li>Otherwise, terminate these steps.
+ <li>Otherwise, return.
  <li>If the <i>important</i> flag is set, set <var>declaration</var>'s <a for="CSS declaration">important flag</a>. Otherwise,
  unset <var>declaration</var>'s <a for="CSS declaration">important flag</a>.
 </ol>
 
 The <dfn method for=CSSStyleDeclaration>removeProperty(<var>property</var>)</dfn> method must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, <a>throw</a>
- a {{NoModificationAllowedError}} exception and terminate these steps.
+ <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>,
  let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
  <li>Let <var>value</var> be the return value of invoking {{CSSStyleDeclaration/getPropertyValue()}}
@@ -2475,7 +2473,7 @@ declarations</a> <var>list</var>, follow these rules:
   <ol>
    <li>Let <var>shorthand</var> be the shorthand property that exactly maps to all the longhand properties in <var>list</var>. If there are multiple such
    shorthand properties, use the first in <a>preferred order</a>.
-   <li>If <var>shorthand</var> cannot represent the values of <var>list</var> in its grammar, return the empty string and terminate these steps.
+   <li>If <var>shorthand</var> cannot represent the values of <var>list</var> in its grammar, then return the empty string.
    <li>Let <var>trimmed list</var> be a new empty array.
    <li>For each <a>CSS declaration</a> <var>declaration</var> in <var>list</var>, if <var>declaration</var>'s
    <a for="CSS declaration">value</a> is not the initial value, or if
@@ -2484,13 +2482,13 @@ declarations</a> <var>list</var>, follow these rules:
    <li>Let <var>values</var> be a new empty array.
    <li>For each <a>CSS declaration</a> <var>declaration</var> in <var>trimmed list</var>, invoke <a>serialize a CSS value</a> of
    <var>declaration</var>, and append the result to <var>values</var>.
-   <li>Return the result of joining <var>values</var> as appropriate according to the grammar of <var>shorthand</var> and terminate these steps.
+   <li>Return the result of joining <var>values</var> as appropriate according to the grammar of <var>shorthand</var>.
   </ol>
  <li>Let <var>values</var> be a new empty array.
  <li>Append the result of invoking <a>serialize a CSS component value</a> of <var>declaration</var>'s
  <a for="CSS declaration">value</a> to <var>values</var>.
  <li>If the grammar of the <a for="CSS declaration">property name</a> of <var>declaration</var> is defined to be
- whitespace-separated, return the result of invoking <a>serialize a whitespace-separated list</a> of <var>values</var> and terminate these steps.
+ whitespace-separated, return the result of invoking <a>serialize a whitespace-separated list</a> of <var>values</var>.
  <li>If the grammar of the <a for="CSS declaration">property name</a> of <var>declaration</var> is defined to be comma-separated,
  return the result of invoking <a>serialize a comma-separated list</a> of <var>values</var>.
 </ol>


### PR DESCRIPTION
This change removes all the "terminate these steps" and "terminate this algorithm" from this spec. They are either removed due to redundancy (already following a "return" or "throw") or replaced with "return".