### PR TITLE
[CSS2] bunch of reference changes

### DIFF
--- a/css2/about.html
+++ b/css2/about.html
@@ -413,7 +413,7 @@ take their initial values.</p>
 marked as "ILLEGAL EXAMPLE".
 
 <P>HTML examples lacking DOCTYPE declarations are SGML Text Entities
-conforming to the HTML 4.01 Strict DTD <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>. Other HTML examples
+conforming to the HTML 4.01 Strict DTD <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>. Other HTML examples
 conform to the DTDs given in the examples.
 
 <P>All notes are informative only.

--- a/css2/about.src
+++ b/css2/about.src
@@ -349,7 +349,7 @@ take their initial values.</p>
 marked as "ILLEGAL EXAMPLE".
 
 <P>HTML examples lacking DOCTYPE declarations are SGML Text Entities
-conforming to the HTML 4.01 Strict DTD [[HTML4]]. Other HTML examples
+conforming to the HTML 4.01 Strict DTD [[HTML401]]. Other HTML examples
 conform to the DTDs given in the examples.
 
 <P>All notes are informative only.

--- a/css2/aural.html
+++ b/css2/aural.html
@@ -1138,7 +1138,7 @@ cells.
 </dl>
 
 <p>Each document language may have different mechanisms that allow
-authors to specify headers. For example, in HTML 4 (<a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>),
+authors to specify headers. For example, in HTML 4 (<a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>),
 it is possible to specify header information with three different
 attributes ("headers", "scope", and "axis"), and the specification
 gives an algorithm for determining header information when these

--- a/css2/aural.src
+++ b/css2/aural.src
@@ -784,7 +784,7 @@ cells.
 </dl>
 
 <p>Each document language may have different mechanisms that allow
-authors to specify headers. For example, in HTML 4 ([[HTML4]]),
+authors to specify headers. For example, in HTML 4 ([[HTML401]]),
 it is possible to specify header information with three different
 attributes ("headers", "scope", and "axis"), and the specification
 gives an algorithm for determining header information when these

--- a/css2/cascade.src
+++ b/css2/cascade.src
@@ -228,7 +228,7 @@ list.
 <p>A target medium matches a media list if one of the items in the
 media list is the target medium or 'all'.
 
-<p class=note>Note that Media Queries [[MEDIAQ]] extends the syntax of
+<p class=note>Note that Media Queries [[-MEDIAQ]] extends the syntax of
 media lists and the definition of matching.
 
 <p>When the same style sheet is imported or linked to a document in

--- a/css2/conform.html
+++ b/css2/conform.html
@@ -315,7 +315,7 @@ document, read it aloud, cause it to be printed, convert it
 to another format, etc.</dd>
 
 <DD>An HTML user agent is one that supports one or more of the HTML
-specifications. A user agent that supports XHTML <a href="refs.html#ref-XHTML" class="noxref"><span class="informref">[XHTML]</span></a>, but not
+specifications. A user agent that supports XHTML <a href="refs.html#ref-XHTML" class="noxref"><span class="informref">[XHTML1]</span></a>, but not
 HTML is not considered an
 HTML user agent for the purpose of conformance with this
 specification.
@@ -417,7 +417,7 @@ property's definition and the rules of <a
 href="cascade.html">cascading and inheritance</a>.
 
 <li>If the source document comes with alternate style sheet sets (such as
-with the "alternate" keyword in HTML 4 <a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>), the UA must
+with the "alternate" keyword in HTML 4 <a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>), the UA must
 allow the user to select which style sheet set the UA should apply.
 
 <li>The UA must allow the user to turn off the influence of author style sheets.

--- a/css2/conform.src
+++ b/css2/conform.src
@@ -283,7 +283,7 @@ document, read it aloud, cause it to be printed, convert it
 to another format, etc.</dd>
 
 <DD>An HTML user agent is one that supports one or more of the HTML
-specifications. A user agent that supports XHTML [[-XHTML]], but not
+specifications. A user agent that supports XHTML [[-XHTML1]], but not
 HTML is not considered an
 HTML user agent for the purpose of conformance with this
 specification.
@@ -388,7 +388,7 @@ property's definition and the rules of <a
 href="cascade.html">cascading and inheritance</a>.
 
 <li>If the source document comes with alternate style sheet sets (such as
-with the "alternate" keyword in HTML 4 [[-HTML4]]), the UA must
+with the "alternate" keyword in HTML 4 [[-HTML401]]), the UA must
 allow the user to select which style sheet set the UA should apply.
 
 <li>The UA must allow the user to turn off the influence of author style sheets.

