### PR TITLE
[cssom] Remove CORS-same-origin from ignored terms

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -17,7 +17,7 @@ Former Editor: Glenn Adams, Cox Communications&#44; Inc. http://www.cox.com, gle
 Former Editor: Anne van Kesteren, Opera Software ASA http://www.opera.com, annevk@annevk.nl, https://annevankesteren.nl/
 !Legacy issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=CSS&amp;component=CSSOM&amp;resolution=---">Bugzilla</a>
 Abstract: CSSOM defines APIs (including generic parsing and serialization rules) for Media Queries, Selectors, and of course CSS itself.
-Ignored Terms: EmptyString, mediaText, cssText, InvalidCharacterError, SecurityError, SyntaxError, IndexSizeError, HierarchyRequestError, InvalidStateError, InvalidModificationError, NoModificationAllowedError, CORS-same-origin, group of selectors, list of css page selectors, CSSCharsetRule, ProcessingInstruction, EventTarget, EventListener, Event, EventInit, Element, Range, Node, Text, style, CSSFontFaceRule, -webkit-transform
+Ignored Terms: EmptyString, mediaText, cssText, InvalidCharacterError, SecurityError, SyntaxError, IndexSizeError, HierarchyRequestError, InvalidStateError, InvalidModificationError, NoModificationAllowedError, group of selectors, list of css page selectors, CSSCharsetRule, ProcessingInstruction, EventTarget, EventListener, Event, EventInit, Element, Range, Node, Text, style, CSSFontFaceRule, -webkit-transform
 Ignored Vars: m1, m2, camel_cased_attribute, webkit_cased_attribute, dashed_attribute
 Include Can I Use Panels: true
 Can I Use URL: https://drafts.csswg.org/cssom/
@@ -1184,7 +1184,7 @@ To <dfn>fetch a CSS style sheet</dfn> with parsed URL <var>parsed URL</var>, ref
  <li>If <var>response</var> is a <a>network error</a>, return an error.
 
  <li>If <var>document</var> is in <a>quirks mode</a>, <var>response</var> is
- <a>CORS-same-origin</a><!--XXX xref--> and the <a>Content-Type metadata</a> of <var>response</var> is not a
+ <a>CORS-same-origin</a> and the <a>Content-Type metadata</a> of <var>response</var> is not a
  <a>supported styling language</a> change the <a>Content-Type metadata</a> of <var>response</var> to
  <code>text/css</code>.
 
@@ -1326,7 +1326,7 @@ must be run:
    "<code>yes</code>", or unset otherwise.
 
    <dt><a>origin-clean flag</a>
-   <dd>Set if <var>response</var> is <a>CORS-same-origin</a><!--XXX xref-->, or unset otherwise.
+   <dd>Set if <var>response</var> is <a>CORS-same-origin</a>, or unset otherwise.
   </dl>
 
   The CSS <a>environment encoding</a> is the result of running the following steps:
@@ -1425,7 +1425,7 @@ must be run:
    "<code>alternate</code>", or false otherwise.
 
    <dt><a>origin-clean flag</a>
-   <dd>Set if <var>response</var> is <a>CORS-same-origin</a><!--XXX xref-->, or unset otherwise.
+   <dd>Set if <var>response</var> is <a>CORS-same-origin</a>, or unset otherwise.
   </dl>
 
 </ol>


### PR DESCRIPTION
Now that the HTML spec exports the definition of CORS-same-origin, the term should be linked correctly and no longer needs to be ignored. Fixes #823.