### PR TITLE
[web-animations-1] Fix box-shadow addition/accumulation

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -213,6 +213,7 @@ spec:cssom-1;
     type: dfn;
         text: CSS declaration block
 spec:infra; type:dfn; text:list
+spec:infra; type:dfn; for:list; text:extend
 </pre>
 
 <script type="text/x-mathjax-config">
@@ -6203,8 +6204,13 @@ with shadows whose color is ''transparent'',
 all lengths are ''0'',
 and whose ''shadow/inset'' (or not) matches the longer list.
 
-<a lt="value addition">Addition</a> of [=shadow lists=] follows the
+<a lt="value addition">Addition</a> of two [=shadow lists=]
+<var>V<sub>a</sub></var> and <var>V<sub>b</sub></var> is defined as <a>list</a>
+concatenation such that <var ignore=''>V<sub>result</sub></var> is equal to
+<var>V<sub>a</sub></var> <a lt="extend">extended</a> with
+<var>V<sub>b</sub></var>.
+
+<a lt="value accumulation">Accumulation</a> of [=shadow lists=] follows the
 matching rules for interpolation above, performing addition on each component
-according to its type,
-or falling back to [=discrete=] animation if the ''shadow/inset'' values
-do not match.
+according to its type, or falling back to [=discrete=] animation if the
+''shadow/inset'' values do not match.


### PR DESCRIPTION
To align with other list-list properties, box-shadow
addition/accumulation is changed to be defined as concatenation for
addition (previously component-wise addition) and component-wise
addition for accumulation (previously unspec'd).

Fixes https://github.com/w3c/csswg-drafts/issues/4330