### PR TITLE
Fix typo: "header element" to "heading element"

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1278,7 +1278,7 @@ The Relational Pseudo-class: '':has()''</h3>
 		<pre>section:has(:not(h1, h2, h3, h4, h5, h6))</pre>
 
 		...would result matching any <code>&lt;section></code> element
-		which contains anything that's not a header element.
+		which contains anything that's not a heading element.
 	</div>
 
 


### PR DESCRIPTION
Change "header element" to "heading element". "Heading" is intended here, since it is referring to HTML heading elements above, and "heading" is also used in a prior description (line 1271).