### PR TITLE
[css-sizing-4] Typo: s/as tall as it is high/as tall as it is wide/

### DIFF
--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -177,7 +177,7 @@ Aspect Ratio Limits Option A: the ''from-ratio''</h3>
 		In the following example,
 		the box is as wide as the container (as usual),
 		and its height is as tall as needed to contain its content
-		but at least as tall as it is high.
+		but at least as tall as it is wide.
 
 		<pre>
 		  div {
@@ -220,7 +220,7 @@ Aspect Ratio Limits Option B: the ''tr'' unit</h3>
 		In the following example,
 		the box is as wide as the container (as usual),
 		and its height is as tall as needed to contain its content
-		but at least as tall as it is high.
+		but at least as tall as it is wide.
 
 		<pre>
 		  div {


### PR DESCRIPTION
"tall" and "high" refer to the same dimension so it doesn't really make sense.
