### PR TITLE
[web-animations-1] reformat all headings to markdown style

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -221,7 +221,8 @@ spec:infra; type:dfn; for:list; text:extend
 </script>
 <script src="MathJax/MathJax.js?config=MML_SVG"></script>
 
-<h2 id="introduction">Introduction</h2>
+Introduction {#introduction}
+=======================================
 <div class='informative-bg'><em>This section is non-normative</em>
 
 Web Animations defines a model for supporting animation and
@@ -232,7 +233,8 @@ In addition, this specification also defines a programming interface to
 the model that may be implemented by user agents that provide support
 for scripting.
 
-<h3 id="use-cases">Use cases</h3>
+Use cases {#use-cases}
+----------------------------------------
 
 The Web Animations model is intended to provide the features necessary
 for expressing CSS Transitions [[CSS-TRANSITIONS-1]],
@@ -371,7 +373,8 @@ requestAnimationFrame(() =&gt; {
 });
 </pre></div>
 
-<h3 id="relationship-to-other-specifications">Relationship to other specifications</h3>
+Relationship to other specifications {#relationship-to-other-specifications}
+----------------------------------------
 
 CSS Transitions [[CSS-TRANSITIONS-1]], CSS Animations [[CSS-ANIMATIONS-1]], and
 SVG [[SVG11]] all provide mechanisms that
@@ -409,7 +412,8 @@ simultaneously without conflict.
 The programming interface component of this specification makes
 some additions to interfaces defined in HTML [[!HTML]].
 
-<h3 id="overview-of-this-specification">Overview of this specification</h3>
+Overview of this specification {#overview-of-this-specification}
+----------------------------------------
 
 This specification begins by defining an abstract model for animation.
 This is followed by a programming interface defined in terms of the
@@ -419,7 +423,8 @@ and is only relevant to user agents that provide scripting support.
 
 </div>
 
-<h2 id="spec-conventions">Specification conventions</h2>
+Specification conventions {#spec-conventions}
+=======================================
 
 This specification begins by describing abstract concepts such as [=animations=]
 and [=animation effects=] and properties that belong to them such as their
@@ -437,7 +442,8 @@ procedure.
 Further documentation conventions that are not specific to this specification
 are described in [[#document-conventions]].
 
-<h2 id="web-animations-model-overview">Web Animations model overview</h2>
+Web Animations model overview {#web-animations-model-overview}
+=======================================
 
 <div class='informative-bg'><em>This section is non-normative</em>
 
@@ -486,12 +492,14 @@ the animation model.
 
 </div>
 
-<h2 id="timing-model">Timing model</h2>
+Timing model {#timing-model}
+=======================================
 
 This section describes and defines the behavior of the Web Animations
 timing model.
 
-<h3 id="timing-model-overview">Timing model overview</h3>
+Timing model overview {#timing-model-overview}
+----------------------------------------
 
 <div class='informative-bg'>
 
@@ -500,7 +508,7 @@ timing model.
 Two features characterize the Web Animations timing model: it is
 <em>stateless</em> and it is <em>hierarchical</em>.
 
-<h4 id="stateless">Stateless</h4>
+### Stateless ### {#stateless}
 
 The Web Animations timing model operates by taking an input time and
 producing an output iteration progress.
@@ -552,7 +560,7 @@ href="#programming-interface" section>programming interface</a>, it has no
 influence on the subsequent updates and hence does not conflict with
 the stateless qualities described above.
 
-<h4 id="hierarchical">Hierarchical</h4>
+### Hierarchical ### {#hierarchical}
 
 The other characteristic feature of the timing model is that time is inherited.
 Time begins at a timeline and cascades down a number of steps to each
@@ -575,7 +583,8 @@ of group effects which allows for deeper timing hierarchies.
 
 </div>
 
-<h3 id="time-value-section">Time values</h3>
+Time values {#time-value-section}
+----------------------------------------
 
 Timing is based on a hierarchy of time relationships between timing nodes.
 Parent nodes provide timing information to their child nodes in the form
@@ -596,7 +605,8 @@ milliseconds will be weakened even further.
 A <a>time value</a> may also be <dfn>unresolved</dfn> if, for example,
 a timing node is not in a state to produce a <a>time value</a>.
 
-<h3 id="timelines">Timelines</h3>
+Timelines {#timelines}
+----------------------------------------
 
 A <dfn>timeline</dfn> provides a source of <a>time values</a> for the
 purpose of synchronization.
@@ -691,7 +701,7 @@ animation model to change, but these operations in themselves do not create
 a new [=animation frame=], rather they merely update the current <a>animation
 frame</a>.
 
-<h4 id="document-timelines">Document timelines</h4>
+### Document timelines ### {#document-timelines}
 
 A <dfn>document timeline</dfn> is a type of <a>timeline</a> that is <a
 lt="timeline associated with a document">associated
@@ -719,7 +729,7 @@ time, |timeline time|, to an origin-relative time</a> for a document timeline,
 |timeline|, return the sum of the |timeline time| and |timeline|'s [=origin
 time=]. If |timeline| is inactive, return an [=unresolved=] [=time value=].
 
-<h4 id="the-documents-default-timeline">The default document timeline</h4>
+### The default document timeline ### {#the-documents-default-timeline}
 
 Each {{Document}} has a <a>document timeline</a> called the <dfn>default
 document timeline</dfn>.
@@ -744,7 +754,8 @@ to the [=update animations and send events=] procedure.
 
 </div>
 
-<h3 id="animations">Animations</h3>
+Animations {#animations}
+----------------------------------------
 
 <div class="informative-bg"><em>This section is non-normative</em>
 
@@ -787,7 +798,7 @@ in which they are created. Certain <a lt="animation class">classes of
 animations</a>, however, may provide alternative means of ordering animations
 (see [[#animation-classes]]).
 
-<h4 id="setting-the-timeline">Setting the timeline of an animation</h4>
+### Setting the timeline of an animation ### {#setting-the-timeline}
 
 The procedure to <dfn>set the timeline of an animation</dfn>,
 <var>animation</var>, to <var>new timeline</var> which may be null, is as
@@ -877,7 +888,7 @@ The procedure to <dfn>reset an animation's pending tasks</dfn> for
     object</a> with value <var>animation</var> in the <a>relevant Realm</a> of
     <var>animation</var>.
 
-<h4 id="the-current-time-of-an-animation">The current time of an animation</h4>
+### The current time of an animation ### {#the-current-time-of-an-animation}
 
 <a>Animations</a> provide a <a>time value</a> to their <a>target
 effect</a> called the animation's <dfn>current time</dfn>.
@@ -913,7 +924,7 @@ matching condition from below:
 
 </div>
 
-<h4 id="setting-the-current-time-of-an-animation">Setting the current time of an animation</h4>
+### Setting the current time of an animation ### {#setting-the-current-time-of-an-animation}
 
 The <a>current time</a> of an animation can be set to a new value to
 <em>seek</em> the animation.
@@ -985,7 +996,7 @@ The procedure to <dfn>set the current time</dfn> of an animation,
     <var>animation</var> with the <var>did seek</var> flag set to true, and
     the <var>synchronously notify</var> flag set to false.
 
-<h4 id='setting-the-start-time-of-an-animation'>Setting the start time of an animation</h4>
+### Setting the start time of an animation ### {#setting-the-start-time-of-an-animation}
 
 The procedure to <dfn>set the start time</dfn>
 of <a>animation</a>, <var>animation</var>, to <var>new start time</var>,
@@ -1043,7 +1054,7 @@ is as follows:
     <var>animation</var> with the <var>did seek</var> flag set to true, and
     the <var>synchronously notify</var> flag set to false.
 
-<h4 id='waiting-for-the-target-effect'>Waiting for the target effect</h4>
+### Waiting for the target effect ### {#waiting-for-the-target-effect}
 
 <div class='informative-bg'>
 
@@ -1081,7 +1092,7 @@ following conditions are true:
 *   the animation is associated with a <a>timeline</a> that is not
     <a lt="inactive timeline">inactive</a>.
 
-<h4 id='the-current-ready-promise'>The current ready promise</h4>
+### The current ready promise ### {#the-current-ready-promise}
 
 Each <a>animation</a> has a <dfn>current ready promise</dfn>.
 The <a>current ready promise</a> is initially a resolved <a>Promise</a> created
@@ -1116,7 +1127,7 @@ animation.play();</pre></div>
 
 </div>
 
-<h4 id='playing-an-animation-section'>Playing an animation</h4>
+### Playing an animation ### {#playing-an-animation-section}
 
 The procedure to <dfn>play an animation</dfn>, <var>animation</var>, given
 a flag <var>auto-rewind</var>, is as follows:
@@ -1286,7 +1297,7 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
     <var>animation</var> with the <var>did seek</var> flag set to false, and
     the <var>synchronously notify</var> flag set to false.
 
-<h4 id='pausing-an-animation-section'>Pausing an animation</h4>
+### Pausing an animation ### {#pausing-an-animation-section}
 
 Whenever an <a>animation</a> has an <a>unresolved</a> [=start time=],
 its <a>current time</a> will be suspended.
@@ -1376,7 +1387,7 @@ follows:
     <var>animation</var> with the <var>did seek</var> flag set to false,
     and the <var>synchronously notify</var> flag set to false.
 
-<h4 id="reaching-the-end">Reaching the end</h4>
+### Reaching the end ### {#reaching-the-end}
 
 <div class='informative-bg'>
 
@@ -1427,7 +1438,7 @@ Similarly, when the [=playback rate=] is negative, the
 
 </div>
 
-<h4 id="the-current-finished-promise">The current finished promise</h4>
+### The current finished promise ### {#the-current-finished-promise}
 
 Each animation has a <dfn>current finished promise</dfn>.
 The <a>current finished promise</a> is initially a pending <a>Promise</a>
@@ -1436,7 +1447,7 @@ object.
 The object is replaced with a new <a>promise</a> every time
 the animation leaves the <a>finished play state</a>.
 
-<h4 id="updating-the-finished-state">Updating the finished state</h4>
+### Updating the finished state ### {#updating-the-finished-state}
 
 For an animation with a positive [=playback rate=], the <a>current time</a>
 continues to increase until it reaches the <a>target effect end</a>.
@@ -1633,7 +1644,7 @@ the procedure to <a>cancel an animation</a> similarly queues the
 
 </div>
 
-<h4 id="finishing-an-animation-section">Finishing an animation</h4>
+### Finishing an animation ### {#finishing-an-animation-section}
 
 An animation can be advanced to the natural end of its current playback
 direction by using the procedure to <dfn>finish an animation</dfn>
@@ -1693,7 +1704,7 @@ for <var>animation</var> defined below:
     <var>animation</var> with the <var>did seek</var> flag set to true,
     and the <var>synchronously notify</var> flag set to true.
 
-<h4 id='canceling-an-animation-section'>Canceling an animation</h4>
+### Canceling an animation ### {#canceling-an-animation-section}
 
 An animation can be canceled which causes the <a>current time</a> to
 become <a>unresolved</a> hence removing any effects caused by the
@@ -1744,7 +1755,7 @@ as follows:
 1.  Make <var>animation</var>'s <a>hold time</a> <a>unresolved</a>.
 1.  Make <var>animation</var>'s [=start time=] <a>unresolved</a>.
 
-<h4 id="speed-control">Speed control</h4>
+### Speed control ### {#speed-control}
 
 <div class="informative-bg">
 
@@ -1767,7 +1778,7 @@ Setting an animation's [=playback rate=]
 to zero effectively pauses the animation (however, the <a>play state</a>
 does not necessarily become <a lt="paused play state">paused</a>).
 
-<h5 id="setting-the-playback-rate-of-an-animation">Setting the playback rate of an animation</h5>
+#### Setting the playback rate of an animation #### {#setting-the-playback-rate-of-an-animation}
 
 The procedure to <dfn>set the playback rate</dfn> of
 an <a>animation</a>, <var>animation</var> to <var>new playback rate</var>
@@ -1785,7 +1796,7 @@ is as follows:
     <a>set the current time</a> of <var>animation</var> to
     <var>previous time</var>
 
-<h5 id="seamlessly-updating-the-playback-rate-of-an-animation">Seamlessly updating the playback rate of an animation</h5>
+#### Seamlessly updating the playback rate of an animation #### {#seamlessly-updating-the-playback-rate-of-an-animation}
 
 For an in-flight animation that is running on another process or thread, the
 procedure to <a>set the playback rate</a> may cause the animation to jump if the
@@ -1879,7 +1890,7 @@ time=] is as follows:
 
     </div>
 
-<h4 id="reversing-an-animation-section">Reversing an animation</h4>
+### Reversing an animation ### {#reversing-an-animation-section}
 
 The procedure to <dfn>reverse an animation</dfn> of <a>animation</a>
 <var>animation</var> is as follows:
@@ -1903,7 +1914,7 @@ The procedure to <dfn>reverse an animation</dfn> of <a>animation</a>
     |animation|'s [=pending playback rate=] to |original pending playback rate|
     and propagate the exception.
 
-<h4 id="play-states">Play states</h4>
+### Play states ### {#play-states}
 
 An <a>animation</a> may be described as being in one of the following
 <dfn lt="play state">play states</dfn> for each of which, a 
@@ -1982,7 +1993,7 @@ animation.ready.then(function() {
 
 </div>
 
-<h4 id="animation-events-section">Animation events</h4>
+### Animation events ### {#animation-events-section}
 
 <dfn>Animation events</dfn> include the [=animation playback events=] defined in
 this specification as well as the <a>events from CSS transitions</a>
@@ -2004,7 +2015,7 @@ Note that this value may be [=unresolved=] if, for example, the [=animation=]'s
 a timeline that tracks scroll-position) or if the [=timeline=] is <a
 lt="inactive timeline">inactive</a>.
 
-<h5 id="sorting-animation-events">Sorting animation events</h5>
+#### Sorting animation events #### {#sorting-animation-events}
 
 The following definitions are provided to assist with sorting queued events.
 
@@ -2054,7 +2065,7 @@ following steps:
      the procedure defined for the [=timeline=] associated with |animation|.
 
 
-<h5 id="animation-playback-events-section">Animation playback events</h5>
+#### Animation playback events #### {#animation-playback-events-section}
 
 As <a>animations</a> play, they report changes to their status through
 <dfn>animation playback events</dfn>.
@@ -2063,7 +2074,7 @@ As <a>animations</a> play, they report changes to their status through
 they are dispatched even when the <a>target effect</a> of the <a>animation</a>
 is absent or has no observable result.
 
-<h5 id="animation-playback-event-types">Types of animation playback events</h5>
+#### Types of animation playback events #### {#animation-playback-event-types}
 
 :   <dfn lt="finish event">finish</dfn>
 ::  Queued whenever an animation enters the <a>finished play state</a>.
@@ -2075,7 +2086,8 @@ is absent or has no observable result.
 ::  Queued whenever an animation is automatically removed.
     See [[#replacing-animations]].
 
-<h3 id="animation-effects">Animation effects</h3>
+Animation effects {#animation-effects}
+----------------------------------------
 
 An <dfn>animation effect</dfn> is an abstract term referring to an item in
 the timing hierarchy.
@@ -2096,7 +2108,7 @@ a timeline</dfn>, <var>timeline</var>, if <var>effect</var> is
 <a>associated with an animation</a> which, in turn, is associated with
 <var>timeline</var>.
 
-<h4 id="types-of-animation-effects">Types of animation effects</h4>
+### Types of animation effects ### {#types-of-animation-effects}
 
 This specification defines a single type of <a>animation effect</a>:
 <a>keyframe effects</a>.
@@ -2106,7 +2118,7 @@ Subsequent levels of this specification will define further types of
 All types of <a>animation effects</a> define a number of common
 properties which are described in the following sections.
 
-<h4 id="the-active-interval">The active interval</h4>
+### The active interval ### {#the-active-interval}
 
 <div class="informative-bg">
 
@@ -2175,7 +2187,7 @@ The <dfn>end time</dfn> of an <a>animation effect</a> is
 the result of evaluating <code>max(<a>start delay</a> + <a>active
 duration</a> + <a>end delay</a>, 0)</code>.
 
-<h4 id="local-time-section">Local time</h4>
+### Local time ### {#local-time-section}
 
 The <dfn>local time</dfn> of an <a>animation effect</a> at a given
 moment is based on the first matching condition from the following:
@@ -2323,7 +2335,8 @@ An animation effect is <dfn>in effect</dfn> if its <a>active time</a>, as
 calculated according to the procedure in [[#calculating-the-active-time]],
 is <em>not</em> <a>unresolved</a>.
 
-<h3 id="fill-behavior">Fill behavior</h3>
+Fill behavior {#fill-behavior}
+----------------------------------------
 
 The effect of an <a>animation effect</a> when it is not <a>in play</a> is
 determined by its <dfn>fill mode</dfn>.
@@ -2399,7 +2412,7 @@ elem.addEventListener('click', async evt => {
 </pre></div>
 </div>
 
-<h4 id="fill-modes">Fill modes</h4>
+### Fill modes ### {#fill-modes}
 
 <div class='informative-bg'><em>This section is non-normative</em>
 
@@ -2459,9 +2472,10 @@ Note: setting a fill mode has no bearing on the endpoints of the
 
 </div>
 
-<h3 id="repeating">Repeating</h3>
+Repeating {#repeating}
+----------------------------------------
 
-<h4 id="iteration-intervals">Iteration intervals</h4>
+### Iteration intervals ### {#iteration-intervals}
 
 It is possible to specify that an animation effect should repeat
 a fixed number of times or indefinitely.
@@ -2507,7 +2521,7 @@ duration</a> is illustrated below.
 
 </div>
 
-<h4 id="controlling-iteration">Controlling iteration</h4>
+### Controlling iteration ### {#controlling-iteration}
 
 The number of times an <a>animation effect</a> repeats is called its
 <dfn>iteration count</dfn>.
@@ -2559,7 +2573,7 @@ operation</a> of
 
 </div>
 
-<h4 id="iteration-time-space">Iteration time space</h4>
+### Iteration time space ### {#iteration-time-space}
 
 <div class="informative-bg"><em>This section is non-normative</em>
 
@@ -2613,7 +2627,7 @@ values</a> of the <a>default document timeline</a> of the
 
 </div>
 
-<h4 id="interval-timing">Interval timing</h4>
+### Interval timing ### {#interval-timing}
 
 <div class="informative-bg"><em>This section is non-normative</em>
 
@@ -2662,10 +2676,10 @@ section></a> and is illustrated below.
 
 </div>
 
-<h3 id="core-animation-effect-calculations">Core animation effect
-calculations</h3>
+Core animation effect calculations {#core-animation-effect-calculations}
+----------------------------------------
 
-<h4 id="animation-effect-calculations-overview">Overview</h4>
+### Overview ### {#animation-effect-calculations-overview}
 
 <div class="informative-bg"><em>This section is non-normative</em>
 
@@ -2728,7 +2742,7 @@ Steps 5 and 6 are described in [[#calculating-the-directed-progress]] and
 </div>
 
 
-<h4 id="calculating-the-active-duration">Calculating the active duration</h4>
+### Calculating the active duration ### {#calculating-the-active-duration}
 
 The <a>active duration</a> is calculated as follows:
 
@@ -2747,9 +2761,9 @@ The <a>active duration</a> is calculated as follows:
     </p>
 </blockquote>
 
-<h4 id="transforming-the-local-time">Transforming the local time</h4>
+### Transforming the local time ### {#transforming-the-local-time}
 
-<h5 id="calculating-the-active-time">Calculating the active time</h5>
+#### Calculating the active time #### {#calculating-the-active-time}
 
 The <dfn>active time</dfn> is based on the <a>local time</a>
 and <a>start delay</a>.
@@ -2802,7 +2816,7 @@ phase as follows,
 
 </div>
 
-<h5 id="calculating-the-overall-progress">Calculating the overall progress</h5>
+#### Calculating the overall progress #### {#calculating-the-overall-progress}
 
 The <dfn>overall progress</dfn> describes the number of iterations that
 have completed (including partial iterations) and is defined as follows:
@@ -2828,7 +2842,7 @@ have completed (including partial iterations) and is defined as follows:
     progress</var> + <a>iteration start</a></code>.
 
 
-<h5 id="calculating-the-simple-iteration-progress">Calculating the simple iteration progress</h5>
+#### Calculating the simple iteration progress #### {#calculating-the-simple-iteration-progress}
 
 The <dfn>simple iteration progress</dfn> is a fraction of the progress
 through the current iteration that ignores transformations to the time
@@ -2872,7 +2886,7 @@ applied to the effect, and is calculated as follows:
 1.  Return <var>simple iteration progress</var>.
 
 
-<h4 id="calculating-the-current-iteration">Calculating the current iteration</h4>
+### Calculating the current iteration ### {#calculating-the-current-iteration}
 
 The <dfn>current iteration</dfn> can be calculated using the
 following steps:
@@ -2889,7 +2903,8 @@ following steps:
 1.  Otherwise, return <code>floor(<a>overall progress</a>)</code>.
 
 
-<h3 id="direction-control">Direction control</h3>
+Direction control {#direction-control}
+----------------------------------------
 
 <a>Animation effects</a> may also be configured to run iterations in
 alternative directions using direction control.
@@ -2925,7 +2940,7 @@ A non-normative definition of these values is as follows:
 
 </div>
 
-<h4 id="calculating-the-directed-progress">Calculating the directed progress</h4>
+### Calculating the directed progress ### {#calculating-the-directed-progress}
 
 The <dfn>directed progress</dfn> is calculated from the
 <a>simple iteration progress</a> using the following steps:
@@ -2965,7 +2980,8 @@ The <dfn>directed progress</dfn> is calculated from the
 
     Otherwise, return <code>1.0 - <a>simple iteration progress</a></code>.
 
-<h3 id="time-transformations">Time transformations</h3>
+Time transformations {#time-transformations}
+----------------------------------------
 
 It is often desirable to control the rate at which an <a>animation
 effect</a> progresses.
@@ -2979,7 +2995,7 @@ them.
 The default <a>timing function</a> is the <a>linear timing
 function</a>.
 
-<h4 id="calculating-the-transformed-progress">Calculating the transformed progress</h4>
+### Calculating the transformed progress ### {#calculating-the-transformed-progress}
 
 The <dfn export>transformed progress</dfn> is calculated from the
 <a>directed progress</a> using the following steps:
@@ -3005,7 +3021,8 @@ The <dfn export>transformed progress</dfn> is calculated from the
     spec=css-easing>input progress value</a> and <var>before flag</var> as the
     <a spec=css-easing>before flag</a>.
 
-<h3 id="the-iteration-progress">The iteration progress</h3>
+The iteration progress {#the-iteration-progress}
+----------------------------------------
 
 The <dfn>iteration progress</dfn> of an <a>animation effect</a> is simply
 its <a>transformed progress</a>.
@@ -3015,7 +3032,8 @@ its <a>transformed progress</a>.
 
 
 
-<h2 id="animation-model">Animation model</h2>
+Animation model {#animation-model}
+=======================================
 
 <div class='informative-bg'><em>This section is non-normative</em>
 
@@ -3030,7 +3048,8 @@ applied to the target properties (see [[#combining-effects]]).
 
 </div>
 
-<h3 id="introduction-to-the-animation-model">Introduction</h3>
+Introduction {#introduction-to-the-animation-model}
+----------------------------------------
 
 An <a>animation effect</a> has zero or more associated properties that
 it affects in response to changes to its timing output. These properties
@@ -3043,7 +3062,8 @@ an <dfn>effect value</dfn> for each <a>animatable</a> <a>target property</a>
 by applying the procedures from the <a>animation type</a> appropriate to the
 property.
 
-<h3 id="animating-properties">Animating properties</h3>
+Animating properties {#animating-properties}
+----------------------------------------
 
 Unless otherwise specified, all CSS properties are
 <dfn id="concept-animatable">animatable</dfn>.
@@ -3151,8 +3171,7 @@ The [=animation type=] of properties that do not yet include
 an [=Animation type=] line in their property definition,
 is defined in [[#animation-types]].
 
-<h4 id=custom-properties>
-Custom Properties</h4>
+### Custom Properties ### {#custom-properties}
 
 For <a>custom properties</a> registered
 using the {{CSS/registerProperty()}} method for the <a>current global object</a>,
@@ -3165,14 +3184,15 @@ or when the <a>custom property</a> is not registered,
 the <a>animation type</a> is <a>discrete</a>.
 
 
-<h3 id="keyframe-effects">Keyframe effects</h3>
+Keyframe effects {#keyframe-effects}
+----------------------------------------
 
 <dfn lt="keyframe effect">Keyframe effects</dfn> are a kind of <a>animation
 effect</a> that use the output of the timing model to update CSS properties for
 an element or pseudo-element such as <code>::before</code> or
 <code>::after</code> [[!SELECT]] referred to as the <dfn>target element</dfn>.
 
-<h4 id="keyframes-section">Keyframes</h4>
+### Keyframes ### {#keyframes-section}
 
 The <a>effect values</a> for a <a>keyframe effect</a>
 are calculated by interpolating between a series of property values
@@ -3210,7 +3230,7 @@ If the <a>keyframe-specific composite operation</a> for a <a>keyframe</a>
 is not set, the <a>composite operation</a> specified for the
 <a>keyframe effect</a> as a whole is used for values specified in that keyframe.
 
-<h4 id="calculating-computed-keyframes">Calculating computed keyframes</h4>
+### Calculating computed keyframes ### {#calculating-computed-keyframes}
 
 Before calculating the <a>effect value</a> of a <a>keyframe effect</a>,
 the property values specified on its <a>keyframes</a> are resolved to
@@ -3513,7 +3533,8 @@ Note: this procedure permits overlapping <a>keyframes</a>.
 </div>
 
 
-<h3 id="combining-effects">Combining effects</h3>
+Combining effects {#combining-effects}
+----------------------------------------
 <div class='informative-bg'><em>This section is non-normative</em>
 
 After calculating the <a>effect values</a> for a
@@ -3563,7 +3584,7 @@ is determined by an <a>effect stack</a> established for each
 animated property.
 </div>
 
-<h4 id="animation-classes">Animation classes</h4>
+### Animation classes ### {#animation-classes}
 
 This specification provides a common animation model intended to be used
 by other specifications that define markup or programming interfaces on
@@ -3586,7 +3607,7 @@ amongst other factors.
 
 </div>
 
-<h4 id="the-effect-stack">The effect stack</h4>
+### The effect stack ### {#the-effect-stack}
 
 Associated with each property <a lt="target property">targeted</a>
 by one or more <a>keyframe effects</a> is an <dfn>effect
@@ -3621,7 +3642,7 @@ established by comparing their properties as follows:
 <a>Animation effects</a> that sort earlier have <em>lower</em>
 composite order.
 
-<h4 id="calculating-the-result-of-an-effect-stack">Calculating the result of an effect stack</h4>
+### Calculating the result of an effect stack ### {#calculating-the-result-of-an-effect-stack}
 
 In order to calculate the final value of an <a>effect stack</a>,
 the <a>effect values</a> of each <a>keyframe effect</a> in the stack are
@@ -3642,7 +3663,7 @@ The final value of an <a>effect stack</a>, called the
 <a>keyframe effect</a> in the stack with the <a>underlying value</a>
 at that point.
 
-<h4 id="effect-composition">Effect composition</h4>
+### Effect composition ### {#effect-composition}
 
 The specific operation used to combine an <a>effect value</a> with an
 <a>underlying value</a> is determined by the
@@ -3672,7 +3693,7 @@ follows:
     defined such that it is not commutative, the order of the operands
     is <a>underlying value</a> followed by <a>effect value</a>.
 
-<h4 id="applying-the-composited-result">Applying the composited result</h4>
+### Applying the composited result ### {#applying-the-composited-result}
 
 Applying a <a>composited value</a> to a <a>target property</a>
 is achieved by adding a specified value to the CSS cascade.
@@ -3712,7 +3733,8 @@ property</a> is applied using the following process.
     effect at the top of the <a>effect stack</a> established for the target
     property.
 
-<h3 id="replacing-animations">Replacing animations</h3>
+Replacing animations {#replacing-animations}
+----------------------------------------
 
 <div class="informative-bg"><em>This section is non-normative</em>
 
@@ -3744,7 +3766,7 @@ automatically removed unless the author explicitly requests they be retained.
 
 </div>
 
-<h4 id="animation-replace-state">Replace state</h4>
+### Replace state ### {#animation-replace-state}
 
 An [=animation=] maintains a <dfn>replace state</dfn> that may be one of the
 following values:
@@ -3760,7 +3782,7 @@ The [=animation effects=] of an [=animation=]
 whose [=replace state=] is [=removed replace state|removed=]
 are not included in the [=effect stacks=] of their [=target properties=].
 
-<h4 id="removing-replaced-animations">Removing replaced animations</h4>
+### Removing replaced animations ### {#removing-replaced-animations}
 
 An [=animation=] is
 <dfn lt="replaceable animation" local-lt="replaceable">replaceable</dfn>
@@ -3828,7 +3850,8 @@ perform the following steps:
      The task source for this task is the [=DOM manipulation task
      source=].
 
-<h3 id="side-effects-section">Side effects of animation</h3>
+Side effects of animation {#side-effects-section}
+----------------------------------------
 
 For every property targeted by at least one <a>animation effect</a> that is
 <a>current</a> or <a>in effect</a>,
@@ -3852,7 +3875,8 @@ phase</a>.
 <!-- End of animation model -->
 
 
-<h2 id="programming-interface">Programming interface</h2>
+Programming interface {#programming-interface}
+=======================================
 
 <div class='informative-bg'><em>This section is non-normative</em>
 
@@ -3864,14 +3888,15 @@ a procedural approach is more suitable.
 
 </div>
 
-<h3 id='time-values-in-the-programming-interface'>
-Time values in the programming interface</h3>
+Time values in the programming interface {#time-values-in-the-programming-interface}
+----------------------------------------
 
 <a>Time values</a> are represented in the programming interface with
 the type <code>double</code>. <a>Unresolved</a> time values are
 represented by the value <code>null</code>.
 
-<h3 id="the-animationtimeline-interface">The <code>AnimationTimeline</code> interface</h3>
+The <code>AnimationTimeline</code> interface {#the-animationtimeline-interface}
+----------------------------------------
 
 <a>Timelines</a> are represented in the Web Animations API by the
 {{AnimationTimeline}} interface.
@@ -3892,7 +3917,8 @@ interface AnimationTimeline {
 
 </div>
 
-<h3 id="the-documenttimeline-interface">The <code>DocumentTimeline</code> interface</h3>
+The <code>DocumentTimeline</code> interface {#the-documenttimeline-interface}
+----------------------------------------
 
 <a>Document timelines</a>, including the <a>default document
 timeline</a>, are represented in the Web Animations API by the
@@ -3940,7 +3966,8 @@ interface DocumentTimeline : AnimationTimeline {
 
 </div>
 
-<h3 id="the-animation-interface">The <code>Animation</code> interface</h3>
+The <code>Animation</code> interface {#the-animation-interface}
+----------------------------------------
 
 <a>Animations</a> are represented in the Web Animations
 API by the {{Animation}} interface.
@@ -4226,7 +4253,7 @@ To <dfn>commit computed styles</dfn> for an [=animation=], |animation|:
 
      1.   [=Update style attribute for=] |inline style|.
 
-<h4 id="the-animationplaystate-enumeration">The <code>AnimationPlayState</code> enumeration</h4>
+### The <code>AnimationPlayState</code> enumeration ### {#the-animationplaystate-enumeration}
 
 <pre class='idl'>
 enum AnimationPlayState { "idle", "running", "paused", "finished" };
@@ -4241,7 +4268,7 @@ enum AnimationPlayState { "idle", "running", "paused", "finished" };
 :   <code>finished</code>
 ::  Corresponds to the <a>finished play state</a>.
 
-<h4 id="the-animationreplacestate-enumeration">The <code>AnimationReplaceState</code> enumeration</h4>
+### The <code>AnimationReplaceState</code> enumeration ### {#the-animationreplacestate-enumeration}
 
 <pre class='idl'>
 enum AnimationReplaceState { "active", "removed", "persisted" };
@@ -4254,7 +4281,8 @@ enum AnimationReplaceState { "active", "removed", "persisted" };
 :   <code>persisted</code>
 ::  Corresponds to the [=persisted replace state=].
 
-<h3 id="the-animationeffect-interface">The <code>AnimationEffect</code> interface</h3>
+The <code>AnimationEffect</code> interface {#the-animationeffect-interface}
+----------------------------------------
 
 <a>Animation effects</a> are represented in the Web Animations API by the
 abstract {{AnimationEffect}} interface.
@@ -4347,7 +4375,7 @@ Issue(2082): The <code>remove()</code> method can be used to remove an effect
 from either its parent group or animation. Should we keep it in level 1 and
 define it simply as removing the animation effect from its animation?
 
-<h4 id="the-effecttiming-dictionaries">The <code>EffectTiming</code> and <code>OptionalEffectTiming</code> dictionaries</h4>
+### The <code>EffectTiming</code> and <code>OptionalEffectTiming</code> dictionaries ### {#the-effecttiming-dictionaries}
 
 The {{EffectTiming}} dictionary represents the timing properties of an
 {{AnimationEffect}}.
@@ -4494,7 +4522,7 @@ dictionary OptionalEffectTiming {
 
 </div>
 
-<h4 id="the-fillmode-enumeration">The <code>FillMode</code> enumeration</h4>
+### The <code>FillMode</code> enumeration ### {#the-fillmode-enumeration}
 
 <pre class='idl'>
 enum FillMode { "none", "forwards", "backwards", "both", "auto" };
@@ -4517,7 +4545,7 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
     In a subsequent level of this specification, this may produce different
     behavior for other types of <a>animation effects</a>.
 
-<h4 id="the-playbackdirection-enumeration">The <code>PlaybackDirection</code> enumeration</h4>
+### The <code>PlaybackDirection</code> enumeration ### {#the-playbackdirection-enumeration}
 
 <pre class='idl'>
 enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
@@ -4539,7 +4567,7 @@ enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" }
     they are specified, odd iterations are played as specified.
 
 
-<h4 id="updating-animationeffect-timing">Updating the timing of an <code>AnimationEffect</code></h4>
+### Updating the timing of an <code>AnimationEffect</code> ### {#updating-animationeffect-timing}
 
 To <dfn>update the timing properties of an animation effect</dfn>, |effect|,
 from an {{EffectTiming}} or {{OptionalEffectTiming}} object, |input|, perform
@@ -4580,7 +4608,7 @@ the following steps:
     *   {{EffectTiming/easing}} &rarr; [=timing function=]
 
 
-<h4 id="the-computedeffecttiming-dictionary">The <code>ComputedEffectTiming</code> dictionary</h4>
+### The <code>ComputedEffectTiming</code> dictionary ### {#the-computedeffecttiming-dictionary}
 
 Timing properties calculated by the timing model are exposed using
 {{ComputedEffectTiming}} dictionary objects.
@@ -4631,7 +4659,8 @@ dictionary ComputedEffectTiming : EffectTiming {
 
 </div>
 
-<h3 id="the-keyframeeffect-interface">The <code>KeyframeEffect</code> interface</h3>
+The <code>KeyframeEffect</code> interface {#the-keyframeeffect-interface}
+----------------------------------------
 
 <a>Keyframe effects</a> are represented by the {{KeyframeEffect}} interface.
 
@@ -4910,7 +4939,7 @@ interface KeyframeEffect : AnimationEffect {
 
 </div>
 
-<h4 id="creating-a-new-keyframeeffect-object">Creating a new <code>KeyframeEffect</code> object</h4>
+### Creating a new <code>KeyframeEffect</code> object ### {#creating-a-new-keyframeeffect-object}
 
 <div class='informative-bg'><em>This section is non-normative</em>
 
@@ -4968,7 +4997,7 @@ elem.animate({ left: '100px' }, 3000);</pre></div>
 
 </div>
 
-<h4 id="property-name-conversion">Property names and IDL names</h4>
+### Property names and IDL names ### {#property-name-conversion}
 
 The <dfn>animation property name to IDL attribute name</dfn> algorithm for
 <var>property</var> is as follows:
@@ -5540,7 +5569,7 @@ elem.animate([{ easing: 'invalid' }]);
 
     </div>
 
-<h4 id="the-keyframeeffectoptions-dictionary">The <code>KeyframeEffectOptions</code> dictionary</h4>
+### The <code>KeyframeEffectOptions</code> dictionary ### {#the-keyframeeffectoptions-dictionary}
 
 Additional parameters may be passed to the {{KeyframeEffect(target, keyframes,
 options)}} constructor by providing a {{KeyframeEffectOptions}} object.
@@ -5563,7 +5592,8 @@ dictionary KeyframeEffectOptions : EffectTiming {
 
 </div>
 
-<h3 id="the-compositeoperation-enumeration">The <code>CompositeOperation</code> and <code>CompositeOperationOrAuto</code> enumerations</h3>
+The <code>CompositeOperation</code> and <code>CompositeOperationOrAuto</code> enumerations {#the-compositeoperation-enumeration}
+----------------------------------------
 
 The possible values of an <a>keyframe effect</a>'s
 composition behavior are represented by the
@@ -5608,7 +5638,8 @@ enum CompositeOperationOrAuto { "replace", "add", "accumulate", "auto" };
 ::  Indicates that the [=composite operation=] of the associated [=keyframe
     effect=] should be used.
 
-<h3 id="the-animatable-interface-mixin">The <code>Animatable</code> interface mixin</h3>
+The <code>Animatable</code> interface mixin {#the-animatable-interface-mixin}
+----------------------------------------
 
 Objects that may be the target of an {{KeyframeEffect}} object implement
 the {{Animatable}} interface mixin.
@@ -5750,7 +5781,8 @@ animation.play();</pre>
 
 </div>
 
-<h3 id="extensions-to-the-document-interface">Extensions to the <code>Document</code> interface</h3>
+Extensions to the <code>Document</code> interface {#extensions-to-the-document-interface}
+----------------------------------------
 
 The following extensions are made to the {{Document}} interface defined in
 [[!DOM]].
@@ -5769,7 +5801,8 @@ partial interface Document {
 
 </div>
 
-<h3 id="extensions-to-the-documentorshadowroot-interface-mixin">Extensions to the <code>DocumentOrShadowRoot</code> interface mixin</h3>
+Extensions to the <code>DocumentOrShadowRoot</code> interface mixin {#extensions-to-the-documentorshadowroot-interface-mixin}
+----------------------------------------
 
 The following extensions are made to the {{DocumentOrShadowRoot}} interface
 mixin defined in [[!DOM]].
@@ -5801,7 +5834,8 @@ partial interface mixin DocumentOrShadowRoot {
 </div>
 
 
-<h3 id="extensions-to-the-element-interface">Extensions to the <code>Element</code> interface</h3>
+Extensions to the <code>Element</code> interface {#extensions-to-the-element-interface}
+----------------------------------------
 
 Since DOM Elements may be the target of an animation,
 the {{Element}} interface [[!DOM]] is extended as follows:
@@ -5815,7 +5849,8 @@ This allows the following kind of usage.
 <div class="example"><pre class="lang-javascript">
 elem.animate({ color: 'red' }, 2000);</pre></div>
 
-<h3 id="extensions-to-the-pseudoelement-interface">Extensions to the <code>CSSPseudoElement</code> interface</h3>
+Extensions to the <code>CSSPseudoElement</code> interface {#extensions-to-the-pseudoelement-interface}
+----------------------------------------
 
 Since <a>keyframe effects</a> may also target pseudo-elements, the
 {{CSSPseudoElement}} interface [[!css-pseudo-4]] is also defined to be
@@ -5825,7 +5860,8 @@ animatable.
 CSSPseudoElement includes Animatable;
 </pre>
 
-<h3 id="the-animationplaybackevent-interface">The <code>AnimationPlaybackEvent</code> interface</h3>
+The <code>AnimationPlaybackEvent</code> interface {#the-animationplaybackevent-interface}
+----------------------------------------
 
 <a>Animation playback events</a> are represented using the
 {{AnimationPlaybackEvent}} interface.
@@ -5879,7 +5915,8 @@ dictionary AnimationPlaybackEventInit : EventInit {
 
 </div>
 
-<h3 id="model-liveness">Model liveness</h3>
+Model liveness {#model-liveness}
+----------------------------------------
 
 Changes made to any part of the model, cause the entire timing model to be
 updated and any dependent style.
@@ -6032,7 +6069,8 @@ div.addEventListener('transitionend', () => {
 </div>
 
 
-<h2 id="integration-with-media-fragments">Integration with Media Fragments</h2>
+Integration with Media Fragments {#integration-with-media-fragments}
+=======================================
 
 The Media Fragments specification [[!MEDIA-FRAGS]] defines a means
 for addressing a temporal range of a media resource.
@@ -6048,7 +6086,8 @@ Note: media fragments are defined to operate on resources based on
     As a result, temporal addressing may not be supported in all situations
     where Web Animations content is used.
 
-<h2 id="interaction-with-page-display">Interaction with page display</h2>
+Interaction with page display {#interaction-with-page-display}
+=======================================
 
 HTML permits user agents to store <a
 lt="an entry with persisted user state">user-agent defined state</a> along with
@@ -6069,16 +6108,19 @@ Issue(2083): Is this at odds with those <a>time values</a> being relative to
     using the same time as <code>document.timeline.currentTime</code>?
 
 
-<h2 id="implementation-requirements">Implementation requirements</h2>
+Implementation requirements {#implementation-requirements}
+=======================================
 
-<h3 id="precision-of-time-values">Precision of time values</h3>
+Precision of time values {#precision-of-time-values}
+----------------------------------------
 
 The internal representation of time values is implementation dependent
 however, it is RECOMMENDED that user agents be able to represent input
 time values with microsecond precision so that a <a>time value</a> (which
 nominally represents milliseconds) of 0.001 is distinguishable from 0.0.
 
-<h3 id="conformance-criteria">Conformance criteria</h3>
+Conformance criteria {#conformance-criteria}
+----------------------------------------
 
 This specification defines an abstract model for animation and, as
 such, for user agents that do not support scripting, there are no
@@ -6094,7 +6136,8 @@ agent that implements the <abbr
 title="Application Programming Interface">API</abbr> defined in
 [[#programming-interface]].
 
-<h2 id="acknowledgements">Acknowledgements</h2>
+Acknowledgements {#acknowledgements}
+=======================================
 
 Thank you to Steve Block, Michael Giuffrida, Ryan Seys, and Eric Willigers
 for their contributions to this specification.
@@ -6109,7 +6152,8 @@ Animation</a> for their kind generosity and patience in introducing the
 editors to the processes and techniques used producing broadcast
 animations.
 
-<h2 id="changes-since-last-publication">Changes since last publication</h2>
+Changes since last publication {#changes-since-last-publication}
+=======================================
 
 The following changes have been made since the <a
   href="https://www.w3.org/TR/2018/WD-web-animations-1-20181011/">11 October
@@ -6141,8 +6185,8 @@ The <a
 provides a more detailed history.
 
 
-<h2 id=animation-types>
-Appendix A: Animation types of existing properties</h2>
+Appendix A: Animation types of existing properties {#animation-types}
+=======================================
 
 Typically the [=animation type=] of a property is included along with its
 definition.


### PR DESCRIPTION
Code health: This allows for much easier navigation in editors with live outline view.
