### PR TITLE
[css-ui] Disallow internal pseudo-elements and 'appearance' values

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1804,25 +1804,6 @@ Computed value: specified keyword
 Animation type: discrete
 </pre>
 
-<div class="note">
-	Note: This specification intentionally refrains from making the appearance
-	of all possible form controls and sub-controls available as values,
-	as had previously been attempted by earlier proposals for this property
-	and by several UA vendors in experimental implementations.
-	Experience has shown that such a list would be very long and not practical to maintain,
-	and UAs would need to add non-standard values
-	to account for the behavior of non-standard pseudo-elements
-	sometimes used to implement form controls.
-	Moreover, many values of such an enumeration only make sense
-	on a single element or pseudo-element,
-	and are never used outside of the UA stylesheet.
-	The ability provided by this approach to turn any arbitrary element
-	into any arbitrary form control or subcontrol
-	was also a significant source of complexity,
-	despite being not particularly useful.
-	The model provided by this specification is deliberately simpler.
-</div>
-
 <dl dfn-type=value dfn-for=appearance>
 	<dt><dfn>none</dfn>
 	<dd>
@@ -1887,6 +1868,23 @@ Animation type: discrete
 
 
 </dl>
+
+Some controls have internal parts, or sub controls.
+For example, an <code class="lang-markup">&lt;input type=search></code> element
+could have a clear button to clear the text.
+Some user agents support pseudo-elements for sub controls,
+and support specific values for the 'appearance' property for those pseudo-elements.
+This specification intentionally does not specify such values.
+
+User agents may support such pseudo-elements and specific 'appearance' values
+in the <a>user agent origin</a> and <a>user origin</a>,
+but must not support them in the <a>author origin</a>,
+and must not expose the computed style of such pseudo-elements in the {{getComputedStyle()}} API.
+
+<div class="note">
+	If some of these pseudo-elements and 'appearance' values do ought to be exposed to authors,
+	all related parts need to be standardized, not just the 'appearance' keywords.
+</div>
 
 <div class=example>
 	An author wanting to customize the look and feel of check boxes in HTML could use the following:


### PR DESCRIPTION
Pseudo-elements for internal parts of controls (e.g., `::-webkit-search-cancel-button`)
and related 'appearance' values (e.g., `searchfield-cancel-button`)
must not be exposed to author origin CSS or in `getComputedStyle()`.

If user agents find that they can't remove support for something,
the pseudo-element and the appearance value should both be specified.

Tests:
- 'appearance' values: already covered by css/css-ui/appearance-cssom-001.html
- pseudo-elements: TODO
- getComputedStyle: TODO

Part of #3024.

---

cc @tkent-google @foolip @MatsPalmgren @emilio