### PR TITLE
[css-writing-modes] not animatable in Changes

### DIFF
--- a/css-writing-modes-3/Overview.bs
+++ b/css-writing-modes-3/Overview.bs
@@ -2463,6 +2463,7 @@ Privacy and Security Considerations {#priv-sec}
     <li>Fixed the fallback “available space” for orthogonal flows
         to handle 'max-height' (and 'min-height') which it forgot to consider.
         (<a href="https://github.com/w3c/csswg-drafts/issues/2239">Issue 2239</a>)
+    <li>direction, unicode-bidi and writing-mode became not animatable.
   </ul>
 
   <h3 class="no-num" id="changes-201512">

--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -225,7 +225,7 @@ Specifying Directionality: the 'direction' property</h3>
   Inherited: yes
   Percentages: n/a
   Computed value: specified value
-  Animatable: no
+  Animation type: not animatable
   Canonical order: n/a
   </pre>
 
@@ -276,6 +276,7 @@ Embeddings and Overrides: the 'unicode-bidi' property</h3>
   Inherited: no
   Percentages: n/a
   Computed value: specified value
+  Animation type: not animatable
   </pre>
 
   <p class="advisement">Because HTML UAs can turn off CSS styling,
@@ -856,7 +857,7 @@ Block Flow Direction: the 'writing-mode' property</h3>
   Inherited: yes
   Percentages: n/a
   Computed value: specified value
-  Animatable: no
+  Animation type: not animatable
   Canonical order: n/a
   </pre>
 


### PR DESCRIPTION
The recent change to make direction, unicode-bidi and writing-mode
not animatable is now listed in Changes, and copied across to
writing-modes-4.