### PR TITLE
[css-transforms-1] Simplify transform function syntaxes

### DIFF
--- a/css-transforms-1/Overview.bs
+++ b/css-transforms-1/Overview.bs
@@ -1529,6 +1529,7 @@ At this point there are no information about potential privacy or security conce
 <h3 class="no-num" id="CR20190214">Since the <a href="https://www.w3.org/TR/2019/CR-css-transforms-1-20190214/">14 February 2019 Candidate Recommendation</a></h3>
 
 * Relax syntax of <a element-attr for>transform</a> attribute: Do not require commas between <<transform-list>> items.
+* Simplified grammar of transform functions. (No normative impact.)
 * Editorial changes.
 
 <h3 class="no-num" id="WD20181130">Since the <a href="https://www.w3.org/TR/2018/WD-css-transforms-1-20181130/">30 November 2018 Working Draft</a></h3>

--- a/css-transforms-1/Overview.bs
+++ b/css-transforms-1/Overview.bs
@@ -992,10 +992,10 @@ A percentage for vertical translations is relative to the height of the [=refere
 ----------------------
 
 <dl dfn-for=transform>
-	: <span class='prod'><dfn>matrix()</dfn> = matrix( <<number>> [, <<number>> ]{5,5} )</span>
+	: <span class='prod'><dfn>matrix()</dfn> = matrix( <<number>>#{6} )</span>
 	:: specifies a 2D transformation in the form of a <a href="#MatrixDefined">transformation matrix</a> of the six values a, b, c, d, e, f.
 
-	: <span class='prod'><dfn>translate()</dfn> = translate( <<length-percentage>> [, <<length-percentage>> ]? )</span>
+	: <span class='prod'><dfn>translate()</dfn> = translate( <<length-percentage>> , <<length-percentage>>? )</span>
 	:: specifies a <a href="#TranslateDefined">2D translation</a> by the vector [tx, ty], where tx is the first translation-value parameter and ty is the optional second translation-value parameter. If <em>&lt;ty></em> is not provided, ty has zero as a value.
 
 	: <span class='prod'><dfn>translateX()</dfn> = translateX( <<length-percentage>> )</span>
@@ -1004,7 +1004,7 @@ A percentage for vertical translations is relative to the height of the [=refere
 	: <span class='prod'><dfn>translateY()</dfn> = translateY( <<length-percentage>> )</span>
 	:: specifies a <a href="#TranslateDefined">translation</a> by the given amount in the Y direction.
 
-	: <span class='prod'><dfn>scale()</dfn> = scale( <<number>> [, <<number>> ]? )</span>
+	: <span class='prod'><dfn>scale()</dfn> = scale( <<number>> , <<number>>? )</span>
 	:: specifies a <a href="#ScaleDefined">2D scale</a> operation by the [sx,sy] scaling vector described by the 2 parameters. If the second parameter is not provided, it takes a value equal to the first. For example, scale(1, 1) would leave an element unchanged, while scale(2, 2) would cause it to appear twice as long in both the X and Y axes, or four times its typical geometric size.
 
 	: <span class='prod'><dfn>scaleX()</dfn> = scaleX( <<number>> )</span>
@@ -1016,7 +1016,7 @@ A percentage for vertical translations is relative to the height of the [=refere
 	: <span class='prod'><dfn>rotate()</dfn> = rotate( [ <<angle>> | <<zero>> ] )</span>
 	:: specifies a <a href="#RotateDefined">2D rotation</a> by the angle specified in the parameter about the origin of the element, as defined by the 'transform-origin' property. For example, ''rotate(90deg)'' would cause elements to appear rotated one-quarter of a turn in the clockwise direction.
 
-	: <span class='prod'><dfn>skew()</dfn> = skew( [ <<angle>> | <<zero>> ] [, [ <<angle>> | <<zero>> ] ]? )</span>
+	: <span class='prod'><dfn>skew()</dfn> = skew( [ <<angle>> | <<zero>> ] , [ <<angle>> | <<zero>> ]? )</span>
 	:: specifies a <a href="#SkewDefined">2D skew</a> by [ax,ay] for X and Y. If the second parameter is not provided, it has a zero value.
 
     	Advisement: ''skew()'' exists for compatibility reasons, and should not be used in new content. Use ''skewX()'' or ''skewY()'' instead, noting that the behavior of ''skew()'' is different from multiplying ''skewX()'' with ''skewY()''.


### PR DESCRIPTION
Simplify syntaxes for `matrix()`, `translate()`, `scale()` and `skew()`