### PR TITLE
[css-animations] animation-name is not inherited

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -494,7 +494,7 @@ The 'animation-name' property</h3>
 	Value: [ none | <<keyframes-name>> ]#
 	Initial: none
 	Applies to: all elements, ::before and ::after pseudo-elements
-	Inherited: none
+	Inherited: no
 	Animatable: no
 	Percentages: N/A
 	Computed value: As specified


### PR DESCRIPTION
The spec previously had "Inherited: none" instead of "no".