--- a/css2/cover.html
+++ b/css2/cover.html
@@ -28,12 +28,12 @@
   <p><a href="https://www.w3.org/"><img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"/></a>
 
   <h1 id="title">Cascading Style Sheets Level 2 Revision 2 (CSS&nbsp;2.2) Specification</h1>
-  <h2 id="W3C-doctype">W3C Editors Draft 11 March 2020</h2>
+  <h2 id="W3C-doctype">W3C Editors Draft 12 March 2020</h2>
 
   <dl>
   <dt>This version:
-  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200311/">
-               https://www.w3.org/TR/2020/ED-CSS2-20200311/</a>
+  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200312/">
+               https://www.w3.org/TR/2020/ED-CSS2-20200312/</a>
   <dt>Latest version:
   <dd><a href="https://www.w3.org/TR/CSS2/">
                https://www.w3.org/TR/CSS2/</a>
@@ -74,7 +74,7 @@
 
   <!--
   <p>Please refer to the <a
-  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200311-errata.html"><strong>
+  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200312-errata.html"><strong>
   errata</strong></a> for this document.
   -->
 

--- a/css2/generate.src
+++ b/css2/generate.src
@@ -810,7 +810,7 @@ recommend that authors specify true numbers.
 
 <p>CSS&nbsp;2 does not define how the list numbering is reset and
 incremented. This is expected to be defined in the CSS List Module
-[[CSS3LIST]].
+[[-CSS3LIST]].
 
 <div class="lang-html example"><P>
 For example, the following HTML document:

--- a/css2/intro.html
+++ b/css2/intro.html
@@ -514,7 +514,7 @@ authors to tailor pages to those devices.
 </UL>
 
 <div class="note"><P> <em><strong>Note.</strong> For more information
-about designing accessible documents using CSS and HTML, see [[-WCAG20]].</em>
+about designing accessible documents using CSS and HTML, see <a href="refs.html#ref-WCAG20" class="noxref"><span class="informref">[WCAG20]</span></a>.</em>
 </div>
 </UL>
 

--- a/css2/intro.html
+++ b/css2/intro.html
@@ -50,7 +50,7 @@
 
 <P> In this tutorial, we show how easy it can be to design simple
 style sheets. For this tutorial, you will need to know a little HTML
-(see <a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>) and some basic desktop publishing terminology.
+(see <a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>) and some basic desktop publishing terminology.
 
 <P>We begin with a small HTML document:</p>
 

--- a/css2/intro.src
+++ b/css2/intro.src
@@ -14,7 +14,7 @@
 
 <P> In this tutorial, we show how easy it can be to design simple
 style sheets. For this tutorial, you will need to know a little HTML
-(see [[-HTML4]]) and some basic desktop publishing terminology.
+(see [[-HTML401]]) and some basic desktop publishing terminology.
 
 <P>We begin with a small HTML document:</p>
 

--- a/css2/media.html
+++ b/css2/media.html
@@ -85,7 +85,7 @@ style sheets:</p>
 </div>
 
 <LI>Specify the target medium within the document language. For
-example, in HTML 4 (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>), the "media" attribute on the LINK
+example, in HTML 4 (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>), the "media" attribute on the LINK
 element specifies the target media of an external style sheet:
 
 <div class="lang-html example">

--- a/css2/media.src
+++ b/css2/media.src
@@ -48,7 +48,7 @@ style sheets:</p>
 </div>
 
 <LI>Specify the target medium within the document language. For
-example, in HTML 4 ([[-HTML4]]), the "media" attribute on the LINK
+example, in HTML 4 ([[-HTML401]]), the "media" attribute on the LINK
 element specifies the target media of an external style sheet:
 
 <div class="lang-html example">

--- a/css2/refs.html
+++ b/css2/refs.html
@@ -258,7 +258,7 @@ Available at <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/">
 https://www.w3.org/TR/2003/REC-SVG11-20030114</a>
 
 <dt><strong><span id="ref-WCAG20"
-class="informref">[WVAG20]</span></strong>
+class="informref">[WCAG20]</span></strong>
 <dd>"Web Content Accessibility Guidelines (WCAG) 2.0", Ben Caldwell,
 Michael Cooper, Loretta Guarino Reid, Gregg Vanderheiden, 11 December 2008.<BR>
 Available at: <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/">

