### PR TITLE
[css-transitions] Change TransitionEvent elapsedTime from 'float' to …

### DIFF
--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -42,7 +42,6 @@ Issue Tracking: Bugzilla bugs for this level https://www.w3.org/Bugs/Public/bugl
 Issue Tracking: Bugzilla bugs for all levels https://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;product=CSS&amp;component=Transitions&amp;resolution=---
 Abstract: CSS Transitions allows property changes in CSS values to occur smoothly over a specified duration.
 Status Text: <strong>This document</strong> is expected to be relatively close to last call.  While some issues raised have yet to be addressed, new features are extremely unlikely to be considered for this level. <p>The following behaviors are at risk: <ul><li><a href="#discrete-interpolation-at-risk">Interpolation in steps of property types that cannot be interpolated</a></li></ul>
-Ignored Terms: float
 Ignored Vars: x1, x2, y1, y2
 Link Defaults: css-transforms (property) transform
 </pre>
@@ -1106,27 +1105,27 @@ associated with transitions.
    Constructor(CSSOMString type, optional TransitionEventInit transitionEventInitDict)]
   interface TransitionEvent : Event {
     readonly attribute CSSOMString propertyName;
-    readonly attribute float elapsedTime;
+    readonly attribute double elapsedTime;
     readonly attribute CSSOMString pseudoElement;
   };
 
   dictionary TransitionEventInit : EventInit {
     CSSOMString propertyName = "";
-    float elapsedTime = 0.0;
+    double elapsedTime = 0.0;
     CSSOMString pseudoElement = "";
   };
 </pre>
 
 ### Attributes ### {#interface-transitionevent-attributes}
 
-:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-propertyName">propertyName</dfn></code> of type <code>CSSOMString</code>, readonly
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-propertyName">propertyName</dfn></code>
 ::  The name of the CSS property associated with the transition.
     <p class="note">Note:  This is always the name of a longhand property.  See 'transition-property' for how specifying shorthand properties causes transitions on longhands.</p>
-:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-elapsedTime">elapsedTime</dfn></code> of type <code>float</code>, readonly
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-elapsedTime">elapsedTime</dfn></code>
 ::  The amount of time the transition has been running, in seconds, when this
     event fired not including any time spent in the delay phase.  The precise
     calculation for of this member is defined along with each event type.
-:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-pseudoElement">pseudoElement</dfn></code> of type <code>CSSOMString</code>, readonly
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-pseudoElement">pseudoElement</dfn></code>
 ::  The name (beginning with two colons) of the CSS
     pseudo-element on which the transition occurred (in
     which case the target of the event is that


### PR DESCRIPTION
…'double'

As per the web-idl spec, float should only be used if there is a
specific reason, as double much more closely matches the ECMAScript
Number type. In the case of TransitionEvent there does not appear to be
such a reason.

Furthermore, switching to double allows the elapsedTime to reach higher
values without overflowing. A rough calculation (with some assumptions
and possible errors) suggests that this change will raise the celing
from ~4.5 hours to years.