### PR TITLE
[css-scrollbars] links to auto keyword

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -113,7 +113,7 @@ which is generally fixed regardless of the scrolling position.
 Thumb refers to the moving part of the scrollbar,
 which usually floats on top of the track.
 
-If this property computes to value other than ''auto'',
+If this property computes to value other than ''scrollbar-color/auto'',
 implementations may render a simpler scrollbar than the default platform UI rendering,
 and color it accordingly.
 
@@ -171,13 +171,13 @@ This property allows the author to set the maximum thickness of an element’s s
 <dd>implementations must use the default platform scrollbar width.
 </dd>
 <dt><dfn>thin</dfn></dt>
-<dd>Implementations should use thinner scrollbars than auto when applicable.
+<dd>Implementations should use thinner scrollbars than ''scrollbar-width/auto'' when applicable.
 This may mean a thin variant of scrollbar provided by the platform,
 or a custom scrollbar thinner than the default platform scrollbar.
 
 Note: Some platforms may only have a tiny scrollbar by default
 which cannot be or makes no sense to make thinner.
-In that case, implementations may treat this value as auto.
+In that case, implementations may treat this value as ''scrollbar-width/auto''.
 </dd>
 <dt><dfn>none</dfn></dt>
 <dd>implementations must not display any scrollbar, however the element's scrollability is not affected.


### PR DESCRIPTION
Link to the scrollbar-color and scrollbar-width
definitions of auto.

Avoid bikeshed warning:
Multiple possible 'maybe' local refs for 'auto'.
