### PR TITLE
[css-conditional-3] @supports is not at risk.

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -19,7 +19,6 @@ Abstract: This module contains the features of CSS for conditional processing of
   conditional processing.
 At Risk: The inclusion of @font-face rules and @keyframes rules as allowed within all of the @-rules in this specification is at risk, though only because of the relative rates of advancement of specifications.  If this specification is able to advance faster than one or both of the specifications defining those rules, then the inclusion of those rules will move from this specification to the specification defining those rules.
 At Risk: The addition of support for @-rules inside of conditional grouping rules is at risk; if interoperable implementations are not found, it may be removed to advance the other features in this specification to Proposed Recommendation.
-At Risk: The @supports rule is at risk; if interoperable implementations are not found, it may be removed to advance the other features in this specification to Proposed Recommendation.
 Default Highlight: css
 </pre>
 


### PR DESCRIPTION
There are multiple interoperable implementations of it.