### PR TITLE
[css-values-3][css-values-4] Fix example in Property Value Examples

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -350,8 +350,8 @@ Property Value Examples</h3>
 				<tr><td>'border-width'
 				    <td>[ &lt;length> | thick | medium | thin ]{1,4}
 				    <td>''2px medium 4px''
-				<tr><td>'text-shadow'
-				    <td>[ inset? && [ &lt;length>{2,4} && &lt;color>? ] ]# | none
+				<tr><td>'box-shadow'
+				    <td>[ inset? && &lt;length>{2,4} && &lt;color>? ]# | none
 				    <td>''3px 3px rgba(50%, 50%, 50%, 50%), lemonchiffon 0 0 4px inset''
 			</tbody>
 		</table>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -342,8 +342,8 @@ Property Value Examples</h3>
 				<tr><td>'border-width'
 				    <td>[ &lt;length> | thick | medium | thin ]{1,4}
 				    <td>''2px medium 4px''
-				<tr><td>'text-shadow'
-				    <td>[ inset? && [ &lt;length>{2,4} && &lt;color>? ] ]# | none
+				<tr><td>'box-shadow'
+				    <td>[ inset? && &lt;length>{2,4} && &lt;color>? ]# | none
 				    <td>''3px 3px rgba(50%, 50%, 50%, 50%), lemonchiffon 0 0 4px inset''
 			</tbody>
 		</table>


### PR DESCRIPTION
- Replaced `text-shadow` for `box-shadow` since `text-shadow` has no `inset` component
- Removed unnecessary grouping ([`<shadow>` definition](https://drafts.csswg.org/css-backgrounds/#typedef-shadow))

According to spec, the order of terms should be `none | [ <color>? && <length>{2,4} && inset? ]#`. However, left it as is since it's not a big deal.