### PR TITLE
[css-transforms-2] Fix scale application in matrix recomposition algorithm.

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -1086,7 +1086,7 @@ if (skew[0])
 
 // apply scale
 for (i = 0; i < 3; i++)
-	for (j = 0; j < 3; j++)
+	for (j = 0; j < 4; j++)
 		matrix[i][j] *= scale[i]
 
 return</pre>


### PR DESCRIPTION
Similar to #2711. You really need to go through the 4 columns.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1459403