### PR TITLE
Explicitly specify what gets set to what with MCW

### DIFF
--- a/css2/tables.html
+++ b/css2/tables.html
@@ -996,7 +996,7 @@ final layout and may demand more than one pass.
   formatted content may span any number of lines but may not overflow
   the cell box. If the specified <a href="visudet.html#propdef-width" class="noxref"><span
   class="propinst-width">'width'</span></a> (W) of the cell is greater
-  than MCW, W is the minimum cell width. A value of 'auto' means that
+  than MCW, the minimum cell width is set to W. A value of 'auto' means that
   MCW is the minimum cell width.
 
   <p>Also, calculate the "maximum" cell width of each cell: formatting


### PR DESCRIPTION
"A is B" can mean both "A = B" and "B = A". It usually means the former; but in this case it's the latter, and that's confusing.