### PR TITLE
[css-multicol] Pass at incorporating the new model plus clarification in the issue re naming

### DIFF
--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -150,11 +150,18 @@ Introduction</h2>
 <h2 id="the-multi-column-model">
 The multi-column model</h2>
 
-	A <dfn lt="multi-column container|multicol container" oldids="multi-column-element" export>multi-column container</dfn>
-	(or <i>multicol container</i> for short)
-	is an element whose 'column-width' or 'column-count'
-	property is not ''column-width/auto'' and therefore acts as a container for
-	multi-column layout.
+    An element whose column-width or column-count property is not auto establishes a <dfn lt="multi-column container|multicol container" oldids="multi-column-element" export>multi-column container</dfn>
+	(or <i>multicol container</i> for short). 
+	It's a regular block container, 
+	that establishes a new block formatting context.
+
+	It consists of zero or more anonymous <i>multi-column rows</i> (<i>multicol rows</i>). There may be multiple rows if there's an outer fragmentation context, such as e.g. pagination.
+	
+	These multicol rows in turn consist of one or more of the following types of children, in any order:
+
+    - <b>Anonymous <i>multi-column line</i></b>: Establishes a new formatting context, and is filled with column boxes.
+    
+	- <b>Spanners</b>: Establish a new formatting context. Type of formatting context depends on display type; block formatting context, flex, grid, table, and so on.
 
 	<wpt>
 	multicol-count-computed-004.xht
@@ -162,27 +169,30 @@ The multi-column model</h2>
 
 	In the traditional CSS box model, the content of an element is
 	flowed into the content box of the corresponding element. Multi-column
-	layout introduces a new type of container between the content box and
-	the content, namely the <dfn export local-lt=column>column box</dfn> (or <i>column</i> for
-	short). The content of a multicol container is flowed into its column
+	layout introduces an anonymous container inside the multi-column lines, 
+	namely the <dfn export local-lt=column>column box</dfn> (or <i>column</i> for
+	short). 
+	The content of a multicol container is flowed into its column
 	boxes.
 
-	Column boxes in a multi-column container are arranged into <dfn export lt="column row" local-lt=row>rows</dfn>.
-	Like table cells,
-	the column boxes in a row are ordered
+	Column boxes in a multi-column container are arranged in their containing multicol lines.
+	Like flex items,
+	the column boxes in a multicol line are ordered
 	in the inline direction of the multicol container.
-	The <dfn export>column width</dfn> is the length of the column box in the inline direction.
+    The <dfn export>column width</dfn> is the length of the column box in the inline direction.
 	The <dfn export>column height</dfn> is the length of the column box in the block direction.
-	All column boxes in a row have the same column width,
-	and all column boxes in a row have the same column height.
-	Within each row in the multi-column container,
+	All column boxes in a line have the same column width,
+	and all column boxes in a line have the same column height.
+	
+	Within each line in the multi-column container,
 	adjacent column boxes are separated by a <dfn noexport>column gap</dfn>,
 	which may contain a <dfn noexport>column rule</dfn>.
-	All column gaps in the same row are equal.
+	Even in cases where a spanner creates multiple lines with a multicol row, 
+	all column gaps in the same row are equal.
 	All column rules in the same row are also equal, if they appear;
 	column rules only appear between columns that both have content.
 
-	In the simplest case a multicol container will contain only one row
+	In the simplest case a multicol container will contain only one row containing one line
 	of columns, and the height of each column will be equivalent to the
 	used height of the multi-column container's content box.
 

--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -187,9 +187,10 @@ The multi-column model</h2>
 	Within each line in the multi-column container,
 	adjacent column boxes are separated by a <dfn noexport>column gap</dfn>,
 	which may contain a <dfn noexport>column rule</dfn>.
-	Even in cases where a spanner creates multiple lines with a multicol row, 
-	all column gaps in the same row are equal.
-	All column rules in the same row are also equal, if they appear;
+	Even in cases where there are multiple rows, 
+	or a spanner creates multiple lines with a multicol row, 
+	all column gaps in the same multi-column container are equal.
+	All column rules in the same multi-column container are also equal, if they appear;
 	column rules only appear between columns that both have content.
 
 	In the simplest case a multicol container will contain only one row containing one line

--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -153,15 +153,15 @@ The multi-column model</h2>
     An element whose column-width or column-count property is not auto establishes a <dfn lt="multi-column container|multicol container" oldids="multi-column-element" export>multi-column container</dfn>
 	(or <i>multicol container</i> for short). 
 	It's a regular block container, 
-	that establishes a new block formatting context.
+	that establishes a new [=block formatting context=].
 
