### PR TITLE
[css-scroll-snap-1] Include scroll arrows in "intended direction" examples. #3752

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -917,7 +917,7 @@ Types of Scrolling Methods {#scroll-types}
         <div class="example">
             Common examples of scrolls with only an <a>intended direction</a> include:
 
-            * pressing an arrow key on the keyboard
+            * pressing an arrow key on the keyboard (or equivalent operations on the scrollbar)
             * a swiping gesture interpreted as a fixed (rather than inertial) scroll
         </div>
 


### PR DESCRIPTION
As per https://github.com/w3c/csswg-drafts/issues/3752

All other scrollbar operations are listed in the examples. Seems odd to not include the arrows.
