### PR TITLE
[css-text-3] treat %age text-indent as 0 for intrinsic size calculations #1597

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -2034,7 +2034,14 @@ Cursive Scripts</h4>
       <dd>Gives the amount of the indent as an absolute length.</dd>
       <dt><dfn>&lt;percentage&gt;</dfn>
       <dd>Gives the amount of the indent as a percentage of the containing
-        block's logical width.</dd>
+        block's logical width.
+
+        Percentages must be treated as ''0'' for the purpose of calculating [=intrinsic size contributions=],
+        but are always resolved normally when performing layout.
+
+        Note: This can lead to the element overflowing.
+        It is not recommended to use percentage indents and intrinsic sizing toghether.
+      </dd>
       <dt><dfn>each-line</dfn>
       <dd>Indentation affects the first line of each block container
         and each line after a <a>forced line break</a>


### PR DESCRIPTION
Closes #1597
