### PR TITLE
[css-regions-1] Convert Region to a mixin (reprise)

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -1176,7 +1176,7 @@ The Region mixin</h3>
 	such as <a href="https://drafts.csswg.org/css3-page-template/#templates-and-slots">slots</a>) in an implementation which can be <a>CSS Regions</a>.
 
 	<pre class="idl">
-		interface Region {
+		interface mixin Region {
 			readonly attribute CSSOMString regionOverset;
 			sequence&lt;Range&gt;? getRegionFlowRanges();
 		};


### PR DESCRIPTION
The actual `mixin` keyword was overlooked in https://github.com/w3c/csswg-drafts/pull/3643.