### PR TITLE
Add note re scripts to text-decoration-skip-ink

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -1076,6 +1076,9 @@ Skipping Glyphs: the 'text-decoration-skip-ink' property</h4>
 			UAs <em>may</em> interrupt underlines and overlines
 			where the line would cross glyph ink
 			and to some distance to either side of the glyph outline.
+			UAs <em>should</em> consider the script of the text (see note below)
+			when determining whether to apply ink-skipping behavior to a given
+			range of content.
 
 		<dt><dfn value for="text-decoration-skip-ink">always</dfn></dt>
 		<dd>
@@ -1085,9 +1088,57 @@ Skipping Glyphs: the 'text-decoration-skip-ink' property</h4>
 
 		<dt><dfn value for="text-decoration-skip-ink">none</dfn></dt>
 		<dd>
-			UA must draw continuous underlines and overlines,
+			UA <em>must</em> draw continuous underlines and overlines,
 			without interruptions when they cross over a glyph.
 	</dl>
+
+	<div class="note">
+        Note: Implementation experience shows that ink-skipping behavior often
+        produces undesirable results when underlined text includes ideographic characters,
+        as the underline position (depending on the font and user agent involved)
+        often clashes with almost all the glyphs,
+        such that only occasional fragments of the line remain to be rendered.
+
+        In principle, this could be resolved by authors using
+        ''text-underline-position: under'' (or possibly 'text-underline-offset')
+        to move the underline to a lower position that does not clash with the glyphs,
+        but this is not always feasible, even if the user agent supports these properties
+        and the author is aware of their potential.
+        In particular, when a page contains arbitrary user-generated content,
+        the author responsible for the design may not know whether CJK content will be present.
+        And with mixed-script content,
+        an underline position designed to work well for CJK content
+        may look bad if the majority of the text is non-CJK.
+
+        Therefore, when ''text-decoration-skip-ink/auto'' is in effect,
+        a UA that implements ink-skipping <em>should</em> refrain from doing so in CJK contexts.
+        (Authors who <em>do</em> want ink-skipping applied to CJK content can use
+        the ''text-decoration-skip-ink/always'' value to explicitly request this.)
+
+        Primarily, this means <em>not</em> applying ink-skipping for characters whose
+        Unicode <a href="http://unicode.org/Public/UCD/latest/ucd/Scripts.txt">Script property</a>
+        is any of the CJK scripts Han, Hiragana, Katakana, Bopomofo, or Hangul,
+        or for characters whose Script property is Inherited or Common,
+        and whose <a href="http://unicode.org/Public/UCD/latest/ucd/ScriptExtensions.txt">ScriptExtensions property</a>
+        includes one or more of the CJK scripts.
+
+        In addition, characters with a Unicode script property of Common and Inherited
+        (primarily generic punctuation and symbols) need to be considered,
+        as these may be used as part of a run of CJK-script content,
+        and it is desirable to treat all text within a given script run in a consistent way.
+        Therefore, the UA <em>should</em> resolve the text into script runs
+        as described in the <a href="https://www.unicode.org/reports/tr24/#Usage_Model">“Implementation Notes”</a>
+        of [[!UAX24]] “Unicode Script Property”, in particular subsections 5.1 and 5.2.
+        After applying the heuristics described there (or a similar analysis of scripts),
+        the UA <em>should</em> disable ink-skipping for all ranges of text
+        that are determined to be in a CJK script.
+
+        Issue: Are there other (non-CJK) scripts where it would be preferable
+        to disable ink-skipping by default
+        (when ''text-decoration-skip-ink/auto'' is in effect)?
+        Perhaps Yi? Arabic?
+        (See also discussion in <a href="https://github.com/w3c/csswg-drafts/issues/1288">Issue 1288</a>.)
+    </div>
 
 <h4 id="ink-skip-shape">
 Shaping Interruptions</h4>


### PR DESCRIPTION
Given that there is not a single canonical algorithm for determining the boundaries of script runs in arbitrary text, and given that some implementor want to retain the freedom to make adjustments based on user feedback, I don't think we can or should currently specify precise, normative requirements for how `text-decoration-skip-ink` behaves down to the level of every individual character.

However, the spec could usefully include a (non-normative) note to offer guidance to implementors. Here is some proposed text for consideration by the editors.