### PR TITLE
[css-backgrounds] list entries not empty

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -15,6 +15,10 @@ Ignored Terms:
 Warning: Not Ready
 </pre>
 
+<pre class="link-defaults">
+spec:css-text-4; type:value; text:collapse
+</pre>
+
 <h2 id="intro">
 Introduction</h2>
 
@@ -81,7 +85,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 
 	<pre class="propdef">
 		Name: background-position-x
-		Value: [ center | [ left | right | x-start | x-end ]? <<length-percentage>>? ]#
+		Value: [ center | [ [ left | right | x-start | x-end ]? <<length-percentage>>? ]! ]#
 		Initial: 0%
 		Inherited: no
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
@@ -93,7 +97,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 
 	<pre class="propdef">
 		Name: background-position-y
-		Value: [ center | [ top | bottom | y-start | y-end ]? <<length-percentage>>? ]#
+		Value: [ center | [ [ top | bottom | y-start | y-end ]? <<length-percentage>>? ]! ]#
 		Initial: 0%
 		Inherited: no
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image


### PR DESCRIPTION
The entries in background-position-x and background-position-y
may not be empty.

We use the exclamation point (!) modifier to indicate that
a keyword or length-percentage (or both) must be present,
they cannot both be omitted.
