### PR TITLE
Deal with overflow:clip

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2070,7 +2070,7 @@ Determining the Baselines of a Box</h2>
 	For the purposes of finding the baselines of a box,
 	it and all its in-flow descendants with a scrolling mechanism (see the 'overflow' property)
 	must be considered as if scrolled to their origin.
-	Furthermore, if, in the case of a box with non-''visible'' overflow,
+	Furthermore, if, in the case of a <a>scroll container</a> box,
 	the resulting position of a first (last) baseline
 	is past a box's end (start) border edge,
 	its position is clamped to that border edge.

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -905,7 +905,7 @@ Automatic Minimum Size of Flex Items</h3>
 
 	To provide a more reasonable default <a>minimum size</a> for <a>flex items</a>,
 	the used value of a <a>main axis</a> <a>automatic minimum size</a>
-	on a <a>flex item</a> which is not a <a>scroll container</a>
+	on a <a>flex item</a> that is not a <a>scroll container</a>
 	is a <dfn>content-based minimum size</dfn>;
 	for <a>scroll containers</a> the <a>automatic minimum size</a> is zero, as usual.
 

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -905,9 +905,9 @@ Automatic Minimum Size of Flex Items</h3>
 
 	To provide a more reasonable default <a>minimum size</a> for <a>flex items</a>,
 	the used value of a <a>main axis</a> <a>automatic minimum size</a>
-	on a <a>flex item</a> whose 'overflow' is ''overflow/visible'' in the <a>main axis</a>
+	on a <a>flex item</a> which is not a <a>scroll container</a>
 	is a <dfn>content-based minimum size</dfn>;
-	any other 'overflow' value means the <a>automatic minimum size</a> is zero, as usual.
+	for <a>scroll containers</a> the <a>automatic minimum size</a> is zero, as usual.
 
 	In general, the <a>content-based minimum size</a> of a <a>flex item</a>
 	is the smaller of its <a>content size suggestion</a> and its <a>specified size suggestion</a>.

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1238,7 +1238,7 @@ Automatic Minimum Size of Grid Items</h3>
 
 	To provide a more reasonable default <a>minimum size</a> for <a>grid items</a>,
 	the used value of an <a>automatic minimum size</a> in a given axis
-	on a <a>grid item</a> whose 'overflow' is ''overflow/visible'' in that same axis
+	on a <a>grid item</a> which is not a <a>scroll container</a>
 	and that spans at least one <a>track</a> in that axis
 	whose <a>min track sizing function</a> is ''grid-template-rows/auto''
 	is a <dfn>content-based minimum size</dfn>;

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1238,7 +1238,7 @@ Automatic Minimum Size of Grid Items</h3>
 
 	To provide a more reasonable default <a>minimum size</a> for <a>grid items</a>,
 	the used value of an <a>automatic minimum size</a> in a given axis
-	on a <a>grid item</a> which is not a <a>scroll container</a>
+	on a <a>grid item</a> that is not a <a>scroll container</a>
 	and that spans at least one <a>track</a> in that axis
 	whose <a>min track sizing function</a> is ''grid-template-rows/auto''
 	is a <dfn>content-based minimum size</dfn>;

--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -677,7 +677,7 @@ Grouping property values {#grouping-property-values}
 
 The following CSS property values require the user agent to create a flattened representation of the descendant elements before they can be applied, and therefore force the used value of ''transform-style'' to ''flat'':
 
-* 'overflow': any value other than ''overflow/visible''.
+* 'overflow': any value other than ''overflow/visible'' or ''overflow/clip''.
 * 'opacity': any value less than 1.
 * 'filter': any value other than ''filter/none''.
 * 'clip': any value other than ''clip/auto''.
@@ -694,7 +694,7 @@ The following CSS property values cause an ''transform-style/auto'' value of ''t
 
 In both cases the computed value of 'transform-style' is not affected.
 
-Issue: Having overflow imply transform-style: flat causes every element with non-visible overflow to become
+Issue: Having overflow imply transform-style: flat causes every element with non-visible/clip overflow to become
 a stacking context, which is unwanted. See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=28252">Bug 28252</a>.
 
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -133,8 +133,8 @@ An element <var>body</var> (which will be <a>the HTML <code>body</code> element<
 <dfn>potentially scrollable</dfn> if all of the following conditions are true:
 
 * <var>body</var> has an associated <a>CSS layout box</a>.
-* <var>body</var>'s <a>parent element</a>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible'' nor ''overflow/clip''.
-* <var>body</var>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible'' nor ''overflow/clip''.
+* <var>body</var>'s <a>parent element</a>'s computed value of the 'overflow-x' or 'overflow-y' properties is neither ''overflow/visible'' nor ''overflow/clip''.
+* <var>body</var>'s computed value of the 'overflow-x' or 'overflow-y' properties is neither ''overflow/visible'' nor ''overflow/clip''.
 
 Note: A <{body}> element that is <a>potentially scrollable</a> might not have a <a>scrolling box</a>.
 For instance, it could have a used value of 'overflow' being ''overflow/auto'' but not have its content overflowing its content area.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -133,8 +133,8 @@ An element <var>body</var> (which will be <a>the HTML <code>body</code> element<
 <dfn>potentially scrollable</dfn> if all of the following conditions are true:
 
 * <var>body</var> has an associated <a>CSS layout box</a>.
-* <var>body</var>'s <a>parent element</a>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
-* <var>body</var>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible''.
+* <var>body</var>'s <a>parent element</a>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible'' nor ''overflow/clip''.
+* <var>body</var>'s computed value of the 'overflow-x' or 'overflow-y' properties is not ''overflow/visible'' nor ''overflow/clip''.
 
 Note: A <{body}> element that is <a>potentially scrollable</a> might not have a <a>scrolling box</a>.
 For instance, it could have a used value of 'overflow' being ''overflow/auto'' but not have its content overflowing its content area.


### PR DESCRIPTION
Make sure that various specs correctly invoke either
"overflow is not visible" or "is a scroll container" since these two are
no longer equivalent.

This change is meant to be editorial prior to the introduction of 'overflow: clip', and to avoid the introduction of 'overflow:clip' to have undesirable normative effects.

----
This PR does not bother with maintained specs like css-box.