### PR TITLE
Link to CSS Values definition of ex units

### DIFF
--- a/css-cascade-3/Overview.bs
+++ b/css-cascade-3/Overview.bs
@@ -18,7 +18,12 @@ Previous Version: https://www.w3.org/TR/2005/WD-css3-cascade-20051215/
 Issue Tracking: Disposition of Comments https://drafts.csswg.org/css-cascade/issues
 Abstract: This CSS module describes how to collate style rules and assign values to all properties on all elements. By way of cascading and inheritance, values are propagated for all properties on all elements.
 Ignored Terms: auto, flex items
-Link Defaults: css2 (property) display
+</pre>
+
+<pre class=link-defaults>
+spec:css-values; type:value; text:ex
+spec:mediaqueries-4; type:type; text:<media-query>
+spec:css2; type:property; text:display
 </pre>
 
 <h2 id="intro">

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -23,6 +23,10 @@ Ignored Terms: auto, flex items, <supports-condition>
 Include Can I Use Panels: yes
 </pre>
 
+<pre class=link-defaults>
+spec:css-values; type:value; text:ex
+</pre>
+
 <h2 id="intro">
 Introduction</h2>
 

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -20,6 +20,7 @@ Ignored Terms: font-palette, <named-palette-color>
 
 <pre class="link-defaults">
 spec:css-color-4; type:property; text:color
+spec:css-values; type:value; text:ex
 spec:css22; type:value; for:/; text:block
 </pre>
 

--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -14,8 +14,21 @@ Issue Tracking: Tracker http://www.w3.org/Style/CSS/Tracker/products/13
 Editor: Elika J. Etemad / fantasai, Invited Expert&#44; formerly Mozilla, http://fantasai.inkedblade.net/contact, w3cid 35400
 Editor: Simon Sapin, Mozilla&#44; formerly Kozea, http://exyr.org/about/, w3cid 58001
 Ignored terms: fit, fit-position, stacking context
-Link defaults: css-break (property) break-after, css2 (property) display, css2 (property) min-height, css2 (property) max-height, css2 (property) min-width, css2 (property) max-width, css2 (property) margin, css2 (property) counter-increment, css2 (property) counter-reset
 Abstract: This CSS module specifies how pages are generated and laid out to hold fragmented content in a paged presentation. It adds functionality for controlling page margins, page size and orientation, and headers and footers, and extends generated content to enable page numbering and running headers / footers. The process of paginating a flow into such generated pages is covered in [[!CSS3-BREAK]].
+</pre>
+
+<pre class=link-defaults>
+spec:css-break; type:property; text:break-after
+spec:css-values; type:value; text:ex
+spec:css2; type: property
+	text: counter-increment
+	text: counter-reset
+	text: display
+	text: margin
+	text: max-height
+	text: max-width
+	text: min-height
+	text: min-width
 </pre>
 
 <style>


### PR DESCRIPTION
Link to css-values definition of ex units
instead of css-inline-3 leading-trim keyword ex.
(Specs already link to css-values for em.)

css-cascade-3 links to mediaqueries-4 instead
of css-cascade-4 for media-query.
