### PR TITLE
[css-color-adjust-1] Don't force colors on SVG text by default #3855

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -335,8 +335,6 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 
 	<pre>
 		color: revert !important;
-		fill: revert !important;
-		stroke: revert !important;
 		text-decoration-color: revert !important;
 		text-emphasis-color: revert !important;
 		background-color: revert !important;
@@ -400,7 +398,7 @@ Opting Out of a Forced Color Scheme: the 'forced-color-adjust' property {#forced
 	<pre>
 		@namespace "http://www.w3.org/2000/svg";
 		svg|svg { forced-color-adjust: none; }
-		svg|text, svg|foreignObject { forced-color-adjust: auto; }
+		svg|foreignObject { forced-color-adjust: auto; }
 	</pre>
 
 Performance-based Color Schemes: the 'color-adjust' property {#perf}

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -335,6 +335,8 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 
 	<pre>
 		color: revert !important;
+		fill: revert !important;
+		stroke: revert !important;
 		text-decoration-color: revert !important;
 		text-emphasis-color: revert !important;
 		background-color: revert !important;


### PR DESCRIPTION
This addresses issue #3855.

The resolution was to no longer adjust colors for SVG `<text>` elements in forced colors mode by default.