### PR TITLE
[css-align] Add 2nd single-quote around 'align-self/stretch'

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -1159,7 +1159,7 @@ Baseline Content-Alignment</h3>
 
 	* If its <a>baseline alignment preference</a> is “first” (“last”),
 		the relevant computed <a>self-alignment property</a>
-		is either 'align-self/stretch'' or ''self-start'' (''self-end'').
+		is either ''align-self/stretch'' or ''self-start'' (''self-end'').
 		For this purpose,
 		the ''start'', ''end'', ''flex-start'', and ''flex-end'' values
 		are treated as either ''self-start'' or ''self-end'',


### PR DESCRIPTION
There's a missing single quote here, which means this one instance of  align-self/stretch gets quoted directly in the spec, with broken linkification around it. Here's the affected section if you're curious:
 https://drafts.csswg.org/css-align/#baseline-content-alignment

And here's a screenshot (good for 14 days):
  https://screenshots.firefox.com/V5tvNjkCu5juNkoF/drafts.csswg.org

Looks like we're just missing a single quote here. This pull request adds the missing single-quote to fix it.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
