### PR TITLE
[css-color-5] change examples to comma-less form

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -403,7 +403,7 @@ Adjusting colors: the ''color-adjust'' function {#coloradjust}
 		* <span class="swatch" style="--color: peru"></span> peru (#CD853F) is lch(62.2532% 54.0114 63.6769)
 		* adjusted lightness is 62.2532% - 20% = 42.2532%
 		* adjusted result is lch(42.2532% 54.0114 63.6769)
-		* which is <span class="swatch" style="--color: rgb(57.58%, 32.47%, 3.82%)"></span> rgb(57.58%, 32.47%, 3.82%)
+		* which is <span class="swatch" style="--color: rgb(57.58% 32.47% 3.82%)"></span> rgb(57.58% 32.47% 3.82%)
 	</div>
 
 <!-- image out of sync with example
@@ -539,7 +539,7 @@ When an origin color is present, the following keywords can also be used in this
 
 <div class="example">
 	''lch(from peru calc(l * 0.8) c h)'' produces a color that is 20% darker than <span class="swatch" style="--color: peru"></span> peru or lch(62.2532% 54.0114 63.6769), with its chroma and hue left unchanged.
-	The result is <span class="swatch" style="--color: rgb(57.58%, 32.47%, 3.82%)"> </span> lch(49.80256% 54.0114 63.6769)
+	The result is <span class="swatch" style="--color: rgb(57.58% 32.47% 3.82%)"> </span> lch(49.80256% 54.0114 63.6769)
 </div>
 
 <div class="example">
@@ -547,7 +547,7 @@ When an origin color is present, the following keywords can also be used in this
 
 	<pre>
 	--mycolor: <span class="swatch" style="--color: orchid"></span> orchid;
-	// orchid is lch(62.753% 62.571, 326.973)
+	// orchid is lch(62.753% 62.571 326.973)
 	--mygray: <span class="swatch" style="--color: rgb(59.515% 59.515% 59.515%)"></span> lch(from var(--mycolor) l 0 h)
 	// mygray is lch(62.753% 0 326.973) which is rgb(59.515% 59.515% 59.515%)
 	</pre>


### PR DESCRIPTION
[css-color-5] Change examples to commaless form

See https://drafts.csswg.org/css-color-4/#changes-from-20160705:

> Describe previous, comma-using color syntaxes as "legacy"; change examples to commaless form