### PR TITLE
[css-ui] Hide proprietary appearance values #3968

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1800,7 +1800,7 @@ Value: ''appearance/none'' | ''auto'' | ''button'' | ''textfield'' | ''menulist-
 Initial: none
 Applies To: all elements
 Inherited: no
-Computed value: specified keyword
+Computed value: See below
 Animation type: discrete
 </pre>
 
@@ -1887,6 +1887,10 @@ Animation type: discrete
 
 
 </dl>
+
+The computed value is the specified value unless it is not included in the set
+of values defined by this specification. In that case, it is the value
+''appearance/auto''.
 
 <div class=example>
 	An author wanting to customize the look and feel of check boxes in HTML could use the following:


### PR DESCRIPTION
This is an attempt to implement the following suggestion from gh-3968:

> The only changed required is that the appearance property on those pseudos must return a value that is supported by the property, and that is absolutely logical and shouldn't require any specific text except maybe a note; browsers who support special values internally can convert those values to 'auto' if those pseudos currently have a proprietary value today (either for real, or just for gCS purposes).

However, in gh-3980, the motivating use case is under discussion. Depending on how that is resolved (e.g. by disabling access to non-standard pseudo-elements), this change may not be necessary. Even in that case, standardizing this behavior could improve consistency in a more immediate timeframe.

The text I've written feels primitive to me, but I can't think of a better way to normatively handle a disallowed situation. For instance, it would be cleaner to allow UAs to extend the set of valid values, but that would also allow authors to use apply those proprietary values in their own code. That doesn't seem like what's desired here.

An alternative to the property's computed value may be [CSSOM's definition of "resolved value"](https://drafts.csswg.org/cssom/#resolved-value). That's a little more indirect, but indirection may be warranted for an edge case like this.

/cc @FremyCompany @zcorpan