### PR TITLE
[css-color-5] Correct comma-separated values

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -86,7 +86,7 @@ Mixing colors: the ''color-mix'' function {#colormix}
 	(and thus, 60% of the lightness of the blue).
 	The chroma and hue of the green are left unchanged.
 
-	<pre class="lang-css">mix-color(rgb(0% 42.35% 33.33%) rgb(41.2% 69.88% 96.64%), lightness(40%));</pre>
+	<pre class="lang-css">mix-color(rgb(0% 42.35% 33.33%) rgb(41.2% 69.88% 96.64%) lightness(40%));</pre>
 
 	The calculation is as follows:
 	  * <span class="swatch" style="--color: rgb(0% 42.35% 33.33%)"></span> rgb(0% 42.35% 33.33%) is lch(40.083% 32.808 171.175)
@@ -140,7 +140,7 @@ Mixing colors: the ''color-mix'' function {#colormix}
 	<!-- showing out of gamut colors next -->
 
 
-<!-- <img src="images/mix_red_white_lightness50.png" alt="Result of mix-color(red, white, lightness(50%)" /> -->
+<!-- <img src="images/mix_red_white_lightness50.png" alt="Result of mix-color(red white lightness(50%)" /> -->
 
 <div class="example">
 	This example produces the mixture of red and yellow,
@@ -164,7 +164,7 @@ Mixing colors: the ''color-mix'' function {#colormix}
 </div>
 
 <!--
-<img src="images/mix_red_yellow_lightness30.png" alt="Result of mix-color(red, yellow, lightness(30%)" />
+<img src="images/mix_red_yellow_lightness30.png" alt="Result of mix-color(red yellow lightness(30%)" />
  this image incorrectly shows red and yellow to be outside gamut as well, which is confusing.
      it also shows the result color after per-component clipping, which is not desirable -->
 
@@ -201,7 +201,7 @@ which applies to all color channels.
 		-->
 </div>
 
-<img src="images/mix_red_yellow_65.png" alt="Result of mix-color(red, yellow, 65%" />
+<img src="images/mix_red_yellow_65.png" alt="Result of mix-color(red yellow 65%" />
 
 <!-- todo: example that specifies a different colorspace -->
 
@@ -376,7 +376,7 @@ Adjusting colors: the ''color-adjust'' function {#coloradjust}
 		* which is <span class="swatch" style="--color: rgb(57.58%, 32.47%, 3.82%)"></span> rgb(57.58%, 32.47%, 3.82%)
 	</div>
 
-<img src="images/adjust_red_lightness30.png" alt="Result of adjust-color(red, lightness(30%)" />
+<img src="images/adjust_red_lightness30.png" alt="Result of adjust-color(red lightness(30%))" />
 
 Relative color syntax {#relative-colors}
 --------------------------------------------------------
@@ -516,7 +516,7 @@ When an origin color is present, the following keywords can also be used in this
 
 	<pre>
 	--mycolor: <span class="swatch" style="--color: orchid"></span> orchid;
-	// orchid is lch(62.753% 62.571, 326.973)
+	// orchid is lch(62.753% 62.571 326.973)
 	--mygray: <span class="swatch" style="--color: rgb(59.515% 59.515% 59.515%)"></span> lch(from var(--mycolor) l 0 h)
 	// mygray is lch(62.753% 0 326.973) which is rgb(59.515% 59.515% 59.515%)
 	</pre>


### PR DESCRIPTION
[css-color-5]

This PR corrects some syntax errors in examples of [css-color-5](https://drafts.csswg.org/css-color-5) based on [related syntax feedback](https://github.com/w3c/csswg-drafts/issues/4738#issuecomment-582107540).