### PR TITLE
rephrase to make it clear which shadow root

### DIFF
--- a/css-shadow-parts-1/Overview.bs
+++ b/css-shadow-parts-1/Overview.bs
@@ -133,17 +133,17 @@ Each part mapping is one of:
 
 <dl class=switch>
     : <code>ident</code>
-    :: Adds «[ ident → el ]» to the <a>shadow root's</a> <a>shadow part map</a>.
+    :: Adds «[ ident → el ]» to the <a>shadow part map</a> of the <a>shadow root</a> containing el.
 
     : <code>ident1 => ident2</code>
     :: If el is a <a>shadow host</a>,
         and it's <a>shadow root's</a> <a>shadow part map</a> |partMap| [=map/contains=] ident1,
-        then this adds «[ ident2 → |partMap|[ident1] ]» to the <a>shadow root's</a> <a>shadow part map</a>.
+        then this adds «[ ident2 → |partMap|[ident1] ]» to the <a>shadow part map</a> of the <a>shadow root</a> containing el.
 
     : <code>* => prefix*</code>
     :: If el is a <a>shadow host</a>,
         then [=map/for each=] |ident| → |subEl| in el's <a>shadow root's</a> <a>shadow part map</a>,
-        «[ prefix + |ident| → |subEl| ]» is added to the <a>shadow root's</a> <a>shadow part map</a>.
+        «[ prefix + |ident| → |subEl| ]» is added to the <a>shadow part map</a> of the <a>shadow root</a> containing el.
 
     : anything else
     :: Ignored for error-recovery / future compat.


### PR DESCRIPTION
When dealing with mappings on host elements there are 2 possible meanings to "shadow root" - the one attached to the host and the one containing the host. In the spec, only one makes sense, so it's unambiguous but this change makes it explicit.