### PR TITLE
[selectors] querySelectorAll not queryAll

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -23,7 +23,7 @@ Abstract: Selectors Level 4 describes the selectors that already exist in [[!SEL
 At Risk: the column combinator
 At Risk: the '':drop()'' pseudo-class
 At Risk: the '':read-write'' pseudo-class
-Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, query(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
+Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
 Ignored Vars: identifier, extended filtering, i
 </pre>
 <pre class=link-defaults>
@@ -61,7 +61,7 @@ Introduction</h2>
 		<li>
 			applied to an entire tree of elements
 			to filter it into a set of elements that match the criteria,
-			such as in the <code>document.queryAll()</code> function defined in [[DOM]]
+			such as in the <code>document.querySelectorAll()</code> function defined in [[DOM]]
 			or the selector of a CSS style rule.
 
 		<li>
@@ -526,7 +526,7 @@ Selectors Overview</h2>
 		<dd>
 			The <a>snapshot</a> profile is appropriate for contexts which aren't extremely performance sensitive;
 			in particular, it's appropriate for contexts which evaluate selectors against a static document tree.
-			For example, the {{Element/query()}} method defined in [[DOM]] should use the <a>snapshot</a> profile.
+			For example, the {{Element/querySelector()}} method defined in [[DOM]] should use the <a>snapshot</a> profile.
 			It includes all of the selectors defined in this document.
 	</dl>
 


### PR DESCRIPTION
The DOM methods are querySelector and querySelectorAll,
not query and queryAll.

resolves #2360