### PR TITLE
[resize-observer-1] attributes cannot be sequence<T> #4683

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -47,6 +47,8 @@ urlPrefix:  https://drafts.csswg.org/css-box-3/
     url: #content-area; type: dfn; text: content area
 urlPrefix:  https://www.w3.org/TR/cssom-view-1/
     url: #dom-window-devicepixelratio; type: dfn; text: devicePixelRatio
+urlPrefix:  https://heycam.github.io/webidl/
+    url: #idl-frozen-array; type: dfn; text: FrozenArray
 
 </pre>
 <pre class=link-defaults>
@@ -250,9 +252,9 @@ This callback delivers {{ResizeObserver}}'s notifications. It is invoked by a
 interface ResizeObserverEntry {
     readonly attribute Element target;
     readonly attribute DOMRectReadOnly contentRect;
-    readonly attribute sequence&lt;ResizeObserverSize> borderBoxSize;
-    readonly attribute sequence&lt;ResizeObserverSize> contentBoxSize;
-    readonly attribute sequence&lt;ResizeObserverSize> devicePixelContentBoxSize;
+    readonly attribute FrozenArray&lt;ResizeObserverSize> borderBoxSize;
+    readonly attribute FrozenArray&lt;ResizeObserverSize> contentBoxSize;
+    readonly attribute FrozenArray&lt;ResizeObserverSize> devicePixelContentBoxSize;
 };
 </pre>
 
@@ -267,24 +269,24 @@ interface ResizeObserverEntry {
         {{Element}}'s <a>content rect</a> when {{ResizeObserverCallback}} is invoked.
     : <dfn>borderBoxSize</dfn>
     ::
-        A sequence containing the {{Element}}'s <a>border box</a> size when {{ResizeObserverCallback}} is invoked.
+        A {{FrozenArray}} containing the {{Element}}'s <a>border box</a> size when {{ResizeObserverCallback}} is invoked.
     : <dfn>contentBoxSize</dfn>
     ::
-        A sequence containing the {{Element}}'s <a>content rect</a> size when {{ResizeObserverCallback}} is invoked.
+        A {{FrozenArray}} containing the {{Element}}'s <a>content rect</a> size when {{ResizeObserverCallback}} is invoked.
     : <dfn>devicePixelContentBoxSize</dfn>
     ::
-        A sequence containing the {{Element}}'s <a>content rect</a> size in integral device pixels when {{ResizeObserverCallback}} is invoked.
+        A {{FrozenArray}} containing the {{Element}}'s <a>content rect</a> size in integral device pixels when {{ResizeObserverCallback}} is invoked.
 
 </div>
 
 <p class="note">
-The box size properties are exposed as sequences in order to support elements that have multiple fragments,
+The box size properties are exposed as {{FrozenArray}} in order to support elements that have multiple fragments,
 which occur in <a>multi-column</a> scenarios.
 However the current definitions of <a>content rect</a> and <a>border box</a>
 do not mention how those boxes are affected by <a>multi-column</a> layout.
-In this spec, there will only be a single ResizeObserverSize returned in the sequences,
+In this spec, there will only be a single ResizeObserverSize returned in the {{FrozenArray}},
 which will correspond to the dimensions of the first column.
-A future version of this spec will extend the returned sequences to contain the per-fragment size information.
+A future version of this spec will extend the returned {{FrozenArray}} to contain the per-fragment size information.
 </p>
 
 <pre class="idl">


### PR DESCRIPTION
w3c/csswg-drafts#4683

Previous change to add support for per-fragment box sizes used invalid webidl, namely that attributes of sequence<T> are disallowed so that authors can never be confused about the liveness of the returned value.

Switch these to FrozenArray instead.