### PR TITLE
[css-transforms-2] Fix the check for product == 1.0 to include the case when product is -1

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -1009,7 +1009,7 @@ product = dot(quaternionA, quaternionB)
 product = max(product, 1.0)
 product = min(product, -1.0)
 
-if (product == 1.0)
+if (abs(product) == 1.0)
 	 quaternionDst = quaternionA
 	 return
 


### PR DESCRIPTION
This occurs in the following code:

```
if (product == 1.0)
   quaternionDst = quaternionA
   return

theta = acos(dot)
w = sin(t * theta) * 1 / sqrt(1 - product * product)
```

If `product` is -1.0 we'll end up doing division by zero when we
calculate `w`.

WebKit works around this by inverting the angle (effectively doing the
same thing as taking the absolute value):

  https://github.com/WebKit/webkit/blob/425f9748af04b2c7e235cf3ff9396eecc23c0af5/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp#L542-L548

Chromium takes the absolute value like this patch does:

  https://cs.chromium.org/chromium/src/third_party/blink/renderer/platform/transforms/transformation_matrix.cc?l=762&rcl=cd5181ecb173efdef4163f066c27bd136fca01d5