--- a/css2/refs.html
+++ b/css2/refs.html
@@ -49,7 +49,7 @@ http://www.cie.co.at/publ/abst/15-2004.html</a>
 <dt><strong><span id="ref-FLEX" class="normref">[FLEX]</span></strong>
 <dd>"Flex: The Lexical Scanner Generator", Version 2.3.7, ISBN 1882114213.
 
-<dt><strong><span id="ref-HTML4" class="normref">[HTML4]</span></strong>
+<dt><strong><span id="ref-HTML4" class="normref">[HTML401]</span></strong>
 <dd>"HTML 4.01 Specification", D. Raggett, A. Le Hors, I. Jacobs,
 24 December 1999.<BR> 
 The latest version of
@@ -203,7 +203,7 @@ href="https://www.w3.org/TR/2002/WD-css3-lists-20021107/">
 https://www.w3.org/TR/2002/WD-css3-lists-20021107</a>
 
 <dt><strong><span id="ref-CSS3SEL"
-class="informref">[CSS3SEL]</span></strong> <dd>"Selectors", D. Glazman,
+class="informref">[SELECTORS-3]</span></strong> <dd>"Selectors", D. Glazman,
 T. &Ccedil;elik, I. Hickson, 15 December 2009<br>
 Available at <a href="https://www.w3.org/TR/2009/PR-css3-selectors-20091215/">
 https://www.w3.org/TR/2009/PR-css3-selectors-20091215/</a>
@@ -223,7 +223,7 @@ href="https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/">
 https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/</a>.
 
 <dt><strong><span id="ref-MATH30"
-class="informref">[MATH30]</span></strong> <dd>"Mathematical Markup
+class="informref">[MATHML3]</span></strong> <dd>"Mathematical Markup
 Language (MathML) Version 3.0", D. Carlisle, P. Ion, R. Miner,
 21 October 2010<br>
 Available at <a href="https://www.w3.org/TR/2010/REC-MathML3-20101021/">
@@ -264,19 +264,19 @@ Michael Cooper, Loretta Guarino Reid, Gregg Vanderheiden, 11 December 2008.<BR>
 Available at: <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/">
 https://www.w3.org/TR/2008/REC-WCAG20-20081211/</a>.
 
-<dt><strong><span id="ref-XHTML" class="informref">[XHTML]</span></strong>
+<dt><strong><span id="ref-XHTML" class="informref">[XHTML1]</span></strong>
 <dd>"XHTML 1.0 The Extensible HyperText Markup Language", various
 authors,<br> Available at: <a
 href="https://www.w3.org/TR/xhtml1/">https://www.w3.org/TR/xhtml1/</a>.
 
-<dt><strong><span id="ref-XMLID" class="informref">[XMLID]</span></strong>
+<dt><strong><span id="ref-XMLID" class="informref">[XML-ID]</span></strong>
 <dd>"xml:id Version 1.0", J. Marsh, D. Veillard N. Walsh, 9 September
 2005, W3C Recommendation. Available at: <a
 href="https://www.w3.org/TR/2005/REC-xml-id-20050909/">
 https://www.w3.org/TR/2005/REC-xml-id-20050909/</a>.
 
 <dt><strong><span id="ref-XMLNAMESPACES"
-class="informref">[XMLNAMESPACES]</span></strong>
+class="informref">[XML-NAMES]</span></strong>
 <dd>"Namespaces in XML 1.0 (third edition)", T. Bray, D. Hollander, A. Layman, R. Tobin, H. S. Thompson, 8 December 2009<br>
 Available at: <a
 href="https://www.w3.org/TR/2009/REC-xml-names-20091208/">

--- a/css2/refs.html
+++ b/css2/refs.html
@@ -58,13 +58,6 @@ https://www.w3.org/TR/html4/</a>. The Recommendation defines three
 document type definitions: Strict, Transitional, and Frameset, all
 reachable from the Recommendation.
 
-<dt><strong><span id="ref-ICC42" class="normref">[ICC42]</span></strong>
-<dd>Specification ICC.1:2004-10 (Profile version 4.2.0.0)  Image
-technology colour management &ndash; Architecture, profile format, and
-data structure.<BR>
-Available at <a href="http://www.color.org/icc_specs2.html">
-http://www.color.org/icc_specs2.html</a>
-
 <dt><strong><span id="ref-ISO8879" class="normref">[ISO8879]</span></strong>
 <dd>"ISO 8879:1986(E): Information processing - Text and Office Systems -
 Standard Generalized Markup Language (SGML)", International Organization
