### PR TITLE
[css-images-4] Fix gradient color stop syntax

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1336,7 +1336,7 @@ Gradient Color-Stops</h3>
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
 			[ <<linear-color-stop>> [, <<linear-color-hint>>]? ]# , <<linear-color-stop>>
-		<dfn>&lt;linear-color-stop></dfn> = <<color>> && <<color-stop-length>>
+		<dfn>&lt;linear-color-stop></dfn> = <<color>> && <<color-stop-length>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 		<dfn>&lt;color-stop-length></dfn> = <<length-percentage>>{1,2}
 


### PR DESCRIPTION
Closes #1334

I'm pretty sure this was the only change required. Not sure why I didn't make a PR at the time I filed the issue, but I guess I was busy…

