### PR TITLE
[css-backgrounds] Initial background-position-x/y

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -82,7 +82,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 	<pre class="propdef">
 		Name: background-position-x
 		Value: [ center | [ left | right | x-start | x-end ]? <<length-percentage>>? ]#
-		Initial: left
+		Initial: 0%
 		Inherited: no
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
 		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword
@@ -94,7 +94,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 	<pre class="propdef">
 		Name: background-position-y
 		Value: [ center | [ top | bottom | y-start | y-end ]? <<length-percentage>>? ]#
-		Initial: left
+		Initial: 0%
 		Inherited: no
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image
 		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword


### PR DESCRIPTION
In CSS Backgrounds and Borders Level 3, the initial value
of background-position is '0% 0%'.

In Level 4, the initial value of background-position-x and
background-position-y is '0%' and '0%', not 'left' and 'left'.