@@ -78,13 +71,6 @@ Plane", ISO/IEC 10646-1:2003.
 Useful <a href="http://www.unicode.org/roadmaps/">roadmap of the BMP
 and plane 1</a> documents show which scripts sit at which numeric
 ranges.
-
-
-<dt><strong><span id="ref-PNG" class="normref">[PNG]</span></strong>
-<dd>"Portable Network Graphics (PNG) Specification (Second Edition)",
-David Duce, ed., 10 November 2003.<BR>
-Available at <a href="https://www.w3.org/TR/PNG/">
-https://www.w3.org/TR/PNG/</a>.
 
 <dt><strong><span id="ref-RFC3986" class="normref">[RFC3986]</span></strong>
 <dd>"Uniform Resource Identifier (URI): Generic Syntax," T.

--- a/css2/refs.src
+++ b/css2/refs.src
@@ -228,7 +228,7 @@ Available at <a href="https://www.w3.org/TR/2003/REC-SVG11-20030114/">
 https://www.w3.org/TR/2003/REC-SVG11-20030114</a>
 
 <dt><strong><span id="ref-WCAG20"
-class="informref">[WVAG20]</span></strong>
+class="informref">[WCAG20]</span></strong>
 <dd>"Web Content Accessibility Guidelines (WCAG) 2.0", Ben Caldwell,
 Michael Cooper, Loretta Guarino Reid, Gregg Vanderheiden, 11 December 2008.<BR>
 Available at: <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/">

--- a/css2/refs.src
+++ b/css2/refs.src
@@ -19,7 +19,7 @@ http://www.cie.co.at/publ/abst/15-2004.html</a>
 <dt><strong><span id="ref-FLEX" class="normref">[FLEX]</span></strong>
 <dd>"Flex: The Lexical Scanner Generator", Version 2.3.7, ISBN 1882114213.
 
-<dt><strong><span id="ref-HTML4" class="normref">[HTML4]</span></strong>
+<dt><strong><span id="ref-HTML4" class="normref">[HTML401]</span></strong>
 <dd>"HTML 4.01 Specification", D. Raggett, A. Le Hors, I. Jacobs,
 24 December 1999.<BR> 
 The latest version of
@@ -173,7 +173,7 @@ href="https://www.w3.org/TR/2002/WD-css3-lists-20021107/">
 https://www.w3.org/TR/2002/WD-css3-lists-20021107</a>
 
 <dt><strong><span id="ref-CSS3SEL"
-class="informref">[CSS3SEL]</span></strong> <dd>"Selectors", D. Glazman,
+class="informref">[SELECTORS-3]</span></strong> <dd>"Selectors", D. Glazman,
 T. &Ccedil;elik, I. Hickson, 15 December 2009<br>
 Available at <a href="https://www.w3.org/TR/2009/PR-css3-selectors-20091215/">
 https://www.w3.org/TR/2009/PR-css3-selectors-20091215/</a>
@@ -193,7 +193,7 @@ href="https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/">
 https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/</a>.
 
 <dt><strong><span id="ref-MATH30"
-class="informref">[MATH30]</span></strong> <dd>"Mathematical Markup
+class="informref">[MATHML3]</span></strong> <dd>"Mathematical Markup
 Language (MathML) Version 3.0", D. Carlisle, P. Ion, R. Miner,
 21 October 2010<br>
 Available at <a href="https://www.w3.org/TR/2010/REC-MathML3-20101021/">
@@ -234,19 +234,19 @@ Michael Cooper, Loretta Guarino Reid, Gregg Vanderheiden, 11 December 2008.<BR>
 Available at: <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/">
 https://www.w3.org/TR/2008/REC-WCAG20-20081211/</a>.
 
-<dt><strong><span id="ref-XHTML" class="informref">[XHTML]</span></strong>
+<dt><strong><span id="ref-XHTML" class="informref">[XHTML1]</span></strong>
 <dd>"XHTML 1.0 The Extensible HyperText Markup Language", various
 authors,<br> Available at: <a
 href="https://www.w3.org/TR/xhtml1/">https://www.w3.org/TR/xhtml1/</a>.
 
-<dt><strong><span id="ref-XMLID" class="informref">[XMLID]</span></strong>
+<dt><strong><span id="ref-XMLID" class="informref">[XML-ID]</span></strong>
 <dd>"xml:id Version 1.0", J. Marsh, D. Veillard N. Walsh, 9 September
 2005, W3C Recommendation. Available at: <a
 href="https://www.w3.org/TR/2005/REC-xml-id-20050909/">
 https://www.w3.org/TR/2005/REC-xml-id-20050909/</a>.
 
 <dt><strong><span id="ref-XMLNAMESPACES"
