### PR TITLE
[css-round-display] Refer to css-shapes-2

### DIFF
--- a/css-round-display-1/Overview.bs
+++ b/css-round-display-1/Overview.bs
@@ -13,7 +13,7 @@ Previous Version: https://www.w3.org/TR/2015/WD-css-round-display-1-20150922/
 Editor: Hyojin Song, LG Electronics, hyojin22.song@lge.com, w3cid 54503
 Editor: Jihye Hong, LG Electronics, jh.hong@lge.com, w3cid 79168
 Editor: Soonbo Han (until June 2015), LG Electronics, soonbo.han@lge.com, w3cid 45470
-Link Defaults: css-shapes-1 (type) <basic-shape>
+Link Defaults: css-shapes-2 (type) <basic-shape>
 Link Defaults: css-transforms-1 (property) transform
 Link Defaults: css-transforms-1 (property) transform-origin
 Abstract: This document describes CSS extensions to support a round display. The extensions help web authors to build a web page suitable for a round display.
@@ -74,7 +74,7 @@ Terminology {#terminology}
 
 This specification follows the CSS property definition conventions from [[!CSS21]]. <br/>
 The detailed description of Media Queries is defined in [[MEDIAQUERIES-4]]<br/>
-The detailed description of CSS Shapes is defined in [[CSS-SHAPES-1]]<br/>
+The detailed description of CSS Shapes is defined in [[CSS-SHAPES-2]]<br/>
 The detailed description of Backgrounds and Borders is defined in [[CSS3BG]]<br/>
 The detailed description of Positioned Layout is defined in [[CSS3-POSITIONING]]<br/>
 
@@ -320,7 +320,7 @@ Aligning content along the display border {#aligning-content}
 
 <h3 id="shape-inside-property">The 'shape-inside' property</h3>
 
-CSS Shapes [[CSS-SHAPES-1]] define the 'shape-inside' property that aligns contents along the edge of a possibly non-rectangular wrapping area. Web authors may use this feature to fit contents inside a round display. However, it can be challenging to specify the wrapping area to be identical to the shape of a display. To address such cases, 'shape-inside' is extended with a new value named '<code>display</code>', such an element having this value will have its content (or contained elements) aligned along the display border automatically.
+CSS Shapes [[CSS-SHAPES-2]] define the 'shape-inside' property that aligns contents along the edge of a possibly non-rectangular wrapping area. Web authors may use this feature to fit contents inside a round display. However, it can be challenging to specify the wrapping area to be identical to the shape of a display. To address such cases, 'shape-inside' is extended with a new value named '<code>display</code>', such an element having this value will have its content (or contained elements) aligned along the display border automatically.
 
 <pre class='link-defaults'>
 spec:css2; type:type; text:<uri>


### PR DESCRIPTION
'shape-inside' property was postponed in level 1 and now resides in level 2.
