### PR TITLE
[css-writing-modes] Clarify how propagation from body works

### DIFF
--- a/css-writing-modes-3/Overview.bs
+++ b/css-writing-modes-3/Overview.bs
@@ -8,6 +8,8 @@ Work Status: Testing
 Group: csswg
 ED: https://drafts.csswg.org/css-writing-modes-3/
 TR: https://www.w3.org/TR/css-writing-modes-3/
+Previous Version: https://www.w3.org/TR/2018/CR-css-writing-modes-3-20180524/
+Previous Version: https://www.w3.org/TR/2017/CR-css-writing-modes-3-20171207/
 Previous Version: https://www.w3.org/TR/2015/CR-css-writing-modes-3-20151215/
 Issue Tracking: Tracker http://www.w3.org/Style/CSS/Tracker/products/30
 Editor: Elika J. Etemad / fantasai, Invited Expert, http://fantasai.inkedblade.net/contact, w3cid 35400
@@ -2234,19 +2236,27 @@ Purely Physical Mappings</h3>
 The Principal Writing Mode</h2>
 
   <p>The <dfn export>principal writing mode</dfn> of the document
-  is determined by the 'writing-mode' and 'direction' values
-  specified on the root element.
+  is determined by the [=used value|used=] 'writing-mode', 'direction', and 'text-orientation' values
+  of the root element.
   This writing mode is used, for example,
   to determine the direction of scrolling
   and the default <a>page progression</a> direction.
 
   <p>As a special case for handling HTML documents,
   if the root element has a <{body}> child element [[!HTML]],
-  the <a>principal writing mode</a> is instead taken
-  from the values of 'writing-mode' and 'direction' on the first such child element
-  instead of taken from the root element.
-  Note that this does not affect the values of 'writing-mode' or 'direction'
-  on the root element itself.
+  the [=used value=] of the of 'writing-mode' and 'direction' properties on root element
+  are taken
+  from the [=computed value|computed=] 'writing-mode' and 'direction'
+  of the first such child element instead of from the root element's own values.
+  The UA <em>may</em> also propagate the value of 'text-decoration' in this manner.
+  Note that this does not affect the computed values of 'writing-mode' or 'direction'
+  of the root element itself.
+
+  Note: Propagation is done on used values rather than computed values
+  to avoid disrupting other aspects of style computation,
+  such as [=inheritance=],
+  [[css-logical-1#box|logical property mapping logic]],
+  or [[css-values-4#lengths|length value computation]].
 
 <h3 id="icb">
 Propagation to the Initial Containing Block</h3>
@@ -2471,6 +2481,19 @@ Privacy and Security Considerations {#priv-sec}
 	or security considerations beyond "implement it correctly".
 
 <h2 class="no-num" id="changes">Changes</h2>
+
+  <h3 class="no-num" id="changes-201805">
+  Changes since the <a href="https://www.w3.org/TR/2018/CR-css-writing-modes-3-20180524/">May
+  2018 CSS Writing Modes Module Level 3 Candidate Recommendation</a></h3>
+
+  <ul>
+    <li>Clarified that propagation of the principal writing mode from the body element
+        to the initial containing block and viewport
+        does affect the used value on root element as well,
+        but not its computed value.
+        Also, optionally allow propagating 'text-orientation' as well.
+        (<a href="https://github.com/w3c/csswg-drafts/issues/3066">Issue 3066</a>)
+  </ul>
 
   <h3 class="no-num" id="changes-201712">
   Changes since the <a href="http://www.w3.org/TR/2015/CR-css-writing-modes-3-20171207/">December

--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -8,6 +8,7 @@ Work Status: Testing
 Group: csswg
 ED: https://drafts.csswg.org/css-writing-modes-4/
 TR: https://www.w3.org/TR/css-writing-modes-4/
+Previous Version: https://www.w3.org/TR/2018/CR-css-writing-modes-4-20180524/
 Issue Tracking: Tracker http://www.w3.org/Style/CSS/Tracker/products/30
 Editor: Elika J. Etemad / fantasai, Invited Expert, http://fantasai.inkedblade.net/contact, w3cid 35400
 Editor: Koji Ishii, Google, kojiishi@gmail.com, w3cid 45369
@@ -2460,19 +2461,27 @@ Purely Physical Mappings</h3>
 The Principal Writing Mode</h2>
 
   <p>The <dfn export>principal writing mode</dfn> of the document
-  is determined by the 'writing-mode' and 'direction' values
-  specified on the root element.
+  is determined by the [=used value|used=] 'writing-mode', 'direction', and 'text-orientation' values
+  of the root element.
   This writing mode is used, for example,
   to determine the direction of scrolling
   and the default <a>page progression</a> direction.
 
   <p>As a special case for handling HTML documents,
   if the root element has a <{body}> child element [[!HTML]],
-  the <a>principal writing mode</a> is instead taken
-  from the values of 'writing-mode' and 'direction' on the first such child element
-  instead of taken from the root element.
-  Note that this does not affect the values of 'writing-mode' or 'direction'
-  on the root element itself.
+  the [=used value=] of the of 'writing-mode' and 'direction' properties on root element
+  are taken
+  from the [=computed value|computed=] 'writing-mode' and 'direction'
+  of the first such child element instead of from the root element's own values.
+  The UA <em>may</em> also propagate the value of 'text-decoration' in this manner.
+  Note that this does not affect the computed values of 'writing-mode' or 'direction'
+  of the root element itself.
+
+  Note: Propagation is done on used values rather than computed values
+  to avoid disrupting other aspects of style computation,
+  such as [=inheritance=],
+  [[css-logical-1#box|logical property mapping logic]],
+  or [[css-values-4#lengths|length value computation]].
 
 <h3 id="icb">
 Propagation to the Initial Containing Block</h3>
@@ -2774,14 +2783,21 @@ Privacy and Security Considerations {#priv-sec}
 	or security considerations beyond “implement it correctly”.
 
 <h2 class="no-num" id="changes">Changes</h2>
-<!--
-  <h3 class="no-num" id="changes-201311">
-  Changes since the <a href="https://www.w3.org/TR/2014/CR-css-writing-modes-3-20140320/">March
-  2014 CSS Writing Modes Module Level 3 Candidate Recommendation</a></h3>
+
+<h3 class="no-num" id="changes-201805">
+Changes since the <a href="https://www.w3.org/TR/2018/CR-css-writing-modes-4-20180524">May
+2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a></h3>
 
   <ul>
+    <li>
+      Clarified that propagation of the principal writing mode from the body element
+      to the initial containing block and viewport
+      does affect the used value on root element as well,
+      but not its computed value.
+      Also, optionally allow propagating 'text-orientation' as well.
+      This change was also applied to level 3.
+      (<a href="https://github.com/w3c/csswg-drafts/issues/3066">Issue 3066</a>)
   </ul>
--->
 
 <h3 id="additions">
 New in Level 4</h3>


### PR DESCRIPTION
'writing-mode' and 'direction' are propagated up from the body element.
This affects the root element in addition to the ICB and viewport,
but only for used values, not for computed values.

The same propagation is optionally allowed for 'text-orientation'.

Closes #3066