### PR TITLE
[css-align] flex-end without semicolon

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -358,7 +358,7 @@ Positional Alignment: the ''center'', ''start'', ''end'', ''self-start'', ''self
 			(to specify default values for 'justify-self' and 'align-self').
 			<pre class='prod'>
 				<dfn>&lt;self-position></dfn> = center | start | end | self-start | self-end |
-								flex-start | flex-end;
+								flex-start | flex-end
 			</pre>
 		<dt><<content-position>>
 		<dd>
@@ -366,7 +366,7 @@ Positional Alignment: the ''center'', ''start'', ''end'', ''self-start'', ''self
 			to align the box's contents within itself.
 
 			<pre class='prod'>
-				<dfn>&lt;content-position></dfn> = center | start | end | flex-start | flex-end;
+				<dfn>&lt;content-position></dfn> = center | start | end | flex-start | flex-end
 			</pre>
 	</dl>
 


### PR DESCRIPTION
The production rules for self-position and content-position
previously ended with `| flex-end;`

The semicolon is not needed.
