### PR TITLE
[css-values-4][css-values-3] fix minor typos

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -1763,7 +1763,7 @@ Range Checking</h4>
 		</pre>
 
 		Note however that ''width: -5px'' is not equivalent to ''width: calc(-5px)''!
-		Out-of-range values <em>outside</em> ''calc()'' are synactically invalid,
+		Out-of-range values <em>outside</em> ''calc()'' are syntactically invalid,
 		and cause the entire declaration to be dropped.
 	</div>
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1908,7 +1908,7 @@ Range Checking</h4>
 		</pre>
 
 		Note however that ''width: -5px'' is not equivalent to ''width: calc(-5px)''!
-		Out-of-range values <em>outside</em> ''calc()'' are synactically invalid,
+		Out-of-range values <em>outside</em> ''calc()'' are syntactically invalid,
 		and cause the entire declaration to be dropped.
 	</div>
 


### PR DESCRIPTION
Section [8.1.4. Range Checking](https://drafts.csswg.org/css-values/#calc-range), in the `Example 25`

> Example 25
> ...
> Note however that 'width: -5px' is not equivalent to 'width: calc(-5px)'!
> Out-of-range values outside 'calc()' are synactically invalid,
> and cause the entire declaration to be dropped.

should likely be s/synactically/syntactically/ ?