### PR TITLE
[css-transitions-1] [css-animations-1] GlobalEventHandlers is a mixin

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -1264,9 +1264,9 @@ The <code>findRule</code> method</h4>
 
 
 <h3 id="interface-globaleventhandlers">
-Extensions to the <code>GlobalEventHandlers</code> Interface</h3>
+Extensions to the <code>GlobalEventHandlers</code> Interface Mixin</h3>
 
-This specification extends the {{GlobalEventHandlers}} interface from HTML to
+This specification extends the {{GlobalEventHandlers}} interface mixin from HTML to
 add <a>event handler IDL attributes</a> for <a href="#events">animation
 events</a> as defined in
 [[#event-handlers-on-elements-document-objects-and-window-objects]].

--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -1232,7 +1232,7 @@ objects, as <a>event handler IDL attributes</a>:
 DOM Interfaces {#interface-dom}
 ===============================
 
-This specification extends the {{GlobalEventHandlers}} interface from HTML to
+This specification extends the {{GlobalEventHandlers}} interface mixin from HTML to
 add <a>event handler IDL attributes</a> for <a
 href="#transition-events">transition events</a> as defined in [[#event-handlers-on-elements-document-objects-and-window-objects]].
 
@@ -1240,7 +1240,7 @@ IDL Definition {#interface-globaleventhandlers-idl}
 --------------
 
 <pre class="idl">
-partial interface GlobalEventHandlers {
+partial interface mixin GlobalEventHandlers {
   attribute EventHandler ontransitionrun;
   attribute EventHandler ontransitionstart;
   attribute EventHandler ontransitionend;


### PR DESCRIPTION
...and thus should only be extended by `partial interface mixin`s.