### PR TITLE
refactor(css‑variables): Simplify `var()` function syntax definition

### DIFF
--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -393,7 +393,7 @@ Using Cascading Variables: the ''var()'' notation</h2>
 	The syntax of ''var()'' is:
 
 	<pre class='prod'>
-	<dfn>var()</dfn> = var( <<custom-property-name>> [, <<declaration-value>> ]? )
+	<dfn>var()</dfn> = var( <<custom-property-name>> , <<declaration-value>>? )
 	</pre>
 
 	The ''var()'' function can be used in place of any part of a value in any property on an element.


### PR DESCRIPTION
https://drafts.csswg.org/css-variables/#using-variables

Opened because of&nbsp;@tabatkins’s comment in&nbsp;https://github.com/w3c/csswg-drafts/pull/3475#issuecomment-451526826.

review?(@tabatkins, @zcorpan)