### PR TITLE
[css-transforms-2] Fix translation in matrix recomposition algorithm.

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -1044,7 +1044,7 @@ for (i = 0; i < 4; i++)
 	matrix[i][3] = perspective[i]
 
 // apply translation
-for (i = 0; i < 3; i++)
+for (i = 0; i < 4; i++)
 	for (j = 0; j < 3; j++)
 		matrix[3][i] += translation[j] * matrix[j][i]
 


### PR DESCRIPTION
You need to apply translation in all the columns.

I found this while hunting a transform recomposition bug in the new Gecko style
engine, which implemented this spec to the letter.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1459403