### PR TITLE
[css-ruby] Describe position and size of ruby level container when empty

### DIFF
--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -629,6 +629,8 @@ Ruby Layout</h2>
 	exactly as if its <i>ruby bases</i> were a regular sequence of inline boxes.
 	Each <i>ruby base container</i> is sized and positioned
 	to contain exactly all of its <i>ruby bases</i>’ margin boxes.
+	If it has no <i>ruby base</i> inside,
+	it behaves as if there is an empty one.
 
 	<p><i>Ruby annotations</i> associated with the <i>base level</i>
 	are then positioned with respect to their <i>ruby base boxes</i>
@@ -638,6 +640,8 @@ Ruby Layout</h2>
 	participating in the same inline formatting context.
 	Each <i>ruby annotation container</i> is sized and positioned
 	to contain exactly all of its <i>ruby annotations</i>’ margin boxes.
+	If it has no <i>ruby annotation</i> inside,
+	it behaves as if there is an empty one.
 
 	<p><i>Ruby annotation containers</i> are stacked outward
 	over or under their corresponding <i>ruby base container</i>,


### PR DESCRIPTION
This intends to fix #4631.

I think this can be considered to be a bug fix and thus wouldn't really need to go through the working group.