### PR TITLE
[css-animations] Change an AnimationEvent member from float to double

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -35,7 +35,7 @@ Former Editor: Sylvain Galineau, Adobe, galineau@adobe.com
 Abstract: This CSS module describes a way for authors to animate the values of CSS properties over time, using keyframes. The behavior of these keyframe animations can be controlled by specifying their duration, number of repeats, and repeating behavior.
 
 Link Defaults: css-values-3 (type) <time>, cssom-1 (interface) cssstyledeclaration, dom-core-ls (interface) event, webidl (type) SyntaxError, css-position-3 (property) left
-Ignored Terms: domstring, float, animationeventinit, event, eventinit, eventtarget, document
+Ignored Terms: domstring, animationeventinit, event, eventinit, eventtarget, document
 </pre>
 <pre class="anchors">
 url: https://dom.spec.whatwg.org/#constructing-events; type: dfn; text: event constructor;
@@ -909,12 +909,12 @@ IDL Definition</h4>
 		 Constructor(CSSOMString type, optional AnimationEventInit animationEventInitDict)]
 		interface AnimationEvent : Event {
 		  readonly attribute CSSOMString animationName;
-		  readonly attribute float elapsedTime;
+		  readonly attribute double elapsedTime;
 		  readonly attribute CSSOMString pseudoElement;
 		};
 		dictionary AnimationEventInit : EventInit {
 		  CSSOMString animationName = "";
-		  float elapsedTime = 0.0;
+		  double elapsedTime = 0.0;
 		  CSSOMString pseudoElement = "";
 		};
 	</pre>
@@ -923,15 +923,15 @@ IDL Definition</h4>
 Attributes</h4>
 
 	<dl dfn-type=attribute dfn-for=AnimationEvent>
-		<dt><dfn>animationName</dfn>, of type {{CSSOMString}}, readonly
+		<dt><dfn>animationName</dfn>
 		<dd>
 			The value of the 'animation-name' property of the animation that fired the event.
-		<dt><dfn>elapsedTime</dfn>, of type float, readonly
+		<dt><dfn>elapsedTime</dfn>
 		<dd>
 			The amount of time the animation has been running, in seconds, when this event fired,
 			excluding any time the animation was paused. The precise calculation for
 			of this member is defined along with each event type.
-		<dt><dfn>pseudoElement</dfn>, of type {{CSSOMString}}, readonly
+		<dt><dfn>pseudoElement</dfn>
 		<dd>
 			The name (beginning with two colons) of the CSS pseudo-element on which the animation
 			runs (in which case the target of the event is that pseudo-element's corresponding


### PR DESCRIPTION
As per the web-idl spec, float should only be used if there is a specific
reason, as double much more closely matches the ECMAScript Number
type. In the case of AnimationEvent's 'elapsedTime' member there does
not appear to be such a reason.

Furthermore, switching to double allows the elapsedTime to reach higher
values without overflowing. A rough calculation (with some assumptions
and possible errors) suggests that this change will raise the celing
from ~4.5 hours to years.