### PR TITLE
[css-fonts-4] Clean up `font-min-size` and `font-max-size`

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -842,7 +842,7 @@ Font size: the 'font-size' property</h3>
     Applies to: all elements
     Inherited: yes
     Percentages: refer to parent element's font size
-    Computed value: an absolute length, as clamped by 'font-min-size' and 'font-max-size'
+    Computed value: an absolute length
     Animation type: by computed value type`
     </pre>
 
@@ -1251,8 +1251,6 @@ Shorthand font property: the 'font' property</h3>
 	all subproperties of 'font-variant!!property',
 	'font-feature-settings!!property',
 	'font-language-override!!property',
-	'font-min-size',
-	'font-max-size',
 	'font-optical-sizing',
 	'font-variation-settings!!property',
 	and 'font-palette'.


### PR DESCRIPTION
The properties were removed in https://github.com/w3c/csswg-drafts/commit/ebca02f2de74aadd45f675ed794cd686a2852d87.
