### PR TITLE
[resize-observer] exclude ResizeObservation IDL from Reffy

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -294,11 +294,12 @@ A future version of this spec will extend the returned sequences to contain the 
 <h2 id="processing-model">Processing Model</h2>
 
 <h3 id="resize-observation-interface">ResizeObservation example struct</h3>
-<p class="note">This section is not normative. ResizeObservation is an example struct that can be used in implementation of Resize Observer. It is being
+
+<p class="note">This section is non-normative. ResizeObservation is an example struct that can be used in implementation of Resize Observer. It is being
 included here in order to help provide clarity during the processing model. It effectively holds observation information for a single {{Element}}. This
 interface is not visible to Javascript.</p>
 
-<pre class="idl">
+<pre class="idl exclude">
 [Constructor(Element target)
 ]
 interface ResizeObservation {


### PR DESCRIPTION
This IDL is non-normative and is excluded by class="exclude":
https://github.com/tidoust/reffy/blob/d886aca8457f85bd7c89c9daf855d27def0d635d/src/cli/extract-webidl.js#L148

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
