### PR TITLE
[cssom-view] Removed instant mention

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -416,7 +416,7 @@ then <var>x</var> must be changed to the value <code>0</code>. [[!WEBIDL]]
 <h2 id=extensions-to-the-window-interface>Extensions to the {{Window}} Interface</h2>
 
 <pre class=idl>
-enum ScrollBehavior { "auto", "instant", "smooth" };
+enum ScrollBehavior { "auto", "smooth" };
 
 dictionary ScrollOptions {
     ScrollBehavior behavior = "auto";


### PR DESCRIPTION
This PR fixes https://github.com/w3c/csswg-drafts/issues/2146.

It removes instant from the IDL.