### PR TITLE
Adding of video-* properties and dynamic-range to handle bi-plane scenarios

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1706,45 +1706,47 @@ Dynamic Range: the 'dynamic-range' feature</h3>
 	</pre>
 </h3>
 
-High dynamic range (HDR) represents the combination of brightness, color depth, transfer function, and color gamut.
+'@media/dynamic-range' represents the combination of brightness and color
+depth.
 
-<dl dfn-type=value dfn-for="dynamic-range">
+<dl dfn-type=value dfn-for="@media/dynamic-range">
 	<dt><dfn>high</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
 		* max brightness is considered high
 		* color depth is greater than 24 bit
-		* has a <a href="#contrast-of-display">high contrast ratio</a>
+		* has a <a>high contrast ratio</a>
 	<dt><dfn>standard</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
-		* max brightness is considered standards
+		* max brightness is considered standard
 		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a <a href="#contrast-of-display">low contrast ratio</a>
+		* has a <a>low contrast ratio</a>
 </dl>
 
 <h3 id="contrast-brightness-of-display">
 	Determining contrast and brightness of display</h3>
 
 This text is non-normative. There currently is no agreed upon standardization of
-high contrast ratio, low contrast ratio, max brightness or low brightness as it
-relates to displays. As such, the determination for <a>dynamic-range</a> and
-<a>video-dymanic-range</a> will be defined by the user agent.
+<dfn export>high contrast ratio</dfn>, <dfn export>low contrast ratio</dfn>,
+max brightness or low brightness as it relates to displays. As such, the
+determination for '@media/dynamic-range' and '@media/video-dynamic-range' will
+be defined by the user agent.
 
 <h3 id="video-prefixed-properties">
-Handling bi-plane scenarios</h3>
+Video Prefixed Properties scenarios</h3>
 
-	In some scenarios, such as TVs, the user agents may have a graphics
-	plane dedicated to video that has its own discrete hardware. In order
-	to allow UAs in environments that have more than one plane for graphics
-	rendering the following properties should be used to correctly answer
-	video specific queries.
+    Some user agents, including many TVs, render video and graphics in two
+	separate "planes" (bi-plane) with distinct screen characteristics. A set of
+	video-prefixed features is provided to describe the video plane.
 
