### PR TITLE
Establishing a new formatting context

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -915,7 +915,7 @@ The 'justify-content' And 'align-content' Properties</h3>
 		<tr>
 			<th>''justify-content/normal'' Behavior
 			<td>
-				All values other than ''justify-content/normal'' force the block container to establish a new formatting context.
+				All values other than ''justify-content/normal'' force the block container to <a>establish a new formatting context</a>.
 
 				For table cells, the behavior of the ''justify-content/normal'' depends on the computed value of 'vertical-align':
 				''vertical-align/top'' makes it behave as ''start'',

--- a/css-contain-1/Overview.bs
+++ b/css-contain-1/Overview.bs
@@ -217,7 +217,7 @@ Layout Containment</h3>
 	layout containment has no effect.
 	Otherwise, giving an element <dfn export>layout containment</dfn> has the following effects:
 
-	1. The element establishes a new <a>formatting context</a>.
+	1. The element <a>establishes a new formatting context</a>.
 
 	2. If a <a>fragmentation context</a> participates in <a>layout containment</a>,
 		the first element with <a>layout containment</a>
@@ -352,7 +352,7 @@ Paint Containment</h3>
 		<span class=note>This is as if to ''overflow: visible'' was changed to ''overflow: clip'' at used value.</span>
 	2. The element acts as a containing block for absolutely positioned and fixed positioned descendants.
 	3. The element creates a <a>stacking context</a>.
-	4. The element establishes a new <a>formatting context</a>.
+	4. The element <a>establishes a new formatting context</a>.
 
 	Possible optimizations that can be enabled by <a>paint containment</a> include (but are not limited to):
 

--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -1055,6 +1055,28 @@ Appendix A: Glossary</h2>
 			<p class="example">
 				As another example, margins do not collapse across [=formatting context=] boundaries.
 
+			Specifications may call for an element or box to
+			<dfn export lt="establishes a formatting context | establish a formatting context | establish a new formatting context | establishes a new formatting context">establish a formatting context</dfn>
+			without further precision as to the type of formatting context or how to do so.
+			This operation is not applicable to
+			non-atomic inline-level boxes
+			nor to boxes with a layout-internal display-type.
+			Specifications that invoke this
+			must either exclude such boxes,
+			or to blockify them first.
+			If the box is a block container that does not establish a BFC,
+			it is made to establish a BFC.
+			Otherwise, the box already establishes a formatting context, and this operation is a no-op.
+			This has no effect on the computed value of the display property.
+
+			Note: If a specification defines a new type of box which is neither
+			non atomic inline level,
+			layout-internal,
+			block containers,
+			or some other display type that establishes a FC,
+			then that specification must define the effect,
+			of invoking “<a>establishes a formatting context</a>” for that type of box.
+
 			<p class="note">
 				Exclusions are able to affect content across [=formatting context=] boundaries.
 				(At time of writing, they are the only layout feature that can.)

--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -1060,7 +1060,7 @@ Appendix A: Glossary</h2>
 			without further precision as to the type of formatting context or how to do so.
 			This operation is not applicable to
 			non-atomic inline-level boxes
-			nor to boxes with a layout-internal display-type.
+			nor to boxes with a layout-internal display type.
 			Specifications that invoke this
 			must either exclude such boxes,
 			or to blockify them first.

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -638,8 +638,7 @@ Flex Items</h2>
 		Its contents will however inherit styles (such as font settings) from the flex container.
 	</div>
 
-	A <a>flex item</a> establishes a new formatting context for its contents.
-	The type of this formatting context is determined by its 'display' value, as usual.
+	A <a>flex item</a> <a>establishes a new formatting context</a> for its contents.
 	However, flex items themselves are <dfn>flex-level</dfn> boxes, not block-level boxes:
 	they participate in their container's flex formatting context,
 	not in a block formatting context.

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1034,8 +1034,7 @@ Grid Items</h2>
 
 <h3 id="grid-item-display">
 	Grid Item Display</h3>
-	A <a>grid item</a> establishes a new formatting context for its contents.
-	The type of this formatting context is determined by its 'display' value, as usual.
+	A <a>grid item</a> <a>establishes a new formatting context</a> for its contents.
 	However, grid items are <dfn>grid-level</dfn> boxes, not block-level boxes:
 	they participate in their container's <a>grid formatting context</a>,
 	not in a block formatting context.

--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -779,7 +779,7 @@ Spanning columns</h2>
 			Content in the normal flow that appears before the
 			element is automatically balanced across all columns in the immediately preceding column row before the
 			element appears. 
-			The element establishes a new <a>formatting context</a>.
+			The element <a>establishes a new formatting context</a>.
 
 			Note: Whether the element establishes a new <a>formatting context</a>
 			does not depend on whether the element is a descendent of a multicol or not.

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -383,9 +383,9 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 			if there is overflow.
 		</dl>
 
-	If the computed value of 'overflow' on a <a>block box</a>
+	If the computed value of 'overflow' on a box
 	is neither ''overflow/visible'' nor ''overflow/clip'' nor a combination thereof,
-	it creates a new <a>block formatting context</a> for its content.
+	it <a>establishes a new formatting context</a> for its content.
 
 
 <h3 id="static-media">

--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -181,7 +181,7 @@ Specifying the Step Size: the 'block-step-size' property {#block-step-size}
 	Negative <<length>> values are invalid.
 
 	Values other than ''block-step-size/none''
-	cause the box to establish a new formatting context.
+	cause the box to <a>establish a new formatting context</a>.
 
 	In situations where margins <a href="https://www.w3.org/TR/CSS2/box.html#collapsing-margins">collapse</a>,
 	only the box’s own margin is considered


### PR DESCRIPTION
As discussed in the resolution of #1457 we should add to css-display a linkable definition for establishing a (new) formatting context without explicitely saying which kind, and still have the right thing happen unambiguously when possible, while being explicit that it is a spec bug to invoke this definition in the cases where it's not meaningful/possible.

This PR attempts to add this definition, and to update all the specs that should use it to do so.

I am not particularly attached to the phrasing I am proposing here. I believe it to be correct, but certainly welcome more elegant ways of saying the same thing if anyone has suggestions.

Review from @fantasai or @tabatkins (but particularly @fantasai) appreciated.

Changes in css-contain css-multicol css-align and css-rhythm should be particularly safe, since this is just adding a link without rephrasing anything.

Changes to the other specs are meant to be no-ops that merely unify the way we talk about this, without any normative effect.