### PR TITLE
[resize-observer-1] Fix some observedBox terminology issues

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -261,10 +261,10 @@ interface ResizeObserverEntry {
         2. Set |this|.{{ResizeObserverEntry/target}} slot to |target|.
 
         3. Set |this|.{{ResizeObserverEntry/borderBoxSize}} slot to result of <a href="#calculate-box-size">
-            computing size given |target| and specificSize of "border-box"</a>.
+            computing size given |target| and observedBox of "border-box"</a>.
 
         4. Set |this|.{{ResizeObserverEntry/contentBoxSize}} slot to result of <a href="#calculate-box-size">
-            computing size given |target| and specificSize of "content-box"</a>.
+            computing size given |target| and observedBox of "content-box"</a>.
 
         5. Set |this|.{{ResizeObserverEntry/contentRect}} to logical |this|.{{ResizeObserverEntry/contentBoxSize}}.
 
@@ -478,14 +478,14 @@ To <dfn>calculate depth for node</dfn>, given a |node|, run these steps:
 
     2. Return number of nodes in |p|.
 
-<h4 id="calculate-box-size">Calculate box size, given target and specific size</h4>
+<h4 id="calculate-box-size">Calculate box size, given target and observed box</h4>
 
-This algorithm computes |target| {{Element}}'s specific size. Type of size is
+This algorithm computes |target| {{Element}}'s observed box size. Type of box is
 described by {{ResizeObserverBoxOptions}}.
 SVG Elements are an exception. SVG size is always its bounding box size, because SVG
 elements do not use standard CSS box model.
 
-To <dfn>calculate box size</dfn>, given |target| and |specificSize|, run these steps:
+To <dfn>calculate box size</dfn>, given |target| and |observedBox|, run these steps:
 
     1. If |target| is an {{SVGGraphicsElement}}
 
@@ -495,13 +495,13 @@ To <dfn>calculate box size</dfn>, given |target| and |specificSize|, run these s
 
     2. If |target| is not an {{SVGGraphicsElement}}
 
-        1. If |specificSize| is "bounding-box"
+        1. If |observedBox| is "border-box"
 
             1. Set |computedSize|.inlineSize to target's <a>border area</a> inline length.
 
             2. Set |computedSize|.blockSize to target's <a>border area</a> block length.
 
-        2. If |specificSize| is "content-box"
+        2. If |observedBox| is "content-box"
 
             1. Set |computedSize|.inlineSize to target's <a>content area</a> inline length.
 


### PR DESCRIPTION
Just fixing some typos.

This commit replaces 'specificBox' with 'observedBox' in several places (which is the actual defined term for this concept in the spec).  This also fixes one mention of "bounding-box" which really meant to say "border-box".