### PR TITLE
[css-animations] animation-name can contain string

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -53,6 +53,7 @@ spec:cssom-1; type:interface; text:CSSRule
 spec:html; type:dfn; text:case-sensitive
 spec:css-backgrounds-3; type:property; text:background-image
 spec:css2; type:property; text:display
+spec:css-values-4; type:dfn; text:string
 </pre>
 
 <h2 id="intro">
@@ -472,7 +473,7 @@ The 'animation-name' property</h3>
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Computed value: list, each item either a case-sensitive <a>css identifier</a> or the keyword ''animation-name/none''
+	Computed value: list, each item either a case-sensitive <a>css identifier</a> or <a>string</a>, or the keyword ''animation-name/none''
 	Animation type: not animatable
 	Canonical order: per grammar
 	</pre>


### PR DESCRIPTION
The computed value for animation-name can contain strings.

For example, the following are valid:
@keyframes "initial" { ... }
@keyframes "None" { ... }

The computed value for animation-name
  `"initial", "None", None`
should be
  `"initial", "None", none`

Without quotes, the computed value would not round trip.
