### PR TITLE
[css-backgrounds] computed background-position-*

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -17,6 +17,7 @@ Warning: Not Ready
 
 <pre class="link-defaults">
 spec:css-text-4; type:value; text:collapse
+spec:css-shapes-2; type:function; text:path()
 </pre>
 
 <h2 id="intro">
@@ -89,7 +90,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Initial: 0%
 		Inherited: no
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
-		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword
+		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 	</pre>
 
 	This property specifies the background position's horizontal component.
@@ -101,7 +102,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Initial: 0%
 		Inherited: no
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image
-		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword
+		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 	</pre>
 
 	This property specifies the background position's vertical component.
@@ -113,7 +114,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Initial: not applicable (initial value comes from physical property)
 		Inherited: no
 		Percentages: refer to inline-size of background positioning area <em>minus</em> inline-size of background image
-		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword
+		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 	</pre>
 
 	This property specifies the background position's inline-axis component.
@@ -125,7 +126,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Initial: not applicable (initial value comes from physical property)
 		Inherited: no
 		Percentages: refer to size of background positioning area <em>minus</em> size of background image
-		Computed value: A list, each item consisting of: an offset given as a combination of an absolute length and a percentage, plus an origin keyword
+		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 	</pre>
 
 	This property specifies the background position's block-axis component.


### PR DESCRIPTION
Computed length-percentage values for background-position longhands
is now specified using the same terminology as for other properties.
