### PR TITLE
[web-animations-1] Resolve remaining issues missed in pseudo-element change.

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -167,7 +167,8 @@ last) as follows:
     *  element
     *  ::marker
     *  ::before
-    *  other pseudo-elements in alphabetical order by selector
+    *  any other pseudo-elements not mentioned specifically in this list,
+       sorted in ascending order by the Unicode codepoints that make up each selector
     *  ::after
     *  element children
 

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -167,6 +167,7 @@ last) as follows:
     *  element
     *  ::marker
     *  ::before
+    *  other pseudo-elements in alphabetical order by selector
     *  ::after
     *  element children
 

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -137,6 +137,7 @@ are sorted in composite order (first to last) as follows:
     *  element
     *  ::marker
     *  ::before
+    *  other pseudo-elements in alphabetical order by selector
     *  ::after
     *  element children
 

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -137,7 +137,8 @@ are sorted in composite order (first to last) as follows:
     *  element
     *  ::marker
     *  ::before
-    *  other pseudo-elements in alphabetical order by selector
+    *  any other pseudo-elements not mentioned specifically in this list,
+       sorted in ascending order by the Unicode codepoints that make up each selector
     *  ::after
     *  element children
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3355,8 +3355,7 @@ an <a>effect target</a> for which computed property values can be calculated.
 1.  Return <var>computed keyframes</var>.
 
 
-<h4 id="the-effect-value-of-a-keyframe-animation-effect">The effect value of
-  a keyframe effect</h4>
+### The effect value of a keyframe effect ### {#the-effect-value-of-a-keyframe-animation-effect}
 
 The <a>effect value</a> of a single property referenced by a <a>keyframe
 effect</a> as one of its <a lt="target property">target properties</a>, for a
@@ -3370,6 +3369,8 @@ given <var>iteration progress</var>, <var ignore=''>current iteration</var> and
 1.  If <a>animation type</a> of the <var>target property</var> is
     <a>not animatable</a> abort this procedure
     since the effect cannot be applied.
+1.  If the [=effect target=] is `null` or cannot have computed property values
+    calsulated, abort this procedure.
 1.  Define the <dfn>neutral value for composition</dfn> as a value
     which, when combined with an <a>underlying value</a> using the <a
     lt="composite operation add">add</a> <a>composite

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3201,6 +3201,11 @@ If the [=effect target=] is a [=pseudo-element=], the [=target element=] is
 its [=originating element=] and the [=target pseudo-selector=] is as required
 to specify that particular [=pseudo-element=].
 
+Note that not all [=effect targets=] specified in this manner (such as ''::part()''
+pseudo-elements, unsupported/invalid pseudo-elements, and `null`) have
+computed property values defined. Such targets are treated as if all
+properties are [=not animatable=].
+
 ### Keyframes ### {#keyframes-section}
 
 The <a>effect values</a> for a <a>keyframe effect</a>
