### PR TITLE
[css-scroll-snap-1] Make <'scroll-padding'> syntax uniform with others

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -422,7 +422,7 @@ Scroll Snapport: the 'scroll-padding' property {#scroll-padding}
 
     <pre class="propdef shorthand">
     Name: scroll-padding
-    Value: [ <<length-percentage>> | auto ]{1,4}
+    Value: [ auto | <<length-percentage>> ]{1,4}
     Initial: auto
     Applies to: <a>scroll containers</a>
     Inherited: no


### PR DESCRIPTION
Move `auto` keyword in the beginning like in any other syntaxes of the spec.