### PR TITLE
[css-scroll-snap] Clarify scroll-padding scrollport (#4393)

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -490,7 +490,13 @@ Scroll Snapport: the 'scroll-padding' property {#scroll-padding}
         : <dfn><<length-percentage>></dfn>
         ::
             Defines an inward offset from the corresponding edge of the [=scrollport=].
-
+	    When the scrollport is the root scroller, the offset is relative to the layout viewport.
+	    
+	    <div class="note">
+	    	Though the [=scrollport=] is defined as the visual viewport of the scroll container,
+		scroll padding offsets are relative to the layout viewport when the scroll container is
+		the root scroller.
+	    </div>
         : <dfn>auto</dfn>
         ::
             Indicates that the offset for the corresponding edge of the [=scrollport=] is UA-determined.


### PR DESCRIPTION
The [scrollport](https://www.w3.org/TR/css-overflow-3/#scrollport) refers to the visual viewport. Add clarification that the scroll-padding property is relative to the layout viewport when the scroll container is the root scroller.

Fixes #4393.
