### PR TITLE
[scroll-animations-1]  Remove outdated trigger syntax from example

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -655,11 +655,8 @@ following effects:
           easing: "linear"
         });
       let timeline = new ScrollTimeline({
-        trigger: new ScrollTrigger({
-          scrollSource: document.documentElement,
-          orientation: "vertical",
-          kind: "range"
-        });
+        scrollSource: document.documentElement,
+        orientation: "vertical",
       });
       let animation = new Animation(effect, timeline);
       animation.play();


### PR DESCRIPTION
The concept of trigger has been removed from spec but this example was remaining.

The example could be done as a scroll-linked animation as opposed to a scroll-triggered one!
The PR makes this change.