### PR TITLE
[css-text-decor-3] Specify animation addition/accumulation behavior for text-shadow

### DIFF
--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -899,9 +899,10 @@ concatenation such that <var ignore>V<sub>result</sub></var> is equal to
 <var>V<sub>a</sub></var> [=list/extended=] with <var>V<sub>b</sub></var>.
 
 <a lt="value accumulation">Accumulation</a> of two text-shadow lists
-<var>V<sub>a</sub></var> and <var>V<sub>b</sub></var> follows the same
-approach as interpolation of two text-shadow lists. The algorithm is defined
-in the <b>Animation type</b> section of 'text-shadow'.
+<var>V<sub>a</sub></var> and <var>V<sub>b</sub></var> follows the padding rules
+for interpolation as defined in the <b>Animation type</b> section of
+'text-shadow'. Instead of interpolating, however, accumulation performs
+addition on each component according to its type.
 
 <h2 id="painting">
 Painting Text Decorations</h2>

--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -24,6 +24,8 @@ Use <i> Autolinks: yes
 <pre class="link-defaults">
 spec:css-break-3; type:dfn; text:fragment
 spec:css-display-3; type:property; text:display
+spec:infra; type:dfn; text:list
+spec:web-animations-1; type:dfn; text:composite operation
 </pre>
 
 <h2 id="intro">
@@ -885,6 +887,21 @@ Text Shadows: the 'text-shadow' property</h2>
 	The ''text-shadow'' property applies to both the
 	<code>::first-line</code> and <code>::first-letter</code>
 	pseudo-elements.
+
+<h3 id="combining-text-shadows">Addition and accumulation of text-shadows</h3>
+
+<a lt="composite operation">Composition</a> of text-shadow values when animating
+follows the same model as 'box-shadow', as follows:
+
+<a lt="value addition">Addition</a> of two text-shadow lists
+<var>V<sub>a</sub></var> and <var>V<sub>b</sub></var> is defined as [=list=]
+concatenation such that <var ignore>V<sub>result</sub></var> is equal to
+<var>V<sub>a</sub></var> [=list/extended=] with <var>V<sub>b</sub></var>.
+
+<a lt="value accumulation">Accumulation</a> of two text-shadow lists
+<var>V<sub>a</sub></var> and <var>V<sub>b</sub></var> follows the same
+approach as interpolation of two text-shadow lists. The algorithm is defined
+in the <b>Animation type</b> section of 'text-shadow'.
 
 <h2 id="painting">
 Painting Text Decorations</h2>


### PR DESCRIPTION
Previously there was no definition of text-shadow composition. To match the behavior of other list-like properties such as transform lists (https://drafts.csswg.org/css-transforms-2/#combining-transform-lists) and box-shadow (https://github.com/w3c/csswg-drafts/pull/4374), this PR specs addition as list concatenation and accumulation as component-wise addition.

See https://github.com/w3c/csswg-drafts/issues/4330