### PR TITLE
[css-ui] Add caret/menulist-textfield/menulist-text appearance values

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1863,7 +1863,7 @@ Animation type: discrete
 		They all have the same effect as ''appearance/none''.
 		Authors should use the ''appearance/none'' value instead.
 
-		<pre class=prod style="white-space: normal"><<compat-auto>> = <dfn>caret</dfn> | <dfn>menulist-textfield</dfn> | <dfn>menulist-text</dfn></pre>
+		<pre class=prod style="white-space: normal"><<compat-auto>> = <dfn>caret</dfn> | <dfn>listbox</dfn> | <dfn>menulist-textfield</dfn> | <dfn>menulist-text</dfn></pre>
 
 
 	<dt><dfn type="">&lt;compat-auto></dfn>
@@ -1875,7 +1875,7 @@ Animation type: discrete
 		Authors should use the ''appearance/auto'' value instead.
 		-->
 
-		<pre class=prod style="white-space: normal"><<compat-auto>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>button-bevel</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>menulist-button</dfn> | <dfn>listbox</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</dfn></pre>
+		<pre class=prod style="white-space: normal"><<compat-auto>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>button-bevel</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>menulist-button</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</dfn></pre>
 
 		Issue: If any of these value is not needed for web compat,
 		they should be dropped from this list;

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1795,7 +1795,7 @@ so that CSS can be used to restyle them.
 
 <pre class="propdef">
 Name: appearance
-Value: ''appearance/none'' | ''auto'' | ''button'' | ''textfield'' | <<compat>>
+Value: ''appearance/none'' | ''auto'' | ''button'' | ''textfield'' | <<compat-none>> | <<compat-auto>>
 Initial: none
 Applies To: all elements
 Inherited: no
@@ -1856,13 +1856,26 @@ Animation type: discrete
 
 		For all other elements, this value has the same effect as ''appearance/auto''.
 
-	<dt><dfn type="">&lt;compat></dfn>
+	<dt><dfn type="">&lt;compat-none></dfn>
+	<dd>
+		These values exist for compatibility of content developed
+		for earlier non standard versions of this property.
+		They all have the same effect as ''appearance/none''.
+		Authors should use the ''appearance/none'' value instead.
+
+		<pre class=prod style="white-space: normal"><<compat-auto>> = <dfn>caret</dfn> | <dfn>menulist-textfield</dfn> | <dfn>menulist-text</dfn></pre>
+
+
+	<dt><dfn type="">&lt;compat-auto></dfn>
 	<dd>
 		These values exist for compatibility of content developed
 		for earlier non standard versions of this property.
 		They all have the same effect as ''appearance/auto''.
+		<!-- Issue: When 'auto' is widely supported, uncomment this:
+		Authors should use the ''appearance/auto'' value instead.
+		-->
 
-		<pre class=prod style="white-space: normal"><<compat>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>button-bevel</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>menulist-button</dfn> | <dfn>listbox</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</pre></dfn>
+		<pre class=prod style="white-space: normal"><<compat-auto>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>button-bevel</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>menulist-button</dfn> | <dfn>listbox</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</dfn></pre>
 
 		Issue: If any of these value is not needed for web compat,
 		they should be dropped from this list;
@@ -1873,7 +1886,6 @@ Animation type: discrete
 		with effects on arbitrary elements like ''button'',
 		or that
 		some of these values need to have some side effects on some form controls.
-
 
 </dl>
 


### PR DESCRIPTION
This is an alias to 'none' for better web compat (compared to not
supporting the value at all or making it equivalent to 'menulist').

See https://bugzilla.mozilla.org/show_bug.cgi?id=1500423#c62