### PR TITLE
[css-fonts-3] Add semicolon after CSSFontFaceRule

### DIFF
--- a/css-fonts-3/Fonts.src.html
+++ b/css-fonts-3/Fonts.src.html
@@ -4358,7 +4358,7 @@ the following extension to the CSS Object Model.</p>
 <pre class="idl">
 interface CSSFontFaceRule : CSSRule {
     readonly attribute CSSStyleDeclaration style;
-}</pre>
+};</pre>
 
 <h2 id="platform-props-to-css" class="no-num">Appendix A: Mapping platform font properties to CSS properties</h2>
 


### PR DESCRIPTION
A missing semicolon causes IDL parser error.