### PR TITLE
Defined @namespace using CSS syntax (fixes #649)

### DIFF
--- a/css-namespaces-3/Overview.bs
+++ b/css-namespaces-3/Overview.bs
@@ -145,21 +145,13 @@ Terminology</h3>
 <h3 id="syntax">
 Syntax</h3>
 
-	The syntax for the ''@namespace'' rule is as follows
-	(using the notation from the <a href="https://www.w3.org/TR/CSS21/grammar.html">Grammar appendix of CSS 2.1</a> [[!CSS21]]):
+	The syntax for the ''@namespace'' rule is:
 
 	<pre>
-		namespace
-		  : NAMESPACE_SYM S* [namespace_prefix S*]? [STRING|URI] S* ';' S*
-		  ;
-		namespace_prefix
-		  : IDENT
-		  ;
+		@namespace <<namespace-prefix>>? [ <<string>> | <<url>> ] ;
+
+		<dfn>&lt;namespace-prefix&gt;</dfn> = <<ident>>
 	</pre>
-
-	with the new token:
-
-	<pre>@{N}{A}{M}{E}{S}{P}{A}{C}{E} {return NAMESPACE_SYM;}</pre>
 
 	Any ''@namespace'' rules must follow all @charset and @import rules
 	and precede all other non-ignored at-rules and style rules in a style sheet.


### PR DESCRIPTION
[css-namespaces-3] This replaces the CSS 2.1 syntax used to define the `@namespace` rule by the newer [CSS Syntax 3](https://drafts.csswg.org/css-syntax-3/) rules used in other specs.