### PR TITLE
[cssom-view] Add window.screenLeft and window.screenTop as aliases

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -471,7 +471,9 @@ partial interface Window {
 
     // client
     [Replaceable] readonly attribute long screenX;
+    [Replaceable] readonly attribute long screenLeft;
     [Replaceable] readonly attribute long screenY;
+    [Replaceable] readonly attribute long screenTop;
     [Replaceable] readonly attribute long outerWidth;
     [Replaceable] readonly attribute long outerHeight;
     [Replaceable] readonly attribute double devicePixelRatio;
@@ -626,12 +628,12 @@ user agent must run these steps:
 1. Add the value of {{scrollY}} to the {{ScrollToOptions/top}} dictionary member.
 1. Act as if the {{Window/scroll()}} method was invoked with <var>options</var> as the only argument.
 
-The <dfn attribute for=Window>screenX</dfn> attribute must return the x-coordinate,
+The <dfn attribute for=Window>screenX</dfn> and <dfn attribute for=Window>screenLeft</dfn> attributes must return the x-coordinate,
 relative to the origin of the <a>Web-exposed screen area</a>, of the left of
 the client window as number of <a lt=px value>CSS pixels</a>, or zero if there is no such
 thing. <!--fingerprint-->
 
-The <dfn attribute for=Window>screenY</dfn> attribute must return the y-coordinate,
+The <dfn attribute for=Window>screenY</dfn> and <dfn attribute for=Window>screenTop</dfn> attributes must return the y-coordinate,
 relative to the origin of the screen of the <a>Web-exposed screen area</a>, of the top of
 the client window as number of <a lt=px value>CSS pixels</a>, or zero if there is no such
 thing. <!--fingerprint-->


### PR DESCRIPTION
Given that usage of these attributes are high and that they are implemented in Chrome, WebKit, and Edge, standardization seems like the best option for `screenLeft` and `screenTop`. Add them into the spec as simple aliases of `screenX` and `screenY`.

Fixes #1091.