### PR TITLE
Uniform `Inherited` values across specs

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -310,7 +310,7 @@ Name: animation-composition
 Value: <<single-animation-composition>>#
 Initial: replace
 Applies to: all elements
-Inherited: none
+Inherited: no
 Percentages: N/A
 Computed value: list, each item a keyword as specified
 Animation type: not animatable

--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -369,7 +369,7 @@ and 'max-block-size'/'max-inline-size' properties</h3>
   Value: <<'width'>>
   Initial: auto
   Applies to: Same as 'height' and 'width'
-  Inherited: No
+  Inherited: no
   Percentages: As for the corresponding physical property
   Computed value: Same as 'height', 'width'
   Animation type: by computed value type
@@ -384,7 +384,7 @@ and 'max-block-size'/'max-inline-size' properties</h3>
   Value: <<'min-width'>>
   Initial: 0
   Applies to: same as 'height' and 'width'
-  Inherited: No
+  Inherited: no
   Percentages: As for the corresponding physical property
   Computed value: Same as 'min-height', 'min-width'
   Animation type: by computed value type

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -510,7 +510,7 @@ as the Flow-Relative box model properties defined in [[css-logical-1#box]].
   Value: <<'overflow'>>
   Initial: visible
   Applies to: Same as 'overflow-x' and 'overflow-y'
-  Inherited: No
+  Inherited: no
   Percentages: N/A
   Computed value: Same as 'overflow-x' and 'overflow-y'
   Animation type: discrete

--- a/css-writing-modes-3/Overview.bs
+++ b/css-writing-modes-3/Overview.bs
@@ -1410,7 +1410,7 @@ Obsolete: the SVG1.1 'glyph-orientation-vertical' property</h4>
   Value: auto | 0deg | 90deg | 0 | 90
   Initial: n/a
   Applies to: n/a
-  Inherited: na/
+  Inherited: n/a
   Percentages: n/a
   Computed value: n/a
   Animatable: n/a

--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -1484,7 +1484,7 @@ Obsolete: the SVG1.1 'glyph-orientation-vertical' property</h4>
   Value: auto | 0deg | 90deg | 0 | 90
   Initial: n/a
   Applies to: n/a
-  Inherited: na/
+  Inherited: n/a
   Percentages: n/a
   Computed value: n/a
   Animatable: n/a


### PR DESCRIPTION
With this patch there will be the following list of values for `Inherited`:
- yes
- no
- no (but see prose)
- no (but see prose, above)
- n/a

Not sure we need to left `n/a`, but not sure about replacement