### PR TITLE
[css-counter-styles-3] Fix <counter-style> syntax to refer to <symbols()> instead of defining it

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -1281,7 +1281,7 @@ Extending 'list-style-type', ''counter()'', and ''counters()''</h2>
 	This module extends these features to take instead the <<counter-style>> type, defined below:
 
 	<pre class='prod'>
-		<dfn type>&lt;counter-style></dfn> = <<counter-style-name>> | <a>symbols()</a>;
+		<dfn type>&lt;counter-style></dfn> = <<counter-style-name>> | <<symbols()>>;
 	</pre>
 
 	If a <<counter-style-name>> is used that does not refer to any existing counter style,


### PR DESCRIPTION
In current form of `counter-style` syntax, `symbols()` is not a reference for the type:
```
<counter-style> = <counter-style-name> | symbols();
```
This change fix that.