### PR TITLE
[css-display] display is not animatable

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -165,7 +165,7 @@ Box Layout Modes: the 'display' property</h2>
 	Applies to: all elements
 	Inherited: no
 	Computed value: see prose in a variety of specs
-	Animatable: no
+	Animation type:	not animatable
 	</pre>
 
 	<p class=all-media>User Agents are expected to support this property on all media, including non-visual ones.</p>
@@ -1272,7 +1272,7 @@ SVG Elements {#unbox-svg}
 	are ignored when rendering the contents.
 	However, SVG [=presentation attributes=]--
 	which map to CSS properties--
-	continue to affect value processing and inheritance [[css-cascade-3]];
+	continue to affect value processing and inheritance [[CSS3-CASCADE]];
 	thus such attributes can affect
 	the layout and visual formatting of the element’s descendants
 	by influencing the values of such properties on those descendants.


### PR DESCRIPTION
Make it clear that display is not animatable (as opposed to supporting
discrete animation.) Clarification discussed for other properties in
https://github.com/w3c/csswg-drafts/issues/2751#issuecomment-402604609

Already tested in WPT
web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html