### PR TITLE
[css-animations-1][css-backgrounds-4][css-fonts-4] Fix multiplier usage in propdef/descdef

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -813,7 +813,7 @@ The 'animation' shorthand property</h3>
 
 	<pre class='propdef'>
 	Name: animation
-	Value: 	<<single-animation>> #
+	Value: 	<<single-animation>>#
 	Initial: see individual properties
 	Applies to: all elements
 	Inherited: no

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -189,7 +189,7 @@ Painting Area: the 'background-clip' property</h3>
 
 	<pre class="propdef shorthand">
 	Name: border-color
-	Value: <<color>>{1,4}#
+	Value: <<color>>#{1,4}
 	</pre>
 
 	These properties set the foreground color of the border specified

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -56,7 +56,7 @@ Font family: the 'font-family!!property' property</h3>
 
     <pre class="propdef">
     Name: font-family
-    Value: [ <<family-name>> | <<generic-family>> ] #
+    Value: [ <<family-name>> | <<generic-family>> ]#
     Initial: depends on user agent
     Applies to: all elements
     Inherited: yes
@@ -2090,7 +2090,7 @@ Font property descriptors: the 'font-style!!descriptor', 'font-weight!!descripto
 
 	<pre class='descdef'>
 	Name: font-style
-	Value: auto | normal | italic | oblique [ <<angle>> | <<angle>> <<angle>> ] ?
+	Value: auto | normal | italic | oblique [ <<angle>> | <<angle>> <<angle>> ]?
 	For: @font-face
 	Initial: auto
 	</pre>
@@ -2212,7 +2212,7 @@ Character range: the 'unicode-range' descriptor</h3>
 
 <pre class='descdef'>
 Name: unicode-range
-Value: <<urange>> #
+Value: <<urange>>#
 Initial: U+0-10FFFF
 For: @font-face
 </pre>
@@ -2442,14 +2442,14 @@ For: @font-face
 
 <pre class='descdef'>
 Name: font-feature-settings
-Value: normal | <<feature-tag-value>> #
+Value: normal | <<feature-tag-value>>#
 Initial: normal
 For: @font-face
 </pre>
 
 <pre class='descdef'>
 Name: font-variation-settings
-Value: normal | [ <<string>> <<number>>] #
+Value: normal | [ <<string>> <<number>>]#
 Initial: normal
 For: @font-face
 </pre>
@@ -4761,7 +4761,7 @@ Low-level font feature settings control: the 'font-feature-settings!!property' p
 <pre class="propdef">
 Name: font-feature-settings
 
-Value: 	normal | <<feature-tag-value>> #
+Value: 	normal | <<feature-tag-value>>#
 Initial: normal
 Applies to: all elements
 Inherited: yes
@@ -5328,7 +5328,7 @@ Low-level font variation settings control: the 'font-variation-settings' propert
 
 <pre class="propdef">
 Name: font-variation-settings
-Value: normal | [ <<string>> <<number>>] #
+Value: normal | [ <<string>> <<number>>]#
 Initial: normal
 Applies to: all elements
 Inherited: yes


### PR DESCRIPTION
- a multiplier should stick to a term
- `#` multiplier should go before `{N,M}`