### PR TITLE
[css-color-4] Align color example comments

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -79,8 +79,8 @@ For example, to specify lime green:
 
 	<div class="example">
 		<pre class="lang-css">
-		em { color: lime; }            /* color keyword   */
-		em { color: rgb(0 255 0); }    /* RGB range 0-255 */
+		em { color: lime; }            /* color keyword     */
+		em { color: rgb(0 255 0); }    /* RGB range 0-255   */
 		em { color: rgb(0% 100% 0%); } /* RGB range 0%-100% */
 		</pre>
 	</div>


### PR DESCRIPTION
No change to the actual content, just align the end of the HTML comments. Currently, only the first 2 are aligned, despite having different lengths; the alternative would be to not align any of the comment ends, to be consistent with a single space before `*/`

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