-	For any UA on a bi-plane device you **MUST** return the values for:
-	<a>video-color-gamut</a>; <a>video-width</a>; <a>video-height</a>; <a>video-resolution</a>;
-	<a>video-dynamic-range</a>; based on the plane that renders video. If the UA is not in a bi-plane
-	scenario then it **MUST** return the values of the single plane
-	(they're effectively aliases to their non-video counterparts).
+	Any bi-plane implementation **MUST** return values based on the video plane
+	for the following features: '@media/video-color-gamut'; '@media/video-width';
+	'@media/video-height'; '@media/video-resolution'; '@media/video-dynamic-range'.
+	All other features **MUST** return values based on the graphics plane.
+
+    Non bi-plane implementations **MUST** return the same values for
+	video-prefixed features and their non-prefixed counterparts.
 
 <h3 id="video-color-gamut">
 Video Color Display Quality: the 'video-color-gamut' feature</h3>
@@ -1757,7 +1759,7 @@ Video Color Display Quality: the 'video-color-gamut' feature</h3>
 	</pre>
 </h3>
 
-The 'video-color-gamut' media feature describes the approximate range of colors
+The '@media/video-color-gamut' media feature describes the approximate range of colors
 	that are supported by the UA and output device's video plane.
 	That is, if the UA receives content with colors in the specified space
 	it can cause the output device to render the appropriate color,
@@ -1776,21 +1778,22 @@ Video Dynamic Range: the 'video-dynamic-range' feature</h3>
 	</pre>
 </h3>
 
-High dynamic range (HDR) represents the combination of brightness, color depth, transfer function, and color gamut.
+'@media/video-dynamic-range' has the same values and definitions as '@media/dynamic-range',
+but describes the UA's and device's video plane.
 
 <dl dfn-type=value dfn-for="video-dynamic-range">
 	<dt><dfn>high</dfn>
 	<dd>
 		If the following are true for the UA and the output device's video plane:
-		* color gamut is <a>p3</a> or <a>rec2020</a>
+		* color gamut is ''p3'' or ''rec2020''
 		* color depth is greater than 24 bit
-		* has a <a href="#contrast-of-display">high contrast ratio</a>
+		* has a high contrast ratio
 	<dt><dfn>standard</dfn>
 	<dd>
 		If the following are true for the UA and the output device's video plane:
-		* color gamut is <a>sRGB</a>
+		* color gamut is sRGB
 		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a <a href="#contrast-of-display">low contrast ratio</a>
+		* has a low contrast ratio
 </dl>
 
 <h3 id="video-width">
@@ -1840,13 +1843,11 @@ Video Display Resolution: the 'video-resolution' feature</h3>
 	Type: range
 	</pre>
 
-	The 'video-resolution' media feature describes the resolution of the output
+	The '@media/video-resolution' media feature describes the resolution of the output
 	device's video plane, i.e. the density of the pixels, taking into account the <a spec=cssom-view>page zoom</a>
 	but assuming a <a spec=cssom-view>pinch zoom</a> of 1.0.
 
 	The 'video-resolution' media feature is <a>false in the negative range</a>
-
-<p class="issue">There needs to be a solution for dynamic range</p>
 
 <!--
 ████ ██    ██ ████████ ████████ ████████     ███     ██████  ████████ ████  ███████  ██    ██

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1695,8 +1695,36 @@ Color Display Quality: the 'color-gamut' feature</h3>
 	you can use this feature in a negated boolean-context fashion:
 	''not (color-gamut)''.
 
+<h3 id="dynamic-range">
+Dynamic Range: the 'dynamic-range' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: dynamic-range
+	Value: standard | high
+	For: @media
+	Type: discrete
+	</pre>
+</h3>
+
+High dynamic range (HDR) represents the combination of brightness, color depth, transfer function, and color gamut.
+
+<dl dfn-type=value dfn-for="dynamic-range">
+	<dt><dfn>high</dfn>
+	<dd>
+		If the following are true for the UA and the output device:
+		* color gamut is <a>p3</a>, <a>rec2020</a>
+		* color depth is greater than 24 bit
+		* has a high contrast ratio
+	<dt><dfn>standard</dfn>
+	<dd>
+		If the following are true for the UA and the output device:
+		* color gamut is <a>sRGB</a>
+		* color depth is 24 bit or 8 bit per color component of RGB
+		* has a low contrast ratio
+</dl>
+
 <h3 id="video-prefixed-properties">
-Handling bi-plane displays</h3>
+Handling bi-plane scenarios</h3>
 
 	In some scenarios, such as TVs, they have a graphics plane dedicated 
 	to video that has its own discrete hardware. In order to allow UAs in 
@@ -1704,13 +1732,14 @@ Handling bi-plane displays</h3>
 	following properties should be used to correctly answer video specific 
 	queries.
 
-	For any useragent on a bi-plane device you **MUST** return the values for: 
-	<a>video-color-gamut</a>; <a>video-width</a>; <a>video-height</a>; <a>video-resolution</a>; 
-	based on the plane that renders video. If the useragent is not in a bi-plane scenario then 
-	you **MUST** return the values of the single plane (they're effectively aliases to their non-video counterparts).
+	For any UA on a bi-plane device you **MUST** return the values for: 
+	<a>video-color-gamut</a>; <a>video-width</a>; <a>video-height</a>; <a>video-resolution</a>;
+	<a>video-dynamic-range</a>; based on the plane that renders video. If the UA is not in a bi-plane 
+	scenario then it **MUST** return the values of the single plane 
+	(they're effectively aliases to their non-video counterparts).
 
 <h3 id="video-color-gamut">
-Color Display Quality: the 'video-color-gamut' feature</h3>
+Video Color Display Quality: the 'video-color-gamut' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: video-color-gamut
@@ -1727,6 +1756,34 @@ The 'video-color-gamut' media feature describes the approximate range of colors
 	or something appropriately close enough.
 
 Value and color space definitions are the same as <a href="#color-gamut">color-gamut</a>
+
+<h3 id="video-dynamic-range">
+Video Dynamic Range: the 'video-dynamic-range' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-dynamic-range
+	Value: standard | high
+	For: @media
+	Type: discrete
+	</pre>
+</h3>
+
+High dynamic range (HDR) represents the combination of brightness, color depth, transfer function, and color gamut.
+
+<dl dfn-type=value dfn-for="video-dynamic-range">
+	<dt><dfn>high</dfn>
+	<dd>
+		If the following are true for the UA and the output device's video plane:
+		* color gamut is <a>p3</a>, <a>rec2020</a>
+		* color depth is greater than 24 bit
+		* has a high contrast ratio
+	<dt><dfn>standard</dfn>
+	<dd>
+		If the following are true for the UA and the output device's video plane:
+		* color gamut is <a>sRGB</a>
+		* color depth is 24 bit or 8 bit per color component of RGB
+		* has a low contrast ratio
+</dl>
 
 <h3 id="video-width">
 Video-Width: the '@media/video-width' feature</h3>
@@ -1765,7 +1822,7 @@ Video-Height: the '@media/video-height' feature</h3>
 
 	'@media/video-height' is <a>false in the negative range</a>.
 
-<h3 id="video-resolution" caniuse="css-media-video-resolution">
+<h3 id="video-resolution">
 Video Display Resolution: the 'video-resolution' feature</h3>
 
 	<pre class='descdef mq'>

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1727,6 +1727,25 @@ The 'video-color-gamut' media feature describes the approximate range of colors
 
 Value and color space definitions are the same as <a href="#color-gamut">color-gamut</a>
 
+<h3 id="video-width">
+Video-Width: the '@media/video-width' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-width
+	Value: <<length>>
+	For: @media
+	Type: range
+	</pre>
+
+	The '@media/video-width' media feature describes the width of the targeted display's video plane area 
+	of the output device. For continuous media, this is the width of the viewport
+	(as described by CSS2, section 9.1.1 [[!CSS21]]) including the size of a rendered scroll bar (if any).
+	For paged media, this is the width of the page box (as described by CSS2, section 13.2 [[!CSS21]]).
+
+	<<length>>s are interpreted according to [[#units]].
+
+	'@media/video-width' is <a>false in the negative range</a>.
+
 <!--
 ████ ██    ██ ████████ ████████ ████████     ███     ██████  ████████ ████  ███████  ██    ██
  ██  ███   ██    ██    ██       ██     ██   ██ ██   ██    ██    ██     ██  ██     ██ ███   ██

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1733,7 +1733,7 @@ max brightness or low brightness as it relates to displays. As such, the
 determination for '@media/dynamic-range' and '@media/video-dynamic-range' will
 be defined by the user agent.
 
-<h3 id="video-prefixed-properties">Video Prefixed Feature</h3>
+<h3 id="video-prefixed-features">Video Prefixed Features</h3>
 
     Some user agents, including many TVs, render video and graphics in two
 	separate "planes" (bi-plane) with distinct screen characteristics. A set of
@@ -1781,7 +1781,7 @@ Video Dynamic Range: the 'video-dynamic-range' feature</h3>
 color depth, and contrast ratio that are supported by the UA and output device's
 video plane.
 
-Supported values are the same as dynamic-range.
+Supported values are the same as <a href="#dynamic-range">dynamic-range</a>.
 
 <h3 id="video-width">
 Video-Width: the '@media/video-width' feature</h3>

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1712,16 +1712,24 @@ High dynamic range (HDR) represents the combination of brightness, color depth, 
 	<dt><dfn>high</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
-		* color gamut is <a>p3</a>, <a>rec2020</a>
+		* color gamut is <a>p3</a> or <a>rec2020</a>
 		* color depth is greater than 24 bit
-		* has a high contrast ratio
+		* has a <a href="#contrast-of-display">high contrast ratio</a>
 	<dt><dfn>standard</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
 		* color gamut is <a>sRGB</a>
 		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a low contrast ratio
+		* has a <a href="#contrast-of-display">low contrast ratio</a>
 </dl>
+
+<h3 id="contrast-of-display">
+	Determining contrast of display</h3>
+
+This text is non-normative. There currently is no agreed upon standardization of 
+high contrast ratio or low contrast ratio as it relates to displays. 
+As such, the determination for <a>dynamic-range</a> and <a>video-dymanic-range</a> 
+will be defined by the user agent.
 
 <h3 id="video-prefixed-properties">
 Handling bi-plane scenarios</h3>
@@ -1774,15 +1782,15 @@ High dynamic range (HDR) represents the combination of brightness, color depth, 
 	<dt><dfn>high</dfn>
 	<dd>
 		If the following are true for the UA and the output device's video plane:
-		* color gamut is <a>p3</a>, <a>rec2020</a>
+		* color gamut is <a>p3</a> or <a>rec2020</a>
 		* color depth is greater than 24 bit
-		* has a high contrast ratio
+		* has a <a href="#contrast-of-display">high contrast ratio</a>
 	<dt><dfn>standard</dfn>
 	<dd>
 		If the following are true for the UA and the output device's video plane:
 		* color gamut is <a>sRGB</a>
 		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a low contrast ratio
+		* has a <a href="#contrast-of-display">low contrast ratio</a>
 </dl>
 
 <h3 id="video-width">

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1704,39 +1704,10 @@ Handling bi-plane displays</h3>
 	following properties should be used to correctly answer video specific 
 	queries.
 
-	For any useragent on a bi-plane device you **MUST** return the values for video [insert props] 
+	For any useragent on a bi-plane device you **MUST** return the values for: 
+	<a>video-color-gamut</a>; <a>video-width</a>; <a>video-height</a>; <a>video-resolution</a>; 
 	based on the plane that renders video. If the useragent is not in a bi-plane scenario then 
 	you **MUST** return the values of the single plane (they're effectively aliases to their non-video counterparts).
-
-<h3 id="video-color">
-Video Color Depth: the '@media/video-color' feature</h3>
-
-	<pre class='descdef mq'>
-	Name: video-color
-	Value: <<integer>>
-	For: @media
-	Type: range
-	</pre>
-
-	The '@media/video-color' media feature describes the number of bits per color component of the output device's video plane.
-	If the device is not a color device, the value is zero.
-
-	'@media/video-color' is <a>false in the negative range</a>.
-
-<h3 id="video-color-index">
-Paletted Color Screens for the Video Plane: the 'video-color-index' feature</h3>
-
-	<pre class='descdef mq'>
-	Name: video-color-index
-	Value: <<integer>>
-	For: @media
-	Type: range
-	</pre>
-
-	The 'video-color-index' media feature describes the number of entries in the color lookup table of the output device's video plane.
-	If the device does not use a color lookup table, the value is zero.
-
-	'@media/video-color-index' is <a>false in the negative range</a>.
 
 <h3 id="video-color-gamut">
 Color Display Quality: the 'video-color-gamut' feature</h3>
@@ -1794,25 +1765,6 @@ Video-Height: the '@media/video-height' feature</h3>
 
 	'@media/video-height' is <a>false in the negative range</a>.
 
-<h3 id='video-aspect-ratio'>
-Video Aspect-Ratio: the 'aspect-ratio' feature</h3>
-
-	<pre class='descdef mq'>
-	Name: video-aspect-ratio
-	Value: <<ratio>>
-	For: @media
-	Type: range
-	</pre>
-
-	The 'video-aspect-ratio' media feature is defined as the ratio of the value of the '@media/video-width' media feature
-	to the value of the '@media/video-height' media feature.
-
-	The <dfn type>&lt;ratio></dfn> value type is a positive (not zero or negative)
-	<<integer>> followed by optional whitespace, followed by a solidus ('/'),
-	followed by optional whitespace, followed by a positive <<integer>>.
-	<<ratio>>s can be ordered or compared by transforming them into the number
-	obtained by dividing their first <<integer>> by their second <<integer>>.
-
 <h3 id="video-resolution" caniuse="css-media-video-resolution">
 Video Display Resolution: the 'video-resolution' feature</h3>
 
@@ -1828,6 +1780,8 @@ Video Display Resolution: the 'video-resolution' feature</h3>
 	but assuming a <a spec=cssom-view>pinch zoom</a> of 1.0.
 
 	The 'video-resolution' media feature is <a>false in the negative range</a>
+
+<p class="issue">There needs to be a solution for dynamic range</p>
 
 <!--
 ████ ██    ██ ████████ ████████ ████████     ███     ██████  ████████ ████  ███████  ██    ██

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1706,8 +1706,8 @@ Dynamic Range: the 'dynamic-range' feature</h3>
 	</pre>
 </h3>
 
-'@media/dynamic-range' represents the combination of brightness and color
-depth.
+'@media/dynamic-range' represents the combination of max brightness,
+color depth, and contrast ratio that are supported by the UA and output device.
 
 <dl dfn-type=value dfn-for="@media/dynamic-range">
 	<dt><dfn>high</dfn>
@@ -1733,19 +1733,18 @@ max brightness or low brightness as it relates to displays. As such, the
 determination for '@media/dynamic-range' and '@media/video-dynamic-range' will
 be defined by the user agent.
 
-<h3 id="video-prefixed-properties">
-Video Prefixed Properties scenarios</h3>
+<h3 id="video-prefixed-properties">Video Prefixed Feature</h3>
 
     Some user agents, including many TVs, render video and graphics in two
 	separate "planes" (bi-plane) with distinct screen characteristics. A set of
 	video-prefixed features is provided to describe the video plane.
 
-	Any bi-plane implementation **MUST** return values based on the video plane
+	Any bi-plane implementation must return values based on the video plane
 	for the following features: '@media/video-color-gamut'; '@media/video-width';
 	'@media/video-height'; '@media/video-resolution'; '@media/video-dynamic-range'.
-	All other features **MUST** return values based on the graphics plane.
+	All other features must return values based on the graphics plane.
 
-    Non bi-plane implementations **MUST** return the same values for
+    Non bi-plane implementations must return the same values for
 	video-prefixed features and their non-prefixed counterparts.
 
 <h3 id="video-color-gamut">
@@ -1778,23 +1777,11 @@ Video Dynamic Range: the 'video-dynamic-range' feature</h3>
 	</pre>
 </h3>
 
-'@media/video-dynamic-range' has the same values and definitions as '@media/dynamic-range',
-but describes the UA's and device's video plane.
+'@media/video-dynamic-range' represents the combination of max brightness,
+color depth, and contrast ratio that are supported by the UA and output device's
+video plane.
 
-<dl dfn-type=value dfn-for="video-dynamic-range">
-	<dt><dfn>high</dfn>
-	<dd>
-		If the following are true for the UA and the output device's video plane:
-		* color gamut is ''p3'' or ''rec2020''
-		* color depth is greater than 24 bit
-		* has a high contrast ratio
-	<dt><dfn>standard</dfn>
-	<dd>
-		If the following are true for the UA and the output device's video plane:
-		* color gamut is sRGB
-		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a low contrast ratio
-</dl>
+Supported values are the same as dynamic-range.
 
 <h3 id="video-width">
 Video-Width: the '@media/video-width' feature</h3>

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1695,6 +1695,38 @@ Color Display Quality: the 'color-gamut' feature</h3>
 	you can use this feature in a negated boolean-context fashion:
 	''not (color-gamut)''.
 
+<h3 id="video-prefixed-properties">
+Handling bi-plane displays</h3>
+
+	In some scenarios, such as TVs, they have a graphics plane dedicated 
+	to video that has its own discrete hardware. In order to allow UAs in 
+	environments that have more than one plane for graphics rendering the 
+	following properties should be used to correctly answer video specific 
+	queries.
+
+	For any useragent on a bi-plane device you **MUST** return the values for video [insert props] 
+	based on the plane that renders video. If the useragent is not in a bi-plane scenario then 
+	you **MUST** return the values of the single plane. 
+
+<h3 id="video-color-gamut">
+Color Display Quality: the 'video-color-gamut' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-color-gamut
+	Value: srgb | p3 | rec2020
+	For: @media
+	Type: discrete
+	</pre>
+</h3>
+
+The 'video-color-gamut' media feature describes the approximate range of colors
+	that are supported by the UA and output device's video plane.
+	That is, if the UA receives content with colors in the specified space
+	it can cause the output device to render the appropriate color,
+	or something appropriately close enough.
+
+Value and color space definitions are the same as <a href="#color-gamut">color-gamut</a>
+
 <!--
 ████ ██    ██ ████████ ████████ ████████     ███     ██████  ████████ ████  ███████  ██    ██
  ██  ███   ██    ██    ██       ██     ██   ██ ██   ██    ██    ██     ██  ██     ██ ███   ██

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1712,38 +1712,38 @@ High dynamic range (HDR) represents the combination of brightness, color depth, 
 	<dt><dfn>high</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
-		* color gamut is <a>p3</a> or <a>rec2020</a>
+		* max brightness is considered high
 		* color depth is greater than 24 bit
 		* has a <a href="#contrast-of-display">high contrast ratio</a>
 	<dt><dfn>standard</dfn>
 	<dd>
 		If the following are true for the UA and the output device:
-		* color gamut is <a>sRGB</a>
+		* max brightness is considered standards
 		* color depth is 24 bit or 8 bit per color component of RGB
 		* has a <a href="#contrast-of-display">low contrast ratio</a>
 </dl>
 
-<h3 id="contrast-of-display">
-	Determining contrast of display</h3>
+<h3 id="contrast-brightness-of-display">
+	Determining contrast and brightness of display</h3>
 
-This text is non-normative. There currently is no agreed upon standardization of 
-high contrast ratio or low contrast ratio as it relates to displays. 
-As such, the determination for <a>dynamic-range</a> and <a>video-dymanic-range</a> 
-will be defined by the user agent.
+This text is non-normative. There currently is no agreed upon standardization of
+high contrast ratio, low contrast ratio, max brightness or low brightness as it
+relates to displays. As such, the determination for <a>dynamic-range</a> and
+<a>video-dymanic-range</a> will be defined by the user agent.
 
 <h3 id="video-prefixed-properties">
 Handling bi-plane scenarios</h3>
 
-	In some scenarios, such as TVs, they have a graphics plane dedicated 
-	to video that has its own discrete hardware. In order to allow UAs in 
-	environments that have more than one plane for graphics rendering the 
-	following properties should be used to correctly answer video specific 
-	queries.
+	In some scenarios, such as TVs, the user agents may have a graphics
+	plane dedicated to video that has its own discrete hardware. In order
+	to allow UAs in environments that have more than one plane for graphics
+	rendering the following properties should be used to correctly answer
+	video specific queries.
 
-	For any UA on a bi-plane device you **MUST** return the values for: 
+	For any UA on a bi-plane device you **MUST** return the values for:
 	<a>video-color-gamut</a>; <a>video-width</a>; <a>video-height</a>; <a>video-resolution</a>;
-	<a>video-dynamic-range</a>; based on the plane that renders video. If the UA is not in a bi-plane 
-	scenario then it **MUST** return the values of the single plane 
+	<a>video-dynamic-range</a>; based on the plane that renders video. If the UA is not in a bi-plane
+	scenario then it **MUST** return the values of the single plane
 	(they're effectively aliases to their non-video counterparts).
 
 <h3 id="video-color-gamut">
@@ -1803,7 +1803,7 @@ Video-Width: the '@media/video-width' feature</h3>
 	Type: range
 	</pre>
 
-	The '@media/video-width' media feature describes the width of the targeted display's video plane area 
+	The '@media/video-width' media feature describes the width of the targeted display's video plane area
 	of the output device. For continuous media, this is the width of the viewport
 	(as described by CSS2, section 9.1.1 [[!CSS21]]) including the size of a rendered scroll bar (if any).
 	For paged media, this is the width of the page box (as described by CSS2, section 13.2 [[!CSS21]]).

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1706,7 +1706,37 @@ Handling bi-plane displays</h3>
 
 	For any useragent on a bi-plane device you **MUST** return the values for video [insert props] 
 	based on the plane that renders video. If the useragent is not in a bi-plane scenario then 
-	you **MUST** return the values of the single plane. 
+	you **MUST** return the values of the single plane (they're effectively aliases to their non-video counterparts).
+
+<h3 id="video-color">
+Video Color Depth: the '@media/video-color' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-color
+	Value: <<integer>>
+	For: @media
+	Type: range
+	</pre>
+
+	The '@media/video-color' media feature describes the number of bits per color component of the output device's video plane.
+	If the device is not a color device, the value is zero.
+
+	'@media/video-color' is <a>false in the negative range</a>.
+
+<h3 id="video-color-index">
+Paletted Color Screens for the Video Plane: the 'video-color-index' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-color-index
+	Value: <<integer>>
+	For: @media
+	Type: range
+	</pre>
+
+	The 'video-color-index' media feature describes the number of entries in the color lookup table of the output device's video plane.
+	If the device does not use a color lookup table, the value is zero.
+
+	'@media/video-color-index' is <a>false in the negative range</a>.
 
 <h3 id="video-color-gamut">
 Color Display Quality: the 'video-color-gamut' feature</h3>
@@ -1745,6 +1775,59 @@ Video-Width: the '@media/video-width' feature</h3>
 	<<length>>s are interpreted according to [[#units]].
 
 	'@media/video-width' is <a>false in the negative range</a>.
+
+<h3 id="video-height">
+Video-Height: the '@media/video-height' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-height
+	Value: <<length>>
+	For: @media
+	Type: range
+	</pre>
+
+	The '@media/video-height' media feature describes the height of the targeted display's video plane area of the output device.
+	For continuous media, this is the height of the viewport including the size of a rendered scroll bar (if any).
+	For paged media, this is the height of the page box.
+
+	<<length>>s are interpreted according to [[#units]].
+
+	'@media/video-height' is <a>false in the negative range</a>.
+
+<h3 id='video-aspect-ratio'>
+Video Aspect-Ratio: the 'aspect-ratio' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-aspect-ratio
+	Value: <<ratio>>
+	For: @media
+	Type: range
+	</pre>
+
+	The 'video-aspect-ratio' media feature is defined as the ratio of the value of the '@media/video-width' media feature
+	to the value of the '@media/video-height' media feature.
+
+	The <dfn type>&lt;ratio></dfn> value type is a positive (not zero or negative)
+	<<integer>> followed by optional whitespace, followed by a solidus ('/'),
+	followed by optional whitespace, followed by a positive <<integer>>.
+	<<ratio>>s can be ordered or compared by transforming them into the number
+	obtained by dividing their first <<integer>> by their second <<integer>>.
+
+<h3 id="video-resolution" caniuse="css-media-video-resolution">
+Video Display Resolution: the 'video-resolution' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: video-resolution
+	Value: <<resolution>> | infinite
+	For: @media
+	Type: range
+	</pre>
+
+	The 'video-resolution' media feature describes the resolution of the output
+	device's video plane, i.e. the density of the pixels, taking into account the <a spec=cssom-view>page zoom</a>
+	but assuming a <a spec=cssom-view>pinch zoom</a> of 1.0.
+
+	The 'video-resolution' media feature is <a>false in the negative range</a>
 
 <!--
 ████ ██    ██ ████████ ████████ ████████     ███     ██████  ████████ ████  ███████  ██    ██


### PR DESCRIPTION
As resolved in issue #4471 I have added in:

```
video-color-gamut
video-dynamic-range
video-width
video-height
video-resolution
dynamic-range
```
And a brief description of the issue along with normative text of when to answer differently between a single or bi-plane scenario.

Specific to dynamic-range we placed a general definition there and are interested in thoughts since standard & high may fluctuate over time but I'd expect the spec text too as well.