### PR TITLE
Flag non-spec IDL with class 'note'

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2324,7 +2324,7 @@ the following partial interface applies where <var>camel-cased attribute</var>
 is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 <var>property</var>.
 
-<pre class="idl extract">
+<pre class="idl extract note">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>camel_cased_attribute</var>;
 };
@@ -2348,7 +2348,7 @@ with the string <code>-webkit-</code>, the following partial interface applies w
 <var>webkit-cased attribute</var> is obtained by running the <a>CSS property to IDL attribute</a>
 algorithm for <var>property</var>, with the <i>lowercase first</i> flag set.
 
-<pre class="idl extract">
+<pre class="idl extract note">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>webkit_cased_attribute</var>;
 };
@@ -2373,7 +2373,7 @@ For each CSS property <var>property</var> that is a <a>supported CSS property</a
 except for properties that have no "<code>-</code>" (U+002D) in the property name,
 the following partial interface applies where <var>dashed attribute</var> is <var>property</var>.
 
-<pre class="idl extract">
+<pre class="idl extract note">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>dashed_attribute</var>;
 };


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/2486 which blocks https://github.com/w3c/web-platform-tests/pull/9776

The snippets are for showing what form the generated output will take, not for should-be-tested IDL.