### PR TITLE
[css-grid-1] Exclude implicit tracks from track listing resolved value. #4475

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1912,9 +1912,9 @@ Resolved Value of a Track Listing</h4>
 
 	<ul>
 		<li>
-			Every track listed individually,
-			whether implicitly or explicitly created,
-			without using the ''repeat()'' notation.
+			Every explicitly created track listed individually,
+			without using the ''repeat()'' notation,
+			and excluding implicitly created tracks.
 
 		<li>
 			Every track size given as a length in pixels,
@@ -4752,6 +4752,19 @@ Major Changes</h4>
 					<dd>
 						The used <a>flex fraction</a> is zero.
 				</dl>
+			</blockquote>
+
+		<li id="change-2017-resolved-track-list-exclude-implicit">
+			Don't include implicit tracks in the resolved value of a track listing,
+			so that the value round-trips.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/4475">Issue 4475</a>)
+			<blockquote>
+				<del>Every track listed individually,
+				whether implicitly or explicitly created,
+				without using the ''repeat()'' notation.</del>
+				<ins>Every explicitly created track listed individually,
+				without using the ''repeat()'' notation,
+				and excluding implicitly created tracks.</ins>
 			</blockquote>
 	</ul>
 <h4 id="minor-2017">


### PR DESCRIPTION
In order to have round-tripping. As resolved in
https://github.com/w3c/csswg-drafts/issues/4475#issuecomment-553525609