### PR TITLE
[css-ui] Restrict appearance: button more

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -87,6 +87,7 @@ spec:css-overflow-4; type:property; text:text-overflow
 spec:selectors-4; type:selector; text::enabled
 spec:selectors-4; type:selector; text::disabled
 spec:css-color-4; type:property; text:color
+spec:html; type:element; text:a
 </pre>
 
 <style>
@@ -1841,19 +1842,24 @@ Animation type: discrete
 
 	<dt><dfn>button</dfn>
 	<dd>
-		The element is rendered with the look and feel of a push button,
-		similar to the ''appearance: auto'' rendering of the [[HTML]] <{button}> element.
+		For <{a}> elements,
+		<{button}> elements,
+		<{input}> elements whose <{input/type}> attribute is in
+		the <a lt="Button state (type=button)">Button</a> state,
+		the <a lt="Reset Button state (type=reset)">Reset</a> state,
+		or the <a lt="Submit Button state (type=submit)">Submit Button</a> state,
+		and <a>drop-down box</a> <{select}> elements:
+		the element is rendered with the look and feel of a push button.
 
-		UAs must treat this value as ''appearance/auto'' on <{input}> elements,
-		<{textarea}> elements, <a spec="html">list box</a> <{select}> elements, <{meter}> elements, and <{progress}> elements.
-
-		Note: Using ''appearance/button'' on a <a spec="html">drop-down box</a> <{select}> element works.
+		For all other elements, this value has the same effect as ''appearance/auto''.
 
 	<dt><dfn>textfield</dfn>
 	<dd>
-		For <{input}> elements where the <{input/type}> attribute is in the Search state,
+		For <{input}> elements where the <{input/type}> attribute is in
+		the <a lt="Text (type=text) state and Search state (type=search)">Search</a> state,
 		the element is rendered as a "normal" text entry widget,
-		similar to an <{input}> element where the <{input/type}> attribute is in the Text state.
+		similar to an <{input}> element where the <{input/type}> attribute is in
+		the <a lt="Text (type=text) state and Search state (type=search)">Text</a> state.
 
 		For all other elements, this value has the same effect as ''appearance/auto''.
 


### PR DESCRIPTION
Per web compat analysis [1], the `button` value can be restricted to

* `a`
* `button`
* `input type=button/reset/submit`
* drop-down box `select`

Part of #3024

Tests: TODO

[1] https://github.com/w3c/csswg-drafts/issues/3024#issuecomment-493818911

---

cc @tkent-google @foolip @MatsPalmgren @emilio @jwatt