### PR TITLE
[mediaqueries-4] Move 'pointer'/'hover' note, reword "can potentially" to "should strongly consider"

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1752,7 +1752,14 @@ Note: the '@media/hover', '@media/any-hover', '@media/pointer', and '@media/any-
 	or the complete absence, of pointing devices,
 	and can not be used to detect the presence of non-pointing device input mechanisms such as keyboards.
 	Authors should take into account the potential presence of non-pointing device inputs,
-	regardless of which values are matched when querying these features. 
+	regardless of which values are matched when querying these features.
+
+	<div class="note">
+		While 'pointer' and 'hover' can be used to design the main style and interaction
+		mode of the page to suit the primary input mechanism (based on the characteristics, or complete absence,
+		of the primary pointing device), authors should strongly consider using 'any-pointer' and 'any-hover'
+		to take into account all possible types of pointing devices	that have been detected.
+	</div>
 
 <h3 id="pointer">
 Pointing Device Quality: the 'pointer' feature</h3>
@@ -1952,12 +1959,6 @@ Note: This feature is at risk.
 	</div>
 
 	<div class="note">
-	While 'pointer' and 'hover' can be used to design the main style and interaction
-	mode of the page to suit the primary input mechanism (based on the characteristics, or complete absence,
-	of the primary pointing device), 'any-pointer' and 'any-hover'
-	can be used to potentially take into account all possible types of pointing devices
-	that have been detected.
-
 	Designing a page that relies on hovering or accurate pointing
 	only because 'any-hover' or 'any-pointer' indicate that at least one of the available
 	input mechanisms has these capabilities	is likely to result in a poor experience.


### PR DESCRIPTION
Based on https://www.smashingmagazine.com/2018/02/media-queries-responsive-design-2018/, and in particular based on the article's note

> "I’d suggest that you should take great care in using these, as making a user switch from their primary pointing device is likely to result in a poor user experience."

I think the fact that relying purely on `pointer` and `hover` can also be just as bad has been missed out by having the note where it is. Moving it right to the start (and strenghtening the suggestion) would probably help in making sure authors don't get too complacent about relying just on whatever the browser/device determines to be the primary pointer input, as ignoring any alternative inputs would conversely force users to only use the primary input even if they don't want to, for whatever reason.