### PR TITLE
[css-text-3] Typo fix

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -1009,7 +1009,7 @@ Line Breaking Details</h3>
       <dd>There is a <a>soft wrap opportunity</a> around every <a>typographic character unit</a>,
       including around any punctuation character or preserved spaces,
       or in the middle of words,
-      disregarding any prohibition against line breaks introduced by characters with the GL, WJ, or ZJW character class (see [[UAX14]]).
+      disregarding any prohibition against line breaks introduced by characters with the GL, WJ, or ZWJ character class (see [[UAX14]]).
       The different wrapping opportunities must not be prioritized.
       Hyphenation is not applied.
 


### PR DESCRIPTION
There's no ZJW class in UAX 14. I guess @frivoal means the ZWJ (Zero Width Joiner) class.