### PR TITLE
[css-text-3] Adding missing word "element"

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -175,7 +175,7 @@ Languages and Typesetting</h3>
   <p>The <dfn export>content language</dfn> of an element is the (human) language
     the element is declared to be in, according to the rules of the
     <a href="https://www.w3.org/TR/CSS2/conform.html#doclanguage">document language</a>.
-    For example, the rules for determining the <a>content language</a> of an HTML
+    For example, the rules for determining the <a>content language</a> of an HTML element
     are <a href="https://html.spec.whatwg.org/multipage/dom.html#language">defined</a> in [[HTML]],
     and the rules for determining the <a>content language</a> of an XML element use
     are <a href="https://www.w3.org/TR/REC-xml/#sec-lang-tag">defined</a> in [[XML10]].


### PR DESCRIPTION
Just a minor update, it seems to me like the word "element" is missing from the sentence:

> [...] the rules for determining the content language of an HTML are defined in [...]