### PR TITLE
[css-shapes] shape-image-threshold accepts percent

### DIFF
--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -918,7 +918,7 @@ Choosing Image Pixels: the 'shape-image-threshold' property</h3>
 
 	<pre class='propdef'>
 		Name: shape-image-threshold
-		Value: <<number>>
+		Value: <<alpha-value>>
 		Initial: 0
 		Applies to: floats
 		Inherited: no


### PR DESCRIPTION
shape-image-threshold now accepts any alpha-value, just like
opacity. (An alpha-value is a number or percentage, that
serializes as a number.)

resolves #4102
