### PR TITLE
[css-round-display] Refer to Backgrounds & Borders

### DIFF
--- a/css-round-display-1/Overview.bs
+++ b/css-round-display-1/Overview.bs
@@ -60,7 +60,7 @@ Current user agents are not capable of detecting the shape of a display so that 
 <br><br>
 To apply the shape of a display to content area, we extend the 'shape-inside' property of CSS Shapes. The position of the element which is overflowed from the display is adjusted inside the display when using this property even if the authors don’t know the exact shape of the display.
 <br><br>
-We also add the 'border-boundary' property to CSS Borders. The borders of the element can be drawn along the edge of the display even if the element is overflowed.
+We also add the 'border-boundary' property to CSS Backgrounds and Borders. The borders of the element can be drawn along the edge of the display even if the element is overflowed.
 <br><br>
 
 This module provides features such as:
@@ -75,7 +75,7 @@ Terminology {#terminology}
 This specification follows the CSS property definition conventions from [[!CSS21]]. <br/>
 The detailed description of Media Queries is defined in [[MEDIAQUERIES-4]]<br/>
 The detailed description of CSS Shapes is defined in [[CSS-SHAPES-1]]<br/>
-The detailed description of Borders is defined in [[CSS3-BORDER]]<br/>
+The detailed description of Backgrounds and Borders is defined in [[CSS3BG]]<br/>
 The detailed description of Positioned Layout is defined in [[CSS3-POSITIONING]]<br/>
 
 Detecting the shape of the display {#extending-media-queries}


### PR DESCRIPTION
The CSS Borders spec (CSS3-BORDER) is obsolete.
We now have CSS Backgrounds and Borders (CSS3BG).