### PR TITLE
[css-logical] Typo: use plural

### DIFF
--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -134,7 +134,7 @@ Flow-Relative Values for the 'float' and 'clear' Properties</h3>
     New values: inline-start | inline-end
   </pre>
 
-  The mapping on this property uses the <a>writing mode</a> of the element’s <a>containing block</a>.
+  The mapping on these properties uses the <a>writing mode</a> of the element’s <a>containing block</a>.
 
   Note: These properties are 1-dimensional in CSS2,
   but are planned to be expanded to two dimensions,


### PR DESCRIPTION
`float` and `clear` are 2 properties, so use plural.