### PR TITLE
[css-gcmp-3] fix incorrect value for break-before per #3524

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -738,11 +738,11 @@ CSS:
 <pre>
 div { 
   page: A;
-  break-before: always;
+  break-before: page;
 }
 child { 
   page: B;
-  break-before: always;
+  break-before: page;
 }
 </pre>
 <figure>
@@ -791,12 +791,12 @@ And CSS:
 <pre>
 div.chapter {
   page: body;
-  break-before: always;
+  break-before: page;
 }
 
 table.broadside {
   page: broadside;
-  break-before: always;
+  break-before: page;
 }
 
 </pre>


### PR DESCRIPTION
I'm so used to page-break-before I forget that break-before has different values. 