### PR TITLE
[css-exclusions] Link to definitions of 'none'

### DIFF
--- a/css-exclusions-1/Overview.bs
+++ b/css-exclusions-1/Overview.bs
@@ -56,7 +56,7 @@ Terminology</h2>
       used to make an element's generated box an exclusion box. An exclusion box
       contributes its <span>exclusion area</span> to its <a href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">containing block's</a>
       <span>wrapping context</span>. An element with a ''float'' computed value other
-      than ''none'' does not become an exclusion.
+      than ''float/none'' does not become an exclusion.
 
     <dt><dfn>Exclusion area</dfn>
     <dd>
@@ -132,7 +132,7 @@ The 'wrap-flow' property</h4>
   Applies to: block-level elements.
   Inherited: no
   Percentages: N/A
-  Computed value: as specified except for element's whose 'float' computed value is not ''none'', in which case the computed value is ''auto''.
+  Computed value: as specified except for element's whose 'float' computed value is not ''float/none'', in which case the computed value is ''auto''.
   </pre>
 
   The values of this property have the following meanings:
@@ -327,16 +327,17 @@ Propagation of Exclusions</h3>
   words it is subject to the exclusions defined <a>outside</a>
   the element.
 
-  Setting the 'wrap-through' property to ''none'' prevents an element from
-  inheriting its parent <a>wrapping context</a>. In other words, exclusions
-  defined ''outside'' the element, have not effect on the element's children layout.
+  Setting the 'wrap-through' property to ''wrap-through/none'' prevents an
+  element from inheriting its parent <a>wrapping context</a>. In other words,
+  exclusions defined ''outside'' the element, have not effect on the element's
+  children layout.
 
   <p class="note">
     Exclusions defined by an element's descendants still contribute to their
     containing block's <a>wrapping context</a>. If that containing block is a
-    child of an element with 'wrap-through' computes to ''none'', or the element
-    itself, then exclusion still have an effect on the children of that
-    containing block element.
+    child of an element with 'wrap-through' computes to ''wrap-through/none'',
+    or the element itself, then exclusion still have an effect on the children
+    of that containing block element.
   </p>
 
 <h4 id="wrap-through-property">


### PR DESCRIPTION
We now link to the `float` and `wrap-through` definitions
of 'none', as appropriate.

Avoid bikeshed warning:
Ambiguous for-less link for 'none'
