### PR TITLE
[css-display] Add space before semicolon

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -202,7 +202,7 @@ Box Layout Modes: the 'display' property</h2>
 	<pre class='prod'>
 	<dfn>&lt;display-outside></dfn>  = block | inline | run-in ;
 	<dfn>&lt;display-inside></dfn>   = flow | flow-root | table | flex | grid | ruby ;
-	<dfn>&lt;display-listitem></dfn> = <<display-outside>>? && [ flow | flow-root ]? && list-item;
+	<dfn>&lt;display-listitem></dfn> = <<display-outside>>? && [ flow | flow-root ]? && list-item ;
 	<dfn>&lt;display-internal></dfn> = table-row-group | table-header-group |
 	                     table-footer-group | table-row | table-cell |
 	                     table-column-group | table-column | table-caption |


### PR DESCRIPTION
For consistency with the other syntax definitions.