### PR TITLE
Reduce references to Bugzilla

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -14,7 +14,6 @@ Previous Version: https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130221/
 Previous Version: https://www.w3.org/TR/2012/WD-css-counter-styles-3-20121009/
 Editor: Tab Atkins Jr., Google, http://xanthir.com/contact/, w3cid 42199
 Abstract: This module introduces the ''@counter-style'' rule, which allows authors to define their own custom counter styles for use with CSS list-marker and generated-content counters [[CSS-LISTS-3]]. It also predefines a set of common counter styles, including the ones present in CSS2 and CSS2.1.
-Issue Tracking: Bugzilla https://www.w3.org/Bugs/Public/buglist.cgi?product=CSS&component=Counter%20Styles&resolution=---
 Link Defaults: css-text-3 (dfn) grapheme cluster, css-pseudo-4 (selector) ::marker, dom-ls (dfn) ASCII case-insensitive
 Deadline: 2015-05-03
 At Risk: the <<image>> value in <<symbol>>

--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -14,7 +14,6 @@ Abstract: Books and other paged media often use special techniques to display in
 Previous Version: https://www.w3.org/TR/2014/WD-css-gcpm-3-20140513/
 Previous version: https://hg.csswg.org/drafts/raw-file/6a5c44d11c2b/css-gcpm/Overview.html
 Previous version: https://www.w3.org/TR/2011/WD-css3-gcpm-20111129/
-Issue Tracking: W3C Bugzilla https://www.w3.org/Bugs/Public/enter_bug.cgi?product=CSS&component=Generated%20Content%20for%20Paged%20Media
 Ignored Terms: content-list,
 
 

--- a/css-gcpm-4/Overview.bs
+++ b/css-gcpm-4/Overview.bs
@@ -9,7 +9,6 @@ ED: https://drafts.csswg.org/css-gcpm-4/
 Editor: Dave Cramer, Hachette Livre, dauwhe@gmail.com, w3cid 65283
 Editor: Daniel Glazman, Disruptive Innovations, daniel.glazman@disruptive-innovations.com, w3cid 13329
 Abstract: Level 4 of GCPM proposes a region-based approach to footnotes and running heads.
-Issue Tracking: W3C Bugzilla https://www.w3.org/Bugs/Public/enter_bug.cgi?product=CSS&component=Generated%20Content%20for%20Paged%20Media
 Ignored Terms:
 Warning: Not Ready
 </pre>

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -11,7 +11,6 @@ Previous Version: http://www.w3.org/TR/2014/CR-css-shapes-1-20140320/
 Editor: Vincent Hardy, Adobe Systems&#44; Inc., vhardy@adobe.com
 Editor: Rossen Atanassov, Microsoft Corporation, ratan@microsoft.com, w3cid 49885
 Editor: Alan Stearns, Adobe Systems&#44; Inc., stearns@adobe.com, w3cid 46659
-!Issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;product=CSS&amp;component=Shapes&amp;resolution=---&amp;cmdtype=doit">In Bugzilla</a>
 Abstract: CSS Shapes describe geometric shapes for use in CSS. For Level 1, CSS Shapes can be applied to floats. A circle shape on a float will cause inline content to <a>wrap</a> around the circle shape instead of the float's bounding box.
 Link Defaults: css2 (property) margin
 </pre>

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -9,7 +9,6 @@ TR: https://www.w3.org/TR/css-shapes-2/
 ED: https://drafts.csswg.org/css-shapes-2/
 Editor: Rossen Atanassov, Microsoft Corporation, ratan@microsoft.com, w3cid 49885
 Editor: Alan Stearns, Adobe Systems&#44; Inc., stearns@adobe.com, w3cid 46659
-!Issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;product=CSS&amp;component=Shapes&amp;resolution=---&amp;cmdtype=doit">In Bugzilla</a>
 Abstract: This draft contains the features of CSS relating to wrapping content around and inside shapes. It (implicitly for now) includes and extends the functionality of CSS Shapes Level 1 [[CSS-SHAPES]]. The main points of extension compared to level 1 include additional ways of defining shapes, defining an exclusion area using a shape, and restricting an element's content area using a shape.
 Link Defaults: css2 (property) margin, css-display-3 (value) table
 </pre>


### PR DESCRIPTION
Remove Bugzilla in the metadata section for specs return "**Zarro Boogs found.**"

The remaining ones are:

* [css-animations-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-animations-1/Overview.bs#L34) and [css-animations-2](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-animations-2/Overview.bs#L46)
* [css-device-adapt-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-device-adapt-1/Overview.bs#L17)
* [css-exclusions-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-exclusions-1/Overview.bs#L15)
* [css-regions-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-regions-1/Overview.bs#L15)
* [css-transitions-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-transitions-1/Overview.bs#L34-L35) and [css-transitions-2](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/css-transitions-2/Overview.bs#L28)
* [cssom-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/cssom-1/Overview.bs#L19)
* [cssom-view-1](https://github.com/w3c/csswg-drafts/blob/70e11db3dcc0fda5cc0ee89be5bd347477d565c2/cssom-view-1/Overview.bs#L20)