### PR TITLE
[css-transforms] 2D and 3D rotation are distinct

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -34,6 +34,7 @@ spec:css-transforms-1;
 		text: <transform-list>
 	type: function;
 		text: matrix()
+spec: filter-effects-1; type:property; text:filter;
 spec: html; type: element; text: a;
 </pre>
 
@@ -845,7 +846,7 @@ In the following <dfn export>3d transform functions</dfn>, a <<zero>> behaves th
 : <span class='prod'><dfn>rotateY()</dfn> = rotateY( [ <<angle>> | <<zero>> ] )</span>
 :: same as ''rotate3d(0, 1, 0, &lt;angle>)''.
 : <span class='prod'><dfn>rotateZ()</dfn> = rotateZ( [ <<angle>> | <<zero>> ] )</span>
-:: same as ''rotate3d(0, 0, 1, &lt;angle>)'', which is also the same as ''rotate(&lt;angle>)''.
+:: same as ''rotate3d(0, 0, 1, &lt;angle>)'', which is a 3d transform equivalent to the 2d transform ''rotate(&lt;angle>)''.
 : <span class='prod'><dfn>perspective()</dfn> = perspective( <<length>> )</span>
 :: specifies a <a href="#PerspectiveDefined">perspective projection matrix</a>. This matrix scales points in X and Y based on their Z value, scaling points with positive Z values away from the origin, and those with negative Z values towards the origin. Points on the z=0 plane are unchanged. The parameter represents the distance of the z=0 plane from the viewer. Lower values give a more flattened pyramid and therefore a more pronounced perspective effect. For example, a value of 1000px gives a moderate amount of foreshortening and a value of 200px gives an extreme amount. The value for depth must be greater than zero, otherwise the function is invalid.
 


### PR DESCRIPTION
rotateZ(angle) is a 3d transform equivalent to the 2d transform
rotate(angle).

The spec previously said they are "the same", which is inaccurate
as 3d transforms can have additional side-effects in UAs.

resolves #2520