### PR TITLE
Move effects of containment on regions from [css-contain-1] to [css-regions-1]

### DIFF
--- a/css-contain-1/Overview.bs
+++ b/css-contain-1/Overview.bs
@@ -224,15 +224,8 @@ Layout Containment</h3>
 		they remain part of the <a>fragmentation context</a>,
 		but do not receive any content from the <a>fragmented flow</a>.
 
-		Specifically:
-			- <a>CSS Regions</a> following the one which traps the content
-				are still considered part of the <a>region chain</a>
-				as returned by the {{NamedFlow/getRegions()}} method
-				of the {{NamedFlow}} interface.
-			- the {{Region/regionOverset}} attribute of the {{Region}} interface
-				of the region which traps the content
-				is set to ''overset'' if the content doesn't fit,
-				even if it is not the last region in the region chain.
+		Note: [[CSS-REGIONS-1]] has details over how <a>layout containment</a> affects
+		regions.
 
 	3. If the contents of the element overflow the element,
 		they must be treated as <a>ink overflow</a>.
@@ -261,8 +254,10 @@ Style Containment</h3>
 
 	Giving an element <dfn export>style containment</dfn> has the following effects:
 
-	1. The 'counter-increment', 'counter-set', 'flow-from', 'flow-into', and <a property spec=css2>content</a> (for the purpose of ''content/open-quote''/etc values) properties
+	1. The 'counter-increment', 'counter-set', and <a property spec=css2>content</a> (for the purpose of ''content/open-quote''/etc values) properties
 	    must be <a for=property>scoped</a> to the element's sub-tree.
+
+	Note: [[CSS-REGIONS-1]] has normative requirements on how <a>style containment</a> affects regions.
 
 	A <dfn export for=property lt="scoped | scoped property | scoped properties">scoped property</dfn> has its effects scoped to a particular element or subtree.
 	It must act as if the scoping element was the root of the document
@@ -416,6 +411,7 @@ This appendix is <em>informative</em>.
 	<li>Clarify to which box paint containment clips.
 	<li>Move the interaction between containment and the <code>bookmark-*</code> and <code>string-set</code> properties to  [[CSS-CONTENT-3]]
 	<li>Remove the effects of style containment on the "break-*" properties.
+	<li>Move the description of the effects of containement on regions from this specification to [[CSS-REGIONS-1]].
 </ul>
 
 <h3 id="2017-04-19-changes">Changes from the

--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -280,7 +280,8 @@ Last region</h3>
 	A <a>CSS region</a> is deemed to be the <dfn lt="last usable region | last usable CSS region">last usable region</dfn>
 	in a <a>region chain</a>
 	if it is the first region in that chain to have <a>layout containment</a>,
-	or the last region in the chain if none of them have <a>layout containment</a>.
+	or the last region in the chain if none of them have <a>layout containment</a>
+	(See [[!CSS-CONTAIN-1]]).
 
 <h3 id="named-flow-section">
 Named flows</h3>

--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -274,6 +274,14 @@ Region chain</h3>
 	into a <a>region chain</a>
 	according to the document order.
 
+<h3 id=last-region>
+Last region</h3>
+
+	A <a>CSS region</a> is deemed to be the <dfn lt="last usable region | last usable CSS region">last usable region</dfn>
+	in a <a>region chain</a>
+	if it is the first region in that chain to have <a>layout containment</a>,
+	or the last region in the chain if none of them have <a>layout containment</a>.
+
 <h3 id="named-flow-section">
 Named flows</h3>
 
@@ -322,12 +330,12 @@ Regions flow breaking rules</h3>
 	at which point the next region
 	in the <a>region chain</a>
 	becomes the current region.
-	If there are no more <a>CSS Regions</a>
+	If there are no more usable <a>CSS Regions</a>
 	in the <a>region chain</a>
 	and there is still content in the flow,
 	the positioning of the remaining content
 	is controlled by the 'region-fragment' property
-	on the last <a>CSS Region</a> in the chain.
+	on the <a>last usable CSS Region</a> in the chain.
 
 	The CSS regions module follows
 	the fragmentation rules defined
@@ -461,6 +469,9 @@ The 'flow-into' property</h3>
 	for the entire flow.
 	The writing mode
 	on subsequent regions is ignored.
+
+	If an element has <a>style containment</a> (See [[!CSS-CONTAIN-1]]),
+	then the 'flow-into' property must be <a for=property>scoped</a> to that element.
 
 	<div class="note"><span class="note-prefix">Note </span>
 
@@ -606,6 +617,9 @@ The 'flow-from' property</h3>
 	are generated as <a>CSS Regions</a>,
 	which is an update to the behavior
 	described in [[!CSS21]].
