### PR TITLE
[selectors-4] Mark :has() as at risk and optional, remove profile (solves #3925)

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -23,6 +23,7 @@ Abstract: <a>Selectors</a> are patterns that match against elements in a tree, a
 Abstract: Selectors Level 4 describes the selectors that already exist in [[!SELECT]], and further introduces new selectors for CSS and other languages that may need them.
 At Risk: the column combinator
 At Risk: the '':read-write'' pseudo-class
+At Risk: the '':has()'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
 Ignored Vars: identifier, extended filtering, i
 </pre>
@@ -486,44 +487,6 @@ Selectors Overview</h2>
 	</table>
 
 	Note: Some Level 4 selectors (noted above as "3-UI") were introduced in [[CSS3UI]].
-
-<h3 id="profiles">
-<a>Live</a> vs <a>Snapshot</a> Selector Profiles</h3>
-
-	Selectors are used in many different contexts,
-	with wildly varying performance characteristics.
-	Some powerful selectors are unfortunately too slow
-	to realistically include in the more performance-sensitive contexts.
-	To accommodate this, two profiles of the Selectors spec are defined:
-
-	<dl>
-		<dt><dfn local-lt="live">live profile</dfn>
-		<dd>
-			The <a>live</a> profile is appropriate for use in any context,
-			including browser CSS selector matching, which is live.
-			It includes every selector defined in this document,
-			except for:
-
-			<ul>
-				<li>The '':has()'' pseudo-class
-			</ul>
-
-		<dt><dfn local-lt="snapshot">snapshot profile</dfn>
-		<dd>
-			The <a>snapshot</a> profile is appropriate for contexts which aren't extremely performance sensitive;
-			in particular, it's appropriate for contexts which evaluate selectors against a static document tree.
-			For example, the {{Element/querySelector()}} method defined in [[DOM]] should use the <a>snapshot</a> profile.
-			It includes all of the selectors defined in this document.
-	</dl>
-
-	CSS implementations conformant to Selectors Level 4 must use the <a>live</a> profile for CSS selection.
-	Implementations using the <a>live</a> profile must treat selectors that are not included in the profile
-	as unknown and invalid.
-
-	<p class='issue'>
-		The categorization of things into the “live” or snapshot profiles needs implementor review.
-		If some things currently not in the live profile can reasonably be done in CSS Selectors,
-		we should move them.
 
 
 <h2 id="syntax">
@@ -1276,6 +1239,8 @@ The Relational Pseudo-class: '':has()''</h3>
 		...would result matching any <code>&lt;section></code> element
 		which contains anything that's not a heading element.
 	</div>
+	
+	Supporting the '':has()'' pseudo-class is not required to conform to this specification.
 
 
 <h2 id="elemental-selectors">
@@ -3901,6 +3866,15 @@ Appendix B: Obsolete but Required Parsing Quirks for Web Compat</h2>
 
 <h2 id="changes">
 Changes</h2>
+<h3 id="changes-2018-11">
+Changes since the 21 November 2018 Working Draft</h3>
+
+	Significant changes since the <a href="https://www.w3.org/TR/2018/WD-selectors-4-20181121/">21 November 2018 Working Draft</a>:
+
+	<ul>
+		<li>Removed the Selector profiles, marked '':has()'' as optional and at-risk instead.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/3925">Issue 3925</a>)
+	</ul>
 
 <h3 id="changes-2018-02">
 Changes since the 2 February 2018 Working Draft</h3>


### PR DESCRIPTION
Remove the notion of the Live and Snapshot Profiles and mark `:has()` as "at risk" and "optional", according [to the resolution](https://github.com/w3c/csswg-drafts/issues/3925#issuecomment-492724267) to #3925 (https://lists.w3.org/Archives/Public/www-style/2019May/0008.html)
