### PR TITLE
[css-pseudo-4] Fix typo

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -29,7 +29,7 @@ spec:css-color-3; type:property; text:color
   <a>Pseudo-elements</a> represent abstract elements of the document
   beyond those elements explicitly created by the document language.
   Since they are not restricted to fitting into the document tree,
-  they can be used the select and style portions of the document
+  they can be used to select and style portions of the document
   that do not necessarily map to the document's tree structure.
   For instance, the ''::first-line'' pseudo-element can
   select content on the first formatted line of an element


### PR DESCRIPTION
Fixes a typo in [this paragraph](https://www.w3.org/TR/css-pseudo-4/#intro).