### PR TITLE
[css-scrollbars-1] Make mentions of properties/values actual references #3315

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -138,13 +138,13 @@ PNG of the same in a browser that supports it currently)
 Implementations may ignore any of the colors
 if the corresponding part do not exist on the underlying platform.
 
-When using scrollbar-color property with specific color values,
+When using ''scrollbar-color'' property with specific color values,
 authors should ensure the specified colors have enough contrast between them.
 For keyword values, UAs should ensure the colors they use have enough contrast.
 UAs should ensure that their actual color values for 
-scrollbar-color: light and scrollbar-color: dark 
+''scrollbar-color/light'' and ''scrollbar-color/dark'' 
 should provide sufficient contrast with the element’s background
-(i.e. scrollbar-color: light on a light background and scrollbar-color: dark on a dark background 
+(i.e. ''scrollbar-color/light'' on a light background and ''scrollbar-color/dark'' on a dark background 
 should always have sufficient contrast)
 See 
 <a href="https://www.w3.org/TR/WCAG21/#non-text-contrast">WCAG 2.1 SC 1.4.11 Non-text Contrast</a> 
@@ -211,10 +211,10 @@ UAs should enforce a minimum actual size of scrollbar width per
 <a href="https://www.w3.org/TR/WCAG21/#target-size">WCAG 2.1 SC 2.5.5 Target Size</a> 
 [[WCAG21]].
 
-Authors that use scrollbar-width: none should provide an alternative/equivalent visual hint that 
+Authors that use ''scrollbar-width/none'' should provide an alternative/equivalent visual hint that 
 scrolling is possible and there is more content. 
 For situations where an element is going to be scrolled by other means instead of direct user manipulation 
-(e.g. programmatically), authors should use overflow: hidden instead of scrollbar-width: none.
+(e.g. programmatically), authors should use overflow: hidden instead of ''scrollbar-width/none''.
 
 Note: Unlike 'overflow' (and overflow-*) properties, 
 a scrollbar-width value set on the HTML body element is not propagated to the viewport.

--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -214,7 +214,7 @@ UAs should enforce a minimum actual size of scrollbar width per
 Authors that use ''scrollbar-width/none'' should provide an alternative/equivalent visual hint that 
 scrolling is possible and there is more content. 
 For situations where an element is going to be scrolled by other means instead of direct user manipulation 
-(e.g. programmatically), authors should use overflow: hidden instead of ''scrollbar-width/none''.
+(e.g. programmatically), authors should use ''overflow: hidden'' instead of ''scrollbar-width/none''.
 
 Note: Unlike 'overflow' (and overflow-*) properties, 
 a scrollbar-width value set on the HTML body element is not propagated to the viewport.

--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -138,7 +138,7 @@ PNG of the same in a browser that supports it currently)
 Implementations may ignore any of the colors
 if the corresponding part do not exist on the underlying platform.
 
-When using ''scrollbar-color'' property with specific color values,
+When using 'scrollbar-color' property with specific color values,
 authors should ensure the specified colors have enough contrast between them.
 For keyword values, UAs should ensure the colors they use have enough contrast.
 UAs should ensure that their actual color values for 


### PR DESCRIPTION
Both to visually differentiate them from surrounding text and to make them actual links once rendered/processed.

Loosely related to #3315