### PR TITLE
Mark some IDL bits as examples.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2251,7 +2251,7 @@ the following partial interface applies where <var>camel-cased attribute</var>
 is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 <var>property</var>.
 
-<pre class="idl extract">
+<pre class="idl example">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>camel_cased_attribute</var>;
 };
@@ -2275,7 +2275,7 @@ with the string <code>-webkit-</code>, the following partial interface applies w
 <var>webkit-cased attribute</var> is obtained by running the <a>CSS property to IDL attribute</a>
 algorithm for <var>property</var>, with the <i>lowercase first</i> flag set.
 
-<pre class="idl extract">
+<pre class="idl example">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>webkit_cased_attribute</var>;
 };
@@ -2300,7 +2300,7 @@ For each CSS property <var>property</var> that is a <a>supported CSS property</a
 except for properties that have no "<code>-</code>" (U+002D) in the property name,
 the following partial interface applies where <var>dashed attribute</var> is <var>property</var>.
 
-<pre class="idl extract">
+<pre class="idl example">
 partial interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>dashed_attribute</var>;
 };


### PR DESCRIPTION
Since they don't define attributes themselves, but a class of them.

Fixes #2486