### PR TITLE
[css-shadow-parts-1] Add missing colon to part forwarding example

### DIFF
--- a/css-shadow-parts-1/Overview.bs
+++ b/css-shadow-parts-1/Overview.bs
@@ -218,7 +218,7 @@ Note: It's okay to map a sub-part to several names.
 &lt;/style&gt;
 
 &lt;template id="c-e-outer-template"&gt;
-  &lt;c-e-inner <b>exportparts="innerspan textspan"</b>&gt;&lt;/c-e-inner&gt;
+  &lt;c-e-inner <b>exportparts="innerspan: textspan"</b>&gt;&lt;/c-e-inner&gt;
 &lt;/template&gt;
 
 &lt;template id="c-e-inner-template"&gt;


### PR DESCRIPTION
The [algorithm for parsing part mappings](https://drafts.csswg.org/css-shadow-parts/#parsing-mapping) states that a colon (`:`) is expected between idents.

As noted in the [fix for the explainer doc](https://github.com/fergald/docs/pull/2), the missing colon in the example is probably an oversight after the syntax change.