### PR TITLE
🐛 FIX: Typos & Grammar

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -57,7 +57,7 @@ Motivation</h3>
 		</pre>
 	</div>
 
-	Nesting allow the grouping of related style rules, like this:
+	Nesting allows the grouping of related style rules, like this:
 
 	<div class='example'>
 		<pre class=lang-css>
@@ -251,14 +251,14 @@ Direct Nesting {#direct}
 	</div>
 
 	Note: The last invalid example is technically not ambiguous,
-	but it's still invalid because allowing it would be an editting hazard.
+	but it's still invalid because allowing it would be an editing hazard.
 	Later edits to the stylesheet might remove the first selector in the list,
 	making the other one the new "first selector",
 	and making the rule invalid.
 	Turning an otherwise-innocuous action
 	(like removing a selector from a list)
 	into a possible error
-	makes editting more complicated,
+	makes editing more complicated,
 	and is author-hostile,
 	so we disallow it as a possibility.
 
@@ -270,14 +270,14 @@ The Nesting At-Rule: ''@nest'' {#at-nest}
 	Some valid nesting selectors,
 	like ''.foo &'',
 	are disallowed,
-	and editting the selector in certain ways can make the rule invalid unexpectedly.
+	and editing the selector in certain ways can make the rule invalid unexpectedly.
 	As well,
-	some people find the nesting difficult to visually distinguish
+	some people find the nesting challenging to distinguish visually
 	from the surrounding declarations.
 
 	To aid in all these issues,
 	this specification defines the ''@nest'' rule,
-	which imposes less restrictions on how to validly nest style rules.
+	which imposes fewer restrictions on how to validly nest style rules.
 	Its syntax is:
 
 	<pre class=prod>


### PR DESCRIPTION
Fixes a couple of typos and grammatical errors like:

```diff
-	editting
+	editing
-	Nesting allow
+	Nesting allows
-	some people find the nesting difficult to visually distinguish
+	some people find the nesting challenging to distinguish visually
```
Looking forward, peace! ✌️