### PR TITLE
[css-shapes] link to closest-side definition

### DIFF
--- a/css-egg-1/Overview.bs
+++ b/css-egg-1/Overview.bs
@@ -10,7 +10,15 @@ TR: https://www.w3.org/TR/css-egg/
 ED: https://drafts.csswg.org/css-egg/
 Editor: Florian Rivoal, Invited Expert, https://florian.rivoal.net, w3cid 43241
 Abstract: This module extends the vocabulary of CSS with terms frequently used in certain domains, making it easier for authors to write understandable and maintainable style sheets.
-Link Defaults: css-values-3 (type) <time>
+</pre>
+
+<pre class="link-defaults">
+spec:css-images-3; type:value;
+	text: closest-side
+	text: farthest-side
+	text: closest-corner
+	text: farthest-corner
+spec:css-values-3; type:type; text:<time>
 </pre>
 
 <style type="text/css">

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -19,6 +19,9 @@ Link Defaults: css2 (property) margin
 spec:css-masking-1; type: value
 	text: nonzero
 	text: evenodd
+spec:css-shapes; type: value
+	text: closest-side
+	text: farthest-side
 </pre>
 
 <style type="text/css">
@@ -599,7 +602,7 @@ Interpolation of Basic Shapes</h3>
 			If both shapes are the same type,
 			that type is ''ellipse()'' or ''circle()'',
 			and none of the radii use
-			the ''closest-side'' or ''farthest-side'' keywords,
+			the <a href="#closest-side">''closest-side''</a> or <a href="#farthest-side">''farthest-side''</a> keywords,
 			interpolate between each value
 			in the shape functions.
 		</li>


### PR DESCRIPTION
Use ''closest-side'' syntax so the keyword is formatted as CSS syntax.
Use link-defaults to prevent definitions in css-images-3 or motion-1 from
being chosen by bikeshed.
Use `<a href="#closest-side">` to link to the definition in CSS Shapes.

Note:
If basic shapes including the closest-side keyword were defined inside a
property such as shape-outside, we could use the
''shape-outide/closest-side'' bikeshed syntax.
