### PR TITLE
remove font-variant support from FontFace

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -84,7 +84,6 @@ The <code>FontFace</code> Interface</h2>
 			CSSOMString weight = "normal";
 			CSSOMString stretch = "normal";
 			CSSOMString unicodeRange = "U+0-10FFFF";
-			CSSOMString variant = "normal";
 			CSSOMString featureSettings = "normal";
 			CSSOMString variationSettings = "normal";
 			CSSOMString display = "auto";
@@ -101,7 +100,6 @@ The <code>FontFace</code> Interface</h2>
 			attribute CSSOMString weight;
 			attribute CSSOMString stretch;
 			attribute CSSOMString unicodeRange;
-			attribute CSSOMString variant;
 			attribute CSSOMString featureSettings;
 			attribute CSSOMString variationSettings;
 			attribute CSSOMString display;
@@ -140,7 +138,6 @@ The <code>FontFace</code> Interface</h2>
 			throw a {{SyntaxError}};
 			otherwise, set the attribute to the serialization of the parsed value.
 
-		: <dfn>variant</dfn>
 		: <dfn>featureSettings</dfn>
 		: <dfn>variationSettings</dfn>
 		: <dfn>display</dfn>
@@ -394,7 +391,7 @@ Interaction with CSS’s ''@font-face'' Rule</h3>
 	This {{FontFace}} object is <dfn>CSS-connected</dfn>.
 
 	The {{FontFace}} object corresponding to a ''@font-face'' rule
-	has its {{FontFace/family}}, {{FontFace/style}}, {{FontFace/weight}}, {{FontFace/stretch}}, {{FontFace/unicodeRange}}, {{FontFace/variant}}, and {{FontFace/featureSettings}} attributes
+	has its {{FontFace/family}}, {{FontFace/style}}, {{FontFace/weight}}, {{FontFace/stretch}}, {{FontFace/unicodeRange}}, and {{FontFace/featureSettings}} attributes
 	set to the same value as the corresponding descriptors in the ''@font-face'' rule.
 	There is a two-way connection between the two:
 	any change made to a ''@font-face'' descriptor is immediately reflected in the corresponding {{FontFace}} attribute,


### PR DESCRIPTION
This implements the Font Loading API part of https://github.com/w3c/csswg-drafts/issues/2531#issuecomment-532073065.