### PR TITLE
[css-overflow-3] Inserting the block ellipsis should not cause relayouts

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -44,6 +44,7 @@ spec:css-display-3; type:property; text:display
 <pre class="anchors">
 url: https://www.w3.org/TR/2008/CR-css3-marquee-20081205/#the-overflow-style; type: property; text: overflow-style;
 url: https://www.w3.org/TR/CSS22/visuren.html#positioned-element; type: dfn; spec:css2; text:positioned;
+url: https://www.w3.org/TR/CSS22/visudet.html#strut-element; type: dfn; spec:css2; text:strut;
 </pre>
 <style>
 .awesome-table td { padding: 5px; }
@@ -849,15 +850,25 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	reducing the space in the line box
 	available to the other contents of the line.
 	This inline is assigned ''unicode-bidi: plaintext''
+	and ''line-height: 0''
 	and is placed in the line box after the last
-	<a>soft wrap opportunity</a> [[!CSS-TEXT-3]]
+	<a>soft wrap opportunity</a> (see [[!CSS-TEXT-3]])
 	that would still allow the entire <a>block overflow ellipsis</a> to fit on the line.
-	(This can result in the entire contents of the line box being replaced.)
 	For this purpose, <a>soft wrap opportunities</a> added by 'overflow-wrap' are ignored.
+	If this results in the entire contents of the line box being displaced,
+	the line box is considered to contain a [=strut=], as defined in [[CSS2/visudet.html#leading]].
 	Text <a href="https://www.w3.org/TR/css-text-3/#justification">alignment and justification</a>
 	occurs after placement,
 	and measures the inserted <a>block overflow ellipsis</a>
 	together with the rest of the line’s content.
+
+	Note: Setting the [=block overflow ellipsis=]'s 'line-height' to ''0''
+	makes sure that inserting it cannot cause the line's height to grow,
+	which could cause further relayouts and potentially cycles.
+	This is almost equivalent to inserting the [=block overflow ellipsis=]
+	as a paint-time operation, except that it still participates in alignment and justification.
+	The downside is that unusually tall / deep glyphs in the [=block overflow ellipsis=]
+	may overflow.
 
 	The [=block overflow ellipsis=] must not be included
 	in either the ''::first-letter'' nor the ''::first-line'' pseudo-elements.
@@ -866,18 +877,11 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	and thus the remainder of the content after the break would be discarded,
 	then the UA may visually replace the contents of the line,
 	as it does for 'text-overflow'.
-	If, however, there is a next <a>fragmentation container</a>
-	that would receive subsequent content,
-	then the content replaced by the <a>block overflow ellipsis</a>
-	must be pushed to the next <a>fragmentation container</a>
-	and the <a>block overflow ellipsis</a> inserted and laid out
-	exactly as if it were part of the <a>in-flow</a> contents of the line.
-	This can result in changes to layout within or impacted by the line.
-	The means of breaking any resulting cycles is up to the UA.
 
-	Issue(2905): We may want to get rid of the "MAY" in the previous paragraph,
-	and require a single behavior.
-	Finding how to break the cycles probably should be defined as well.
+	If there is a subsequent <a>fragmentation container</a> in the [=fragmentation context=]
+	that would receive subsequent content,
+	then the content displaced by the <a>block overflow ellipsis</a>
+	must be pushed to that <a>fragmentation container</a>.
 
 	The UA must treat the <a>block overflow ellipsis</a> as an unbreakable string,
 	If any part of the [=block overflow ellipsis=] overflows,
@@ -885,8 +889,7 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	and its rendering is affected by the 'text-overflow' property.
 
 	The <a>block overflow ellipsis</a> does not capture events:
-	pointer events are dispatched to whatever is underneath
-	or otherwise visually replaced by it.
+	pointer events are dispatched to whatever is underneath it.
 
 	It also has no effect on the intrinsic size of the box:
 	its <a lt="min-content size">min-content</a> and <a lt="max-content size">max-content</a> sizes


### PR DESCRIPTION
Treating it as ''line-height: 0'' should handle that.

This is slightly different from the resolution taken in #2905, but this should be equally safe with regards to relayout, while still allowing text alignment and especially justification to work fine.