### PR TITLE
[css-transforms-2] Permit piecewise rotation interpolation when 0deg angle is present #3236

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -1103,7 +1103,7 @@ Two transform functions with the same name and the same number of arguments are 
 
 The transform functions <<matrix()>>, ''matrix3d()'' and ''perspective()'' get converted into 4x4 matrices first and interpolated as defined in section <a href="#matrix-interpolation">Interpolation of Matrices</a> afterwards.
 
-For interpolations with the primitive ''rotate3d()'', the direction vectors of the transform functions get normalized first. If the normalized vectors are equal, the rotation angle gets interpolated numerically. Otherwise the transform functions get converted into 4x4 matrices first and interpolated as defined in section <a href="#matrix-interpolation">Interpolation of Matrices</a> afterwards.
+For interpolations with the primitive ''rotate3d()'', the direction vectors of the transform functions get normalized first. If the normalized vectors are not equal and both rotation angles are non-zero the transform functions get converted into 4x4 matrices first and interpolated as defined in section <a href="#matrix-interpolation">Interpolation of Matrices</a> afterwards. Otherwise the rotation angle gets interpolated numerically and the rotation vector of the non-zero angle is used or (0, 0, 1) if both angles are zero.
 
 Addition and accumulation of transform lists {#combining-transform-lists}
 ============================================


### PR DESCRIPTION
[css-transforms-2] Permit piecewise rotation interpolation when 0deg angle is present #3236

This change makes rotations like `rotateX(45deg)` and `rotateY(0deg)` compatible for simple interpolation without triggering matrix interpolation. Any 0deg rotation can interpolate cleanly with any other rotation.