### PR TITLE
Revert "[css-tables-3] Remove invisible symbols in <'border-spacing'> syntax definition"

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -815,7 +815,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 			<pre class='propdef'>
 				Name: border-spacing
-				Value: <length>{1,2}
+				Value: <​length​>{1,2}
 				Initial: 0px 0px
 				Inherited: yes
 				Applies To: <a>table grid boxes</a> when 'border-collapse' is ''border-collapse/separate''


### PR DESCRIPTION
Reverts w3c/csswg-drafts#4275