### PR TITLE
[css-values] resolve #3696

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -589,6 +589,9 @@ Relative URLs</h4>
 	Style sheets embedded within a document have
 	the base URL associated with their container.
 
+	Note: For HTML documents,
+	the <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dynamic-changes-to-base-urls">base URL is mutable</a>.
+
 	When a <<url>> appears in the computed value of a property,
 	it is resolved to an absolute URL,
 	as described in the preceding paragraph.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -688,6 +688,9 @@ Relative URLs</h4>
 	Style sheets embedded within a document have
 	the base URL associated with their container.
 
+	Note: For HTML documents,
+	the <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dynamic-changes-to-base-urls">base URL is mutable</a>.
+
 	When a <<url>> appears in the computed value of a property,
 	it is resolved to an absolute URL,
 	as described in the preceding paragraph.


### PR DESCRIPTION
Add editorial note to resolve #3696 by noting that for HTML docs, base is mutable.

See also [discussion in tag review of json-ld](https://github.com/w3ctag/design-reviews/issues/312)
