### PR TITLE
[cssom] Fix a typo in #serialize-a-local

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -259,7 +259,7 @@ string, followed by "<code>)</code>".
 
 To <dfn export>serialize a LOCAL</dfn> means to create a string represented by
 "<code>local(</code>", followed by the
-<a lt="serialize a string">serialization</a> of the URL as a
+<a lt="serialize a string">serialization</a> of the LOCAL as a
 string, followed by "<code>)</code>".
 
 To <dfn export>serialize a comma-separated list</dfn> concatenate all items of


### PR DESCRIPTION
> To serialize a URL means to create a string represented by "url(", followed by the serialization of the URL as a string, followed by ")".
> 
> To serialize a LOCAL means to create a string represented by "local(", followed by the serialization of the URL as a string, followed by ")".

`s/URL/LOCAL/` in that last line. Looks like it was copied from the rule above and incompletely replaced.