### PR TITLE
[css-animations-2] Document attributes of web animations can require pending style changes

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -599,7 +599,7 @@ properties on elements. User agents may, as an optimization, defer recomputing
 these values until it becomes necessary.
 However, all operations included in programming interface defined in this
 specification, as well as those operations defined in Web Animations
-[[!WEB-ANIMATIONS]] that may return objects or animaiton state defined by this
+[[!WEB-ANIMATIONS]] that may return objects or animation state defined by this
 specification, must produce a result consistent with having fully processed
 any such pending changes to computed values.
 

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -599,9 +599,9 @@ properties on elements. User agents may, as an optimization, defer recomputing
 these values until it becomes necessary.
 However, all operations included in programming interface defined in this
 specification, as well as those operations defined in Web Animations
-[[!WEB-ANIMATIONS]] that may return objects defined by this specification,
-must produce a result consistent with having fully processed any such pending
-changes to computed values.
+[[!WEB-ANIMATIONS]] that may return objects or animaiton state defined by this
+specification, must produce a result consistent with having fully processed
+any such pending changes to computed values.
 
 <div class="note">
 As an example, in the following code fragment, when the specified style of
@@ -618,6 +618,16 @@ create the requested {{CSSAnimation}} object before returning its result.
 <div><pre class="example lang-javascript">
 elem.style.animation = 'fadeOut 1s';
 elem.getAnimations()[0].pause();
+</pre></div>
+
+Similarly, reading {{Animation/playState}} may depend on pending style
+changes.
+
+<div><pre class="example lang-javascript">
+elem.style.animation = 'fadeOut 1s paused';
+const anim = elem.getAnimations()[0];
+elem.style.animationPlayState = 'running';
+console.log(anim.playState); // Should be 'running'.
 </pre></div>
 
 </div>


### PR DESCRIPTION
css-animations-2 makes clear that returning web-animations objects may
require pending style changes but we also test that reading animation
state also requires pending style flushing.

For example:
https://github.com/web-platform-tests/wpt/blob/master/css/css-animations/CSSAnimation-playState.tentative.html#L43