-class="informref">[XMLNAMESPACES]</span></strong>
+class="informref">[XML-NAMES]</span></strong>
 <dd>"Namespaces in XML 1.0 (third edition)", T. Bray, D. Hollander, A. Layman, R. Tobin, H. S. Thompson, 8 December 2009<br>
 Available at: <a
 href="https://www.w3.org/TR/2009/REC-xml-names-20091208/">

--- a/css2/refs.src
+++ b/css2/refs.src
@@ -28,13 +28,6 @@ https://www.w3.org/TR/html4/</a>. The Recommendation defines three
 document type definitions: Strict, Transitional, and Frameset, all
 reachable from the Recommendation.
 
-<dt><strong><span id="ref-ICC42" class="normref">[ICC42]</span></strong>
-<dd>Specification ICC.1:2004-10 (Profile version 4.2.0.0)  Image
-technology colour management &ndash; Architecture, profile format, and
-data structure.<BR>
-Available at <a href="http://www.color.org/icc_specs2.html">
-http://www.color.org/icc_specs2.html</a>
-
 <dt><strong><span id="ref-ISO8879" class="normref">[ISO8879]</span></strong>
 <dd>"ISO 8879:1986(E): Information processing - Text and Office Systems -
 Standard Generalized Markup Language (SGML)", International Organization
@@ -48,13 +41,6 @@ Plane", ISO/IEC 10646-1:2003.
 Useful <a href="http://www.unicode.org/roadmaps/">roadmap of the BMP
 and plane 1</a> documents show which scripts sit at which numeric
 ranges.
-
-
-<dt><strong><span id="ref-PNG" class="normref">[PNG]</span></strong>
-<dd>"Portable Network Graphics (PNG) Specification (Second Edition)",
-David Duce, ed., 10 November 2003.<BR>
-Available at <a href="https://www.w3.org/TR/PNG/">
-https://www.w3.org/TR/PNG/</a>.
 
 <dt><strong><span id="ref-RFC3986" class="normref">[RFC3986]</span></strong>
 <dd>"Uniform Resource Identifier (URI): Generic Syntax," T.

--- a/css2/sample.html
+++ b/css2/sample.html
@@ -33,7 +33,7 @@
 <P><em>This appendix is informative, not normative.</em></P>
 
 <P>This style sheet describes the typical formatting of all HTML 4
-(<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>) elements based on extensive research into current UA
+(<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>) elements based on extensive research into current UA
 practice. Developers are encouraged to use it as a default style sheet
 in their implementations.
 

--- a/css2/sample.src
+++ b/css2/sample.src
@@ -10,7 +10,7 @@
 <P><em>This appendix is informative, not normative.</em></P>
 
 <P>This style sheet describes the typical formatting of all HTML 4
-([[-HTML4]]) elements based on extensive research into current UA
+([[-HTML401]]) elements based on extensive research into current UA
 practice. Developers are encouraged to use it as a default style sheet
 in their implementations.
 

--- a/css2/selector.html
+++ b/css2/selector.html
@@ -152,7 +152,7 @@ selector matches if all of its components match.
 <p class="note">Note: the terminology used here in CSS&nbsp;2 is
 different from what is used in CSS3. For example, a "simple selector"
 refers to a smaller part of a selector in CSS3 than in CSS&nbsp;2.
-See the CSS3 Selectors module <a href="refs.html#ref-CSS3SEL" class="noxref"><span class="informref">[CSS3SEL]</span></a>.
+See the CSS3 Selectors module <a href="refs.html#ref-CSS3SEL" class="noxref"><span class="informref">[SELECTORS-3]</span></a>.
 
 <P>A <span id="x4" class="index-def"
 title="selector"><dfn>selector</dfn></span> is a chain of one or more
@@ -508,7 +508,7 @@ for definitions of these subsets.)
 Depending on the UA, a default attribute value defined in the external
 subset of the DTD might or might not appear in the document tree.
 
