### PR TITLE
[css-shapes] Refer css-shapes-1 for shape-margin

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -14,6 +14,13 @@ Abstract: This draft contains the features of CSS relating to wrapping content a
 Link Defaults: css2 (property) margin, css-display-3 (value) table
 </pre>
 
+<pre class='link-defaults'>
+spec:css-masking-1; type: value
+	text: nonzero
+	text: evenodd
+spec:css-shapes-1; type:property; text:shape-margin
+</pre>
+
 <style type="text/css">
 	.singleImgExample {
 		display: block;


### PR DESCRIPTION
css-shapes-2 refers to css-shapes-1 for shape-margin.

css-shapes-2 (like css-shapes-1) refers to css-masking-1 for 'nonzero'
and 'evenodd'.