### PR TITLE
[css-overflow] Accept two values in overflow

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -297,7 +297,7 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 
 	<pre class=propdef>
 		Name: overflow
-		Value: ''visible'' | ''hidden'' | ''clip'' | ''scroll'' | ''auto''
+		Value: [ ''visible'' | ''hidden'' | ''clip'' | ''scroll'' | ''auto'' ]{1,2}
 		Initial: see individual properties
 		Applies to: block containers [[!CSS21]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
 		Inherited: no
@@ -309,8 +309,8 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 	</pre>
 
 	The 'overflow' property is a shorthand property
-	that sets the specified values of both 'overflow-x' and 'overflow-y'
-	to the value specified for 'overflow'.
+	that sets the specified values of 'overflow-x' and 'overflow-y' in that order.
+	If the second value is omitted, it is copied from the first.
 
 	Values have the following meanings:
 


### PR DESCRIPTION
Resolves #2484 by changing the grammar of `overflow` to accept two values, and identifying the order in which they are parsed.