### PR TITLE
[css-values] fix indentation

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2837,7 +2837,7 @@ Syntax</h3>
 	on what their <<calc-sum>> arguments can contain.
 	Check the definitions of the individual functions for details.
 
-	UAs must support [=calculations=] of at least 20 <<calc-values>> terms.
+	UAs must support [=calculations=] of at least 20 <<calc-value>> terms.
 	If a [=calculation=] contains more than the supported number of terms,
 	it must be treated as if it were invalid.
 
@@ -3248,7 +3248,7 @@ Serialization</h3>
 			2. The percentage, if present
 			3. The dimensions, ordered by their units <a>ASCII case-insensitive</a> alphabetically
 			4. <a href="#comp-func">Comparison</a>, <a href="#trig-funcs">trigonometric</a>
-			  and <a href="#exponent-funcs">exponential</a> functions,
+				and <a href="#exponent-funcs">exponential</a> functions,
 				in the order they appeared in the original expression.
 
 		2. Serialize all the terms,


### PR DESCRIPTION
Avoid bikeshed error report:
FATAL ERROR: Line 3251 isn't indented enough (needs 1 indent) to be valid Markdown:

Fix reference to `<<calc-value>>`
