### PR TITLE
typo fix

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -142,7 +142,7 @@ Supported Shapes</h3>
 					or ''evenodd''.
 					Default value when omitted is ''nonzero''.</li>
 				<li>
-					The <string> represents an
+					The <dfn><<string>></dfn>  represents an
 					<a href="https://www.w3.org/TR/SVG11/paths.html#PathData">SVG Path data string</a>.
 					The path data string must be conform
 					to the grammar and parsing rules of SVG 1.1.

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -126,10 +126,11 @@ Supported Shapes</h3>
 	section, with the following integrated.
 
 	<dl>
-		<dt><dfn>path()</dfn> =
-			path( [<<fill-rule>>,]? <<string>> )
-		</dt>
-		<dd>
+		<dt>
+			<pre class=prod>
+				<dfn>path()</dfn> = path( [<<fill-rule>>,]? <<string>> )
+			</pre>
+		<dd dfn-type=value dfn-for="path()">
 			<ul>
 				<li>
 					<dfn><<fill-rule>></dfn> -
@@ -138,9 +139,9 @@ Supported Shapes</h3>
 					of the path.
 					See <a href="https://www.w3.org/TR/SVG/painting.html#FillRuleProperty">fill-rule</a> property
 					in SVG for details.
-					Possible values are ''nonzero''
-					or ''evenodd''.
-					Default value when omitted is ''nonzero''.</li>
+					Possible values are <dfn>''nonzero''</dfn>
+					or <dfn>''evenodd''</dfn>.
+					Default value when omitted is ''nonzero''.
 				<li>
 					The <dfn><<string>></dfn>  represents an
 					<a href="https://www.w3.org/TR/SVG11/paths.html#PathData">SVG Path data string</a>.
@@ -150,9 +151,7 @@ Supported Shapes</h3>
 					by the first “move to” argument
 					in the path string.
 					For the initial direction follow SVG 1.1.
-				</li>
 			</ul>
-		</dd>
 	</dl>
 
 	<div class="issue-marker wrapper">


### PR DESCRIPTION
`<string>` was considered a tag, so switched to `<dfn><<string>></dfn>`  so it would be visible