### PR TITLE
[css-grid-1] Initialize growth limits of flexible tracks to infinity. #4313

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -3894,12 +3894,9 @@ Initialize Track Sizes</h3>
 			Resolve to an absolute length and use that size as the track’s initial <a>growth limit</a>.
 
 		<dt>An <a>intrinsic sizing function</a>
-		<dd>
-			Use an initial <a>growth limit</a> of infinity.
-
 		<dt>A <a>flexible sizing function</a>
 		<dd>
-			Use the track’s initial <a>base size</a> as its initial <a>growth limit</a>.
+			Use an initial <a>growth limit</a> of infinity.
 	</dl>
 
 	In all cases, if the <a>growth limit</a> is less than the <a>base size</a>,
@@ -4177,9 +4174,6 @@ Resolve Intrinsic Track Sizes</h3>
 			an <a lt="intrinsic sizing function">intrinsic</a> <a>min track sizing function</a>
 			while
 			<ul>
-				<li>
-					treating <a>flexible tracks</a> as having
-					an infinite <a>growth limit</a>
 				<li>
 					distributing space <em>only</em> to <a>flexible tracks</a>
 					(i.e. treating all other tracks as having a <a>fixed sizing function</a>)
@@ -4765,6 +4759,27 @@ Minor Changes</h4>
 						then one is first <a lt="synthesize baselines">synthesized</a>
 						from its border edges.
 				</ul>
+			</blockquote>
+		<li id="change-2017-flex-initial-growth-limit">
+			Initialize the <a>growth limit</a> of <a>flexible tracks</a> to infinity,
+			instead of setting it first to the base size and changing it later.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/4313">Issue 4313</a>)
+			<blockquote>
+				<dl>
+					<dt>An <a>intrinsic sizing function</a>
+					<dt><ins>A <a>flexible sizing function</a></ins>
+					<dd>
+						Use an initial <a>growth limit</a> of infinity.
+
+					<dt><del>A <a>flexible sizing function</a></del>
+					<dd>
+						<del>Use the track’s initial <a>base size</a> as its initial <a>growth limit</a>.</del>
+			</blockquote>
+			<blockquote>
+				<ul>
+					<li>
+						<del>treating <a>flexible tracks</a> as having
+						an infinite <a>growth limit</a>
 			</blockquote>
 	</ul>
 


### PR DESCRIPTION
Fixes #4313.

I added the changes into "Minor Changes", but the change has no effect in practice, not sure if this means it should be in "Clarifications" instead.