### PR TITLE
[css-fonts-4] Stop claiming that 'ch' uses the first available font, since it doesn't

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -1012,7 +1012,7 @@ Relative sizing: the 'font-size-adjust' property</h3>
 	The value of 'font-size-adjust' affects the used value of 'font-size'
 	but does not affect the computed value.
 	It affects the size of relative units
-	that are based on font metrics of the <a>first available font</a>
+	that are based on font metrics
 	such as <code>ex</code> and <code>ch</code>
 	but does not affect the size of <code>em</code> units.
 	Since numeric values of 'line-height'
@@ -3175,7 +3175,7 @@ to ensure that the results are as consistent as possible across user agents,
 given an identical set of available fonts and rendering technology.
 
 The <dfn export>first available font</dfn>,
-used for example in the definition of <a>font-relative lengths</a> such as ''ex'' and ''ch''
+used for example in the definition of <a>font-relative lengths</a> such as ''ex''
 or in the definition of the 'line-height' property
 is defined to be the first available font
 that would match the U+0020 (space) character


### PR DESCRIPTION
css-fonts-4 claims that the 'ch' unit uses the "first available font", but [it doesn't](https://drafts.csswg.org/css-values-4/#ch).  This revises the spec to stop making this claim.

Note that the same claim is made in css-fonts-3.  Given its status, I'm not sure whether to suggest the same edit there...