### PR TITLE
[css-pseudo-4] Rename the values of CSSPseudoElement.type to match the corresponding pseudo-elements

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -850,19 +850,17 @@ Interface CSSPseudoElement</h3>
   This can be one of the following values:
 
   <dl>
-    <dt>‘before’
+    <dt>‘::before’
     <dd>The pseudo-element was created before the element's contents.
-    <dt>‘after’
+    <dt>‘::after’
     <dd>The pseudo-element was created after the element's contents.
-    <dt>‘letter’
+    <dt>‘::first-letter’
     <dd>The pseudo-element is the first letter of the element.
-    <dt>‘line’
+    <dt>‘::first-line’
     <dd>The pseudo-element is the first line of the element.
-    <dt>‘selection’
+    <dt>‘::selection’
     <dd>The selection pseudo-element for the element.
   </dl>
-
-  Issue: Why are these strings different from the name of the pseudo-element?
 
   The <dfn attribute for=CSSPseudoElement>element</dfn> attribute is the
   [=originating element=] of the pseudo-element.
@@ -953,8 +951,8 @@ Changes</h2>
     <li>Links to pseudo-element OM design discussions.
     <li>Various minor clarifications.
     <li>Use ''spelling-error'' and ''grammar-error'' with ''::spelling-error'' and ''::grammar-error'' in the UA stylesheet.
-    <li>Added the {{CSSPseudoElement/element}} attribute to the
-    {{CSSPseudoElement}} interface.
+    <li>Added the {{CSSPseudoElement/element}} attribute to the {{CSSPseudoElement}} interface.
+    <li>Changed the values of the {{CSSPseudoElement/type}} attribute on the {{CSSPseudoElement}} interface to match the corresponding pseudo-elements.
   </ul>
 
 <h2 class="no-num" id="acknowledgements">


### PR DESCRIPTION
Fixes #2815.