### PR TITLE
[css-transforms-2] Use reference-box for translate property. 

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -552,7 +552,7 @@ Value: none | <<length-percentage>> [ <<length-percentage>> <<length>>? ]?
 Initial: none
 Applies to: <a>transformable elements</a>
 Inherited: no
-Percentages: relative to the width of the containing block (for the first value) or the height (for the second value)
+Percentages: relative to the width of the <a>reference box</a> (for the first value) or the height (for the second value)
 Computed Value: the keyword ''translate/none'' or a pair of computed <<length-percentage>> values and optionally an absolute length
 Animation type: by computed value, adding a third ''0'' value if needed to match components, but see below for ''translate/none''
 </pre>


### PR DESCRIPTION
Fixes #4193.