### PR TITLE
[css-nav-1] Update the search origin after scrolling

### DIFF
--- a/css-nav-1/Overview.bs
+++ b/css-nav-1/Overview.bs
@@ -1089,17 +1089,18 @@ run the following steps:
     then return it.
 3. Otherwise, return <var>searchOrigin</var>.
 
-If the status of <var>old focus target</var> changed not by the spatial navigation,
+If the status of <var>old focus target</var> changed not by moving the focus,
 <dfn lt="update the search origin | updating the search origin">update the <a>search origin</a></dfn> as following:
-1. If <var>old focus target</var> becomes
+1. If <var>old focus target</var> is
     <a>actually disabled</a> or
     <a>expressly inert</a> or
     not <a>being rendered</a>,
     then let <var>searchOrigin</var> be the [=boundary box=] of <var>old focus target</var>.
 2. If <var>old focus target</var> is <a>removed</a>,
     then let <var>searchOrigin</var> be the [=boundary box=] of <var>old focus target</var> with the position of <var>old focus target</var> when it existed.
-3. Otherwise,
-    let <var>searchOrigin</var> be the viewport of <var>old focus target</var>'s <a>spatial navigation container</a>.
+3. If <var>old focus target</var> is completely off-screen,
+    then let <var>searchOrigin</var> be the viewport of <var>old focus target</var>'s <a>spatial navigation container</a>.
+
 </div>
 
 <div algorithm="to find focusable areas">


### PR DESCRIPTION
The search origin will be updated only when the old focus target is completely off-screen after the scrolling.

(Note: If the old focus target is partially in the view after scrolling, the search origin won't be changed)

Related issue: https://github.com/w3c/csswg-drafts/issues/3392
