### PR TITLE
[css-grid] [css-sizing] links to column-gap

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -14,6 +14,12 @@ Editor: Rossen Atanassov, Microsoft, ratan@microsoft.com, w3cid 49885
 Abstract: This CSS module defines a two-dimensional grid-based layout system, optimized for user interface design. In the grid layout model, the children of a grid container can be positioned into arbitrary slots in a predefined flexible or fixed-size layout grid. Level 2 expands Grid by adding “subgrid” capabilities for nested grids to participate in the sizing of their parent grids; and aspect-ratio&ndash;controlled gutters.
 </pre>
 
+<pre class=link-defaults>
+spec:css-align-3;
+	type:property; text:column-gap
+	type:value; for:column-gap; text:normal
+</pre>
+
 Introduction {#intro}
 =====================
 

--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -18,6 +18,7 @@ Ignored Terms: block-level box
 
 <pre class='link-defaults'>
 spec:css-display-3; type:dfn; text:box
+spec:css-align-3; type:property; text:column-gap
 spec:css2; type: property
 	text: min-width
 	text: min-height


### PR DESCRIPTION
css-grid-2 refers to css-align-3 column-gap (and row-gap).
    
css-sizing-4 refers to css-align-3 column-gap (and css-multicol-1 column-count).
