### PR TITLE
[css-fonts-3][css-fonts-4] letter-spacing disables optional ligatures. #2644

### DIFF
--- a/css-fonts-3/Fonts.html
+++ b/css-fonts-3/Fonts.html
@@ -4975,7 +4975,7 @@ body { font-feature-settings: "hwid"; /* Half-width OpenType feature */ }
     title="font-feature-settings!!property">‘<code
     class=property>font-feature-settings</code>’</a>. For example, setting
     a non-default value for the ‘<code
-    class=property>letter-spacing</code>’ property disables common
+    class=property>letter-spacing</code>’ property disables optional
     ligatures.
 
    <li>Font features implied by the value of <a

--- a/css-fonts-3/Fonts.src.html
+++ b/css-fonts-3/Fonts.src.html
@@ -3719,7 +3719,7 @@ text run.</p>
   <li>Feature settings determined by properties other than
   <span title="font-variant!!property">'font-variant'</span> or
   <span title="font-feature-settings!!property">'font-feature-settings'</span>.  For example, setting a
-  non-default value for the 'letter-spacing' property disables common ligatures.</li>
+  non-default value for the 'letter-spacing' property disables optional ligatures.</li>
 
   <li>Font features implied by the value of <span title="font-feature-settings!!property">'font-feature-settings'</span> property.</li>
 </ol>

--- a/css-fonts-3/Overview-wip.bs
+++ b/css-fonts-3/Overview-wip.bs
@@ -3554,7 +3554,7 @@ text run.
 	<li>Feature settings determined by properties other than
 	'font-variant' or
 	'font-feature-settings'.  For example, setting a
-	non-default value for the 'letter-spacing' property disables common ligatures.
+	non-default value for the 'letter-spacing' property disables optional ligatures.
 
 	<li>Font features implied by the value of 'font-feature-settings' property.
 </ol>

--- a/css-fonts-3/Overview.html
+++ b/css-fonts-3/Overview.html
@@ -4977,7 +4977,7 @@ body { font-feature-settings: "hwid"; /* Half-width OpenType feature */ }
     title="font-feature-settings!!property">‘<code
     class=property>font-feature-settings</code>’</a>. For example, setting
     a non-default value for the ‘<code
-    class=property>letter-spacing</code>’ property disables common
+    class=property>letter-spacing</code>’ property disables optional
     ligatures.
 
    <li>Font features implied by the value of <a

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -5050,7 +5050,7 @@ text run.
 
 11. Feature settings determined by properties other than 'font-variant!!property' or
 	'font-feature-settings!!property' are applied. For example, setting a
-	non-default value for the 'letter-spacing' property disables common ligatures.
+	non-default value for the 'letter-spacing' property disables optional ligatures.
 
 12. Font variations implied by the value of the 'font-variation-settings!!property' property are applied.
 	These values should be clamped to the values that are supported by the font.


### PR DESCRIPTION
A non-default value for letter-spacing should disable all
optional ligatures, not just common ligatures. Defer to css-text for
optional ligature definition.

Test that letter-spacing disables discretionary ligatures in particular at
https://chromium-review.googlesource.com/c/chromium/src/+/1294874
