### PR TITLE
[css-text-decor-4] typo in text-decoration-skip-ink property name

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -451,11 +451,11 @@ Text Decoration Line Continuity: the 'text-decoration-skip-ink' property</h4>
 	The UA must also skip a small distance to either side of the glyph outline.
 
 	<div class="figure">
-		<p><img title="text-decoration-skip: ink"
+		<p><img title="text-decoration-skip-ink: auto"
 				alt="An alphabetic underline through Myanmar text skips around descenders and the vertical strokes of combining characters that drop below the alphabetic baseline."
 				src="images/decoration-skip-ink.png"
 				>
-		<p class="caption">''text-decoration-skip: ink''</p>
+		<p class="caption">''text-decoration-skip-ink: auto''</p>
 	</div>
 
 	<div class="issue">


### PR DESCRIPTION
It looks like 70e40c9315bf8d478ddecf0da5e5af3ddacbc509 introduced the `text-decoration-skip-ink` property, but kept the example from the previous `text-decoration-skip` one.
