### PR TITLE
[css-logical-1] s/as specified/specified keyword

### DIFF
--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -197,7 +197,7 @@ Flow-Relative Values for the 'float' and 'clear' Properties</h3>
   <pre class="propdef partial">
     Name: float, clear
     New values: inline-start | inline-end
-    Computed value: as specified
+    Computed value: specified keyword
   </pre>
 
   The mapping on these properties uses the <a>writing mode</a> of the element’s <a>containing block</a>.


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/8dbce74efa894eb8c7183440bd312316cb1ce449#diff-d7d080704a1157585de808649f930ae7 did this change for `caption-side`, `text-align` and `resize`, but forgot about `float, clear`.
