### PR TITLE
[css-tables-3] Remove invisible symbols in <'border-spacing'> syntax definition

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -815,7 +815,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 			<pre class='propdef'>
 				Name: border-spacing
-				Value: <​length​>{1,2}
+				Value: <length>{1,2}
 				Initial: 0px 0px
 				Inherited: yes
 				Applies To: <a>table grid boxes</a> when 'border-collapse' is ''border-collapse/separate''


### PR DESCRIPTION
Removed symbols even not visible on GitHub's diff view.
The diff from GitHub Desktop client:
![image](https://user-images.githubusercontent.com/270491/64230787-6bf4e900-cef6-11e9-8e22-c6674af1a2d7.png)
