### PR TITLE
[css-images-4] Uncomment IDL attribtue

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -877,11 +877,9 @@ Using Out-Of-Document Sources: the <code>ElementSources</code> interface</h4>
 
 	<pre class='idl'>
 		partial namespace CSS {
-			// [SameObject] readonly attribute Map elementSources;
+			[SameObject] readonly attribute any elementSources;
 		};
 	</pre>
-
-	Issue(428): IDL namespaces don't support attributes yet.
 
 	Any entries in the <a idl>elementSources</a> map with a string key
 	and a value that is an object providing a <a>paint source</a>


### PR DESCRIPTION
Closes #428

Because current Web IDL spec [allows namespaces to include readonly attributes](https://heycam.github.io/webidl/#idl-namespaces).

Also `Map` is replaced to `any` because AFAIK there is no valid way to represent ES map object in IDL.