### PR TITLE
[[css-gcpm-4] Fix reference to dpub-latinreq

### DIFF
--- a/css-gcpm-4/Overview.bs
+++ b/css-gcpm-4/Overview.bs
@@ -36,7 +36,7 @@ The existing mechanisms do not cover many use cases.
 
 Headers often contain document content, and it is desirable to both display that content normally (for example, as an <code>h1</code>) and to use the content in a running head. [[CSS3-REGIONS]] allows for an element to be moved to a ''named flow'', but doesn't allow for using the same content in two ways. The 'copy-into' property allows an element to be copied into a content fragment which can then be placed with the 'content' property.
 
-<p class="note">Use cases for running heads can be found in [[LATINREQ]] http://w3c.github.io/dpub-pagination/#content</p>
+<p class="note">Use cases for running heads can be found in [[dpub-latinreq]] https://w3c.github.io/dpub-pagination/#content</p>
 
 
 


### PR DESCRIPTION
Avoids bikeshed failure:
FATAL ERROR: Couldn't find 'LATINREQ' in bibliography data.

Also use https for github link.
