### PR TITLE
Remove `>>>` combinator from the css-scoping spec.

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -397,57 +397,6 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 	is by styling the <a>slot</a> and relying on inheritance.
 
 <!--
-██    ██    ██
- ██    ██    ██
-  ██    ██    ██
-   ██    ██    ██
-  ██    ██    ██
- ██    ██    ██
-██    ██    ██
--->
-
-<h4 id='deep-combinator'>
-Selecting Through Shadows: the ''>>>'' combinator</h4>
-
-	When a <dfn selector id="selectordef-shadow-piercing-descendant-combinator">>>></dfn> combinator
-	(or <dfn export>shadow-piercing descendant combinator</dfn>)
-	is encountered in a selector,
-	replace every element in the <a>selector match list</a>
-	with every element reachable from the original element
-	by traversing any number of child lists or shadow trees.
-
-	<div class='example'>
-		For example, say you had a component with a <a>shadow tree</a> like the following:
-
-		<pre>
-			&lt;x-foo>
-				&lt;"shadow tree">
-					&lt;div>
-						&lt;span id="not-top">...&lt;/span>
-					&lt;/div>
-					&lt;span id="top">...&lt;/span>
-					&lt;x-bar>
-						&lt;"shadow tree">
-							&lt;span id="nested">...&lt;/span>
-						&lt;/>
-					&lt;/x-bar>
-				&lt;/>
-			&lt;/x-foo>
-		</pre>
-
-		For a stylesheet in the outer document,
-		the selector ''x-foo >>> span''
-		selects all three of <code>&lt;span></code> elements:
-		''#top'', ''#not-top'', <em>and</em> ''#nested''.
-	</div>
-
-	The <a>shadow-piercing descendant combinator</a> is part of the <a>static profile</a> of Selectors,
-	not the <a>dynamic profile</a>.
-	This means that it is usable in,
-	for example, the {{querySelector()}} method,
-	but is invalid when used in stylesheets.
-
-<!--
  ██████     ███     ██████   ██████     ███    ████████  ████████
 ██    ██   ██ ██   ██    ██ ██    ██   ██ ██   ██     ██ ██
 ██        ██   ██  ██       ██        ██   ██  ██     ██ ██


### PR DESCRIPTION
This was discussed at
https://github.com/w3c/csswg-drafts/issues/640

Blink has implemented this behind the flag, but it looks never used.
https://www.chromestatus.com/metrics/feature/timeline/popularity/1691