### PR TITLE
[css-syntax-3] Missing character after Unicode name

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -1250,7 +1250,7 @@ Consume a url token</h4>
 					create a <<bad-url-token>>,
 					and return it.
 
-				<dt>U+005C REVERSE SOLIDUS
+				<dt>U+005C REVERSE SOLIDUS (\)
 				<dd>
 					If the stream <a>starts with a valid escape</a>,
 					<a>consume an escaped code point</a>


### PR DESCRIPTION
Adds missing `(\)` after `U+005C REVERSE SOLIDUS`