### PR TITLE
fix(css‑env): Fix `env()` function syntax definition

### DIFF
--- a/css-env-1/Overview.bs
+++ b/css-env-1/Overview.bs
@@ -114,8 +114,8 @@ Using Environment Variables: the ''env()'' notation {#env-function}
 In order to substitute the value of an [=environment variable=] into a CSS context,
 use the ''env()'' function:
 
-<pre class=prod>
-	<dfn function>env()</dfn> = env( <<custom-ident>> , <<declaration-value>>? )
+<pre class='prod'>
+	<dfn function>env()</dfn> = env( <<custom-ident>> [, <<declaration-value>> ]? )
 </pre>
 
 The ''env()'' function can be used in place of any part of a value in any property on any element,


### PR DESCRIPTION
https://drafts.csswg.org/css-env-1/#env-function

The current specification would require `prop: env(safe-area-inset-top,)` to be valid and `prop: env(safe-area-inset-top)` to be invalid, but as we all know, it’s the other way around, so the spec is incorrect.

## See also:
- https://github.com/mdn/data/pull/326