### PR TITLE
[scroll-anchoring-1] Add a scroll anchoring suppression trigger for zero scroll offset

### DIFF
--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -229,6 +229,8 @@ These triggers are:
 	Note that this trigger applies regardless of whether the modified element is
 	on the path from the anchor node to the scrollable element.
 
+* The scroll offset of the scrollable element becoming zero.
+
 Note: Suppression triggers exist for compatibility with existing web content that has negative
 interactions with scroll anchoring due to shifting content in scroll event handlers.
 

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -229,7 +229,7 @@ These triggers are:
 	Note that this trigger applies regardless of whether the modified element is
 	on the path from the anchor node to the scrollable element.
 
-* The scroll offset of the scrollable element becoming zero.
+* The scroll offset of the scrollable element being zero.
 
 Note: Suppression triggers exist for compatibility with existing web content that has negative
 interactions with scroll anchoring due to shifting content in scroll event handlers.


### PR DESCRIPTION
Chromium has, since launch of the scroll anchoring feature, had a suppression trigger when
scroll offset becomes zero. We should just add it to the spec.

One reason to do so is that scroll offset zero is a conceptual stable point that can be observed by the user, and therefore should be maintained. It is also common to trigger feature such as pull-to-refresh based on zero scroll offset.

A third reason is web compatibility. An example bug related to this in which Firefox currently differs from Chromiu is [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1022615). Others were found during the pre-launch testing of scroll anchoring for Chromium.