### PR TITLE
[css-transforms-1] Fix typo and simplify transforms syntax

### DIFF
--- a/css-transforms-1/Overview.bs
+++ b/css-transforms-1/Overview.bs
@@ -687,7 +687,7 @@ Note: The syntax reflects implemented behavior in user agents and differs from t
     <pre class='railroad'>
     Stack:
       Seq:
-        T: skewX
+        T: skewY
         Star:
           N: wsp
         T: (
@@ -759,7 +759,7 @@ matrix
   <dt id="svg-transforms">transforms</dt>
   <dd><pre>
 transform
-| transform wsp* comma-wsp? transforms
+| transform comma-wsp? transforms
   </dd></pre>
   <dd>
     <pre class='railroad'>
@@ -767,8 +767,6 @@ transform
       N: transform
       Seq:
         N: transform
-        Star:
-          N: wsp
         Optional:
           N: comma-wsp
         N: transforms


### PR DESCRIPTION
`wsp*` is already a prefix of `comma-wsp` and thus is useless here


Non-substantive change