### PR TITLE
[css-fonts-4] Add explicit [Exposed=Window]

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -5929,7 +5929,9 @@ The <code id="cssfontfeaturevaluesrule-interface">CSSFontFeatureValuesRule</code
 
 <p>The <dfn>CSSFontFeatureValuesRule</dfn> interface represents a <code>@font-feature-values</code> rule.</p>
 
-<pre class='idl'>interface CSSFontFeatureValuesRule : CSSRule {
+<pre class='idl'>
+[Exposed=Window]
+interface CSSFontFeatureValuesRule : CSSRule {
   attribute CSSOMString fontFamily;
   readonly attribute CSSFontFeatureValuesMap annotation;
   readonly attribute CSSFontFeatureValuesMap ornaments;
@@ -5939,6 +5941,7 @@ The <code id="cssfontfeaturevaluesrule-interface">CSSFontFeatureValuesRule</code
   readonly attribute CSSFontFeatureValuesMap styleset;
 };
 
+[Exposed=Window]
 interface CSSFontFeatureValuesMap {
   maplike&lt;CSSOMString, sequence&lt;unsigned long&gt;&gt;;
   void set(CSSOMString featureValueName,
@@ -5983,10 +5986,10 @@ a single value.
 <h3 id="om-fontpalettevalues">
 The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interface</h3>
 <pre class='idl'>partial interface CSSRule {
-
   const unsigned short FONT_PALETTE_VALUES_RULE = 15;
 };
 
+[Exposed=Window]
 interface CSSFontPaletteValuesRule : CSSRule {
   maplike&lt;unsigned long, CSSOMString>;
   attribute CSSOMString fontFamily;


### PR DESCRIPTION
Required after heycam/webidl#423. (Found from web-platform-tests/wpt#18382)
