### PR TITLE
[css-contain] Add links to display keywords

### DIFF
--- a/css-contain-1/Overview.bs
+++ b/css-contain-1/Overview.bs
@@ -512,8 +512,8 @@ Size Containment</h3>
 <h3 id='containment-layout'>
 Layout Containment</h3>
 
-	If the element does not generate a <a>principal box</a> (as is the case with ''display: contents'' or ''display: none''),
-	or if the element is an <a spec="css-display-3">internal table element</a> other than ''display: table-cell'',
+	If the element does not generate a <a>principal box</a> (as is the case with 'display' values of ''display/contents'' or ''display/none''),
+	or if the element is an <a spec="css-display-3">internal table element</a> other than ''display/table-cell'',
 	or if the element is an <a spec="css-display-3">internal ruby element</a>,
 	or if the element's <a>principal box</a> is a <a spec="css-display-3" lt="atomic inline">non-atomic</a> <a spec="css-display-3">inline-level</a> box,
 	layout containment has no effect.
@@ -784,8 +784,8 @@ Style Containment</h3>
 <h3 id='containment-paint'>
 Paint Containment</h3>
 
-	If the element does not generate a <a>principal box</a> (as is the case with ''display: contents'' or ''display: none''),
-	or if the element is an <a spec="css-display-3">internal table element</a> other than ''display: table-cell'',
+	If the element does not generate a <a>principal box</a> (as is the case with 'display' values of ''display/contents'' or ''display/none''),
+	or if the element is an <a spec="css-display-3">internal table element</a> other than ''display/table-cell'',
 	or if the element is an <a spec="css-display-3">internal ruby element</a>,
 	or if the element's <a>principal box</a> is a <a spec="css-display-3" lt="atomic inline">non-atomic</a> <a spec="css-display-3">inline-level</a> box,
 	paint containment has no effect.


### PR DESCRIPTION
Display keywords 'none' 'contents' and 'table-cell' now
appear as links.

resolves #3889
