### PR TITLE
[css-inline] link to keywords first and last

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -167,7 +167,7 @@ Transverse Box Alignment: the 'vertical-align' property</h3>
 	<p class="advisement">
 		Authors should use this property ('vertical-align') instead of its longhands.
 
-	ISSUE: This property will gain ''first'' and ''last'' keywords,
+	ISSUE: This property will gain ''justify-self/first'' and ''justify-self/last'' keywords,
 	like in the <a href="https://www.w3.org/TR/css-align-3/">box alignment properties</a>,
 	see [[css-align-3#baseline-values]].
 	The <a href="https://github.com/w3c/csswg-drafts/issues/861">open question</a>


### PR DESCRIPTION
Reference a box alignment property that supports first and last,
avoiding bikeshed message:
Multiple possible 'last' maybe refs.
