### PR TITLE
[cssom] Treat DocumentOrShadowRoot as an interface mixin

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1147,10 +1147,10 @@ sheet</a> in the collection. If there is no <var>index</var>th object in the col
 The <dfn attribute for=StyleSheetList>length</dfn> attribute must return the number of <a>CSS style sheets</a>
 represented by the collection.
 
-### Extensions to the {{DocumentOrShadowRoot}} Interface ### {#extensions-to-the-document-or-shadow-root-interface}
+### Extensions to the {{DocumentOrShadowRoot}} Interface Mixin ### {#extensions-to-the-document-or-shadow-root-interface}
 
 <pre class=idl>
-partial interface DocumentOrShadowRoot {
+partial interface mixin DocumentOrShadowRoot {
   [SameObject] readonly attribute StyleSheetList styleSheets;
 };
 </pre>


### PR DESCRIPTION
Matching https://dom.spec.whatwg.org/#mixin-documentorshadowroot.