-<p>A UA that recognizes an XML namespace <a href="refs.html#ref-XMLNAMESPACES" class="noxref"><span class="informref">[XMLNAMESPACES]</span></a> may, but is not
+<p>A UA that recognizes an XML namespace <a href="refs.html#ref-XMLNAMESPACES" class="noxref"><span class="informref">[XML-NAMES]</span></a> may, but is not
 required to, use its knowledge of that namespace to treat default
 attribute values as if they were present in the document. (E.g., an
 XHTML UA is not required to use its built-in knowledge of the XHTML
@@ -568,7 +568,7 @@ specification for a particular namespace (e.g., SVG 1.1 <a href="refs.html#ref-S
 describes the <a
 href="https://www.w3.org/TR/2003/REC-SVG11-20030114/styling.html#ClassAttribute">SVG
 &quot;class&quot; attribute</a> and how a UA should interpret it, and
-similarly MathML 3.0 <a href="refs.html#ref-MATH30" class="noxref"><span class="informref">[MATH30]</span></a> describes the <a
+similarly MathML 3.0 <a href="refs.html#ref-MATH30" class="noxref"><span class="informref">[MATHML3]</span></a> describes the <a
 href="https://www.w3.org/TR/MathML2/chapter2.html#fund.globatt">MathML
 &quot;class&quot; attribute</a>.)
 
@@ -721,7 +721,7 @@ an "!important" priority to the declarations: <code>[name=p371]
 <p>If an element has multiple ID attributes, all of them must be
 treated as IDs for that element for the purposes of the ID
 selector. Such a situation could be reached using mixtures of xml:id
-<a href="refs.html#ref-XMLID" class="noxref"><span class="informref">[XMLID]</span></a>, DOM3 Core <a href="refs.html#ref-DOM-LEVEL-3-CORE" class="noxref"><span class="informref">[DOM-LEVEL-3-CORE]</span></a>, XML DTDs <a href="refs.html#ref-XML10" class="noxref"><span class="informref">[XML10]</span></a> and
+<a href="refs.html#ref-XMLID" class="noxref"><span class="informref">[XML-ID]</span></a>, DOM3 Core <a href="refs.html#ref-DOM-LEVEL-3-CORE" class="noxref"><span class="informref">[DOM-LEVEL-3-CORE]</span></a>, XML DTDs <a href="refs.html#ref-XML10" class="noxref"><span class="informref">[XML10]</span></a> and
 namespace-specific knowledge.
 
 <h2><span class="secno">5.10</span> <span id="pseudo-elements">Pseudo-elements</span> and <span
@@ -732,7 +732,7 @@ position in the <a href="conform.html#doctree">document tree</a>. This
 simple model is sufficient for many cases, but some common publishing
 scenarios may not be possible due to the structure of the <a
 href="conform.html#doctree">document tree</a>. For instance, in HTML
-4 (see <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>), no element refers to the first line of a
+4 (see <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>), no element refers to the first line of a
 paragraph, and therefore no simple CSS selector may refer to it.</p>
 
 <p>CSS introduces the concepts of <span id="x22" class="index-def"
@@ -1019,7 +1019,7 @@ class="index-def" title="pseudo-classes:::lang|:lang|lang
 <p>If the document language specifies how the <span id="x44" class="index-inst"
 title="language (human)">human language</span> of an element is
 determined, it is possible to write selectors in CSS that match an
-element based on its language. For example, in HTML <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>, the
+element based on its language. For example, in HTML <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>, the
 language is determined by a combination of the "lang" attribute, the
 META element, and possibly by information from the protocol (such as
 HTTP headers). XML uses an attribute called xml:lang, and there may be

--- a/css2/selector.src
+++ b/css2/selector.src
@@ -93,7 +93,7 @@ selector matches if all of its components match.
 <p class="note">Note: the terminology used here in CSS&nbsp;2 is
 different from what is used in CSS3. For example, a "simple selector"
 refers to a smaller part of a selector in CSS3 than in CSS&nbsp;2.
-See the CSS3 Selectors module [[-CSS3SEL]].
+See the CSS3 Selectors module [[-SELECTORS-3]].
 
 <P>A <span class="index-def"
 title="selector"><dfn>selector</dfn></span> is a chain of one or more
@@ -449,7 +449,7 @@ for definitions of these subsets.)
 Depending on the UA, a default attribute value defined in the external
 subset of the DTD might or might not appear in the document tree.
 
