### PR TITLE
[css-text-3] Normatively disallow break-word

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -2449,6 +2449,8 @@ Line Breaking Details</h3>
       ''word-break: normal'' and ''overflow-wrap: anywhere'',
       regardless of the actual value of the 'overflow-wrap' property.
       <!-- This is officially sad -->
+      However, the ''word-break/break-word'' keyword is not appropriate for
+      newly-written style sheets. Authors must not use it.
 
       <wpt>
         white-space/pre-wrap-008.html


### PR DESCRIPTION
This change adds a normative *“Authors must not”* statement prohibiting authors from using the (deprecated) `break-word` value with the `word-break` property.

This change aligns with similar normative author-conformance prohibitions in other specs which define certain features as deprecated; see, for example, the language used in the Media Queries spec with regard to the deprecated `device-width`, etc., media features:

https://drafts.csswg.org/mediaqueries-4/#mf-deprecated
> The following media features are deprecated. They are kept for
> backward compatibility, but are not appropriate for newly written style
> sheets. Authors must not use them.