### PR TITLE
[css-multicol] Refer to line-style,line-width

### DIFF
--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -820,7 +820,7 @@ Column gaps and rules</h2>
 
 	<pre class=propdef>
 	Name: column-rule-style
-	Value: <<'border-style'>>
+	Value: <<line-style>>
 	Initial: none
 	Applies to: multicol containers
 	Inherited: no
@@ -831,7 +831,7 @@ Column gaps and rules</h2>
 	</pre>
 
 	The 'column-rule-style' property sets the style of the rule between columns of an element.
-	The <<'border-style'>> values are interpreted as in the <a href="https://www.w3.org/TR/CSS2/tables.html#collapsing-borders">collapsing border model</a>.
+	The <<line-style>> values are interpreted as in the <a href="https://www.w3.org/TR/CSS2/tables.html#collapsing-borders">collapsing border model</a>.
 
 	The ''border-style/none'' value forces the computed value of 'column-rule-width' to be ''0''.
 
@@ -841,7 +841,7 @@ Column gaps and rules</h2>
 
 	<pre class=propdef>
 	Name: column-rule-width
-	Value: <<'border-width'>>
+	Value: <<line-width>>
 	Initial: medium
 	Applies to: multicol containers
 	Inherited: no


### PR DESCRIPTION
The grammar rules are now

 - column-rule-style: < line-style >
 - column-rule-width: < line-width >

instead of

 - column-rule-style: <‘border-style’>
 - column-rule-width: <‘border-width’>
 - border-style: < line-style >{1,4}
 - border-width: < line-width >{1,4}

resolves #2379