### PR TITLE
[css-text-3] Disambiguate "space"

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -619,7 +619,7 @@ Text Processing</h3>
     <p>Text transformation happens after [[#white-space-phase-1]]
       but before [[#white-space-phase-2]].
       This means that ''full-width'' only transforms
-      U+0020 spaces to U+3000 within <a>preserved</a> white space.
+      U+0020 spaces to U+3000 within <a>preserved</a> [=white space=].
 
       <wpt>
         text-transform/text-transform-fullwidth-006.html
@@ -788,10 +788,10 @@ Text Processing</h3>
     <dt><dfn>break-spaces</dfn></dt>
     <dd>The behavior is identical to that of ''white-space/pre-wrap'',
       except that:
-      * Any sequence of <a>preserved</a> white space always takes up space,
+      * Any sequence of <a>preserved</a> [=white space=] always takes up space,
         including at the end of the line.
       * A line breaking opportunity exists after every <a>preserved</a> <a>white space</a> character,
-        including between white space characters.
+        including between [=white space characters=].
 
         <wpt>
           overflow-wrap/overflow-wrap-break-word-002.html
@@ -832,7 +832,7 @@ Text Processing</h3>
           white-space/break-spaces-tab-006.html
         </wpt>
 
-      Such preserved spaces take up space and do not [=hang=],
+      Such [=preserved=] [=white space characters=] take up space and do not [=hang=],
       and thus affect the box's intrinsic sizes
       ([=min-content size=] and [=max-content size=]).
 
@@ -841,12 +841,12 @@ Text Processing</h3>
         white-space/white-space-intrinsic-size-002.html
       </wpt>
 
-      <p class="note">Note: This value does not guarantee that there will never be any overflow due to spaces:
-      for example, if the line length is so short that even a single space does not fit,
+      <p class="note">Note: This value does not guarantee that there will never be any overflow due to white space:
+      for example, if the line length is so short that even a single white space character does not fit,
       overflow is unavoidable.</p>
 
     <dt><dfn>pre-line</dfn></dt>
-    <dd>Like ''white-space/normal'', this value collapses consecutive spaces and allows wrapping,
+    <dd>Like ''white-space/normal'', this value collapses consecutive [=white space characters=] and allows wrapping,
       but preserves <a>segment breaks</a> in the source as <a>forced line breaks</a>.
 
       <wpt pathprefix="/css/CSS2/text/">
@@ -941,15 +941,15 @@ Text Processing</h3>
   </table>
 
   <p>See <a href="#white-space-processing">White Space Processing Rules</a>
-    for details on how white space collapses. An informative summary of
+    for details on how [=white space=] collapses. An informative summary of
     collapsing (''white-space/normal'' and ''nowrap'') is presented below:
     <ul>
       <li>A sequence of segment breaks and other <a>white space</a> between two
         Chinese, Japanese, or Yi characters collapses into nothing.
-      <li>A zero width space before or after a white space sequence
+      <li>A zero width space before or after a [=white space=] sequence
         containing a segment break causes the entire sequence of <a>white space</a>
         to collapse into a zero width space.
-      <li>Otherwise, consecutive <a>white space</a> collapses into a single space.
+      <li>Otherwise, consecutive <a>white space</a> collapses into a single [=space=].
     </ul>
 
   <p>See <a href="#line-breaking">Line Breaking</a>
@@ -962,10 +962,10 @@ Text Processing</h3>
     that is not relevant to the final rendering: for example,
     <a href="http://rhodesmill.org/brandon/2012/one-sentence-per-line/">breaking the source into segments</a>
     (lines) for ease of editing
-    or adding white space characters such as tabs and spaces to indent the source code.
+    or adding [=white space characters=] such as [=tabs=] and [=spaces=] to indent the source code.
     CSS white space processing allows the author to control interpretation of such formatting:
     to preserve or collapse it away when rendering the document.
-    White space processing in CSS interprets white space characters only for rendering:
+    White space processing in CSS interprets [=white space characters=] only for rendering:
     it has no effect on the underlying document data.
 
   <p>White space processing in CSS is controlled with the 'white-space' property.
@@ -1084,7 +1084,7 @@ Text Processing</h3>
     <p>Except where specified otherwise,
     White space processing in CSS affects only
       the <dfn export lt="white space|white space characters| document white space|document white space characters">document white space characters</dfn>:
-      spaces (U+0020), tabs (U+0009), and <a href="#white-space-processing">segment breaks</a>.
+      <dfn>spaces</dfn> (U+0020), <dfn>tabs</dfn> (U+0009), and <a href="#white-space-processing">segment breaks</a>.
 
       <wpt pathprefix="/css/CSS2/text/">
         white-space-normal-003.xht
@@ -1147,7 +1147,7 @@ Text Processing</h3>
     <p>For each inline (including anonymous inlines;
       see [[CSS2]] section <a href="https://www.w3.org/TR/CSS2/visuren.html#anonymous">9.2.2.1</a>)
       within an inline
-      formatting context, white space characters are handled as follows,
+      formatting context, [=white space characters=] are handled as follows,
       ignoring <dfn noexport>bidi formatting characters</dfn>
       (characters with the <code>Bidi_Control</code> property [[!UAX9]])
       as if they were not there:
@@ -1159,10 +1159,10 @@ Text Processing</h3>
     <ul>
     <li id="collapse"><p>If 'white-space' is set to
       ''white-space/normal'', ''nowrap'', or ''pre-line'',
-      white space characters are considered <dfn export lt="collapsible white space|collapsible">collapsible</dfn>
+      [=white space characters=] are considered <dfn export lt="collapsible white space|collapsible">collapsible</dfn>
       and are processed by performing the following steps:</p>
       <ol>
-        <li>Any sequence of collapsible spaces and tabs
+        <li>Any sequence of collapsible [=spaces=] and [=tabs=]
           immediately preceding or following a <a>segment break</a>
           is removed.
 
@@ -1181,7 +1181,7 @@ Text Processing</h3>
         <li>Collapsible <a>segment breaks</a> are transformed for
           rendering according to the <a href="#line-break-transform">segment break transformation rules</a>.
         </li>
-        <li>Every collapsible tab is converted to a collapsible space (U+0020).
+        <li>Every [=collapsible=] [=tab=] is converted to a collapsible space (U+0020).
 
           <wpt>
             white-space/white-space-collapse-000.html
@@ -1192,9 +1192,9 @@ Text Processing</h3>
             white-space-processing-021.xht
           </wpt>
         </li>
-        <li>Any collapsible space immediately following another collapsible space&mdash;even
-          one outside the boundary of the inline containing that space,
-          provided both spaces are within the same inline formatting
+        <li>Any [=collapsible=] [=space=] immediately following another [=collapsible=] [=space=]&mdash;even
+          one outside the boundary of the inline containing that [=space=],
+          provided both [=spaces=] are within the same inline formatting
           context&mdash;is collapsed to have zero advance width. (It is
           invisible, but retains its <a>soft wrap opportunity</a>, if any.)
 
@@ -1240,9 +1240,9 @@ Text Processing</h3>
     <li><p>If 'white-space' is set to ''pre'', ''pre-wrap'', or ''break-spaces'',
       any sequence of spaces is treated as a sequence of non-breaking spaces.
       However, for ''pre-wrap'',
-      a <a>soft wrap opportunity</a> exists at the end of a sequence of spaces and/or tabs,
+      a <a>soft wrap opportunity</a> exists at the end of a sequence of [=spaces=] and/or [=tabs=],
       while for ''break-spaces'',
-      a <a>soft wrap opportunity</a> exists after every space and every tab.
+      a <a>soft wrap opportunity</a> exists after every [=space=] and every [=tab=].
       <wpt>
         overflow-wrap/overflow-wrap-break-word-004.html
         overflow-wrap/overflow-wrap-break-word-005.html
@@ -1320,7 +1320,7 @@ Text Processing</h3>
     <div class="example" id="egbidiwscollapse">
       <p>The following example illustrates
         the interaction of white-space collapsing and bidirectionality.
-        Consider the following markup fragment, taking special note of spaces
+        Consider the following markup fragment, taking special note of [=spaces=]
         (with varied backgrounds and borders for emphasis and identification):
 
       <pre><code>&lt;ltr&gt;A<span class="egbidiwsaA">&#160;</span>&lt;rtl&gt;<span class="egbidiwsbB">&#160;</span>B<span class="egbidiwsaB">&#160;</span>&lt;/rtl&gt;<span class="egbidiwsbC">&#160;</span>C&lt;/ltr&gt;</code></pre>
@@ -1331,13 +1331,13 @@ Text Processing</h3>
         the white-space processing model will result in the following:
 
       <ul style="line-height:1.3">
-        <li>The space before the B (<span class="egbidiwsbB">&#160;</span>)
-          will collapse with the space after the A (<span class="egbidiwsaA">&#160;</span>).
-        <li>The space before the C (<span class="egbidiwsbC">&#160;</span>)
-          will collapse with the space after the B (<span class="egbidiwsaB">&#160;</span>).
+        <li>The [=space=] before the B (<span class="egbidiwsbB">&#160;</span>)
+          will collapse with the [=space=] after the A (<span class="egbidiwsaA">&#160;</span>).
+        <li>The [=space=] before the C (<span class="egbidiwsbC">&#160;</span>)
+          will collapse with the [=space=] after the B (<span class="egbidiwsaB">&#160;</span>).
       </ul>
 
-      <p>This will leave two spaces,
+      <p>This will leave two [=spaces=],
         one after the A in the left-to-right embedding level,
         and one after the B in the right-to-left embedding level.
         The text will then be ordered according to the Unicode bidirectional algorithm,
@@ -1345,9 +1345,9 @@ Text Processing</h3>
 
       <pre>A<span class="egbidiwsaA">&#160;</span><span class="egbidiwsaB">&#160;</span>BC</pre>
 
-      <p>Note that there will be two spaces between A and B,
+      <p>Note that there will be two [=spaces=] between A and B,
         and none between B and C.
-        This is best avoided by putting spaces outside the element
+        This is best avoided by putting [=spaces=] outside the element
         instead of just inside the opening and closing tags and, where practical,
         by relying on implicit bidirectionality instead of explicit embedding levels.
     </div>
@@ -1383,8 +1383,8 @@ Text Processing</h3>
         </wpt>
 
       <ul>
-        <li>If the character immediately before or immediately after the segment
-          break is the zero-width space character (U+200B), then the break
+        <li>If the character immediately before or immediately after the [=segment break=]
+	  is the zero-width space character (U+200B), then the break
           is removed, leaving behind the zero-width space.
 
           <wpt>
@@ -1396,11 +1396,11 @@ Text Processing</h3>
             segment-break-transformation-removable-3.html
           </wpt>
         <li>Otherwise, if the <a>East Asian Width property</a> [[!UAX11]] of both
-          the character before and after the segment break is
+          the character before and after the [=segment break=] is
           <code>Fullwidth</code>, <code>Wide</code>, or <code>Halfwidth</code>
           (not <code>Ambiguous</code>),
           and neither side is Hangul,
-          then the segment break is removed.
+          then the [=segment break=] is removed.
 
           <wpt>
             white-space/seg-break-transformation-001.html
@@ -1471,18 +1471,18 @@ Text Processing</h3>
           </wpt>
         <li>Otherwise, if the <a>writing system</a> of the <a>segment break</a>
           is <a for=writing-system>Chinese</a>, <a for=writing-system>Japanese</a>, or Yi,
-          and the character before or after the segment break
+          and the character before or after the [=segment break=]
           is punctuation or a symbol (Unicode <a>general category</a> P* or S*)
           and has an <a>East Asian Width property</a> of <code>Ambiguous</code>,
-          and the character on the other side of the segment break is
+          and the character on the other side of the [=segment break=] is
           <code>Fullwidth</code>, <code>Wide</code>, or <code>Halfwidth</code>,
           and not Hangul,
-          then the segment break is removed.
+          then the [=segment break=] is removed.
 
           <wpt>
             writing-system/writing-system-segment-break-001.html
           </wpt>
-        <li>Otherwise, the segment break is converted to a space (U+0020).
+        <li>Otherwise, the [=segment break=] is converted to a space (U+0020).
       </ul>
 
       <p>
@@ -1494,7 +1494,7 @@ Text Processing</h3>
         <code>Ambiguous</code>.
 
       <p class="note">Note: The white space processing rules have already
-        removed any tabs and spaces after the segment break before these checks
+        removed any [=tabs=] and [=spaces=] after the [=segment break=] before these checks
         take place.</p>
 
       <div class="example">
@@ -1504,7 +1504,7 @@ Text Processing</h3>
         <a href="#white-space-processing">broken into segments</a>
         to make the document source code easier to work with.
         In languages that use word separators, such as English and Korean,
-        “unbreaking” a line requires joining the two lines with a space.
+        “unbreaking” a line requires joining the two lines with a [=space=].
 
         <figure>
           <pre>
@@ -1515,7 +1515,7 @@ Text Processing</h3>
           </pre>
           <p>Here is an English paragraph that is broken into multiple lines in the source code so that it can be more easily read in a text editor.</p>
           <figcaption>
-            Eliminating a line break in English requires maintaining a space in its place.
+            Eliminating a line break in English requires maintaining a [=space=] in its place.
           </figcaption>
         </figure>
 
@@ -1530,7 +1530,7 @@ Text Processing</h3>
           </pre>
           <p>这个段落是呢么长，在一行不行。最好用三行写。</p>
           <figcaption>
-            Eliminating a line break in Chinese requires eliminating any intervening white space.
+            Eliminating a line break in Chinese requires eliminating any intervening [=white space=].
           </figcaption>
         </figure>
 
@@ -1550,7 +1550,7 @@ Text Processing</h3>
 
     <p>As each line is laid out,</p>
     <ol>
-      <li>A sequence of collapsible spaces at the beginning of a line
+      <li>A sequence of [=collapsible=] [=spaces=] at the beginning of a line
         (ignoring any intervening <a>inline box</a> boundaries)
         is removed.
 
@@ -1567,14 +1567,14 @@ Text Processing</h3>
           white-space-processing-040.xht
           white-space-processing-041.xht
         </wpt>
-      <li>If the tab size is zero, tabs are not rendered.
-        Otherwise, each tab is rendered as a horizontal shift
+      <li>If the [=tab size=] is zero, [=preserved=] [=tabs=] are not rendered.
+        Otherwise, each [=preserved=] [=tab=] is rendered as a horizontal shift
         that lines up the start edge of the next glyph with the next <a>tab stop</a>.
         If this distance is less than 0.5<a href="https://www.w3.org/TR/css-values-3/#ch">ch</a>,
         then the subsequent <a>tab stop</a> is used instead.
-        <dfn lt="tab stop">Tab stops</dfn> occur at points that are multiples of the tab size
+        <dfn lt="tab stop">Tab stops</dfn> occur at points that are multiples of the [=tab size=]
         from the block's starting content edge.
-        The tab size is given by the 'tab-size' property.
+        The [=tab size=] is given by the 'tab-size' property.
 
         <wpt>
           white-space/tab-stop-threshold-001.html
@@ -1595,7 +1595,7 @@ Text Processing</h3>
 
       <li>A sequence at the end of a line
         (ignoring any intervening <a>inline box</a> boundaries)
-        of <a>collapsible</a> spaces (U+0020)
+        of <a>collapsible</a> [=spaces=]
         and/or [=other space separators=] whose 'white-space' value collapses spaces
         is removed.
 
@@ -1623,7 +1623,7 @@ Text Processing</h3>
         </wpt>
       <li>If there remains any sequence of <a>white space</a>,
         [=other space separators=],
-	and/or tabs
+	and/or [=preserved=] [=tabs=]
         at the end of a line:
         <ul>
           <li>If 'white-space' is set to ''pre-wrap'',
@@ -1671,7 +1671,9 @@ Text Processing</h3>
              Note: [=Hanging=] the white space rather than collapsing it
              allows users to see the space when selecting or editing text.
           <li>If 'white-space' is set to ''break-spaces'',
-             [=hanging=] or collapsing the advance width of the spaces or tabs
+             [=hanging=] or collapsing the advance width of the [=spaces=],
+	     [=tabs=],
+	     or [=other space separators=]
              at the end of the line is not allowed;
              those that overflow must <a>wrap</a> to the next line.
 
@@ -1716,10 +1718,10 @@ Text Processing</h3>
       &lt;p>Lorem ipsum      &lt;/p>
       </code></pre>
 
-      As the preserved spaces at the end of the line must [=hang=],
+      As the [=preserved=] [=spaces=] at the end of the line must [=hang=],
       they are not considered when placing the rest of the line during text alignment.
       When aligning towards the end,
-      this means any such spaces will overflow,
+      this means any such [=spaces=] will overflow,
       and will not prevent the rest of the line's content from being flush with the edge of the line.
       The sample above would therefore be rendered as follows:
       <pre class=output style="width: 20ch; border: solid 1px; text-align: end;">
@@ -1751,7 +1753,7 @@ Text Processing</h3>
       parsing/tab-size-computed.html
     </wpt>
 
-    <p>This property determines the tab size used to render preserved tab characters (U+0009).
+    <p>This property determines the <dfn id=tab-size-dfn>tab size</dfn> used to render [=preserved=] tab characters (U+0009).
       A <<number>> represents the measure as a multiple of the space character's advance width (U+0020)
       including its associated 'letter-spacing' and 'word-spacing'.
       Negative values are not allowed.
@@ -1800,7 +1802,7 @@ Text Processing</h3>
 
   <p>In most writing systems,
     in the absence of hyphenation a <a>soft wrap opportunity</a> occurs only at word boundaries.
-    Many such systems use spaces or punctuation to explicitly separate words,
+    Many such systems use [=spaces=] or punctuation to explicitly separate words,
     and <a>soft wrap opportunities</a> can be identified by these characters.
     Scripts such as Thai, Lao, and Khmer, however,
     do not use spaces or punctuation to separate words.
@@ -2293,7 +2295,7 @@ Line Breaking Details</h3>
       <code>NU</code>, <code>AL</code>, <code>AI</code>, or <code>ID</code>
       Unicode line breaking classes [[!UAX14]]).
       It does not affect rules governing the <a>soft wrap opportunities</a>
-      created by spaces (including [=other space separators=]) and around punctuation.
+      created by [=white space=] (as well as by [=other space separators=]) and around punctuation.
       (See 'line-break' for controls affecting punctuation and small kana.)
 
       <wpt>
@@ -2452,9 +2454,9 @@ Line Breaking Details</h3>
           word-break/word-break-keep-all-003.html
         </wpt>
 
-        <p class=note>Note: This is the other common behavior for Korean (which uses spaces between words),
+        <p class=note>Note: This is the other common behavior for Korean (which uses [=spaces=] between words),
         and is also useful for mixed-script text where CJK snippets are mixed
-        into another language that uses spaces for separation.
+        into another language that uses [=spaces=] for separation.
     </dl>
 
     <p>Symbols that line-break the same way as letters of a particular category
@@ -2654,7 +2656,7 @@ Line Breaking Details</h3>
         because in other cases:
         * [=preserved white space=] at the end/start of the line is discarded (''white-space/normal'', ''white-space/pre-line'')
         * wrapping is forbidden altoghether (''nowrap'', ''pre'')
-        * the spaces [=hang=] (''pre-wrap'').
+        * the [=preserved white space=] [=hang=] (''pre-wrap'').
 
         When it does have an effect on [=preserved white space=],
         with ''white-space: break-spaces'',
@@ -3379,7 +3381,7 @@ Shaping Across Intra-word Breaks</h3>
 
     <p>In the case of ''justify'', the UA may stretch or shrink any inline boxes
       by <a href="#text-justify-property">adjusting</a> their text. (See 'text-justify'.)
-      If an element's white space is not <a href="#collapse">collapsible</a>,
+      If an element's [=white space=] is not <a href="#collapse">collapsible</a>,
       then the UA is not required to adjust its text for the purpose of justification
       and may instead treat the text as having no <a>justification opportunities</a>.
       If the UA chooses to adjust the text, then it must ensure
@@ -4099,7 +4101,7 @@ Cursive Scripts</h4>
         <tr><td><img src="images/arabic-stretch-suppressed.png" alt="">
             <td class="ok">OK
             <th>Suppressing 'letter-spacing' between Arabic letters.
-                <em>Notice 'letter-spacing' is nonetheless applied to non-Arabic characters (like spaces).</em>
+                <em>Notice 'letter-spacing' is nonetheless applied to non-Arabic characters (like [=spaces=]).</em>
         <tr><td><img src="images/arabic-stretch-unjoined.png" alt="">
             <td class="no">BAD
             <th>Applying 'letter-spacing' only between non-joined letters.
@@ -4666,7 +4668,7 @@ Appendix B: Conversion to Plaintext</h2>
   <ul>
     <li>The 'text-transform' property has no effect.
     <li>[[#white-space-phase-1]] is applied and any sequence of
-        <a>collapsible</a> spaces at the beginning of a <a>block</a>
+        <a>collapsible</a> [=white space=] at the beginning of a <a>block</a>
         or immediately following a <a>forced line break</a> is removed.
   </ul>
 


### PR DESCRIPTION
Linkify and use non ambiguous terminology for "white space", "spaces",
and related terminology throughout normative prose.

Closes #4267