### PR TITLE
Add :focus-visible recommendation for tabindex/appearance.

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2295,6 +2295,30 @@ The Focus-Indicated Pseudo-class: '':focus-visible''</h3>
 			apply '':focus-visible''.
 	</div>
 
+	<div class="note">
+		Note: It is a common practice by UAs to always draw a focus indicator on any
+		element with a <pre>tabindex</pre> attribute, or any element whose
+		''appearance'' has been altered. However, it is recommended that
+		'':focus-visible'' should only be applied to these elements if they receive
+		focus via a keyboard interaction.
+		
+		<a
+		href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">Custom
+		Elements</a>, for example, will always need to apply a <pre>tabindex</pre>
+		attribute to be keyboard operable, but the mere presence of a
+		<pre>tabindex</pre> attribute is not a strong enough signal to indicate that
+		the element should always display a focus indicator.
+
+		Similarly, applying a style to an element which modifies its ''appearance''
+		is not a strong enough signal to indicate that the element should always
+		display a focus indicator. It is not uncommon for page authors to style
+		<pre>button</pre> elements such that their ''appearance'' is modified. This
+		causes some UAs to start drawing a focus indicator on these elements,
+		regardless of the user's input modality. Surprised by this new behavior,
+		page authors commonly "correct" the system by adding a '':focus''
+		style to disable the ''outline'' entirely.
+	</div>
+
 <h3 id="the-focus-within-pseudo">
 The Focus Container Pseudo-class: '':focus-within''</h3>
 


### PR DESCRIPTION
Although the `:focus-visible` spec says it's up to the UA's heuristic to determine when to match, I wanted to add a note to recommend that `:focus-visible` not match on mouse-focused elements with `tabindex=0` or modified `appearance`. What do y'all think?

cc @alice @bkardell @tabatkins 