### PR TITLE
[css-values] sin and cos can reach -1

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2588,8 +2588,8 @@ Trigonometric Functions: ''sin()'', ''cos()'', ''tan()'', ''asin()'', ''acos()''
 	all represent the same value,
 	approximately ''.707''.)
 	They all represent a <<number>>;
-	''sin()'' and ''cos()'' will always return a number between -1 and 1,
-	while ''tan()'' can return any number between +∞ and −∞.
+	''sin()'' and ''cos()'' will always return a number between −1 and 1,
+	while ''tan()'' can return any number between −∞ and +∞.
 	(See [[#calc-type-checking]] for details on how [=math functions=] handle ∞.)
 
 	The <dfn lt="asin()">asin(A)</dfn>, <dfn lt="acos()">acos(A)</dfn>, and <dfn lt="atan()">atan(A)</dfn> functions


### PR DESCRIPTION
Use minus sign instead of hyphen.

Use increasing order for tan, improving consistency
as we use increasing order for sin and cos.
