### PR TITLE
[css-text] Remove stray text

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -1422,8 +1422,7 @@ Line Breaking Details</h3>
 
     <p>This property specifies whether the UA may break at otherwise disallowed points within a line
       to prevent overflow,
-      when an otherwise-unbreakable string is too long to fit within the line box,
-      or when sequences of <a>preserved</a> white space would <a>hang</a>.
+      when an otherwise-unbreakable string is too long to fit within the line box.
       It only has an effect when
       'white-space' allows <a>wrapping</a>. Possible values:</p>
 


### PR DESCRIPTION
This sentence is a leftover form where break-spaces was defined as a
value of overflow-wrap, and no longer makes sense now that it has been
moved to the white-space property

cc @fantasai 

Note: I did not update the DoC or the Change section in this patch, so that needs to be done after merging.