-	It consists of zero or more anonymous <i>multi-column rows</i> (<i>multicol rows</i>). There may be multiple rows if there's an outer fragmentation context, such as e.g. pagination.
+	By default this creates a single anonymous <i>multi-column row</i> (<i>multicol row</i>). There may be multiple multi-column rows if there's an outer fragmentation context, such as e.g. pagination.
 	
-	These multicol rows in turn consist of one or more of the following types of children, in any order:
+	These multi-column rows in turn consist of one or more of the following types of children, in any order:
 
-    - <b>Anonymous <i>multi-column line</i></b>: Establishes a new formatting context, and is filled with column boxes.
+    - <b>Anonymous <i>multi-column line</i></b>: Establishes a new column-line [=formatting context=], and is filled with column boxes.
     
-	- <b>Spanners</b>: Establish a new formatting context. Type of formatting context depends on display type; block formatting context, flex, grid, table, and so on.
+	- <b>Spanners</b>: Establish a new [=independent formatting context=]. Type of formatting context depends on display type; block formatting context, flex, grid, table, and so on.
 
 	<wpt>
 	multicol-count-computed-004.xht
@@ -172,12 +172,12 @@ The multi-column model</h2>
 	layout introduces an anonymous container inside the multi-column lines, 
 	namely the <dfn export local-lt=column>column box</dfn> (or <i>column</i> for
 	short). 
-	The content of a multicol container is flowed into its column
+	A multi-column line may contain one or more of these column boxes. 
+	The content of a multicol container is flowed into the column
 	boxes.
 
 	Column boxes in a multi-column container are arranged in their containing multicol lines.
-	Like flex items,
-	the column boxes in a multicol line are ordered
+	The column boxes in a multicol line are ordered
 	in the inline direction of the multicol container.
     The <dfn export>column width</dfn> is the length of the column box in the inline direction.
 	The <dfn export>column height</dfn> is the length of the column box in the block direction.

--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -150,52 +150,77 @@ Introduction</h2>
 <h2 id="the-multi-column-model">
 The multi-column model</h2>
 
-    An element whose column-width or column-count property is not auto establishes a <dfn lt="multi-column container|multicol container" oldids="multi-column-element" export>multi-column container</dfn>
-	(or <i>multicol container</i> for short). 
-	It's a regular block container, 
-	that establishes a new [=block formatting context=].
+    An element whose 'column-width' or 'column-count' property is not ''column-width/auto'' 
+	establishes a <dfn lt="multi-column container|multicol container" oldids="multi-column-element" export>multi-column container</dfn>
+	(or <i>multicol container</i> for short),
+	and therefore acts as a container for [=multi-column layout=].
 
-	By default this creates a single anonymous <i>multi-column row</i> (<i>multicol row</i>). There may be multiple multi-column rows if there's an outer fragmentation context, such as e.g. pagination.
-	
-	These multi-column rows in turn consist of one or more of the following types of children, in any order:
+	In the traditional CSS box model, 
+	the content of an element is
+	flowed into the content box of the corresponding element. 
+	Multi-column layout introduces a [=fragmentation context=]
+	formed of <a lt="anonymous box">anonymous</a> [=fragmentation containers=] 
+	called <dfn export lt="column box" local-lt=column>column boxes</dfn> 
+	(or <i>columns</i> for short).
+	These [=column boxes=] establish
+	an independent [=block formatting context=]
+	into which the multi-column container's content flows,
+	and form the [=containing block=] for its non-positioned childen.
+	Content overflowing a [=column box=] in the [=block axis=]
+	[=fragments=] and continues in the next [=column box=].
 
