### PR TITLE
[css-scrollbars-1] Loosen requirement for scrollbar-width:thin

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -143,8 +143,13 @@ This property allows the author to set the maximum thickness of an element’s s
 <dd>implementations must use the default platform scrollbar width.
 </dd>
 <dt><dfn>thin</dfn></dt>
-<dd>implementations must use either a thin scrollbar width variant on platforms that provide that option, 
-or display a scrollbar thinner than the default platform scrollbar width.
+<dd>Implementations should use thinner scrollbars than auto when applicable.
+This may mean a thin variant of scrollbar provided by the platform,
+or a custom scrollbar thinner than native.
+
+Note: Some platforms may only have a tiny scrollbar by default
+which doesn't make sense to be thinner.
+In that case, implementations can treat this the same as auto.
 </dd>
 <dt><dfn>none</dfn></dt>
 <dd>implementations must not display any scrollbar, however the element's scrollability is not affected.


### PR DESCRIPTION
I think the main point of having thin scrollbars is to give content more room when the space is already tight, so it is probably better using the concept of "scrollbar gutter" for this value, which is also clearer when overlay scrollbar / auto-expand scrollbar involves.

Also when the scrollbar is already fully overlay (e.g. on macOS when trackpad is used, or on Android), I believe there is no point to create an even thinner scrollbar, so the value probably shouldn't use a "must".