### PR TITLE
CSSFontFaceRule etc. exposed to Window

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2514,6 +2514,7 @@ The <code>CSSCounterStyleRule</code> interface</h3>
 	The <a interface>CSSCounterStyleRule</a> interface represents a ''@counter-style'' rule.
 
 	<pre class='idl'>
+	[Exposed=Window]
 	interface CSSCounterStyleRule : CSSRule {
 	  attribute CSSOMString name;
 	  attribute CSSOMString system;

--- a/css-device-adapt-1/Overview.bs
+++ b/css-device-adapt-1/Overview.bs
@@ -585,13 +585,13 @@ Values have the following meanings:
     or limit (with <code>max-zoom</code>) the ability of users to resize
     a document, as this causes accessibility and usability issues.
 
-    There may be specific use cases where preventing users from zooming 
-    may be appropriate, such as map applications – where custom zoom 
-    functionality is handled via scripting. However, in general this 
+    There may be specific use cases where preventing users from zooming
+    may be appropriate, such as map applications – where custom zoom
+    functionality is handled via scripting. However, in general this
     practice should be avoided.
 
-    Most user agents now allow users to always zoom, regardless 
-    of any restrictions specified by web content – either by default, or 
+    Most user agents now allow users to always zoom, regardless
+    of any restrictions specified by web content – either by default, or
     as a setting/option (which may however not be immediately apparent
     to users).
 </div>
@@ -926,6 +926,7 @@ The <dfn interface>CSSViewportRule</dfn> interface represents the
 style rule for an ''@viewport'' rule.
 
 <pre class=idl>
+[Exposed=Window]
 interface CSSViewportRule : CSSRule {
     readonly attribute CSSStyleDeclaration style;
 };

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -3649,6 +3649,7 @@ The <code id="cssfontfacerule2">CSSFontFaceRule</code> interface</h3>
 The <dfn>CSSFontFaceRule</dfn> interface represents a <<@font-face>> rule.
 
 <pre class="idl">
+[Exposed=Window]
 interface CSSFontFaceRule : CSSRule {
     readonly attribute CSSStyleDeclaration style;
 };


### PR DESCRIPTION
CSSFontFaceRule, CSSViewportRule, CSSCounterStyleRule are now
explicitly exposed to Window.

The other CSSRule interfaces defined in csswg-drafts are
already exposed to Window.

resolves #2342