### PR TITLE
[css-tables-3] Editorial: Fix constrainedness references

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -1244,11 +1244,11 @@ spec:css-sizing-3; type:property; text:box-sizing
 						<li>The <b>outer min-content width</b> of a table-column or table-column-group is
 							<code>max('min-width', 'width')</code>.
 
-						<li>The <b>outer max-content width</b> of a table-cell in a <a href="#constrainedness">non-constrained column</a> is
+						<li>The <b>outer max-content width</b> of a table-cell in a [=constrainedness|non-constrained column=] is
 								<code>max('min-width', 'width', min-content width, min('max-width', max-content width))</code>
 								adjusted by the cell intrinsic offsets.
 
-						<li>The <b>outer max-content width</b> of a table-cell in a <a href="#constrainedness">constrained column</a> is
+						<li>The <b>outer max-content width</b> of a table-cell in a [=constrainedness|constrained column=] is
 								<code>max('min-width', 'width', min-content width, min('max-width', 'width'))</code>
 								adjusted by the cell intrinsic offsets.
 
@@ -1703,7 +1703,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 								<li>its min-content width
 							</ul>
 
-						<li>any other column that is <a href="#constrainedness">constrained</a>
+						<li>any other column that is [=constrainedness|constrained=]
 							is assigned its max-content width
 
 						<li>all other columns are assigned their min-content width.
@@ -1820,7 +1820,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 		<ol>
 
-			<li>If there are <a href="#constrainedness">non-constrained columns</a> that have originating cells
+			<li>If there are [=constrainedness|non-constrained columns=] that have originating cells
 					with intrinsic percentage width of 0% and
 					with nonzero max-content width
 					<i class="hint">(aka the columns allowed to grow by this rule)</i>,
@@ -1828,7 +1828,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 					are increased in proportion to max-content width
 					so the total increase adds to the excess width.
 
-			<li>Otherwise, if there are <a href="#constrainedness">non-constrained columns</a> that have originating cells
+			<li>Otherwise, if there are [=constrainedness|non-constrained columns=] that have originating cells
 					with intrinsic percentage width of 0%
 					<i class="hint">(aka the columns allowed to grow by this rule,
 					which thanks to the previous rule must have zero max-content width)</i>,
@@ -1836,7 +1836,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 					are increased by equal amounts
 					so the total increase adds to the excess width.
 
-			<li>Otherwise, if there are (<a href="#constrainedness">constrained</a>) columns
+			<li>Otherwise, if there are [=constrainedness|constrained columns=]
 					with intrinsic percentage width of 0% and
 					with nonzero max-content width
 					<i class="hint">(aka the columns allowed to grow by this rule, which, due to other rules, must have originating cells)</i>,


### PR DESCRIPTION
bikeshed didn't give the definition the ② ③ links when the
references were done with a href.