### PR TITLE
Fix typo: Closing tag missing character '>'

### DIFF
--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -701,7 +701,7 @@ Conditions of Reordering-induced Box Fragmentation</h5>
     and uppercase letters represent RTL letters,
     bidi reordering causes the <code>&lt;em></code>’s <a>inline box</a>
     to be divided into two <a>box fragments</a>
-    separated by text outside the <code>&lt;em</code>.
+    separated by text outside the <code>&lt;em></code>.
 
     Source code (logical order):
     <pre>&lt;p>here is &lt;em>some MIXED&lt;/em> TEXT.&lt;/p></pre>


### PR DESCRIPTION
Tiny typo fix.
