### PR TITLE
[web-animations-1] Fix invalid error code for KeyfameEffect.pseudoElement

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -4846,7 +4846,7 @@ interface KeyframeEffect : AnimationEffect {
 
     *   If the provided value is not `null` or a syntactically valid
         <pseudo-element-selector> the user agent must [=throw=]
-        a {{DOMException}} with error name {{TypeError}} and leave the
+        a {{DOMException}} with error name {{SyntaxError}} and leave the
         [=target pseudo-selector=] of this [=animation effect=] unchanged.
 
     *   If one of the legacy Selectors Level 2 single-colon selectors


### PR DESCRIPTION
Since `TypeError` is not a valid DOMException error name, change it to `SyntaxError` (the code for this kind of type error).