### PR TITLE
Fix typo (s/is not be/is not/)

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1771,7 +1771,7 @@ so this specification allows flexibility.
 	Instead, we'd just have an "auto" value that makes form controls look like whatever they need,
 	and a "none" value that suppresses "native" look.
 
-	However, there is evidence that this alone is not be web compatible,
+	However, there is evidence that this alone is not web compatible,
 	due in part to uses such as:
 	<pre><code highlight=css>
 	input { appearance: none; }


### PR DESCRIPTION
This text used to say "may not be"; and at some point, "may not" was replaced
with "is not", and the word "be" was left in accidentally.