### PR TITLE
[css-animations] animation-delay is not animatable

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -719,7 +719,7 @@ The 'animation-delay' property</h3>
 	Initial: 0s
 	Applies to: all elements
 	Inherited: no
-	Animatable: no
+	Animation type: not animatable
 	Percentages: N/A
 	Computed value: list, each item a duration
 	Canonical order: per grammar


### PR DESCRIPTION
Replace the old phrasing
Animatable: no
with the new phrasing
Animation type: not animatable
