### PR TITLE
[css-tables-3] Remove vestiges of min-width percents

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -1259,7 +1259,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 				<!--——————————————————————————————————————————————————————————————————————————-->
 				<dt><dfn>percentage contribution</dfn>s</dt>
 				<dd>The percentage contribution of a table cell, column, or column group
-						is defined in terms of the computed values of 'width', 'max-width', and 'min-width'
+						is defined in terms of the computed values of 'width' and 'max-width'
 						that have computed values that are percentages:<br/>
 					<br/>
 					<code>min(percentage 'width', percentage 'max-width')</code>.<br/>
@@ -1778,9 +1778,6 @@ spec:css-sizing-3; type:property; text:box-sizing
 			<img src="images/CSS-Tables-Column-Width-Assignment.svg" style="width: 100%" />
 			<figcaption>Overview of the width distribution algorithm. Not normative.</figcaption>
 		</figure>
-
-		ISSUE(607): Should min-width support percentages?
-
 
 		<h5 id="width-distribution-in-fixed-mode">Changes to width distribution in fixed mode</h5>
 


### PR DESCRIPTION
[css-tables-3] Remove vestiages of min-width percents from #607

WG resolved to ignore percent min-width for column widths in #607 but
not everything was removed.
