### PR TITLE
[css-fonts-4] Fix ID for the font-variant-emoji section

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -3633,7 +3633,7 @@ might result in different used palettes
 because the value of variables inside the ''@font-palette-values'' rule
 might apply differently in the context of those two elements.
 
-<h3 id="font-variant-emoji-desc">
+<h3 id="font-variant-emoji-prop">
 Selecting the text presentation style: The 'font-variant-emoji' property</h3>
 
 <pre class="propdef">


### PR DESCRIPTION
Use "prop" to be consistent with other property sections. (`font-variant-emoji` is a property, not a descriptor.)