+
+	If an element has <a>style containment</a> (See [[!CSS-CONTAIN-1]]),
+	then the 'flow-from' property must be <a for=property>scoped</a> to that element.
 
 	<div class="note"><span class="note-prefix">Note </span>
 
@@ -903,7 +917,7 @@ The region-fragment property</h3>
 	</pre>
 
 	The 'region-fragment' property controls the behavior
-	of the <em id="last-region">last region</em>
+	of the <a>last usable region</a>
 	associated with a <a>named flow</a>.
 
 	<dl>
@@ -915,7 +929,7 @@ The region-fragment property</h3>
 			it is subject to the
 			<a href= "https://www.w3.org/TR/CSS21/visufx.html#propdef-overflow">overflow</a>
 			property's computed value on the <a>CSS Region</a>.
-			Region breaks must be ignored on the last region.
+			Region breaks must be ignored on the <a>last usable region</a>.
 		</dd>
 
 		<dt>break</dt>
@@ -929,7 +943,7 @@ The region-fragment property</h3>
 			See the <a href= "#regions-flow-breaking-rules">breaking rules</a> section.
 			A forced region break takes precedence over a natural break point.
 
-			Flow content that follows the last break in the last region is not rendered.
+			Flow content that follows the last break in the <a>last usable region</a> is not rendered.
 		</dd>
 	</dl>
 
@@ -1152,6 +1166,7 @@ The NamedFlow interface</h3>
 	method returns the sequence
 	of regions in the <a>region chain</a>
 	associated with the <a>named flow</a>.
+	Regions after the <a>last usable region</a>, if any, are included.
 	Note that the returned values
 	is a static sequence
 	in document order.
@@ -1240,7 +1255,7 @@ The Region interface</h3>
 		<dt>''overset''</dt>
 
 		<dd>
-			The region is the last one in the
+			The region is the <a>last usable region</a> in the
 			<a>region chain</a> and
 			not able to fit the remaining content from the <a>named flow</a>.
 			Note that the region's
@@ -1249,7 +1264,7 @@ The Region interface</h3>
 			property value can be used to control the
 			visibility of the overflowing content and the
 			'region-fragment' property controls whether or not fragmentation happens
-			on the content that overflows the last region.
+			on the content that overflows the <a>last usable region</a>.
 		</dd>
 
 		<dt>''fit''</dt>
@@ -1258,11 +1273,11 @@ The Region interface</h3>
 			The region's flow fragment content
 			fits into the region's
 			<a href="https://www.w3.org/TR/CSS21/box.html#box-dimensions">content box</a>.
-			If the region is the last one
+			If the region is the <a>last usable region</a>
 			in the <a>region chain</a>,
 			it means that the content
 			fits without overflowing.
-			If the region is not the last one
+			If the region is not the <a>last usable region</a>
 			in the <a>region chain</a>,
 			that means the <a>named flow</a> content
 			may be further fitted in subsequent regions.
@@ -1317,7 +1332,7 @@ The Region interface</h3>
 	is the first <code>Node</code>
 	in the <a>named flow</a>
 	and the <code>startOffset</code> is zero.
-	If the region is the last region
+	If the region is the <a>last usable region</a>
 	in the <a>region chain</a>
 	(but not the first and only one),
 	the <code>startContainer</code>
@@ -1501,7 +1516,7 @@ Multi-column regions</h2>
 	the remaining <a>region chain</a>.
 	However,
 	if a multicol region
-	is the last region
+	is the <a>last usable region</a>
 	in a <a>region chain</a>,
 	then the multicol region must follow the
 	<a href="https://drafts.csswg.org/css3-multicol/#overflow-columns">overflow column rules</a>
@@ -2136,6 +2151,7 @@ Changes from <a href="https://www.w3.org/TR/2014/WD-css3-regions-20140218/">Febr
 	<ul>
 		<li>Added three simpler examples to the introduction</li>
 		<li>Moved complex example to the <a href="http://wiki.csswg.org/spec/css3-regions/complex-layout-example">CSSWG wiki</a></li>
+		<li>Moved the effects of CSS containment to this specification from [[CSS-CONTAIN-1]].
 	</ul>
 
 <h3 id="changes_from_May_28_2013">


### PR DESCRIPTION
As discussed in https://github.com/w3c/csswg-drafts/issues/1872#issuecomment-365686723, this PR moves the effect of containment on regions from the containment spec to the regions spec.

@astearns I vouch for the css-contain part of this patch. Can you review (and hopefully approve, then merge) the css-regions part?