### PR TITLE
[selectors-4] Fixes according latest changes

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -24,7 +24,7 @@ Abstract: Selectors Level 4 describes the selectors that already exist in [[!SEL
 At Risk: the column combinator
 At Risk: the '':read-write'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
-Ignored Vars: identifier, extended filtering, i, s
+Ignored Vars: identifier, extended filtering, i
 </pre>
 <pre class=link-defaults>
 spec:css-syntax-3; type:dfn; text:identifier

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -22,10 +22,9 @@ Former Editor: John Williams
 Abstract: <a>Selectors</a> are patterns that match against elements in a tree, and as such form one of several technologies that can be used to select nodes in a document. Selectors have been optimized for use with HTML and XML, and are designed to be usable in performance-critical code. They are a core component of <abbr title="Cascading Style Sheets">CSS</abbr> (Cascading Style Sheets), which uses Selectors to bind style properties to elements in the docu	ment.
 Abstract: Selectors Level 4 describes the selectors that already exist in [[!SELECT]], and further introduces new selectors for CSS and other languages that may need them.
 At Risk: the column combinator
-At Risk: the '':drop()'' pseudo-class
 At Risk: the '':read-write'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
-Ignored Vars: identifier, extended filtering, i
+Ignored Vars: identifier, extended filtering, i, s
 </pre>
 <pre class=link-defaults>
 spec:css-syntax-3; type:dfn; text:identifier
@@ -3426,7 +3425,7 @@ Grammar</h2>
 
 	<dfn noexport>&lt;attr-matcher></dfn> = [ '~' | '|' | '^' | '$' | '*' ]? '='
 
-	<dfn noexport>&lt;attr-modifier></dfn> = i
+	<dfn noexport>&lt;attr-modifier></dfn> = i | s
 
 	<dfn>&lt;pseudo-class-selector></dfn> = ':' <<ident-token>> |
 	                          ':' <<function-token>> <<any-value>> ')'


### PR DESCRIPTION
- Removed `:drop()` from the at-risk feature list since removed from the spec
- Added `s` to `Ignored Vars`. Not sure its needed
- Added `s` to `<attr-modifier>` syntax
