### PR TITLE
[css-inline] [css-scroll-anchoring] content area

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -29,6 +29,7 @@ At Risk: the 'initial-letters-wrap' property
 
 <pre class="link-defaults">
 spec:css-align-3; type:dfn; text:alignment baseline
+spec:css-box; type:dfn; text:content area
 spec:css-break-3; type:dfn; text:fragment
 </pre>
 

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -18,6 +18,7 @@ Abstract: This spec also proposes an API for web developers to opt-out of this b
 </pre>
 
 <pre class=link-defaults>
+spec:css-box; type:dfn; text:content area
 spec:css22;
 	type:property;
 		text:max-height


### PR DESCRIPTION
Select the css-box-3 definition of 'content area',
not the description in css-exclusions-1.

Avoid bikeshed message:
Multiple possible 'content area' dfn refs.