@@ -4699,6 +4704,18 @@ interface KeyframeEffect : AnimationEffect {
 
     1.  Set the <a>target element</a> of <var>effect</var> to <var>target</var>.
 
+    1.  Set the [=target pseudo-selector=] to the result corresponding to the first
+        matching condition from below.
+
+        :   If <var>options</var> is a {{KeyframeEffectOptions}} object with a
+            {{KeyframeEffectOptions/pseudoElement}} property,
+        ::  Set the [=target pseudo-selector=] to the value of that property,
+            following the validation procedure from the
+            {{KeyframeEffect/pseudoElement}} setter.
+
+        :   Otherwise,
+        ::  Set the [=target pseudo-selector=] to `null`.
+
     1.  Let <var>timing input</var> be the result corresponding to the first
         matching condition from below.
 
@@ -4810,8 +4827,15 @@ interface KeyframeEffect : AnimationEffect {
     This is `null` if the [=effect target=] is an {{Element}} or is itself `null`.
     When not `null`, this must be a [=pseudo-element=] selector with
     [[selectors-4#pseudo-element-syntax|valid syntax]].
-    This will not accept invalid values and will always return the selector in
-    its canonical form (i.e. `::before` instead of `:before`).
+
+    This will only accept `null` or syntactically-valid selectors
+    (i.e. `:before`, `:after`, `:first-letter`, `:first-line`, or a string starting with `::`).
+    If such a string is not given, this will throw a {{DOMException}} with
+    error name {{SyntaxError}}.
+
+    If one of the legacy single-colon selectors is given, the selector is
+    changed to its double-colon version. If the empth string is given,
+    the selector is changed to `null`.
 
 :   <dfn attribute for=KeyframeEffect>composite</dfn>
 ::  The <a>composite operation</a> used to composite this

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3304,8 +3304,7 @@ To produce <a>computed keyframe offsets</a>, we define a procedure to
 
 <a>Computed keyframes</a> are produced using the following procedure.
 Note that this procedure is only performed on a <a>keyframe effect</a> having
-an <a>effect target</a> for which computed property values can be calculated,
-as otherwise all propereties are <a>not animatable</a>.
+an <a>effect target</a> for which computed property values can be calculated.
 
 1.  Let <var>computed keyframes</var> be an empty list of <a>keyframes</a>.
 
@@ -3364,9 +3363,6 @@ The <a>effect value</a> of a single property referenced by a <a>keyframe
 effect</a> as one of its <a lt="target property">target properties</a>, for a
 given <var>iteration progress</var>, <var ignore=''>current iteration</var> and
 <var>underlying value</var> is calculated as follows.
-Note that this procedure is only performed on a <a>keyframe effect</a> having
-an <a>effect target</a> for which computed property values can be calculated,
-as otherwise case all propereties are <a>not animatable</a>.
 
 1.  If <var>iteration progress</var> is <a>unresolved</a> abort this
     procedure.
@@ -3734,9 +3730,6 @@ will be added to &lsquo;Transition declarations&rsquo; level of the cascade.
 
 The <a>composited value</a> calculated for a CSS <a>target
 property</a> is applied using the following process.
-Note that this procedure is only performed on a <a>keyframe effect</a> having
-an <a>effect target</a> for which computed property values can be calculated,
-as otherwise case all propereties are <a>not animatable</a>.
 
 1.  Calculate the <var>base value</var> of the property as
     the value generated for that property by computing the computed value
@@ -4711,8 +4704,8 @@ interface KeyframeEffect : AnimationEffect {
 
     1.  Set the <a>target element</a> of <var>effect</var> to <var>target</var>.
 
-    1.  Set the <a>target pseudo-selector</a> of <var>effect</var> to the result
-        corresponding to the first matching condition from below.
+    1.  Set the [=target pseudo-selector=] to the result corresponding to the first
+        matching condition from below.
 
         :   If <var>options</var> is a {{KeyframeEffectOptions}} object with a
             {{KeyframeEffectOptions/pseudoElement}} property,
@@ -4835,15 +4828,13 @@ interface KeyframeEffect : AnimationEffect {
     When not `null`, this must be a [=pseudo-element=] selector with
     [[selectors-4#pseudo-element-syntax|valid syntax]].
 
-    This will only accept `null`, the empty string, or syntactically-valid
-    selectors (i.e. `:before`, `:after`, `:first-letter`, `:first-line`,
-    or a string starting with `::`).
+    This will only accept `null` or syntactically-valid selectors
+    (i.e. `:before`, `:after`, `:first-letter`, `:first-line`, or a string starting with `::`).
     If such a string is not given, this will throw a {{DOMException}} with
     error name {{SyntaxError}}.
 
     If one of the legacy single-colon selectors is given, the selector is
-    changed to its double-colon version. If the empth string is given,
-    the selector is changed to `null`.
+    changed to its double-colon version.
 
 :   <dfn attribute for=KeyframeEffect>composite</dfn>
 ::  The <a>composite operation</a> used to composite this

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3203,8 +3203,7 @@ to specify that particular [=pseudo-element=].
 
 Note that not all [=effect targets=] specified in this manner (such as ''::part()''
 pseudo-elements, unsupported/invalid pseudo-elements, and `null`) have
-computed property values defined. Such targets are treated as if all
-properties are [=not animatable=].
+computed property values defined.
 
 ### Keyframes ### {#keyframes-section}
 
@@ -4709,9 +4708,13 @@ interface KeyframeEffect : AnimationEffect {
 
         :   If <var>options</var> is a {{KeyframeEffectOptions}} object with a
             {{KeyframeEffectOptions/pseudoElement}} property,
-        ::  Set the [=target pseudo-selector=] to the value of that property,
-            following the validation procedure from the
-            {{KeyframeEffect/pseudoElement}} setter.
+        ::  Set the [=target pseudo-selector=] to the value of the
+            {{KeyframeEffectOptions/pseudoElement}} property.
+
+            When assigning this property, the error-handling defined for the
+            {{KeyframeEffect/pseudoElement}} setter on the interface is applied.
+            If the setter requires an exception to be thrown, this procedure
+            must throw the same exception and abort all further steps.
 
         :   Otherwise,
         ::  Set the [=target pseudo-selector=] to `null`.
@@ -4824,17 +4827,24 @@ interface KeyframeEffect : AnimationEffect {
 
 :   <dfn attribute for=KeyframeEffect>pseudoElement</dfn>
 ::  The [=target pseudo-selector=].
-    This is `null` if the [=effect target=] is an {{Element}} or is itself `null`.
-    When not `null`, this must be a [=pseudo-element=] selector with
-    [[selectors-4#pseudo-element-syntax|valid syntax]].
+    `null` if this effect has no [=effect target=] or
+    if the [=effect target=] is an element (i.e. not a pseudo-element).
+    When the [=effect target=] is a pseudo-element,
+    this specifies the pseudo-element selector (e.g. `::before`).
 
-    This will only accept `null` or syntactically-valid selectors
-    (i.e. `:before`, `:after`, `:first-letter`, `:first-line`, or a string starting with `::`).
-    If such a string is not given, this will throw a {{DOMException}} with
-    error name {{SyntaxError}}.
+    On setting,
+    sets the [=target pseudo-selector=] of the [=animation effect=]
+    to the provided value after applying the following exceptions:
 
-    If one of the legacy single-colon selectors is given, the selector is
-    changed to its double-colon version.
+    *   If the provided value is not `null` or a syntactically valid
+        <pseudo-element-selector> the user agent must [=throw=]
+        a {{DOMException}} with error name {{TypeError}} and leave the
+        [=target pseudo-selector=] of this [=animation effect=] unchanged.
+
+    *   If one of the legacy Selectors Level 2 single-colon selectors
+        (':before', ':after', ':first-letter', or ':first-line') is
+        specified, the [=target pseudo-selector=] must be set to the
+        equivalent two-colon selector (e.g. '::before').
 
 :   <dfn attribute for=KeyframeEffect>composite</dfn>
 ::  The <a>composite operation</a> used to composite this

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3304,7 +3304,8 @@ To produce <a>computed keyframe offsets</a>, we define a procedure to
 
 <a>Computed keyframes</a> are produced using the following procedure.
 Note that this procedure is only performed on a <a>keyframe effect</a> having
-an <a>effect target</a> for which computed property values can be calculated.
+an <a>effect target</a> for which computed property values can be calculated,
+as otherwise all propereties are <a>not animatable</a>.
 
 1.  Let <var>computed keyframes</var> be an empty list of <a>keyframes</a>.
 
@@ -3363,6 +3364,9 @@ The <a>effect value</a> of a single property referenced by a <a>keyframe
 effect</a> as one of its <a lt="target property">target properties</a>, for a
 given <var>iteration progress</var>, <var ignore=''>current iteration</var> and
 <var>underlying value</var> is calculated as follows.
+Note that this procedure is only performed on a <a>keyframe effect</a> having
+an <a>effect target</a> for which computed property values can be calculated,
+as otherwise case all propereties are <a>not animatable</a>.
 
 1.  If <var>iteration progress</var> is <a>unresolved</a> abort this
     procedure.
@@ -3730,6 +3734,9 @@ will be added to &lsquo;Transition declarations&rsquo; level of the cascade.
 
 The <a>composited value</a> calculated for a CSS <a>target
 property</a> is applied using the following process.
+Note that this procedure is only performed on a <a>keyframe effect</a> having
+an <a>effect target</a> for which computed property values can be calculated,
+as otherwise case all propereties are <a>not animatable</a>.
 
 1.  Calculate the <var>base value</var> of the property as
     the value generated for that property by computing the computed value
@@ -4704,8 +4711,8 @@ interface KeyframeEffect : AnimationEffect {
 
     1.  Set the <a>target element</a> of <var>effect</var> to <var>target</var>.
 
-    1.  Set the [=target pseudo-selector=] to the result corresponding to the first
-        matching condition from below.
+    1.  Set the <a>target pseudo-selector</a> of <var>effect</var> to the result
+        corresponding to the first matching condition from below.
 
         :   If <var>options</var> is a {{KeyframeEffectOptions}} object with a
             {{KeyframeEffectOptions/pseudoElement}} property,
@@ -4828,8 +4835,9 @@ interface KeyframeEffect : AnimationEffect {
     When not `null`, this must be a [=pseudo-element=] selector with
     [[selectors-4#pseudo-element-syntax|valid syntax]].
 
-    This will only accept `null` or syntactically-valid selectors
-    (i.e. `:before`, `:after`, `:first-letter`, `:first-line`, or a string starting with `::`).
+    This will only accept `null`, the empty string, or syntactically-valid
+    selectors (i.e. `:before`, `:after`, `:first-letter`, `:first-line`,
+    or a string starting with `::`).
     If such a string is not given, this will throw a {{DOMException}} with
     error name {{SyntaxError}}.
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3202,7 +3202,7 @@ its [=originating element=] and the [=target pseudo-selector=] is as required
 to specify that particular [=pseudo-element=].
 
 Note that not all [=effect targets=] specified in this manner (such as ''::part()''
-pseudo-elements, unsupported/invalid pseudo-elements, and `null`) have
+pseudo-elements and unsupported pseudo-elements) have
 computed property values defined.
 
 ### Keyframes ### {#keyframes-section}
@@ -3369,8 +3369,9 @@ given <var>iteration progress</var>, <var ignore=''>current iteration</var> and
 1.  If <a>animation type</a> of the <var>target property</var> is
     <a>not animatable</a> abort this procedure
     since the effect cannot be applied.
-1.  If the [=effect target=] is `null` or cannot have computed property values
-    calsulated, abort this procedure.
+1.  If the  [=keyframe effect=] does not have an [=effect target=],
+    or if the [=effect target=] cannot have computed property values
+    calculated, abort this procedure.
 1.  Define the <dfn>neutral value for composition</dfn> as a value
     which, when combined with an <a>underlying value</a> using the <a
     lt="composite operation add">add</a> <a>composite


### PR DESCRIPTION
Fixup of #4437 addressing #4301.

* Add pseudoElement option to KeyframeEffect constructor body
* Fix #4502 adding catch-all pseudo-element case to composite order
* Fix #4586 adding error handling to KeyframeEffect.pseudoElement
* Fix #4701 making note of case when property values cannot be calculated