### PR TITLE
[css-content-3] Typo fix

### DIFF
--- a/css-content-3/Overview.bs
+++ b/css-content-3/Overview.bs
@@ -75,8 +75,8 @@ Introduction</h2>
 		/* Replace &lt;figure&gt; elements with the referenced document, or,
 		 * failing that, with either the contents of the alt attribute or the
 		 * contents of the element itself if there is no alt attribute */
-		figure[alt] { content: attr(href, url), attr(alt); }
-		figure:not([alt]) { content: attr(href, url), contents; }
+		figure[alt] { content: attr(href url), attr(alt); }
+		figure:not([alt]) { content: attr(href url), contents; }
 		</pre>
 	</div>
 


### PR DESCRIPTION
In `attr()`, `<type-or-unit>` is space-separated, instead of comma-separated, with `<attr-name>`.
