### PR TITLE
[css-grid] Exclude 'auto' from line name

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1583,9 +1583,9 @@ Named Grid Lines: the <css>[<<custom-ident>>*]</css> syntax</h4>
 		</figure>
 	</div>
 
-	A line name cannot be <css>span</css>,
+	A line name cannot be <css>span</css> or <css>auto</css>,
 	i.e. the <<custom-ident>> in the <<line-names>> production
-	excludes the keyword <css>span</css>.
+	excludes the keywords <css>span</css> and <css>auto</css>.
 
 <!--
 ████████  ████████ ████████  ████████    ███    ████████   ███ ███
@@ -2848,7 +2848,7 @@ Line-based Placement: the 'grid-row-start', 'grid-column-start', 'grid-row-end',
 	</dl>
 
 	In all the above productions,
-	the <<custom-ident>> additionally excludes the keyword <css>span</css>.
+	the <<custom-ident>> additionally excludes the keywords <css>span</css> and <css>auto</css>.
 
 	<div class='example'>
 			Given a single-row, 8-column grid and the following 9 named lines:
@@ -4438,6 +4438,10 @@ Major Changes</h4>
 				If a grid item is placed outside this limit,
 				its grid area must be <a>clamped</a> to within this limited grid.
 			</blockquote>
+
+        <li id="change-2018-line-name-auto">
+            Exclude 'auto' from line name <<custom-ident>>.
+            (<a href="https://github.com/w3c/csswg-drafts/issues/2856">Issue 2856</a>)
 	</ul>
 
 <h4 id="clarify-2017">


### PR DESCRIPTION
The custom-ident for line name cannot be 'auto'.

Resolved in
https://github.com/w3c/csswg-drafts/issues/2856#issuecomment-411476346

fixes #2856
