### PR TITLE
[css-scrollbars-1] Make scrollbar-width inheritable

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -157,7 +157,7 @@ See related <a href="https://github.com/w3c/csswg-drafts/issues/1956">Issue 1956
 Name: scrollbar-width 
 Value: auto | thin | none | <<length>>
 Initial: auto
-Inherited: no
+Inherited: yes
 Computed value: specified keyword or absolute length
 Animation type: by computed value
 Applies to: boxes to which 'overflow' applies


### PR DESCRIPTION
[We wanted to add custom scrollbar properties](https://github.com/thelounge/thelounge/pull/2974) in our app, as these properties already shipped in Firefox, but realized an oddity.

`scrollbar-color` can be applied to body, and any child elements with a scrollbar will have the color applied, but this doesn't work on `scrollbar-width` and requires each scrollable element to have it defined separately.

I could not find any discussion on this.