### PR TITLE
[css-env-1] use standardized spelling

### DIFF
--- a/css-env-1/Overview.bs
+++ b/css-env-1/Overview.bs
@@ -25,7 +25,7 @@ capable of being substituted into arbitrary other properties via the ''var()'' f
 
 This specification defines a related, but simpler, concept of [=environment variables=].
 Unlike "cascading variables",
-which can change thruout the page as their corresponding [=custom property=] takes on different values,
+which can change throughout the page as their corresponding [=custom property=] takes on different values,
 an [=environment variable=] is "global" to a particular document--
 its value is the same everywhere.
 The ''env()'' function can then be used to substitute the value into arbitrary locations,
@@ -73,7 +73,7 @@ Note that mixing CSS rules and JS-defined stuff can easily get messy,
 as demonstrated by CSSFontFaceRule vs FontFace...
 
 The following UA-defined [=environment variables=] are officially defined and must be supported,
-tho user agents may define additional undocumented [=environment variables=]:
+though user agents may define additional undocumented [=environment variables=]:
 
 * Issue: define list of predefined vars
 


### PR DESCRIPTION
There were just two spelling issues I noticed when reviewing the env() spec again last night. Thanks for writing this up, by the way! 😄

Also, I see you’ve merely used a “less common spelling”, _tho_ it may not be used in any other specs? https://www.merriam-webster.com/dictionary/tho