### PR TITLE
[css-animations] Change definition of GlobalEventHandlers to mixin

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -1308,7 +1308,7 @@ events</a> as defined in
 IDL Definition</h4>
 
 <pre class="idl">
-partial interface GlobalEventHandlers {
+partial interface mixin GlobalEventHandlers {
   attribute EventHandler onanimationstart;
   attribute EventHandler onanimationiteration;
   attribute EventHandler onanimationend;


### PR DESCRIPTION
`GlobalEventHandlers` is now defined as a `mixin` per https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers. Update the partial interface's definition to indicate that it is a `mixin`.