### PR TITLE
[cssom] Define legacy CSSStyleSheet methods as implemented in Blink.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -949,6 +949,39 @@ The <dfn method for=CSSStyleSheet>deleteRule(<var>index</var>)</dfn> method must
  <li><a>Remove a CSS rule</a> in the <a for=CSSStyleSheet>CSS rules</a> at <var>index</var>.
 </ol>
 
+#### Legacy CSSStyleSheet members #### {#legacy-css-style-sheet-members}
+
+<p class=advisement>
+  Note: These members are required for compatibility with existing sites.
+  Authors are encouraged to use the standard members defined above instead,
+  which are consistent with {{CSSGroupingRule}}.
+</p>
+
+<pre class=idl>
+partial interface CSSStyleSheet {
+  [SameObject] readonly attribute CSSRuleList rules;
+  long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
+  void removeRule(optional unsigned long index = 0);
+};
+</pre>
+
+The <dfn attribute for=CSSStyleSheet>rules</dfn> attribute must follow the same steps as {{CSSStyleSheet/cssRules}}, and return the same object {{CSSStyleSheet/cssRules}} would return.
+
+The <dfn method for=CSSStyleSheet>removeRule(<var>index</var>)</dfn> method must run the same steps as {{CSSStyleSheet/deleteRule()}}.
+
+The <dfn method for=CSSStyleSheet>addRule(<var>selector</var>, <var>block</var>, <var>optionalIndex</var>)</dfn> method must run the following steps:
+
+<ol>
+ <li>Let <var>rule</var> be an empty string.
+ <li>Append <var>selector</var> to <var>rule</var>.
+ <li>Append <code>" { "</code> to <var>rule</var>.
+ <li>If <var>block</var> is not empty, append <var>block</var>, followed by a space, to <var>rule</var>.
+ <li>Append <code>"}"</code> to <var>rule</var>
+ <li>Let <var>index</var> be <var>optionalIndex</var> if provided, or the number of <a for=CSSStyleSheet>CSS rules</a> in the stylesheet otherwise.
+ <li>Call {{CSSStyleSheet/insertRule()}}, with <var>rule</var> and <var>index</var> as arguments.
+ <li>Return <code>-1</code>.
+</ol>
+
 CSS Style Sheet Collections {#css-style-sheet-collections}
 ----------------------------------------------------------
 


### PR DESCRIPTION
Fixes #3814. 