### PR TITLE
[selectors-4] Add :defined pseudo-class

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1415,6 +1415,33 @@ Namespaces in Elemental Selectors</h3>
 	that has not been previously <a href="#nsdecl">declared</a>
 	is an <a>invalid selector</a>.
 
+<h3 id="the-defined-pseudo">
+The Defined Pseudo-class: '':defined()''</h3>
+
+	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> matches any element that is
+        <a for=Element>defined</a>.
+
+	Note: The '':defined'' pseudo-class is used to differentiate between a <a>custom element</a> that
+        has been successfully constructed from custom elements that have not yet been constructed or have
+        failed to be constructed.
+
+	<div class="example">
+		For example, the '':defined'' pseudo-class can be used to hide a custom element before a
+                script defines the custom element but after it is initially rendered:
+
+		<pre>custom-element { visibility: hidden }</pre>
+		<pre>custom-element:defined { visibility: visible }</pre>
+	</div>
+
+	An element that is not a custom element will also match the '':defined'' pseudo-class.
+
+	<div class="example">
+		For example, this style sheet will turn all paragraph text green:
+
+		<pre>p:defined { color: green }</pre>
+	</div>
+
+
 <h2 id="attribute-selectors">
 Attribute selectors</h2>
 

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1419,15 +1419,15 @@ Namespaces in Elemental Selectors</h3>
 The Defined Pseudo-class: '':defined()''</h3>
 
 	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> matches any element that is
-        <a for=Element>defined</a>.
+	<a for=Element>defined</a>.
 
 	Note: The '':defined'' pseudo-class is used to differentiate between a <a>custom element</a> that
-        has been successfully constructed from custom elements that have not yet been constructed or have
-        failed to be constructed.
+	has been successfully constructed from custom elements that have not yet been constructed or have
+	failed to be constructed.
 
 	<div class="example">
 		For example, the '':defined'' pseudo-class can be used to hide a custom element before a
-                script defines the custom element but after it is initially rendered:
+		script defines the custom element but after it is initially rendered:
 
 		<pre>custom-element { visibility: hidden }</pre>
 		<pre>custom-element:defined { visibility: visible }</pre>
@@ -1440,7 +1440,6 @@ The Defined Pseudo-class: '':defined()''</h3>
 
 		<pre>p:defined { color: green }</pre>
 	</div>
-
 
 <h2 id="attribute-selectors">
 Attribute selectors</h2>

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1418,25 +1418,20 @@ Namespaces in Elemental Selectors</h3>
 <h3 id="the-defined-pseudo">
 The Defined Pseudo-class: '':defined()''</h3>
 
-	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> matches any element that is
-	<a for=Element>defined</a>.
-
-	Note: The '':defined'' pseudo-class is used to differentiate between a <a>custom element</a> that
-	has been successfully constructed from custom elements that have not yet been constructed or have
-	failed to be constructed.
+	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> allows authors to
+	differentiate between elements that has been successfully constructed from
+	elements that have not yet been constructed or have failed to be constructed.
 
 	<div class="example">
-		For example, the '':defined'' pseudo-class can be used to hide a custom element before a
+		In HTML, the '':defined'' pseudo-class can be used to hide a custom element before a
 		script defines the custom element but after it is initially rendered:
 
 		<pre>custom-element { visibility: hidden }</pre>
 		<pre>custom-element:defined { visibility: visible }</pre>
 	</div>
 
-	An element that is not a custom element will also match the '':defined'' pseudo-class.
-
 	<div class="example">
-		For example, this style sheet will turn all paragraph text green:
+		In HTML, an element that is not a custom element will also match the '':defined'' pseudo-class.
 
 		<pre>p:defined { color: green }</pre>
 	</div>

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1416,7 +1416,7 @@ Namespaces in Elemental Selectors</h3>
 	is an <a>invalid selector</a>.
 
 <h3 id="the-defined-pseudo">
-The Defined Pseudo-class: '':defined()''</h3>
+The Defined Pseudo-class: '':defined''</h3>
 
 	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> allows authors to
 	differentiate between elements that has been successfully constructed from

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1418,22 +1418,30 @@ Namespaces in Elemental Selectors</h3>
 <h3 id="the-defined-pseudo">
 The Defined Pseudo-class: '':defined''</h3>
 
-	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> allows authors to
-	differentiate between elements that has been successfully constructed from
-	elements that have not yet been constructed or have failed to be constructed.
+	In some host languages,
+	elements can have a distinction between being “defined”/“constructed” or not.
+	The <dfn id='defined-pseudo'>:defined</dfn> <a>pseudo-class</a> matches elements
+	that are fully defined,
+	as dictated by the host language.
+	
+	If the host language does not have this sort of distinction,
+	all elements in it match '':defined''.
 
 	<div class="example">
-		In HTML, the '':defined'' pseudo-class can be used to hide a custom element before a
-		script defines the custom element but after it is initially rendered:
+		In HTML, all built-in elements are always considered to be defined,
+		so the following example will always match:
+		
+		<pre highlight=css>p:defined { ... }</pre>
+		
+		[=Custom elements=], on the other hand,
+		start out <em>un</em>defined,
+		and only become defined when <l spec=html>[=element definition|properly registered=]</l>.
+		This means the '':defined'' pseudo-class 
+		can be used to hide a custom element
+		until it has been registered:
 
 		<pre>custom-element { visibility: hidden }</pre>
 		<pre>custom-element:defined { visibility: visible }</pre>
-	</div>
-
-	<div class="example">
-		In HTML, an element that is not a custom element will also match the '':defined'' pseudo-class.
-
-		<pre>p:defined { color: green }</pre>
 	</div>
 
 <h2 id="attribute-selectors">


### PR DESCRIPTION
[selectors-4] Add the `:defined` pseudo-class as discussed in #2258. 

The original definition has been moved verbatim from the html spec and a note and examples added. PR to remove the [definition from the html spec from WHATWG](https://github.com/whatwg/html/pull/4433).

A test for this definition has previously been submitted: https://github.com/ewilligers/web-platform-tests/commit/92a561a3121a1831214a7b9f47931904ae3df5e7

Worked on with @zcorpan and @isaacdurazo.