### PR TITLE
[css-values-4] Fix typos in comma-separated-list multiplier notes

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -97,8 +97,8 @@ Component Value Types</h3>
 			Such a type does <em>not</em> include <a href="#common-keywords">CSS-wide keywords</a> such as ''inherit'',
 			and also does not include any top-level <a href="#mult-comma">comma-separated-list multiplier</a>
 			(i.e. if a property named <css>pairing</css> is defined as <css>[ <<custom-ident>> <<integer>>? ]#</css>,
-			then \<<\'pairing'>> is equivalent to <css>[ <<custom-ident>> <<integer>>? ]</css>,
-			not <css><<custom-ident>> <<integer>> ]#</css>).
+			then \<\'pairing'> is equivalent to <css>[ <<custom-ident>> <<integer>>? ]</css>,
+			not <css>[ <<custom-ident>> <<integer>>? ]#</css>).
 
 		<li>
 			non-terminals that do not share the same name as a property.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -97,7 +97,7 @@ Component Value Types</h3>
 			Such a type does <em>not</em> include <a href="#common-keywords">CSS-wide keywords</a> such as ''inherit'',
 			and also does not include any top-level <a href="#mult-comma">comma-separated-list multiplier</a>
 			(i.e. if a property named <css>pairing</css> is defined as <css>[ <<custom-ident>> <<integer>>? ]#</css>,
-			then \<\'pairing'> is equivalent to <css>[ <<custom-ident>> <<integer>>? ]</css>,
+			then <css>&lt;\'pairing'></css> is equivalent to <css>[ <<custom-ident>> <<integer>>? ]</css>,
 			not <css>[ <<custom-ident>> <<integer>>? ]#</css>).
 
 		<li>


### PR DESCRIPTION
- Added missed chars in example definition, since it should be as original defined
- Remove doubling `<` and `>` around "pairing", since it renders odd

![image](https://user-images.githubusercontent.com/270491/66390333-246ceb80-e9d3-11e9-9e03-d5ec5612505d.png)

