### PR TITLE
[web-animations-1] Make the definition of "is current" reflect the associated animation's playback rate

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2226,9 +2226,8 @@ follows:
 
 :   <a>current</a>
 ::  Corresponds to an <a>animation effect</a> that is either <a>in
-    play</a> or may become <a>in play</a> in the future.
-    This will be the case if the <a>animation effect</a> is <a>in
-    play</a> or in its <a>before phase</a>.
+    play</a> or may become <a>in play</a> in the future based on its
+    [=animation=]'s current [=playback rate=].
 
 :   <a>in effect</a>
 ::  Corresponds to an <a>animation effect</a> that has a resolved
@@ -2291,11 +2290,16 @@ of the following conditions are met:
 2.  the <a>animation effect</a> is <a>associated with an animation</a> that is not
     <a lt="finished play state">finished</a>.
 
-An <a>animation effect</a> is <dfn>current</dfn> if <em>either</em>
-of the following conditions is true:
+An <a>animation effect</a> is <dfn>current</dfn> if <em>any</em>
+of the following conditions are true:
 
-*   the <a>animation effect</a> is in the <a>before phase</a>, or
-*   the <a>animation effect</a> is <a>in play</a>.
+*   the [=animation effect=] is [=in play=], or
+*   the [=animation effect=] is [=associated with an animation=] with
+    a [=playback rate=] &ge; 0 and
+    the [=animation effect=] is in the [=before phase=], or
+*   the [=animation effect=] is [=associated with an animation=] with
+    a [=playback rate=] &lt; 0 and
+    the [=animation effect=] is in the [=after phase=].
 
 An animation effect is <dfn>in effect</dfn> if its <a>active time</a>, as
 calculated according to the procedure in [[#calculating-the-active-time]],
@@ -5785,7 +5789,9 @@ The following changes have been made since the <a
   href="https://www.w3.org/TR/2018/WD-web-animations-1-20181011/">11 October
 2018 Working Draft</a>:
 
-(None yet)
+*   Made the definition of a [=current=] [=animation effect=] incorporate the
+    associated animation's [=playback rate=] (<a
+    href="https://github.com/w3c/csswg-drafts/issues/3193">#3193</a>).
 
 The <a
   href="https://github.com/w3c/csswg-drafts/commits/master/web-animations-1">changelog</a>


### PR DESCRIPTION
Fixes #3193.