-<p>A UA that recognizes an XML namespace [[-XMLNAMESPACES]] may, but is not
+<p>A UA that recognizes an XML namespace [[-XML-NAMES]] may, but is not
 required to, use its knowledge of that namespace to treat default
 attribute values as if they were present in the document. (E.g., an
 XHTML UA is not required to use its built-in knowledge of the XHTML
@@ -509,7 +509,7 @@ specification for a particular namespace (e.g., SVG 1.1 [[-SVG11]]
 describes the <a
 href="https://www.w3.org/TR/2003/REC-SVG11-20030114/styling.html#ClassAttribute">SVG
 &quot;class&quot; attribute</a> and how a UA should interpret it, and
-similarly MathML 3.0 [[-MATH30]] describes the <a
+similarly MathML 3.0 [[-MATHML3]] describes the <a
 href="https://www.w3.org/TR/MathML2/chapter2.html#fund.globatt">MathML
 &quot;class&quot; attribute</a>.)
 
@@ -662,7 +662,7 @@ an "!important" priority to the declarations: <code>[name=p371]
 <p>If an element has multiple ID attributes, all of them must be
 treated as IDs for that element for the purposes of the ID
 selector. Such a situation could be reached using mixtures of xml:id
-[[-XMLID]], DOM3 Core [[-DOM-LEVEL-3-CORE]], XML DTDs [[-XML10]] and
+[[-XML-ID]], DOM3 Core [[-DOM-LEVEL-3-CORE]], XML DTDs [[-XML10]] and
 namespace-specific knowledge.
 
 <h2><span id="pseudo-elements">Pseudo-elements</span> and <span
@@ -673,7 +673,7 @@ position in the <a href="conform.html#doctree">document tree</a>. This
 simple model is sufficient for many cases, but some common publishing
 scenarios may not be possible due to the structure of the <a
 href="conform.html#doctree">document tree</a>. For instance, in HTML
-4 (see [[HTML4]]), no element refers to the first line of a
+4 (see [[HTML401]]), no element refers to the first line of a
 paragraph, and therefore no simple CSS selector may refer to it.</p>
 
 <p>CSS introduces the concepts of <span class="index-def"
@@ -962,7 +962,7 @@ class="index-def" title="pseudo-classes:::lang|:lang|lang
 <p>If the document language specifies how the <span class="index-inst"
 title="language (human)">human language</span> of an element is
 determined, it is possible to write selectors in CSS that match an
-element based on its language. For example, in HTML [[HTML4]], the
+element based on its language. For example, in HTML [[HTML401]], the
 language is determined by a combination of the "lang" attribute, the
 META element, and possibly by information from the protocol (such as
 HTTP headers). XML uses an attribute called xml:lang, and there may be

--- a/css2/syndata.html
+++ b/css2/syndata.html
@@ -669,7 +669,7 @@ not be nested.
 delimit CSS
 comments. They are permitted so that style rules appearing in an HTML
 source document (in the STYLE element) may be hidden from pre-HTML 3.2
-user agents. See the HTML 4 specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>) for more information.
+user agents. See the HTML 4 specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>) for more information.
 </p>
 
 <h2><span class="secno">4.2</span> <span id="parsing-errors">Rules for handling parsing
@@ -1441,7 +1441,7 @@ title="character encoding">encoded</span> by a character encoding that
 supports the set of characters available in US-ASCII (e.g., UTF-8, ISO
 8859-x, SHIFT JIS, etc.).  For a good introduction to character sets
 and character encodings, please consult the HTML 4
-specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML4]</span></a>, chapter 5). See also the XML 1.0
+specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="informref">[HTML401]</span></a>, chapter 5). See also the XML 1.0
 specification (<a href="refs.html#ref-XML10" class="noxref"><span class="informref">[XML10]</span></a>, sections 2.2 and 4.3.3, and Appendix F).
 </p>
 <p>When a style sheet is embedded in another document, such as in the
@@ -1572,7 +1572,7 @@ This ensures that:
 represented in the current character encoding.  These characters must
 be written as <a href="#escaped-characters">escaped</a> references to
 ISO 10646 characters. These escapes serve the same purpose as numeric
