### PR TITLE
[css-fonts-4] Fix Web IDL syntax

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -3817,13 +3817,13 @@ The <code>CSSFontFeatureValuesRule</code> interface</h3>
   readonly attribute CSSFontFeatureValuesMap swash;
   readonly attribute CSSFontFeatureValuesMap characterVariant;
   readonly attribute CSSFontFeatureValuesMap styleset;
-}
+};
 
-[MapClass(CSSOMString, sequence&lt;unsigned long&gt;)]
 interface CSSFontFeatureValuesMap {
+  maplike&lt;CSSOMString, sequence&lt;unsigned long&gt;&gt;;
   void set(CSSOMString featureValueName,
            (unsigned long or sequence&lt;unsigned long&gt;) values);
-}</pre>
+};</pre>
 
 <dl class='idl-attributes'>
 <dt><var>fontFamily</var> of type <code>CSSOMString</code>
@@ -3865,13 +3865,13 @@ The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interfa
 <pre class='idl'>partial interface CSSRule {
 
   const unsigned short FONT_PALETTE_VALUES_RULE = 15;
-}
+};
 
 interface CSSFontPaletteValuesRule : CSSRule {
   maplike&lt;unsigned long, (CSSOMString or CSSOMRGBColor)>;
   attribute CSSOMString fontFamily;
   attribute CSSOMString basePalette;
-}</pre>
+};</pre>
 
 If the value of the 'setlike' functions is a CSSOMString, it is parsed as a solid color (e.g. using the <code>rgb()</code> syntax). If it refers to anything other than a solid color, the call is ignored or returns <code>undefined</code>.
 


### PR DESCRIPTION
Previous Web IDL update (https://github.com/w3c/csswg-drafts/commit/146c023e7b8b218874fd82d9b52b354f116aeffa) only fixed the first syntax error reported by Reffy.

A few other semi-colons were still missing. Also, the spec used the `MapClass` extended attribute, which no longer exists in Web IDL. The `CSSFontFeatureValuesMap` interface now uses a [maplike declaration](https://heycam.github.io/webidl/#idl-maplike).