### PR TITLE
[css-regions] Consistent references to CSS3-BREAK

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -836,7 +836,7 @@ Controlling Region Flow Breaks</h3>
 	affect content flowed through regions just as they do content flowed through columns or pages,
 	and the ''break-before/region'' and ''break-before/avoid-region'' values
 	provide region-specific breaking controls.
-	See [[css-break-3]] for details.
+	See [[CSS3-BREAK]] for details.
 
 <h3 id="the-region-fragment-property">
 The region-fragment property</h3>
@@ -2086,7 +2086,7 @@ Changes</h2>
 
 		<ul>
 			<li>Add animation type lines</li>
-			<li>Remove definition of break properties, since they're already defined in [[CSS-BREAK-3]].</li>
+			<li>Remove definition of break properties, since they're already defined in [[CSS3-BREAK]].</li>
 			<li>Mention effects of containment on regions.</li>
 		</ul>
 


### PR DESCRIPTION
Avoid the bikeshed warning:
The biblio refs [[css-break-3]] and [[CSS3-BREAK]] are both aliases of the same base reference [[css-break-3]]. Please choose one name and use it consistently.
