### PR TITLE
[css-values] Change MAY into MUST regarding calc() on table

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -3333,7 +3333,7 @@ Computed Value</h3>
 	math expressions mixing both percentages and lengths for widths and heights on
 	table columns, table column groups, table rows, table row groups, and table cells
 	in both auto and fixed layout tables
-	MAY be treated as if ''width/auto'' had been specified.
+	MUST be treated as if ''width/auto'' had been specified.
 
 
 <h3 id='calc-range'>


### PR DESCRIPTION
#94 has made a resolution that certain `calc()` mixing both lengths and percentages MUST be treated as `auto` instead of MAY. Updating spec accordingly.

Relevant WPT are updated in https://chromium-review.googlesource.com/c/chromium/src/+/1832619.