### PR TITLE
[css-display] Values without semicolons

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -203,16 +203,16 @@ Box Layout Modes: the 'display' property</h2>
 	Values are defined as follows:
 
 	<pre class='prod'>
-	<dfn>&lt;display-outside></dfn>  = block | inline | run-in ;
-	<dfn>&lt;display-inside></dfn>   = flow | flow-root | table | flex | grid | ruby ;
-	<dfn>&lt;display-listitem></dfn> = <<display-outside>>? && [ flow | flow-root ]? && list-item ;
+	<dfn>&lt;display-outside></dfn>  = block | inline | run-in
+	<dfn>&lt;display-inside></dfn>   = flow | flow-root | table | flex | grid | ruby
+	<dfn>&lt;display-listitem></dfn> = <<display-outside>>? && [ flow | flow-root ]? && list-item
 	<dfn>&lt;display-internal></dfn> = table-row-group | table-header-group |
 	                     table-footer-group | table-row | table-cell |
 	                     table-column-group | table-column | table-caption |
 	                     ruby-base | ruby-text | ruby-base-container |
-	                     ruby-text-container ;
-	<dfn>&lt;display-box></dfn>      = contents | none ;
-	<dfn>&lt;display-legacy></dfn>   = inline-block | inline-table | inline-flex | inline-grid ;
+	                     ruby-text-container
+	<dfn>&lt;display-box></dfn>      = contents | none
+	<dfn>&lt;display-legacy></dfn>   = inline-block | inline-table | inline-flex | inline-grid
 	</pre>
 
 	The following informative table summarizes the values of 'display':


### PR DESCRIPTION
The production rules for display values
previously ended with `;`

The semicolon is not needed.
