### PR TITLE
[resize-observer-1] Remove JavaScript constructor for ResizeObserverEntry #3946

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -243,7 +243,7 @@ This callback delivers {{ResizeObserver}}'s notifications. It is invoked by a
 <h3 id="resize-observer-entry-interface">ResizeObserverEntry</h3>
 
 <pre class="idl">
-[Exposed=Window, Constructor(Element target)]
+[Exposed=Window]
 interface ResizeObserverEntry {
     readonly attribute Element target;
     readonly attribute DOMRectReadOnly contentRect;
@@ -283,36 +283,6 @@ In this spec, there will only be a single ResizeObserverSize returned in the seq
 which will correspond to the dimensions of the first column.
 A future version of this spec will extend the returned sequences to contain the per-fragment size information.
 </p>
-
-<div dfn-type="method" dfn-for="ResizeObserverEntry">
-    : <dfn constructor lt="ResizeObserverEntry(target)">new ResizeObserverEntry(target)</dfn>
-    ::
-        1. Let |this| be a new {{ResizeObserverEntry}}.
-
-        2. Set |this|.{{ResizeObserverEntry/target}} slot to |target|.
-
-        3. Set |this|.{{ResizeObserverEntry/borderBoxSize}} slot to result of <a href="#calculate-box-size">
-            computing size given |target| and observedBox of "border-box"</a>.
-
-        4. Set |this|.{{ResizeObserverEntry/contentBoxSize}} slot to result of <a href="#calculate-box-size">
-            computing size given |target| and observedBox of "content-box"</a>.
-
-        5. Set |this|.{{ResizeObserverEntry/devicePixelContentBoxSize}} slot to result of <a href="#calculate-box-size">
-            computing size given |target| and observedBox of "device-pixel-content-box"</a>.
-
-        6. Set |this|.{{ResizeObserverEntry/contentRect}} to logical |this|.{{ResizeObserverEntry/contentBoxSize}} given |target| and observedBox of "content-box".
-
-        7. If |target| is not an SVG element do these steps:
-
-            1. Set |this|.|contentRect|.top to |target|.<a>padding top</a>.
-
-            2. Set |this|.|contentRect|.left to |target|.<a>padding left</a>.
-
-        8. If |target| is an SVG element do these steps:
-
-            1. Set |this|.|contentRect|.top and |this|.contentRect.left to 0.
-
-</div>
 
 <pre class="idl">
     interface ResizeObserverSize {
@@ -456,6 +426,36 @@ To determine if {{Document}} <dfn>has skipped observations</dfn> run these steps
 
 2. return false.
 
+<h4 id="create-and-populate-resizeobserverentry-h">
+Create and populate a ResizeObserverEntry
+</h4>
+To <dfn>create and populate a ResizeObserverEntry</dfn> for a given |target|,
+run these steps:
+1. Let |this| be a new {{ResizeObserverEntry}}.
+
+2. Set |this|.{{ResizeObserverEntry/target}} slot to |target|.
+
+3. Set |this|.{{ResizeObserverEntry/borderBoxSize}} slot to result of <a href="#calculate-box-size">
+            computing size given |target| and observedBox of "border-box"</a>.
+
+4. Set |this|.{{ResizeObserverEntry/contentBoxSize}} slot to result of <a href="#calculate-box-size">
+            computing size given |target| and observedBox of "content-box"</a>.
+
+5. Set |this|.{{ResizeObserverEntry/devicePixelContentBoxSize}} slot to result of <a href="#calculate-box-size">
+            computing size given |target| and observedBox of "device-pixel-content-box"</a>.
+
+6. Set |this|.{{ResizeObserverEntry/contentRect}} to logical |this|.{{ResizeObserverEntry/contentBoxSize}} given |target| and observedBox of "content-box".
+
+7. If |target| is not an SVG element do these steps:
+
+    1. Set |this|.|contentRect|.top to |target|.<a>padding top</a>.
+
+    2. Set |this|.|contentRect|.left to |target|.<a>padding left</a>.
+
+8. If |target| is an SVG element do these steps:
+
+    1. Set |this|.|contentRect|.top and |this|.contentRect.left to 0.
+
 <h4 id="broadcast-resize-notifications-h">Broadcast active observations</h4>
 
 <dfn>broadcast active observations</dfn> delivers all active observations
@@ -474,7 +474,7 @@ run these steps:
 
     3. For each |observation| in {{ResizeObserver/activeTargets}} perform these steps:
 
-        1. Let |entry| be new {{ResizeObserverEntry}}(|observation|.target)
+        1. Let |entry| be the result of running <a>create and populate a {{ResizeObserverEntry}}</a> given |observation|.{{ResizeObservation/target}}.
 
         2. Add |entry| to |entries|.
 


### PR DESCRIPTION
Link to minutes: https://github.com/w3c/csswg-drafts/issues/3946#issuecomment-550567232

The ResizeObserverEntry constructor should not be exposed to JavaScript. However, it is still useful to have around as a concept for the `broadcast active observations` algorithm 