### PR TITLE
[css-regions] Skip inherit in flow-from grammar

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -556,7 +556,7 @@ The 'flow-from' property</h3>
 
 	<pre class='propdef'>
 		Name: flow-from
-		Value: <<ident>> | none | inherit
+		Value: <<ident>> | none
 		Initial: none
 		Applies To: Non-replaced <a href="https://www.w3.org/TR/CSS21/visuren.html#block-boxes">block containers</a>. <br/> This might be expanded in future versions of the specification to allow other types of containers to receive flow content.
 		Inherited: no


### PR DESCRIPTION
CSS-wide keywords such as `inherit` do not need to be included
in the grammar for a specific property such as `flow-from`.
