### PR TITLE
[css-overflow-3] Change class order in markup as in other specs

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -329,7 +329,7 @@ Scrolling and Clipping Overflow: the 'overflow-x', 'overflow-y', and 'overflow' 
 	of <a>overflow</a> in the vertical direction
 	(i.e., overflow from the top and bottom sides of the box).
 
-	<pre class="shorthand propdef">
+	<pre class="propdef shorthand">
 		Name: overflow
 		Value: [ visible | hidden | clip | scroll | auto ]{1,2}
 		Initial: visible
@@ -920,7 +920,7 @@ Fragmenting Overflow</h2>
 <h3 id=line-clamp>
 Limiting Visible Lines: the 'line-clamp' shorthand property</h3>
 
-	<pre class="shorthand propdef">
+	<pre class="propdef shorthand">
 		Name: line-clamp
 		Value: none | <<integer>> <<'block-ellipsis'>>?
 		Initial: none


### PR DESCRIPTION
That's a single spec where order of CSS class goes in that ways. It would be great to keep consistent order of classes in such cases.