### PR TITLE
[cs-text-3] Close stale issue

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -1427,12 +1427,6 @@ Line Breaking Details</h3>
       It only has an effect when
       'white-space' allows <a>wrapping</a>. Possible values:</p>
 
-      Issue: It has been proposed that this property could also apply when the 'white-space' property
-      does not allow <a>wrapping</a>,
-      introducing a break anywhere the line would otherwise overflow,
-      but without causing any change to intrinsic size computations.
-      See <a href="https://github.com/w3c/csswg-drafts/issues/1171#issuecomment-295522963">https://github.com/w3c/csswg-drafts/issues/1171#issuecomment-295522963</a>
-
     <dl dfn-for=overflow-wrap dfn-type=value>
     <dt><dfn>normal</dfn></dt>
     <dd>Lines may break only at allowed break points. However, the restrictions


### PR DESCRIPTION
This issue was open while we were still trying to solve the 'word-break:break-word' problem, with the assumption that 'overflow-wrap: break-word' could be made to change intrinsic sizing computations, but that 'overflow-wrap: break-word; white-space: nowrap' (or 'white-space: pre') would result into intrinsic computations not being affected (because of white-space), but could still be made to enable overflow-wrapping.

Since we've solved the problem differently, this suggestion is no longer relevant and should be removed.

cc: @fantasai 

Note: This PR does not update the DoC or the Change section. That needs to be done after merging.