### PR TITLE
[css-scroll-snap] scroll-padding is not negative.

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -1023,6 +1023,7 @@ Physical Longhands for 'scroll-padding' {#padding-longhands-physical}
     These <a>longhands</a> of 'scroll-padding' specify
     the top, right, bottom, and left edges
     of the <a>snapport</a>, respectively.
+    Negative values are invalid.
 
 Flow-relative Longhands for 'scroll-padding'  {#padding-longhands-logical}
 --------------------------------------------------------------------------
@@ -1041,6 +1042,7 @@ Flow-relative Longhands for 'scroll-padding'  {#padding-longhands-logical}
     These <a>longhands</a> of 'scroll-padding' specify
     the block-start, inline-start, block-end, and inline-end edges
     of the <a>snapport</a>, respectively.
+    Negative values are invalid.
 
     <pre class="propdef shorthand">
     Name: scroll-padding-block, scroll-padding-inline


### PR DESCRIPTION
Discussed in #1084 and
https://drafts.csswg.org/css-scroll-snap-1/#changes-20161020
