### PR TITLE
[css-rhythm] line-height-step initial value

### DIFF
--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -347,7 +347,7 @@ Adjusting Line Box Heights: the 'line-height-step' property {#line-height-step}
 	<pre class='propdef'>
 	Name: line-height-step
 	Value: <<length>>
-	Initial: 0
+	Initial: 0px
 	Applies to: block containers
 	Inherited: yes
 	Animatable: no


### PR DESCRIPTION
line-height-step is a length, so the initial
value is '0px', not '0'.

WPT: https://github.com/web-platform-tests/wpt/pull/13572
