### PR TITLE
[css-text-decor-4] Skip punctuation for emphasis marks

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -427,7 +427,7 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 		</tr>
 		<tr>
 			<th>Initial:</th>
-			<td>spaces
+			<td>spaces punctuation
 		</tr>
 		<tr>
 			<th>Applies to:</th>

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -411,46 +411,16 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 	<p class="issue">This section is under brainstorming.
 	It's also not yet clear if this property is needed quite yet, despite differences in desired behavior among publications.
 
-	<table class="propdef">
-	<tbody>
-		<tr>
-			<th>Name:</th>
-			<td><dfn>text-emphasis-skip</dfn></td>
-		</tr>
-		<tr>
-			<th>Value:</th>
-			<td>spaces ||
-				punctuation ||
-				symbols ||
-				narrow
-			</td>
-		</tr>
-		<tr>
-			<th>Initial:</th>
-			<td>spaces punctuation
-		</tr>
-		<tr>
-			<th>Applies to:</th>
-			<td>all elements</td>
-		</tr>
-		<tr>
-			<th>Inherited:</th>
-			<td>yes</td>
-		</tr>
-		<tr>
-			<th>Percentages:</th>
-			<td>N/A</td>
-		</tr>
-		<tr>
-			<th>Media:</th>
-			<td>visual</td>
-		</tr>
-		<tr>
-			<th>Computed&#160;value:</th>
-			<td>as specified</td>
-		</tr>
-	</tbody>
-	</table>
+	<pre class="propdef">
+			Name: text-emphasis-skip
+			Value: spaces || punctuation || symbols || narrow
+			Initial: spaces punctuation
+			Applies to: all elements
+			Inherited: yes
+			Percentages: N/A
+			Media: visual
+			Computed value: as specified
+	</pre>
 
 	This property describes for which characters marks are drawn.
 	The values have following meanings:
@@ -458,7 +428,7 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 	<dl for=text-emphasis-skip type=value>
 		<dt><dfn>spaces</dfn>
 		<dd>
-			Skip <a href="https://www.w3.org/TR/css-text/#word-separator">Word separators</a> or characters
+			Skip <a href="https://www.w3.org/TR/css-text/#word-separator">word separators</a> or other <a>characters</a>
 			belonging to the Unicode separator category (Z*).
 			(But note that emphasis marks <em>are</em> drawn for a space
 			 that combines with any combining characters.)
@@ -469,8 +439,8 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 			Punctuation in this definition includes characters belonging to
 			the Unicode Pc, Pd, Ps, Pe, Pi, or Pf categories.
 			It also includes characters where the Unicode category is Po and
-			the Sentence_Break property [[!UAX29]] of the Unicode database
-			[[!UAX44]] is ATerm, Close, SContinue, or STerm.
+			the <code>Sentence_Break</code> property [[!UAX29]] of the Unicode database
+			[[!UAX44]] is <code>ATerm</code>, <code>Close</code>, <code>SContinue</code>, or <code>STerm</code>.
 
 		<dt><dfn>symbols</dfn>
 		<dd>Skip symbols.

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -454,7 +454,7 @@ Emphasis Mark Skip: the 'text-emphasis-skip' property</h3>
 			that are not defined as ''<a>punctuation</a>'' above.
 
 		<dt><dfn>narrow</dfn>
-		<dd>Skip characters where the East_Asian_Width property [[!UAX11]]
+		<dd>Skip characters where the <code>East_Asian_Width</code> property [[!UAX11]]
 			of the Unicode database [[!UAX44]] is not F (Fullwidth) or W (Wide).
 	</dl>
 

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -17,6 +17,10 @@ Link Defaults: css-color-3 (property) color, css-break-3 (dfn) fragment
 Ignored Terms: svg shape, svg shapes, invalid, repeatable list, simple list, valid image
 </pre>
 
+<pre class="link-defaults">
+spec:css-text-3; type:dfn; text:character
+</pre>
+		
 <h2 id=intro>Introduction</h2>
 
 	This is the initial draft of CSS Text Decoration Level 4;


### PR DESCRIPTION
This PR updates the L4 spec, along with some formatting changes to the section (in separate commits, for the ease of review).