-character references in HTML or XML documents (see <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>,
+character references in HTML or XML documents (see <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>,
 chapters 5 and 25).
 </p>
 <p>The character escape mechanism should be used when only a few

--- a/css2/syndata.src
+++ b/css2/syndata.src
@@ -611,7 +611,7 @@ not be nested.
 delimit CSS
 comments. They are permitted so that style rules appearing in an HTML
 source document (in the STYLE element) may be hidden from pre-HTML 3.2
-user agents. See the HTML 4 specification ([[-HTML4]]) for more information.
+user agents. See the HTML 4 specification ([[-HTML401]]) for more information.
 </p>
 
 <h2><span id="parsing-errors">Rules for handling parsing
@@ -1391,7 +1391,7 @@ title="character encoding">encoded</span> by a character encoding that
 supports the set of characters available in US-ASCII (e.g., UTF-8, ISO
 8859-x, SHIFT JIS, etc.).  For a good introduction to character sets
 and character encodings, please consult the HTML 4
-specification ([[-HTML4]], chapter 5). See also the XML 1.0
+specification ([[-HTML401]], chapter 5). See also the XML 1.0
 specification ([[-XML10]], sections 2.2 and 4.3.3, and Appendix F).
 </p>
 <p>When a style sheet is embedded in another document, such as in the
@@ -1522,7 +1522,7 @@ This ensures that:
 represented in the current character encoding.  These characters must
 be written as <a href="#escaped-characters">escaped</a> references to
 ISO 10646 characters. These escapes serve the same purpose as numeric
-character references in HTML or XML documents (see [[HTML4]],
+character references in HTML or XML documents (see [[HTML401]],
 chapters 5 and 25).
 </p>
 <p>The character escape mechanism should be used when only a few

--- a/css2/visuren.html
+++ b/css2/visuren.html
@@ -2363,7 +2363,7 @@ or authors of special documents. If a default style sheet specifies
 these properties, authors and users should not specify rules to
 override them. 
 </p>
-<p>The HTML 4 specification ([HTML4], section 8.2) defines
+<p>The HTML 4 specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>, section 8.2) defines
 bidirectionality behavior for HTML elements. The style sheet
 rules that would achieve the bidi behavior specified in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a> are
 given in <a href="sample.html#bidi">the sample style sheet</a>. The

--- a/css2/visuren.html
+++ b/css2/visuren.html
@@ -2363,9 +2363,9 @@ or authors of special documents. If a default style sheet specifies
 these properties, authors and users should not specify rules to
 override them. 
 </p>
-<p>The HTML 4 specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>, section 8.2) defines
+<p>The HTML 4 specification (<a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>, section 8.2) defines
 bidirectionality behavior for HTML elements. The style sheet
-rules that would achieve the bidi behavior specified in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a> are
+rules that would achieve the bidi behavior specified in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a> are
 given in <a href="sample.html#bidi">the sample style sheet</a>. The
 HTML 4 specification also contains more information on
 bidirectionality issues.
@@ -2419,7 +2419,7 @@ The <a href="visuren.html#propdef-direction" class="noxref"><span class="propins
 specified for table column elements, is not inherited by cells in the
 column since columns are not the ancestors of the cells in the document tree. 
 Thus, CSS cannot easily capture the "dir" attribute inheritance rules described
-in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML4]</span></a>, section 11.3.2.1.
+in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>, section 11.3.2.1.
 </em></p></div>
 
 <div class="propdef">

--- a/css2/visuren.src
+++ b/css2/visuren.src
@@ -2133,9 +2133,9 @@ or authors of special documents. If a default style sheet specifies
 these properties, authors and users should not specify rules to
 override them. 
 </p>
-<p>The HTML 4 specification ([[HTML4]], section 8.2) defines
+<p>The HTML 4 specification ([[HTML401]], section 8.2) defines
 bidirectionality behavior for HTML elements. The style sheet
-rules that would achieve the bidi behavior specified in [[HTML4]] are
+rules that would achieve the bidi behavior specified in [[HTML401]] are
 given in <a href="sample.html#bidi">the sample style sheet</a>. The
 HTML 4 specification also contains more information on
 bidirectionality issues.
@@ -2174,7 +2174,7 @@ The <span class="propinst-direction">'direction'</span> property, when
 specified for table column elements, is not inherited by cells in the
 column since columns are not the ancestors of the cells in the document tree. 
 Thus, CSS cannot easily capture the "dir" attribute inheritance rules described
-in [[HTML4]], section 11.3.2.1.
+in [[HTML401]], section 11.3.2.1.
 </em></p></div>
 
 <!-- #include src=properties/unicode-bidi.srb -->

--- a/css2/visuren.src
+++ b/css2/visuren.src
@@ -2133,7 +2133,7 @@ or authors of special documents. If a default style sheet specifies
 these properties, authors and users should not specify rules to
 override them. 
 </p>
-<p>The HTML 4 specification ([HTML4], section 8.2) defines
+<p>The HTML 4 specification ([[HTML4]], section 8.2) defines
 bidirectionality behavior for HTML elements. The style sheet
 rules that would achieve the bidi behavior specified in [[HTML4]] are
 given in <a href="sample.html#bidi">the sample style sheet</a>. The


### PR DESCRIPTION
Fixes #4837 (renaming refs to match what specref knows about, with the exception of `[[CSS20]]`) and a couple of other minor issues.