### PR TITLE
[css-images] optimizeQuality behaves like smooth

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -1568,7 +1568,7 @@ Determining How To Scale an Image: the 'image-rendering' property {#the-image-re
 	This property previously accepted the values ''optimizeSpeed'' and ''optimizeQuality''.
 	These are now deprecated;
 	a user agent must accept them as valid values
-	but must treat them as having the same behavior as ''pixelated'' and ''image-rendering/auto'' respectively,
+	but must treat them as having the same behavior as ''pixelated'' and ''smooth'' respectively,
 	and authors must not use them.
 
 


### PR DESCRIPTION
The deprecated image-rendering value 'optimizeQuality' has the same behavior as 'smooth'.

resolves https://github.com/w3c/csswg-drafts/issues/3283
