### PR TITLE
[resize-observer] remove SVG specific text

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -234,8 +234,6 @@ interface ResizeObserver {
 
         2. Clear the {{ResizeObserver/activeTargets}} list.
 
-        3. Remove |this| from {{Document}}.<var>resizeObservers</var> slot.
-
 </div>
 
 <h3 id="resize-observer-callback">ResizeObserverCallback</h3>
@@ -305,16 +303,6 @@ interface ResizeObserverEntry {
             computing size given |target| and specificSize of "device-pixel-border-box"</a>.
 
         7. Set |this|.{{ResizeObserverEntry/contentRect}} to logical |this|.{{ResizeObserverEntry/contentSize}}.
-
-        8. If |target| is not an SVG element do these steps:
-
-            1. Set |this|.|contentRect|.top to |target|.<a>padding top</a>.
-
-            2. Set |this|.|contentRect|.left to |target|.<a>padding left</a>.
-
-        9. If |target| is an SVG element do these steps:
-
-            1. Set |this|.|contentRect|.top and |this|.contentRect.left to 0.
 
 </div>
 
@@ -412,13 +400,6 @@ Watching content rect means that:
 * non-replaced inline Elements will always have an empty content rect.
 
 * observations will not be triggered by CSS transforms.
-
-Web content can also contain SVG elements. SVG Elements define <a>bounding box</a> instead of a content box.
-Content rect for <a>SVGGraphicsElement</a>s is a rect whose:
-
-* width is <a>bounding box</a> width
-* height is <a>bounding box</a> height
-* top and left are 0
 
 <h3 id="algorithms">Algorithms</h3>
 
@@ -527,38 +508,28 @@ To <dfn>calculate depth for node</dfn>, given a |node|, run these steps:
 
 This algorithm computes |target| {{Element}}'s specific size. Type of size is
 described by {{ResizeObserverBoxOptions}}.
-SVG Elements are an exception. SVG size is always its bounding box size, because SVG
-elements do not use standard CSS box model.
 
 To <dfn>calculate box size</dfn>, given |target| and |specificSize|, run these steps:
 
-    1. If |target| is an {{SVGGraphicsElement}}
+    1. If |specificSize| is "bounding-box"
 
-        1. Set |computedSize|.inlineSize to |target|'s <a>bounding box</a> inline length.
+        1. Set |computedSize|.inlineSize to target's <a>border area</a> inline length.
 
-        2. Set |computedSize|.blockSize to |target|'s <a>bounding box</a> block length.
+        2. Set |computedSize|.blockSize to target's <a>border area</a> block length.
 
-    2. If |target| is not an {{SVGGraphicsElement}}
+    2. If |specificSize| is "content-box"
 
-        1. If |specificSize| is "bounding-box"
+        1. Set |computedSize|.inlineSize to target's <a>content area</a> inline length.
 
-            1. Set |computedSize|.inlineSize to target's <a>border area</a> inline length.
+        2. Set |computedSize|.blockSize to target's <a>content area</a> block length.
 
-            2. Set |computedSize|.blockSize to target's <a>border area</a> block length.
+    3. If |specificSize| is "scoll-box"
 
-        2. If |specificSize| is "content-box"
+        1. Set |computedSize|.inlineSize to target's <a>scrollport</a> inline size.
 
-            1. Set |computedSize|.inlineSize to target's <a>content area</a> inline length.
+        2. Set |computedSize|.blockSize to target's <a>scrollport</a> block size.
 
-            2. Set |computedSize|.blockSize to target's <a>content area</a> block length.
-
-        3. If |specificSize| is "scoll-box"
-
-            1. Set |computedSize|.inlineSize to target's <a>scrollport</a> inline size.
-
-            2. Set |computedSize|.blockSize to target's <a>scrollport</a> block size.
-
-        4. return |computedSize|.
+    4. return |computedSize|.
 
 <h3 id="lifetime">ResizeObserver Lifetime</h3>
 
@@ -628,3 +599,9 @@ For each fully active Document in docs, run the following steps for that Documen
 6. If {{Document}} <a>has skipped observations</a> then <a>deliver resize loop error notification</a>
 
 7. Update the rendering or user interface of {{Document}} and its browsing context to reflect the current state.
+
+<h3 id="changes-2019">Changes</h3>
+ * **SVG Interaction:** Removed the special case for SVG root elements since SVG root elements produce CSS boxes and so 
+                        SVG root elements should adhere to the same model as other elements. Additionally we've removed 
+                        the definition for elements within an SVG as the BBox doesn't change on resize and thus aren't 
+                        firing an observer. <a href="https://github.com/w3c/csswg-drafts/issues/4032" target="_blank">Discussion Issue</a>


### PR DESCRIPTION
Per resolution in #4032 I have removed all SVG specific text since since the SVG root element results in CSS boxes and should follow the same model as the rest. I also added this to the changes section. @AmeliaBR & @bkardell can you please review. cc: @atotic 
