### PR TITLE
Revert "[scroll-anchor-1] Add scroll-anchor suppression trigger for overflow-anchor"

### DIFF
--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -221,7 +221,6 @@ These triggers are:
 	* 'width', 'height', 'min-width', 'max-width', 'min-height', or 'max-height'
 	* 'position'
 	* 'transform'
-	* 'overflow-anchor'
 
 * Any change to the computed value of the 'position' property
 	on any element within the scrollable element (or document),


### PR DESCRIPTION
Reverts w3c/csswg-drafts#4681

I don't think we want this after all. On change of overflow-anchor, a layout has not actually occurred, and we just need to re-compute the anchor, not suppress the whole action for the next
layout.

css/css-scroll-anchoring/subtree-exclusion.html is such a case, that would break otherwise.