### PR TITLE
[css-print] correct Bikeshed Shortname variable

### DIFF
--- a/css-print/Overview.bs
+++ b/css-print/Overview.bs
@@ -29,7 +29,7 @@
 <body>
 <pre class="metadata">
 Title: CSS Print Profile
-Shortname: css-mobile
+Shortname: css-print
 Group: csswg
 Level:
 Status: ED


### PR DESCRIPTION
It erroneously used `css-mobile` instead of `css-print`.