### PR TITLE
[css-font-loading] Fix invalid WebIDL syntax

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -993,7 +993,7 @@ Interaction with CSS Font Loading and Matching</h3>
 The <code>FontFaceSource</code> interface</h2>
 
 	<pre class='idl'>
-		[Exposed=(Window,Worker)
+		[Exposed=(Window,Worker),
 		 NoInterfaceObject]
 		interface FontFaceSource {
 			readonly attribute FontFaceSet fonts;


### PR DESCRIPTION
Missing comma-separate in Extended Attribute list of FontFaceSource