### PR TITLE
[css-display] link to css-position for 'fixed'

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -29,6 +29,7 @@ spec:css2;
 spec: html;
 	type: dfn; text: rendered legend
 	type: element; text: a
+spec:css-position-3; type:value; text:fixed
 spec:css-pseudo-4; type:selector;
 	text: ::first-letter
 	text: ::first-line


### PR DESCRIPTION
This avoid the blikeshed warning

LINK ERROR: Multiple possible 'fixed' maybe refs.
Arbitrarily chose https://drafts.csswg.org/css-position-3/#valdef-position-fixed
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
spec:css-backgrounds-3; type:value; text:fixed
spec:css-counter-styles-3; type:value; text:fixed
spec:css-position-3; type:value; text:fixed
spec:css-device-adapt-1; type:value; text:fixed
