### PR TITLE
[css-syntax] make "plus sign" match other 2 items

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -925,7 +925,7 @@ Consume a token</h4>
 		<dd>
 			If the input stream <a>starts with a number</a>,
 			<a>reconsume the current input code point</a>,
-			<a>consume a numeric token</a>
+			<a>consume a numeric token</a>,
 			and return it.
 
 			Otherwise,


### PR DESCRIPTION
when consuming a token, the first instruction for PLUS SIGN, HYPHEN-MINUS, and FULL STOP are all the same, but the PLUS SIGN instructions are missing a comma.

visit: https://www.w3.org/TR/css-syntax-3/#consume-comment

search the page for:
```
If the input stream starts with a number, reconsume the current input code point, consume a numeric token and return it. 
```
there is only 1 instance.

search the page for:
```
If the input stream starts with a number, reconsume the current input code point, consume a numeric token, and return it.
```
there are 2 instances.

i think all 3 versions should match.

