### PR TITLE
[css-ui] outline-width refers to line-width

### DIFF
--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -299,13 +299,13 @@ Animation type: see individual properties
 
 <pre class="propdef"> 
 Name: outline-width 
-Value: <'border-width'> 
+Value: <<line-width>>
 Initial: medium 
 Applies to: all elements 
 Inherited: no 
 Percentages: N/A 
 Media: visual 
-Computed value: absolute length; ''0'' if the outline style is ''outline-width/none''. 
+Computed value: absolute length; ''0'' if the outline style is ''border-style/none''.
 Animation type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
 

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -384,13 +384,13 @@ Animation type: see individual properties
 
 <pre class="propdef">
 Name: outline-width
-Value: <'border-width'>
+Value: <<line-width>>
 Initial: medium
 Applies to: all elements
 Inherited: no
 Percentages: N/A
 Media: visual
-Computed value: absolute length; ''0'' if the outline style is ''outline-width/none''.
+Computed value: absolute length; ''0'' if the outline style is ''border-style/none''.
 Animation type: <a href="https://drafts.csswg.org/css3-transitions/#animtype-length">length</a>
 </pre>
 


### PR DESCRIPTION
outline-width only permits one line-width, not two or three or four.

resolves #2535