### PR TITLE
[css-inline] line-height cannot have two values

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -537,7 +537,7 @@ Line Spacing: the 'line-height' property</h3>
 
 	<pre class="propdef">
 	Name: line-height
-	Value: normal | <<number>> || <<length-percentage>>
+	Value: normal | <<number>> | <<length-percentage>>
 	Initial: normal
 	Applies to: inline boxes
 	Inherited: yes


### PR DESCRIPTION
line-height must be normal or a number or a length-percentage.

It cannot be a number followed by a length-percentage.

This brings the definition of line-height into consistency with CSS 2.
https://www.w3.org/TR/CSS2/visudet.html#propdef-line-height