-    - <b>Anonymous <i>multi-column line</i></b>: Establishes a new column-line [=formatting context=], and is filled with column boxes.
-    
-	- <b>Spanners</b>: Establish a new [=independent formatting context=]. Type of formatting context depends on display type; block formatting context, flex, grid, table, and so on.
+	Note: Column boxes, which are [=anonymous boxes=],
+	do not become the containing block
+	for [=absolutely-positioned boxes=].
+	The 'position' property, which establishes a containing block for such boxes,
+	applies to the [=multicol container=], it being the [=principal box=].
+
+	The column boxes are ordered
+	in the [=inline base direction=] of the multicol container
+	and arranged into <dfn lt="multi-column line | multi-col line">multicol lines</dfn>.
+    The <dfn export>column width</dfn> is the length of the column box in the inline direction.
+	The <dfn export>column height</dfn> is the length of the column box in the block direction.
+	All column boxes in a line have the same column width,
+	and all column boxes in a line have the same column height.
+
+	Within each [=multi-col line=] in the multi-column container,
+	adjacent column boxes are separated by a <dfn noexport>column gap</dfn>,
+	which may contain a <dfn noexport>column rule</dfn>.
+	All column gaps in the same multi-column container are equal.
+	All column rules in the same multi-column container are also equal, if they appear;
+	column rules only appear between columns that both have content.
+
+	In the simplest case a multicol container will contain only one line
+	of columns, and the height of each column will be equivalent to the
+	used height of the multi-column container's content box.
+	However, [=fragmentation=] or [=spanners=]
+	can split the content of the [=multi-column container=]
+	into multiple [=multi-col lines=].
+
+	If the multi-column container is paginated, the height of each column is
+	constrained by the page and the content continues in a new line of
+	column boxes on the next page; a column box never splits across pages.
+
+	The same effect occurs when a <i>spanning element</i> divides the
+	multi-column container: the columns before the spanning element are
+	balanced and shortened to fit their content. Content after the
+	spanning element then flows into a new, subsequent line of column boxes.
+
+	A [=multi-column container=] therefore is a regular [=block container=]
+	that establishes a new [=independent formatting context=]
+	whose contents consist of a series of
+	[=multi-col lines=] and [=multi-col spanners=].
+	Each [=multi-column line=] acts as a [=block-level box=]
+	that establishes a [=multi-column formatting context=]
+	for its [=column boxes=];
+	and each [=spanner=] acts as a [=block-level box=]
+	that establishes an [=independent formatting context=]
+	with its type depending on its 'display' value as usual.
 
 	<wpt>
 	multicol-count-computed-004.xht
 	</wpt>
 
-	In the traditional CSS box model, the content of an element is
-	flowed into the content box of the corresponding element. Multi-column
-	layout introduces an anonymous container inside the multi-column lines, 
-	namely the <dfn export local-lt=column>column box</dfn> (or <i>column</i> for
-	short). 
-	A multi-column line may contain one or more of these column boxes. 
-	The content of a multicol container is flowed into the column
-	boxes.
-
-	Column boxes in a multi-column container are arranged in their containing multicol lines.
-	The column boxes in a multicol line are ordered
-	in the inline direction of the multicol container.
-    The <dfn export>column width</dfn> is the length of the column box in the inline direction.
-	The <dfn export>column height</dfn> is the length of the column box in the block direction.
-	All column boxes in a line have the same column width,
-	and all column boxes in a line have the same column height.
-	
-	Within each line in the multi-column container,
-	adjacent column boxes are separated by a <dfn noexport>column gap</dfn>,
-	which may contain a <dfn noexport>column rule</dfn>.
-	Even in cases where there are multiple rows, 
-	or a spanner creates multiple lines with a multicol row, 
-	all column gaps in the same multi-column container are equal.
-	All column rules in the same multi-column container are also equal, if they appear;
-	column rules only appear between columns that both have content.
-
-	In the simplest case a multicol container will contain only one row containing one line
-	of columns, and the height of each column will be equivalent to the
-	used height of the multi-column container's content box.
 
 	<div class="example">
 		Column gaps (diagonal hatching) and column rules are shown in this
@@ -217,15 +242,6 @@ The multi-column model</h2>
 		</figure>
 	</div>
 
-	If the multi-column container is paginated, the height of each row is
-	constrained by the page and the content continues in a new row of
-	column boxes on the next page; a column box never splits across pages.
-
-	The same effect occurs when a <i>spanning element</i> divides the
-	multi-column container: the columns before the spanning element are
-	balanced and shortened to fit their content. Content after the
-	spanning element then flows into a new row of column boxes.
-
 	<div class="example">
 		<figure>
 			<img alt="a diagram showing a spanning element causing the shortened columns above the element with text continuing in new columns below" src="images/simple-span-example.svg">
@@ -233,9 +249,6 @@ The multi-column model</h2>
 		</figure>
 	</div>
 
-	Column boxes are block container boxes. The multi-column container is the principal box, and column boxes are anonymous.
-
-	Note: Column boxes do not become the containing block for elements with ''position: fixed'' or ''position: absolute''. The containing block is the multicol container, it being the principal box.
 
 	<wpt>
 	multicol-containing-001.xht


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/issues/1072

Given the fiddliness of this I have opened a PR. I'm just looking at this first part now, with regard to the inclusion of the new model plus the naming we discussed. If we can get this right I'll go through the spec looking for any naming problems that fall out of it. I'll address the parts that deal with spanners specifically separately. I wanted to sort all these anonymous boxes first.

1. I think we essentially add an extra container (2 in @frivoal's writeup in the issue) when we do this, I've attempted to write that in. We end up with multiple multicol rows in the case of pagination (these contain the box 1 in @frivoal's writeup) and spanners. In future we might then add the concept or rows being created in the block dimension by height restricting the row.

2. This means a bit of a change to the text below that about gaps, and clarification that gaps are the same across all rows and lines in the container, even if we have multiple rows, or a spanner creates multiple lines.

Please let me know any thoughts.
