### PR TITLE
[css-ui] appearance: Remove 'button-bevel'

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1796,7 +1796,7 @@ so that CSS can be used to restyle them.
 
 <pre class="propdef">
 Name: appearance
-Value: ''appearance/none'' | ''auto'' | ''button'' | ''textfield'' | ''menulist-button'' | <<compat>>
+Value: ''appearance/none'' | ''auto'' | ''button'' | ''textfield'' | ''menulist-button'' | <<compat-auto>>
 Initial: none
 Applies To: all elements
 Inherited: no
@@ -1867,13 +1867,16 @@ Animation type: discrete
 
 		For all other elements, this value has the same effect as ''appearance/auto''.
 
-	<dt><dfn type="">&lt;compat></dfn>
+	<dt><dfn type="">&lt;compat-auto></dfn>
 	<dd>
 		These values exist for compatibility of content developed
 		for earlier non standard versions of this property.
 		They all have the same effect as ''appearance/auto''.
 
-		<pre class=prod style="white-space: normal"><<compat>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>button-bevel</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>listbox</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</pre></dfn>
+		<pre class=prod style="white-space: normal"><<compat>> =  <dfn>searchfield</dfn> | <dfn>textarea</dfn> | <dfn>push-button</dfn> | <dfn>slider-horizontal</dfn> | <dfn>checkbox</dfn> | <dfn>radio</dfn> | <dfn>square-button</dfn> | <dfn>menulist</dfn> | <dfn>listbox</dfn> | <dfn>meter</dfn> | <dfn>progress-bar</dfn></pre>
+
+		Issue: When 'auto' is widely supported,
+		recommend using 'auto' instead.
 
 		Issue: If any of these value is not needed for web compat,
 		they should be dropped from this list;


### PR DESCRIPTION
The 'button-bevel' value is removed in Chromium 75:

https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/ldH_uIfk_QE/Ua0bGyLIAwAJ

Tests: https://github.com/web-platform-tests/wpt/pull/14980

---

cc @tkent-google @MatsPalmgren 