### PR TITLE
[css-gcpm-3] fix CSS errors in example 14

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -783,11 +783,11 @@ Consider the following HTML:
 And CSS:
 
 <pre>
-div.Chapter {
+div.chapter {
 page: body;
 }
 
-div.broadside {
+table.broadside {
 page: broadside;
 }
 

--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -9,7 +9,7 @@ ED: https://drafts.csswg.org/css-gcpm/
 TR: https://www.w3.org/TR/css-gcpm-3/
 Editor: Dave Cramer, Hachette Livre, dave.cramer@hbgusa.com, w3cid 65283
 Former Editor: Håkon Wium Lie, Opera Software
-Link defaults: css-content-3 (property) counter-increment, css-content-3 (property) counter-reset, css2 (property) string, css2 (property) max-height
+Link defaults: css-content-3 (property) counter-increment, css-content-3 (property) counter-reset, css21 (property) string, css2 (property) max-height
 Abstract: Books and other paged media often use special techniques to display information. Content may be moved to or generated for special areas of the page, such as running heads or footnotes. Generated content within pages, such as tab leaders or cross-references, helps readers navigate within and between pages.
 Previous Version: https://www.w3.org/TR/2014/WD-css-gcpm-3-20140513/
 Previous version: https://hg.csswg.org/drafts/raw-file/6a5c44d11c2b/css-gcpm/Overview.html
@@ -31,7 +31,7 @@ This module defines new properties and values, so that authors may bring these t
 <h3 id="values">
 Value Definitions</h3>
 
-This specification follows the <a href="https://www.w3.org/TR/CSS2/about.html#property-defs">CSS property definition conventions</a> from [[!CSS2]]
+This specification follows the <a href="https://www.w3.org/TR/CSS2/about.html#property-defs">CSS property definition conventions</a> from [[!CSS21]]
 using the <a href="https://www.w3.org/TR/css-values-3/#value-defs">value definition syntax</a> from [[!CSS-VALUES-3]].
 Value types not defined in this specification are defined in CSS Values &amp; Units [[!CSS-VALUES-3]].
 Combination with other CSS modules may expand the definitions of these value types.
@@ -89,7 +89,7 @@ The 'string-set' property contains one or more pairs, each consisting of an cust
 	<dt>content()</dt>
 	<dd>The ''content()'' function, described below.</dd>
 	<dt>attr(&lt;identifier>)</dt>
-	<dd>Returns the string value of the attribute &lt;identifier>, as defined in [[CSS3VAL]]</dd>
+	<dd>Returns the string value of the attribute &lt;identifier>, as defined in [[CSS-VALUES-3]]</dd>
 </dl>
 
 <h5 id="content-function-header">The ''content()'' function</h5>


### PR DESCRIPTION
There was a mismatch between the markup and the CSS in example 14. There is still ongoing discussion of this example in #3524 