### PR TITLE
[css-conditional] Remove duplicate definition of CSSGroupingRule (issue #3528)

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -545,50 +545,6 @@ interface CSSGroupingRule : CSSRule {
 </dl>
 
 
-<h3 id="the-cssconditionrule-interface">
-The <code>CSSConditionRule</code> interface</h3>
-
-The {{CSSConditionRule}} interface represents
-all the &ldquo;conditional&rdquo; at-rules,
-  which consist of a condition and a statement block.
-
-<pre class='idl' export>
-[Exposed=Window]
-interface CSSConditionRule : CSSGroupingRule {
-    attribute CSSOMString conditionText;
-};
-</pre>
-
-<dl class='idl-attributes'>
-
-  <dt><code>conditionText</code> of type <code>CSSOMString</code>
-  <dd>
-    The <code>conditionText</code> attribute represents
-    the condition of the rule.
-    Since what this condition does
-    varies between the derived interfaces of <code>CSSConditionRule</code>,
-    those derived interfaces
-    may specify different behavior for this attribute
-    (see, for example, <code>CSSMediaRule</code> below).
-    In the absence of such rule-specific behavior,
-    the following rules apply:
-
-    The <code>conditionText</code> attribute, on getting, must return
-    the result of serializing the associated condition.
-
-    On setting the <code>conditionText</code> attribute these steps
-      must be run:
-
-    <ol>
-      <li>Trim the given value of white space.
-      <li>If the given value matches the grammar of the
-        appropriate condition production for the given rule,
-        replace the associated CSS condition with the given value.
-      <li>Otherwise, do nothing.
-    </ol>
-</dl>
-
-
 <h3 id="the-cssmediarule-interface">
 The <code>CSSMediaRule</code> interface</h3>
 


### PR DESCRIPTION
Fixes #3528.

Tests: https://github.com/web-platform-tests/wpt/pull/17276