### PR TITLE
Add [Exposed=Window] to interfaces

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -580,7 +580,8 @@ updating the set of keyframes returned by
 Something like,
 
 <pre class="idl">
-[Constructor (CSSOMString keyframesName, CSSOMString defaultEasing)]
+[Exposed=Window,
+ Constructor (CSSOMString keyframesName, CSSOMString defaultEasing)]
 interface CSSKeyframeEffectReadOnly : KeyframeEffectReadOnly {
   readonly attribute CSSOMString keyframesName;
   readonly attribute CSSOMString defaultEasing;

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -820,6 +820,7 @@ Interface CSSPseudoElement</h3>
   </div>
 
   <pre class="idl">
+    [Exposed=Window]
     interface CSSPseudoElement {
         readonly attribute CSSOMString <a href="#dom-csspseudochild-type">type</a>;
         readonly attribute <a href="https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration">CSSStyleDeclaration</a> <a href="#dom-csspseudochild-style">style</a>;
@@ -866,6 +867,7 @@ Interface CSSPseudoElementList</h3>
   of <code>CSSPseudoElement</code> instances.
 
   <pre class="idl">
+    [Exposed=Window]
     interface CSSPseudoElementList {
         readonly attribute unsigned long <a href="#dom-csspseudochildlist-length">length</a>;
         CSSPseudoElement <a href="#dom-csspseudochildlist-item">item</a>(unsigned long index);

--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -1094,7 +1094,8 @@ The NamedFlow interface</h3>
 	and is read-only.
 
 	<pre class="idl">
-		[MapClass(CSSOMString, NamedFlow)] interface NamedFlowMap {
+		[Exposed=Window,
+		 MapClass(CSSOMString, NamedFlow)] interface NamedFlowMap {
 			NamedFlow? get(CSSOMString flowName);
 			boolean has(CSSOMString flowName);
 			NamedFlowMap set(CSSOMString flowName, NamedFlow flowValue);
@@ -1140,6 +1141,7 @@ The NamedFlow interface</h3>
 	would be false.
 
 	<pre class="idl">
+		[Exposed=Window]
 		interface NamedFlow : EventTarget {
 			readonly attribute CSSOMString name;
 			readonly attribute boolean overset;

--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -1102,7 +1102,8 @@ associated with transitions.
 ### IDL Definition ### {#interface-transitionevent-idl}
 
 <pre class="idl">
-  [Constructor(CSSOMString type, optional TransitionEventInit transitionEventInitDict)]
+  [Exposed=Window,
+   Constructor(CSSOMString type, optional TransitionEventInit transitionEventInitDict)]
   interface TransitionEvent : Event {
     readonly attribute CSSOMString propertyName;
     readonly attribute float elapsedTime;


### PR DESCRIPTION
From #2342:
WebIDL now defines that interfaces include the Exposed extended attribute even in the case where it is only exposed to Window.

The following interfaces previously omitted the Exposed extended attribute:

NamedFlow, NamedFlowMap,
CSSPseudoElement, CSSPseudoElementList,
CSSKeyframeEffectReadOnly,
TransitionEvent