### PR TITLE
Use `<custom-ident>` consistently for counter names

### DIFF
--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -1041,8 +1041,8 @@ Outputting Counters: the ''counter()'' and ''counters()'' functions</h3>
 	but can be used by an author anywhere that accepts a <<string>>.  Their syntax is:
 
 	<pre>
-		<dfn>counter()</dfn>  =  counter( <<ident>>, [ <<counter-style>> | none ]? )
-		<dfn>counters()</dfn> = counters( <<ident>>, <<string>>, [ <<counter-style>> | none ]? )
+		<dfn>counter()</dfn>  =  counter( <<custom-ident>>, [ <<counter-style>> | none ]? )
+		<dfn>counters()</dfn> = counters( <<custom-ident>>, <<string>>, [ <<counter-style>> | none ]? )
 	</pre>
 
 	For both functions, the first argument represents the name of a counter,
@@ -1221,7 +1221,7 @@ Outputting Counters: the ''counter()'' and ''counters()'' functions</h3>
 		but this is a *little bit* clumsy,
 		and doesn't work for siblings.)
 
-		Suggestion is to add a <css>counter-value(<<ident>>)</css> function,
+		Suggestion is to add a <css>counter-value(<<custom-ident>>)</css> function,
 		which returns the value of the named counter as an integer,
 		rather than returning a string.
 	</div>


### PR DESCRIPTION
The functions `counter()` and `counters()` were badly specified, using
`<ident>` for the counter names, even though `counter-increment` and friends
will only accept `<custom-ident>` for those names.