### PR TITLE
Define terms in CSS2 in a Bikeshed compatible way

### DIFF
--- a/css2/about.html
+++ b/css2/about.html
@@ -192,7 +192,7 @@ information that resembles the following:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'property-name'"><dfn id="propdef-property-name" class="propdef-title" data-dfn-type="property" data-lt="property-name"><strong>'property-name'</strong></dfn></span>
+<span class="index-def" data-term="'property-name'"><dfn id="propdef-property-name" class="propdef-title" data-dfn-type="property" data-lt="property-name"><strong>'property-name'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>legal values &amp; syntax
@@ -362,7 +362,7 @@ for how this definition is used.
 
 <H3><span class="secno">1.4.3</span> <span id="shorthand">Shorthand properties</span></H3>
 
-<p>Some properties are <span id="x1" class="index-def" title="shorthand
+<p>Some properties are <span id="x1" class="index-def" data-term="shorthand
 property"><dfn>shorthand properties</dfn></span>, meaning that they allow
 authors to specify the values of several properties with a single
 property.

--- a/css2/about.html
+++ b/css2/about.html
@@ -192,7 +192,7 @@ information that resembles the following:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'property-name'"><span id="propdef-property-name" class="propdef-title"><strong>'property-name'</strong></span></span>
+<span class="index-def" title="'property-name'"><dfn id="propdef-property-name" class="propdef-title" data-dfn-type="property" data-lt="property-name"><strong>'property-name'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>legal values &amp; syntax

--- a/css2/about.src
+++ b/css2/about.src
@@ -298,7 +298,7 @@ for how this definition is used.
 
 <H3><span id="shorthand">Shorthand properties</span></H3>
 
-<p>Some properties are <span class="index-def" title="shorthand
+<p>Some properties are <span class="index-def" data-term="shorthand
 property"><dfn>shorthand properties</dfn></span>, meaning that they allow
 authors to specify the values of several properties with a single
 property.

--- a/css2/aural.html
+++ b/css2/aural.html
@@ -221,7 +221,7 @@ class="propinst-volume">'volume'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'volume'"><span id="propdef-volume" class="propdef-title"><strong>'volume'</strong></span></span>
+<span class="index-def" title="'volume'"><dfn id="propdef-volume" class="propdef-title" data-dfn-type="property" data-lt="volume"><strong>'volume'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | silent | x-soft | soft | medium | loud |
@@ -306,7 +306,7 @@ class="propinst-speak">'speak'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak'"><span id="propdef-speak" class="propdef-title"><strong>'speak'</strong></span></span>
+<span class="index-def" title="'speak'"><dfn id="propdef-speak" class="propdef-title" data-dfn-type="property" data-lt="speak"><strong>'speak'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | none | spell-out | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -358,7 +358,7 @@ class="propinst-pause">'pause'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause-before'"><span id="propdef-pause-before" class="propdef-title"><strong>'pause-before'</strong></span></span>
+<span class="index-def" title="'pause-before'"><dfn id="propdef-pause-before" class="propdef-title" data-dfn-type="property" data-lt="pause-before"><strong>'pause-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -375,7 +375,7 @@ class="propinst-pause">'pause'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause-after'"><span id="propdef-pause-after" class="propdef-title"><strong>'pause-after'</strong></span></span>
+<span class="index-def" title="'pause-after'"><dfn id="propdef-pause-after" class="propdef-title" data-dfn-type="property" data-lt="pause-after"><strong>'pause-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -422,7 +422,7 @@ sheets in the face of large changes in speech-rate.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause'"><span id="propdef-pause" class="propdef-title"><strong>'pause'</strong></span></span>
+<span class="index-def" title="'pause'"><dfn id="propdef-pause" class="propdef-title" data-dfn-type="property" data-lt="pause"><strong>'pause'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [<a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a>]{1,2} ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -461,7 +461,7 @@ class="propinst-cue">'cue'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue-before'"><span id="propdef-cue-before" class="propdef-title"><strong>'cue-before'</strong></span></span>
+<span class="index-def" title="'cue-before'"><dfn id="propdef-cue-before" class="propdef-title" data-dfn-type="property" data-lt="cue-before"><strong>'cue-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -478,7 +478,7 @@ class="propinst-cue">'cue'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue-after'"><span id="propdef-cue-after" class="propdef-title"><strong>'cue-after'</strong></span></span>
+<span class="index-def" title="'cue-after'"><dfn id="propdef-cue-after" class="propdef-title" data-dfn-type="property" data-lt="cue-after"><strong>'cue-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -514,7 +514,7 @@ h1 {cue-before: url("pop.au"); cue-after: url("pop.au") }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue'"><span id="propdef-cue" class="propdef-title"><strong>'cue'</strong></span></span>
+<span class="index-def" title="'cue'"><dfn id="propdef-cue" class="propdef-title" data-dfn-type="property" data-lt="cue"><strong>'cue'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="aural.html#propdef-cue-before" class="noxref"><span class="propinst-cue-before">&lt;'cue-before'&gt;</span></a> || <a href="aural.html#propdef-cue-after" class="noxref"><span class="propinst-cue-after">&lt;'cue-after'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -562,7 +562,7 @@ class="propinst-play-during">'play-during'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'play-during'"><span id="propdef-play-during" class="propdef-title"><strong>'play-during'</strong></span></span>
+<span class="index-def" title="'play-during'"><dfn id="propdef-play-during" class="propdef-title" data-dfn-type="property" data-lt="play-during"><strong>'play-during'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> [ mix || repeat ]? | auto | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -641,7 +641,7 @@ hardware will become more widely available.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'azimuth'"><span id="propdef-azimuth" class="propdef-title"><strong>'azimuth'</strong></span></span>
+<span class="index-def" title="'azimuth'"><dfn id="propdef-azimuth" class="propdef-title" data-dfn-type="property" data-lt="azimuth"><strong>'azimuth'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle">&lt;angle&gt;</span></a> | [[ left-side | far-left | left | center-left | center |
@@ -730,7 +730,7 @@ hemisphere values.  One method is as follows:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'elevation'"><span id="propdef-elevation" class="propdef-title"><strong>'elevation'</strong></span></span>
+<span class="index-def" title="'elevation'"><dfn id="propdef-elevation" class="propdef-title" data-dfn-type="property" data-lt="elevation"><strong>'elevation'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle">&lt;angle&gt;</span></a>  | below | level | above | higher | lower | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -788,7 +788,7 @@ class="propinst-voice-family">'voice-family'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speech-rate'"><span id="propdef-speech-rate" class="propdef-title"><strong>'speech-rate'</strong></span></span>
+<span class="index-def" title="'speech-rate'"><dfn id="propdef-speech-rate" class="propdef-title" data-dfn-type="property" data-lt="speech-rate"><strong>'speech-rate'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a>  | x-slow | slow | medium | fast | x-fast | faster | slower
@@ -833,7 +833,7 @@ synthesizers.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'voice-family'"><span id="propdef-voice-family" class="propdef-title"><strong>'voice-family'</strong></span></span>
+<span class="index-def" title="'voice-family'"><dfn id="propdef-voice-family" class="propdef-title" data-dfn-type="property" data-lt="voice-family"><strong>'voice-family'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[[<a href="aural.html#value-def-specific-voice" class="noxref"><span class="value-inst-specific-voice">&lt;specific-voice&gt;</span></a>  | <a href="aural.html#value-def-generic-voice" class="noxref"><span class="value-inst-generic-voice">&lt;generic-voice&gt;</span></a> ],]* [<a href="aural.html#value-def-specific-voice" class="noxref"><span class="value-inst-specific-voice">&lt;specific-voice&gt;</span></a>  |
@@ -885,7 +885,7 @@ characters inside the voice family name is converted to a single space.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pitch'"><span id="propdef-pitch" class="propdef-title"><strong>'pitch'</strong></span></span>
+<span class="index-def" title="'pitch'"><dfn id="propdef-pitch" class="propdef-title" data-dfn-type="property" data-lt="pitch"><strong>'pitch'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-frequency" class="noxref"><span class="value-inst-frequency">&lt;frequency&gt;</span></a> | x-low | low | medium | high | x-high | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -922,7 +922,7 @@ order (i.e., 'x-low' is a lower frequency than 'low', etc.).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pitch-range'"><span id="propdef-pitch-range" class="propdef-title"><strong>'pitch-range'</strong></span></span>
+<span class="index-def" title="'pitch-range'"><dfn id="propdef-pitch-range" class="propdef-title" data-dfn-type="property" data-lt="pitch-range"><strong>'pitch-range'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -959,7 +959,7 @@ inflection.  Pitch ranges greater than 50 produce animated voices.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'stress'"><span id="propdef-stress" class="propdef-title"><strong>'stress'</strong></span></span>
+<span class="index-def" title="'stress'"><dfn id="propdef-stress" class="propdef-title" data-dfn-type="property" data-lt="stress"><strong>'stress'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -998,7 +998,7 @@ meaning than '50' for an Italian voice.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'richness'"><span id="propdef-richness" class="propdef-title"><strong>'richness'</strong></span></span>
+<span class="index-def" title="'richness'"><dfn id="propdef-richness" class="propdef-title" data-dfn-type="property" data-lt="richness"><strong>'richness'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1037,7 +1037,7 @@ described below.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-punctuation'"><span id="propdef-speak-punctuation" class="propdef-title"><strong>'speak-punctuation'</strong></span></span>
+<span class="index-def" title="'speak-punctuation'"><dfn id="propdef-speak-punctuation" class="propdef-title" data-dfn-type="property" data-lt="speak-punctuation"><strong>'speak-punctuation'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>code | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1066,7 +1066,7 @@ naturally as various pauses.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-numeral'"><span id="propdef-speak-numeral" class="propdef-title"><strong>'speak-numeral'</strong></span></span>
+<span class="index-def" title="'speak-numeral'"><dfn id="propdef-speak-numeral" class="propdef-title" data-dfn-type="property" data-lt="speak-numeral"><strong>'speak-numeral'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>digits | continuous | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1108,7 +1108,7 @@ class="propinst-speak-header">'speak-header'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-header'"><span id="propdef-speak-header" class="propdef-title"><strong>'speak-header'</strong></span></span>
+<span class="index-def" title="'speak-header'"><dfn id="propdef-speak-header" class="propdef-title" data-dfn-type="property" data-lt="speak-header"><strong>'speak-header'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>once | always | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/aural.html
+++ b/css2/aural.html
@@ -145,8 +145,8 @@ paragraphs of class "peter" from the right. Paragraphs with class
 
 <H3><span class="secno">A.2.1</span> <span id="angles">Angles</span></H3>
 <P>Angle values are denoted by <span class="index-def"
-title="&lt;angle&gt;::definition of"><span
-id="value-def-angle">&lt;angle&gt;</span></span> in the text.
+title="&lt;angle&gt;::definition of"><dfn
+id="value-def-angle" data-dfn-type="type">&lt;angle&gt;</dfn></span> in the text.
 Their format is a <span id="x4" class="index-inst"
 title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
@@ -172,7 +172,7 @@ zero: '0deg' may be written as '0'.
 
 <H3><span class="secno">A.2.2</span> <span id="times">Times</span></H3>
 
-<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><span id="value-def-time">&lt;time&gt;</span></span> in the
+<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
 text.
 Their format is a <span id="x6" class="index-inst"
 title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
@@ -194,8 +194,8 @@ zero: '0s' may be written as '0'.
 <H3><span class="secno">A.2.3</span> <span id="frequencies">Frequencies</span></H3>
 
 <P>Frequency values are denoted by <span class="index-def"
-title="&lt;frequency&gt;::definition of"><span
-id="value-def-frequency">&lt;frequency&gt;</span></span> in the text.
+title="&lt;frequency&gt;::definition of"><dfn
+id="value-def-frequency" data-dfn-type="type">&lt;frequency&gt;</dfn></span> in the text.
 Their format is a <span id="x8" class="index-inst"
 title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
@@ -856,11 +856,11 @@ following meanings:</P>
 
 <dl>
 <dt><span class="index-def" title="&lt;generic-voice&gt;,
-definition of"><span
-id="value-def-generic-voice"><strong>&lt;generic-voice&gt;</strong></span></span>
+definition of"><dfn
+id="value-def-generic-voice" data-dfn-type="type"><strong>&lt;generic-voice&gt;</strong></dfn></span>
 <dd>Values are voice families. Possible values
 are 'male', 'female', and 'child'.
-<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><span id="value-def-specific-voice"><strong>&lt;specific-voice&gt;</strong></span></span>
+<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
 <dd>Values are specific instances (e.g., comedian, trinoids, carlos, lani).
 </dl>
 

--- a/css2/aural.html
+++ b/css2/aural.html
@@ -98,9 +98,9 @@ while
 
 <p>The aural rendering of a document, already commonly used by the
 blind and print-impaired communities, combines speech synthesis and
-<span id="x0" class="index-def" title="auditory icon">"auditory icons."</span> Often
+<span id="x0" class="index-def" data-term="auditory icon">"auditory icons."</span> Often
 such aural presentation occurs by converting the document to plain
-text and feeding this to a <span id="x1" class="index-def" title="screen
+text and feeding this to a <span id="x1" class="index-def" data-term="screen
 reader"><dfn>screen reader</dfn></span> -- software or hardware that
 simply reads all the characters on the screen.  This results in less
 effective presentation than would be the case if the document
@@ -114,7 +114,7 @@ and medical documentation systems (intranets), home entertainment, and
 to help users learning to read or who have difficulty reading.
 
 <p>When using aural properties, the <span id="x2" class="index-inst"
-title="canvas">canvas</span> consists of a three-dimensional physical
+data-term="canvas">canvas</span> consists of a three-dimensional physical
 space (sound surrounds) and a temporal space (one may specify sounds
 before, during, and after other sounds). The CSS properties also
 allow authors to vary the quality of synthesized speech (voice type,
@@ -145,10 +145,10 @@ paragraphs of class "peter" from the right. Paragraphs with class
 
 <H3><span class="secno">A.2.1</span> <span id="angles">Angles</span></H3>
 <P>Angle values are denoted by <span class="index-def"
-title="&lt;angle&gt;::definition of"><dfn
+data-term="&lt;angle&gt;::definition of"><dfn
 id="value-def-angle" data-dfn-type="type">&lt;angle&gt;</dfn></span> in the text.
 Their format is a <span id="x4" class="index-inst"
-title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
 followed by an angle unit identifier.
 
@@ -172,10 +172,10 @@ zero: '0deg' may be written as '0'.
 
 <H3><span class="secno">A.2.2</span> <span id="times">Times</span></H3>
 
-<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
+<P>Time values are denoted by <span class="index-def" data-term="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
 text.
 Their format is a <span id="x6" class="index-inst"
-title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
 followed by a time unit identifier.
 
@@ -194,10 +194,10 @@ zero: '0s' may be written as '0'.
 <H3><span class="secno">A.2.3</span> <span id="frequencies">Frequencies</span></H3>
 
 <P>Frequency values are denoted by <span class="index-def"
-title="&lt;frequency&gt;::definition of"><dfn
+data-term="&lt;frequency&gt;::definition of"><dfn
 id="value-def-frequency" data-dfn-type="type">&lt;frequency&gt;</dfn></span> in the text.
 Their format is a <span id="x8" class="index-inst"
-title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
 followed by a frequency unit identifier.
 
@@ -221,7 +221,7 @@ class="propinst-volume">'volume'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'volume'"><dfn id="propdef-volume" class="propdef-title" data-dfn-type="property" data-lt="volume"><strong>'volume'</strong></dfn></span>
+<span class="index-def" data-term="'volume'"><dfn id="propdef-volume" class="propdef-title" data-dfn-type="property" data-lt="volume"><strong>'volume'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | silent | x-soft | soft | medium | loud |
@@ -237,7 +237,7 @@ x-loud | <a href="cascade.html#value-def-inherit" class="noxref"><span class="va
 </div>
 
 
-<P><span id="x10" class="index-def" title="volume">Volume</span> refers to the
+<P><span id="x10" class="index-def" data-term="volume">Volume</span> refers to the
 median volume of the waveform. In other words, a highly inflected
 voice at a volume of 50 might peak well above that. The overall values
 are likely to be human adjustable for comfort, for example with a
@@ -249,14 +249,14 @@ range.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x11" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+<dt><span id="x11" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 		class="value-inst-number"><strong>&lt;number&gt;</strong>
 </span></a></span>
 <dd>Any number between '0' and '100'.
 '0' represents the <em>minimum audible</em>
 volume level and 100 corresponds to the
 <em>maximum comfortable</em> level.
-<dt><span id="x12" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x12" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 <dd>Percentage values are calculated relative to the inherited value,
 and are then clipped to the range '0' to '100'.
 <dt><strong>silent</strong>
@@ -306,7 +306,7 @@ class="propinst-speak">'speak'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak'"><dfn id="propdef-speak" class="propdef-title" data-dfn-type="property" data-lt="speak"><strong>'speak'</strong></dfn></span>
+<span class="index-def" data-term="'speak'"><dfn id="propdef-speak" class="propdef-title" data-dfn-type="property" data-lt="speak"><strong>'speak'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | none | spell-out | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -358,7 +358,7 @@ class="propinst-pause">'pause'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause-before'"><dfn id="propdef-pause-before" class="propdef-title" data-dfn-type="property" data-lt="pause-before"><strong>'pause-before'</strong></dfn></span>
+<span class="index-def" data-term="'pause-before'"><dfn id="propdef-pause-before" class="propdef-title" data-dfn-type="property" data-lt="pause-before"><strong>'pause-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -375,7 +375,7 @@ class="propinst-pause">'pause'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause-after'"><dfn id="propdef-pause-after" class="propdef-title" data-dfn-type="property" data-lt="pause-after"><strong>'pause-after'</strong></dfn></span>
+<span class="index-def" data-term="'pause-after'"><dfn id="propdef-pause-after" class="propdef-title" data-dfn-type="property" data-lt="pause-after"><strong>'pause-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -400,9 +400,9 @@ around the cues and content rather than between them. See
 <a href="refs.html#ref-CSS3SPEECH" class="noxref"><span class="informref">[CSS3SPEECH]</span></a> for details.
 
 <dl>
-<dt><span id="x16" class="index-inst" title="&lt;time&gt;"><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time"><strong>&lt;time&gt;</strong></span></a></span>
+<dt><span id="x16" class="index-inst" data-term="&lt;time&gt;"><a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time"><strong>&lt;time&gt;</strong></span></a></span>
 <dd>Expresses the pause in absolute time units (seconds and milliseconds).
-<dt><span id="x17" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x17" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 <dd>Refers to the inverse of the value of the
 <a href="aural.html#propdef-speech-rate" class="noxref"><span class="propinst-speech-rate">'speech-rate'</span></a> property.
 For example, if the speech-rate is 120 words per minute
@@ -422,7 +422,7 @@ sheets in the face of large changes in speech-rate.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pause'"><dfn id="propdef-pause" class="propdef-title" data-dfn-type="property" data-lt="pause"><strong>'pause'</strong></dfn></span>
+<span class="index-def" data-term="'pause'"><dfn id="propdef-pause" class="propdef-title" data-dfn-type="property" data-lt="pause"><strong>'pause'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [<a href="aural.html#value-def-time" class="noxref"><span class="value-inst-time">&lt;time&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a>]{1,2} ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -461,7 +461,7 @@ class="propinst-cue">'cue'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue-before'"><dfn id="propdef-cue-before" class="propdef-title" data-dfn-type="property" data-lt="cue-before"><strong>'cue-before'</strong></dfn></span>
+<span class="index-def" data-term="'cue-before'"><dfn id="propdef-cue-before" class="propdef-title" data-dfn-type="property" data-lt="cue-before"><strong>'cue-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -478,7 +478,7 @@ class="propinst-cue">'cue'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue-after'"><dfn id="propdef-cue-after" class="propdef-title" data-dfn-type="property" data-lt="cue-after"><strong>'cue-after'</strong></dfn></span>
+<span class="index-def" data-term="'cue-after'"><dfn id="propdef-cue-after" class="propdef-title" data-dfn-type="property" data-lt="cue-after"><strong>'cue-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -498,7 +498,7 @@ elements. Sounds may be played before and/or after the element to
 delimit it. Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x21" class="index-inst" title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></a></span>
+<dt><span id="x21" class="index-inst" data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></a></span>
 <dd> The URI must designate an auditory icon resource. If the URI resolves to something other than an audio file, such as an image, the resource should be ignored and the property treated as if it had the value 'none'.
 
 <dt><strong>none</strong>
@@ -514,7 +514,7 @@ h1 {cue-before: url("pop.au"); cue-after: url("pop.au") }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cue'"><dfn id="propdef-cue" class="propdef-title" data-dfn-type="property" data-lt="cue"><strong>'cue'</strong></dfn></span>
+<span class="index-def" data-term="'cue'"><dfn id="propdef-cue" class="propdef-title" data-dfn-type="property" data-lt="cue"><strong>'cue'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="aural.html#propdef-cue-before" class="noxref"><span class="propinst-cue-before">&lt;'cue-before'&gt;</span></a> || <a href="aural.html#propdef-cue-after" class="noxref"><span class="propinst-cue-after">&lt;'cue-after'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -562,7 +562,7 @@ class="propinst-play-during">'play-during'</span></a></H2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'play-during'"><dfn id="propdef-play-during" class="propdef-title" data-dfn-type="property" data-lt="play-during"><strong>'play-during'</strong></dfn></span>
+<span class="index-def" data-term="'play-during'"><dfn id="propdef-play-during" class="propdef-title" data-dfn-type="property" data-lt="play-during"><strong>'play-during'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> [ mix || repeat ]? | auto | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -585,9 +585,9 @@ while an element's content is spoken.
 Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x24" class="index-inst" title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></a></span>
+<dt><span id="x24" class="index-inst" data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></a></span>
 <dd>The sound designated by this <span id="x25" class="index-inst"
-title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
+data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
 class="value-inst-uri">&lt;uri&gt;</span></a></span> is played
 as a background while the element's content is spoken.
 <dt><strong>mix</strong>
@@ -595,7 +595,7 @@ as a background while the element's content is spoken.
 the sound inherited from the parent element's <a href="aural.html#propdef-play-during" class="noxref"><span
 class="propinst-play-during">'play-during'</span></a> property continues
 to play and the sound designated by the <span id="x26"
-class="index-inst" title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
+class="index-inst" data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
 class="value-inst-uri">&lt;uri&gt;</span></a></span> is mixed with it. If
 'mix' is not specified, the element's background sound replaces
 the parent's.
@@ -641,7 +641,7 @@ hardware will become more widely available.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'azimuth'"><dfn id="propdef-azimuth" class="propdef-title" data-dfn-type="property" data-lt="azimuth"><strong>'azimuth'</strong></dfn></span>
+<span class="index-def" data-term="'azimuth'"><dfn id="propdef-azimuth" class="propdef-title" data-dfn-type="property" data-lt="azimuth"><strong>'azimuth'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle">&lt;angle&gt;</span></a> | [[ left-side | far-left | left | center-left | center |
@@ -661,7 +661,7 @@ leftwards | rightwards | <a href="cascade.html#value-def-inherit" class="noxref"
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x28" class="index-inst" title="&lt;angle&gt;"><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></a></span>
+<dt><span id="x28" class="index-inst" data-term="&lt;angle&gt;"><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></a></span>
 <dd>Position is described in terms of an angle
 within the range '-360deg' to '360deg'.
 The value '0deg' means directly ahead in the center of the sound
@@ -730,7 +730,7 @@ hemisphere values.  One method is as follows:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'elevation'"><dfn id="propdef-elevation" class="propdef-title" data-dfn-type="property" data-lt="elevation"><strong>'elevation'</strong></dfn></span>
+<span class="index-def" data-term="'elevation'"><dfn id="propdef-elevation" class="propdef-title" data-dfn-type="property" data-lt="elevation"><strong>'elevation'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle">&lt;angle&gt;</span></a>  | below | level | above | higher | lower | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -748,7 +748,7 @@ hemisphere values.  One method is as follows:</p>
 <P>Values of this property have the following meanings:</p>
 
 <dl>
-<dt><span id="x30" class="index-inst" title="&lt;angle&gt;"><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></a></span>
+<dt><span id="x30" class="index-inst" data-term="&lt;angle&gt;"><a href="aural.html#value-def-angle" class="noxref"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></a></span>
 <dd>Specifies the elevation as an angle, between '-90deg' and '90deg'.
 '0deg' means on the forward horizon, which loosely means level with
 the listener.  '90deg' means directly overhead and '-90deg' means directly
@@ -788,7 +788,7 @@ class="propinst-voice-family">'voice-family'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speech-rate'"><dfn id="propdef-speech-rate" class="propdef-title" data-dfn-type="property" data-lt="speech-rate"><strong>'speech-rate'</strong></dfn></span>
+<span class="index-def" data-term="'speech-rate'"><dfn id="propdef-speech-rate" class="propdef-title" data-dfn-type="property" data-lt="speech-rate"><strong>'speech-rate'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a>  | x-slow | slow | medium | fast | x-fast | faster | slower
@@ -810,7 +810,7 @@ class="propinst-font-size">'font-size'</span></a>). Values have
 the following meanings:</p>
 
 <dl>
-<dt><span id="x32" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+<dt><span id="x32" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
 <dd>Specifies the speaking rate in words per minute, a quantity that varies
 somewhat by language but is nevertheless widely supported by speech
@@ -833,7 +833,7 @@ synthesizers.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'voice-family'"><dfn id="propdef-voice-family" class="propdef-title" data-dfn-type="property" data-lt="voice-family"><strong>'voice-family'</strong></dfn></span>
+<span class="index-def" data-term="'voice-family'"><dfn id="propdef-voice-family" class="propdef-title" data-dfn-type="property" data-lt="voice-family"><strong>'voice-family'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[[<a href="aural.html#value-def-specific-voice" class="noxref"><span class="value-inst-specific-voice">&lt;specific-voice&gt;</span></a>  | <a href="aural.html#value-def-generic-voice" class="noxref"><span class="value-inst-generic-voice">&lt;generic-voice&gt;</span></a> ],]* [<a href="aural.html#value-def-specific-voice" class="noxref"><span class="value-inst-specific-voice">&lt;specific-voice&gt;</span></a>  |
@@ -855,12 +855,12 @@ class="propinst-font-family">'font-family'</span></a>). Values have the
 following meanings:</P>
 
 <dl>
-<dt><span class="index-def" title="&lt;generic-voice&gt;,
+<dt><span class="index-def" data-term="&lt;generic-voice&gt;,
 definition of"><dfn
 id="value-def-generic-voice" data-dfn-type="type"><strong>&lt;generic-voice&gt;</strong></dfn></span>
 <dd>Values are voice families. Possible values
 are 'male', 'female', and 'child'.
-<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
+<dt><span class="index-def" data-term="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
 <dd>Values are specific instances (e.g., comedian, trinoids, carlos, lani).
 </dl>
 
@@ -885,7 +885,7 @@ characters inside the voice family name is converted to a single space.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pitch'"><dfn id="propdef-pitch" class="propdef-title" data-dfn-type="property" data-lt="pitch"><strong>'pitch'</strong></dfn></span>
+<span class="index-def" data-term="'pitch'"><dfn id="propdef-pitch" class="propdef-title" data-dfn-type="property" data-lt="pitch"><strong>'pitch'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="aural.html#value-def-frequency" class="noxref"><span class="value-inst-frequency">&lt;frequency&gt;</span></a> | x-low | low | medium | high | x-high | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -908,7 +908,7 @@ but for a female voice, it's around 210Hz.</p>
 <P>Values have the following meanings:</P>
 
 <dl>
-<dt><span id="x37" class="index-inst" title="&lt;frequency&gt;"><a href="aural.html#value-def-frequency" class="noxref"><span class="value-inst-frequency"><strong>&lt;frequency&gt;</strong></span></a></span>
+<dt><span id="x37" class="index-inst" data-term="&lt;frequency&gt;"><a href="aural.html#value-def-frequency" class="noxref"><span class="value-inst-frequency"><strong>&lt;frequency&gt;</strong></span></a></span>
 <dd>Specifies the average pitch of the speaking voice in hertz (Hz).
 <dt><strong>x-low</strong>, <strong>low</strong>,
 <strong>medium</strong>, <strong>high</strong>, <strong>x-high</strong>
@@ -922,7 +922,7 @@ order (i.e., 'x-low' is a lower frequency than 'low', etc.).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'pitch-range'"><dfn id="propdef-pitch-range" class="propdef-title" data-dfn-type="property" data-lt="pitch-range"><strong>'pitch-range'</strong></dfn></span>
+<span class="index-def" data-term="'pitch-range'"><dfn id="propdef-pitch-range" class="propdef-title" data-dfn-type="property" data-lt="pitch-range"><strong>'pitch-range'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -950,7 +950,7 @@ from the average pitch.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x39" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
+<dt><span id="x39" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
 <dd>A value between '0' and '100'. A pitch range of '0' produces
 a flat, monotonic voice. A pitch range of 50 produces normal
 inflection.  Pitch ranges greater than 50 produce animated voices.
@@ -959,7 +959,7 @@ inflection.  Pitch ranges greater than 50 produce animated voices.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'stress'"><dfn id="propdef-stress" class="propdef-title" data-dfn-type="property" data-lt="stress"><strong>'stress'</strong></dfn></span>
+<span class="index-def" data-term="'stress'"><dfn id="propdef-stress" class="propdef-title" data-dfn-type="property" data-lt="stress"><strong>'stress'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -987,7 +987,7 @@ provided to allow developers to exploit higher-end auditory displays.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x41" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
+<dt><span id="x41" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
 <dd>A value, between '0' and '100'. The meaning of values
 depends on the language being spoken. For example,
 a level of '50' for a
@@ -998,7 +998,7 @@ meaning than '50' for an Italian voice.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'richness'"><dfn id="propdef-richness" class="propdef-title" data-dfn-type="property" data-lt="richness"><strong>'richness'</strong></dfn></span>
+<span class="index-def" data-term="'richness'"><dfn id="propdef-richness" class="propdef-title" data-dfn-type="property" data-lt="richness"><strong>'richness'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1020,7 +1020,7 @@ rich voice will "carry" in a large room, a smooth voice will not.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x43" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
+<dt><span id="x43" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
 <dd>A value between '0' and '100'.
 The higher the value, the more the voice will carry.
 A lower value will produce a soft, mellifluous voice.
@@ -1037,7 +1037,7 @@ described below.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-punctuation'"><dfn id="propdef-speak-punctuation" class="propdef-title" data-dfn-type="property" data-lt="speak-punctuation"><strong>'speak-punctuation'</strong></dfn></span>
+<span class="index-def" data-term="'speak-punctuation'"><dfn id="propdef-speak-punctuation" class="propdef-title" data-dfn-type="property" data-lt="speak-punctuation"><strong>'speak-punctuation'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>code | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1066,7 +1066,7 @@ naturally as various pauses.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-numeral'"><dfn id="propdef-speak-numeral" class="propdef-title" data-dfn-type="property" data-lt="speak-numeral"><strong>'speak-numeral'</strong></dfn></span>
+<span class="index-def" data-term="'speak-numeral'"><dfn id="propdef-speak-numeral" class="propdef-title" data-dfn-type="property" data-lt="speak-numeral"><strong>'speak-numeral'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>digits | continuous | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1108,7 +1108,7 @@ class="propinst-speak-header">'speak-header'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'speak-header'"><dfn id="propdef-speak-header" class="propdef-title" data-dfn-type="property" data-lt="speak-header"><strong>'speak-header'</strong></dfn></span>
+<span class="index-def" data-term="'speak-header'"><dfn id="propdef-speak-header" class="propdef-title" data-dfn-type="property" data-lt="speak-header"><strong>'speak-header'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>once | always | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/aural.src
+++ b/css2/aural.src
@@ -49,9 +49,9 @@ while
 
 <p>The aural rendering of a document, already commonly used by the
 blind and print-impaired communities, combines speech synthesis and
-<span class="index-def" title="auditory icon">"auditory icons."</span> Often
+<span class="index-def" data-term="auditory icon">"auditory icons."</span> Often
 such aural presentation occurs by converting the document to plain
-text and feeding this to a <span class="index-def" title="screen
+text and feeding this to a <span class="index-def" data-term="screen
 reader"><dfn>screen reader</dfn></span> -- software or hardware that
 simply reads all the characters on the screen.  This results in less
 effective presentation than would be the case if the document
@@ -65,7 +65,7 @@ and medical documentation systems (intranets), home entertainment, and
 to help users learning to read or who have difficulty reading.
 
 <p>When using aural properties, the <span class="index-inst"
-title="canvas">canvas</span> consists of a three-dimensional physical
+data-term="canvas">canvas</span> consists of a three-dimensional physical
 space (sound surrounds) and a temporal space (one may specify sounds
 before, during, and after other sounds). The CSS properties also
 allow authors to vary the quality of synthesized speech (voice type,
@@ -96,10 +96,10 @@ paragraphs of class "peter" from the right. Paragraphs with class
 
 <H3><span id="angles">Angles</span></H3>
 <P>Angle values are denoted by <span class="index-def"
-title="&lt;angle&gt;::definition of"><dfn
+data-term="&lt;angle&gt;::definition of"><dfn
 id="value-def-angle" data-dfn-type="type">&lt;angle&gt;</dfn></span> in the text.
 Their format is a <span class="index-inst"
-title="&lt;number&gt;"><span
+data-term="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
 followed by an angle unit identifier.
 
@@ -123,10 +123,10 @@ zero: '0deg' may be written as '0'.
 
 <H3><span id="times">Times</span></H3>
 
-<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
+<P>Time values are denoted by <span class="index-def" data-term="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
 text.
 Their format is a <span class="index-inst"
-title="&lt;number&gt;"><span
+data-term="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
 followed by a time unit identifier.
 
@@ -145,10 +145,10 @@ zero: '0s' may be written as '0'.
 <H3><span id="frequencies">Frequencies</span></H3>
 
 <P>Frequency values are denoted by <span class="index-def"
-title="&lt;frequency&gt;::definition of"><dfn
+data-term="&lt;frequency&gt;::definition of"><dfn
 id="value-def-frequency" data-dfn-type="type">&lt;frequency&gt;</dfn></span> in the text.
 Their format is a <span class="index-inst"
-title="&lt;number&gt;"><span
+data-term="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
 followed by a frequency unit identifier.
 
@@ -172,7 +172,7 @@ class="propinst-volume">'volume'</span></H2>
 
 <!-- #include src=properties/volume.srb -->
 
-<P><span class="index-def" title="volume">Volume</span> refers to the
+<P><span class="index-def" data-term="volume">Volume</span> refers to the
 median volume of the waveform. In other words, a highly inflected
 voice at a volume of 50 might peak well above that. The overall values
 are likely to be human adjustable for comfort, for example with a
@@ -184,14 +184,14 @@ range.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;number&gt;"><span
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span
 		class="value-inst-number"><strong>&lt;number&gt;</strong>
 </span></span>
 <dd>Any number between '0' and '100'.
 '0' represents the <em>minimum audible</em>
 volume level and 100 corresponds to the
 <em>maximum comfortable</em> level.
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 <dd>Percentage values are calculated relative to the inherited value,
 and are then clipped to the range '0' to '100'.
 <dt><strong>silent</strong>
@@ -290,9 +290,9 @@ around the cues and content rather than between them. See
 [[-CSS3SPEECH]] for details.
 
 <dl>
-<dt><span class="index-inst" title="&lt;time&gt;"><span class="value-inst-time"><strong>&lt;time&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;time&gt;"><span class="value-inst-time"><strong>&lt;time&gt;</strong></span></span>
 <dd>Expresses the pause in absolute time units (seconds and milliseconds).
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 <dd>Refers to the inverse of the value of the
 <span class="propinst-speech-rate">'speech-rate'</span> property.
 For example, if the speech-rate is 120 words per minute
@@ -343,7 +343,7 @@ elements. Sounds may be played before and/or after the element to
 delimit it. Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;uri&gt;"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;uri&gt;"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></span>
 <dd> The URI must designate an auditory icon resource. If the URI resolves to something other than an audio file, such as an image, the resource should be ignored and the property treated as if it had the value 'none'.
 
 <dt><strong>none</strong>
@@ -400,9 +400,9 @@ while an element's content is spoken.
 Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;uri&gt;"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;uri&gt;"><span class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></span>
 <dd>The sound designated by this <span class="index-inst"
-title="&lt;uri&gt;"><span
+data-term="&lt;uri&gt;"><span
 class="value-inst-uri">&lt;uri&gt;</span></span> is played
 as a background while the element's content is spoken.
 <dt><strong>mix</strong>
@@ -410,7 +410,7 @@ as a background while the element's content is spoken.
 the sound inherited from the parent element's <span
 class="propinst-play-during">'play-during'</span> property continues
 to play and the sound designated by the <span
-class="index-inst" title="&lt;uri&gt;"><span
+class="index-inst" data-term="&lt;uri&gt;"><span
 class="value-inst-uri">&lt;uri&gt;</span></span> is mixed with it. If
 'mix' is not specified, the element's background sound replaces
 the parent's.
@@ -459,7 +459,7 @@ hardware will become more widely available.</p>
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;angle&gt;"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;angle&gt;"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></span>
 <dd>Position is described in terms of an angle
 within the range '-360deg' to '360deg'.
 The value '0deg' means directly ahead in the center of the sound
@@ -531,7 +531,7 @@ hemisphere values.  One method is as follows:</p>
 <P>Values of this property have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;angle&gt;"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;angle&gt;"><span class="value-inst-angle"><strong>&lt;angle&gt;</strong></span></span>
 <dd>Specifies the elevation as an angle, between '-90deg' and '90deg'.
 '0deg' means on the forward horizon, which loosely means level with
 the listener.  '90deg' means directly overhead and '-90deg' means directly
@@ -577,7 +577,7 @@ class="propinst-font-size">'font-size'</span>). Values have
 the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;number&gt;"><span
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span
 class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
 <dd>Specifies the speaking rate in words per minute, a quantity that varies
 somewhat by language but is nevertheless widely supported by speech
@@ -606,12 +606,12 @@ class="propinst-font-family">'font-family'</span>). Values have the
 following meanings:</P>
 
 <dl>
-<dt><span class="index-def" title="&lt;generic-voice&gt;,
+<dt><span class="index-def" data-term="&lt;generic-voice&gt;,
 definition of"><dfn
 id="value-def-generic-voice" data-dfn-type="type"><strong>&lt;generic-voice&gt;</strong></dfn></span>
 <dd>Values are voice families. Possible values
 are 'male', 'female', and 'child'.
-<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
+<dt><span class="index-def" data-term="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
 <dd>Values are specific instances (e.g., comedian, trinoids, carlos, lani).
 </dl>
 
@@ -644,7 +644,7 @@ but for a female voice, it's around 210Hz.</p>
 <P>Values have the following meanings:</P>
 
 <dl>
-<dt><span class="index-inst" title="&lt;frequency&gt;"><span class="value-inst-frequency"><strong>&lt;frequency&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;frequency&gt;"><span class="value-inst-frequency"><strong>&lt;frequency&gt;</strong></span></span>
 <dd>Specifies the average pitch of the speaking voice in hertz (Hz).
 <dt><strong>x-low</strong>, <strong>low</strong>,
 <strong>medium</strong>, <strong>high</strong>, <strong>x-high</strong>
@@ -671,7 +671,7 @@ from the average pitch.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
 <dd>A value between '0' and '100'. A pitch range of '0' produces
 a flat, monotonic voice. A pitch range of 50 produces normal
 inflection.  Pitch ranges greater than 50 produce animated voices.
@@ -693,7 +693,7 @@ provided to allow developers to exploit higher-end auditory displays.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
 <dd>A value, between '0' and '100'. The meaning of values
 depends on the language being spoken. For example,
 a level of '50' for a
@@ -711,7 +711,7 @@ rich voice will "carry" in a large room, a smooth voice will not.
 <P>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
 <dd>A value between '0' and '100'.
 The higher the value, the more the voice will carry.
 A lower value will produce a soft, mellifluous voice.

--- a/css2/aural.src
+++ b/css2/aural.src
@@ -96,8 +96,8 @@ paragraphs of class "peter" from the right. Paragraphs with class
 
 <H3><span id="angles">Angles</span></H3>
 <P>Angle values are denoted by <span class="index-def"
-title="&lt;angle&gt;::definition of"><span
-id="value-def-angle">&lt;angle&gt;</span></span> in the text.
+title="&lt;angle&gt;::definition of"><dfn
+id="value-def-angle" data-dfn-type="type">&lt;angle&gt;</dfn></span> in the text.
 Their format is a <span class="index-inst"
 title="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
@@ -123,7 +123,7 @@ zero: '0deg' may be written as '0'.
 
 <H3><span id="times">Times</span></H3>
 
-<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><span id="value-def-time">&lt;time&gt;</span></span> in the
+<P>Time values are denoted by <span class="index-def" title="&lt;time&gt;::definition of"><dfn id="value-def-time" data-dfn-type="type">&lt;time&gt;</dfn></span> in the
 text.
 Their format is a <span class="index-inst"
 title="&lt;number&gt;"><span
@@ -145,8 +145,8 @@ zero: '0s' may be written as '0'.
 <H3><span id="frequencies">Frequencies</span></H3>
 
 <P>Frequency values are denoted by <span class="index-def"
-title="&lt;frequency&gt;::definition of"><span
-id="value-def-frequency">&lt;frequency&gt;</span></span> in the text.
+title="&lt;frequency&gt;::definition of"><dfn
+id="value-def-frequency" data-dfn-type="type">&lt;frequency&gt;</dfn></span> in the text.
 Their format is a <span class="index-inst"
 title="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
@@ -607,11 +607,11 @@ following meanings:</P>
 
 <dl>
 <dt><span class="index-def" title="&lt;generic-voice&gt;,
-definition of"><span
-id="value-def-generic-voice"><strong>&lt;generic-voice&gt;</strong></span></span>
+definition of"><dfn
+id="value-def-generic-voice" data-dfn-type="type"><strong>&lt;generic-voice&gt;</strong></dfn></span>
 <dd>Values are voice families. Possible values
 are 'male', 'female', and 'child'.
-<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><span id="value-def-specific-voice"><strong>&lt;specific-voice&gt;</strong></span></span>
+<dt><span class="index-def" title="&lt;specific-voice&gt;::definition of"><dfn id="value-def-specific-voice" data-dfn-type="type"><strong>&lt;specific-voice&gt;</strong></dfn></span>
 <dd>Values are specific instances (e.g., comedian, trinoids, carlos, lani).
 </dl>
 

--- a/css2/bin/addhanch
+++ b/css2/bin/addhanch
@@ -87,11 +87,13 @@ sub addanchor {
     my ($chapno, $seqno, $stag, $lvl, $title, $content, $cmt, $etag) = @_;
     my ($anchor, $anchor1, $anchor2016, $txt, $i);
     my $file = $chapter[$chapno];
+    my $has_anchor = 0;
 
     # Generate the anchor
-    if ($content =~ /<span\s+[^>]*?id\s*=\s*(?:([^\s\">]+)|\"([^\"]+)\"|\'([^\']+)\')/io) { # Reuse first anchor in header.
+    if ($content =~ /<[a-z0-9]+\s+[^>]*?id\s*=\s*(?:([^\s\">]+)|\"([^\"]+)\"|\'([^\']+)\')/io) { # Reuse first anchor in header.
 	$anchor = "$1$2$3";	# Only one of $1, $2, $3 will match.
 	$anchor1 = "#$anchor";
+        $has_anchor = 1;
     } else {
 	$anchor = "q$seqno";	# Use simple sequence number
 	$anchor2016 = "q$chapno.$seqno";	# 2016 anchors
@@ -108,7 +110,7 @@ sub addanchor {
 
     # Remove anchors from heading text
     $txt = cleanup($content);
-    $txt =~ s/<\/?span[^>]*>//gio;
+    $txt =~ s/<\/?[0-9a-z]+[^>]*>//gio;
 
     # Determine title/comment
     $cmt = cleanup(defined $title ? $title : defined $cmt ? $cmt : '');
@@ -122,7 +124,7 @@ sub addanchor {
     $anchors{$dbkey} = $dbentry;
 
     # Construct the new heading
-    if ($content =~ /<span\s+[^>]*?id\s*=/sio) {
+    if ($has_anchor) {
 	# Don't add anchors if there is already an anchor
 	return "$stag$num $content$etag";
     } else {

--- a/css2/bin/addianch
+++ b/css2/bin/addianch
@@ -65,7 +65,7 @@ while ($buf =~ /$defp/sio) {
     @entries = split(/\|/o, cleanup($entry));
 
     # Create an anchor
-    if ($content =~ /<span\s+[^>]*?id\s*=\s*(?:[\"]([^\"]+)[\"]|[\']([^\']+)[\']|[\s]([^\s>]+)[\s>])/sio) {
+    if ($content =~ /<(?:[0-9a-z]+)\s+[^>]*?id\s*=\s*(?:[\"]([^\"]+)[\"]|[\']([^\']+)[\']|[\s]([^\s>]+)[\s>])/sio) {
 	# Already a name in the content, re-use it
 	$anchor = "$1$2$3";
 	print OUTPUT $elem;

--- a/css2/bin/addianch
+++ b/css2/bin/addianch
@@ -55,8 +55,8 @@ while ($buf =~ /$defp/sio) {
     $content = $3;
     $elem = $&;
 
-    # Check if there is a title attribute, otherwise use content
-    if ($stag =~ /title\s*=\s*(?:\"([^\"]*)\"|\'([^\']*)\'|([^\s>]*))/sio) {
+    # Check if there is a data-term attribute, otherwise use content
+    if ($stag =~ /data-term\s*=\s*(?:\"([^\"]*)\"|\'([^\']*)\'|([^\s>]*))/sio) {
 	$entry = $1.$2.$3;	# Only one of the three is non-empty
     } else {
 	$entry = $content;	# Assume content is index term

--- a/css2/bin/mkanchdb
+++ b/css2/bin/mkanchdb
@@ -31,7 +31,7 @@ my $buf = readfile($file);	# Read file
 $buf =~ s/<!--.*?-->//sgio;	# Remove comments
 
 # Loop over all anchors, store them in database, prefixed with filename
-while ($buf =~ /<span\s+[^>]*?id\s*=\s*[\"\']?($prefix[^\s\"\'>]+)[\"\']?.*?>/sio) {
+while ($buf =~ /<(?:[0-9a-z]+)\s+[^>]*?id\s*=\s*[\"\']?($prefix[^\s\"\'>]+)[\"\']?.*?>/sio) {
     $buf = $';
     $anch = "$hfil#$1";
     if (($anchors{$1} ne "") && ($anchors{$1} ne $anch)) {

--- a/css2/bin/pextr
+++ b/css2/bin/pextr
@@ -60,7 +60,7 @@ print output "<dl><dt>\n";
 @names = split(/[, \t\n]+/, $name);
 $comma = "";
 foreach $n (@names) {
-  print output "$comma<span class=\"index-def\" title=\"'$n'\"><dfn id=\"propdef-$n\" class=\"propdef-title\" data-dfn-type=\"property\" data-lt=\"$n\"><strong>'$n'</strong></dfn></span>";
+  print output "$comma<span class=\"index-def\" data-term=\"'$n'\"><dfn id=\"propdef-$n\" class=\"propdef-title\" data-dfn-type=\"property\" data-lt=\"$n\"><strong>'$n'</strong></dfn></span>";
   $comma = ", ";
 }
 print output "\n<dd>\n";

--- a/css2/bin/pextr
+++ b/css2/bin/pextr
@@ -60,7 +60,7 @@ print output "<dl><dt>\n";
 @names = split(/[, \t\n]+/, $name);
 $comma = "";
 foreach $n (@names) {
-  print output "$comma<span class=\"index-def\" title=\"'$n'\"><span id=\"propdef-$n\" class=\"propdef-title\"><strong>'$n'</strong></span></span>";
+  print output "$comma<span class=\"index-def\" title=\"'$n'\"><dfn id=\"propdef-$n\" class=\"propdef-title\" data-dfn-type=\"property\" data-lt=\"$n\"><strong>'$n'</strong></dfn></span>";
   $comma = ", ";
 }
 print output "\n<dd>\n";

--- a/css2/box.html
+++ b/css2/box.html
@@ -235,8 +235,8 @@ vertical margins will not have any effect on non-replaced inline
 elements.
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;margin-width&gt;::definition of"><span
-id="value-def-margin-width"><strong>&lt;margin-width&gt;</strong></span></span>
+class="index-def" title="&lt;margin-width&gt;::definition of"><dfn
+id="value-def-margin-width" data-dfn-type="type"><strong>&lt;margin-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>
@@ -516,9 +516,9 @@ padding for all four sides while the other padding properties only set
 their respective side. 
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;padding-width&gt;::definition of"><span
-id="value-def-padding-width"><strong>&lt;padding-width&gt;</strong>
-</span></span> value type, which may take one of the following values:</p>
+class="index-def" title="&lt;padding-width&gt;::definition of"><dfn
+id="value-def-padding-width" data-dfn-type="type"><strong>&lt;padding-width&gt;</strong>
+</dfn></span> value type, which may take one of the following values:</p>
 
 <dl>
 <dt><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a>
@@ -645,9 +645,9 @@ class="propinst-border-bottom-width">'border-bottom-width'</span></a>,
 <P>The border width properties specify the width of the <a
 href="#box-border-area">border area</a>.  The properties
 defined in this section refer to the <span class="index-def"
-title="&lt;border-width&gt;::definition of"><span
-id="value-def-border-width"
-class="value-def"><strong>&lt;border-width&gt;</strong></span></span>
+title="&lt;border-width&gt;::definition of"><dfn
+id="value-def-border-width" data-dfn-type="type"
+class="value-def"><strong>&lt;border-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</P>
 
 <dl>
@@ -824,8 +824,8 @@ p {
 <P>The border style properties specify the line style of a box's
 border (solid, double, dashed, etc.). The properties defined in this
 section refer to the <span class="index-def"
-title="&lt;border-style&gt;, definition of"><span
-id="value-def-border-style"><strong>&lt;border-style&gt;</strong></span></span>
+title="&lt;border-style&gt;, definition of"><dfn
+id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>

--- a/css2/box.html
+++ b/css2/box.html
@@ -262,7 +262,7 @@ implementation-specific limits.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin-top'"><span id="propdef-margin-top" class="propdef-title"><strong>'margin-top'</strong></span></span>, <span class="index-def" title="'margin-bottom'"><span id="propdef-margin-bottom" class="propdef-title"><strong>'margin-bottom'</strong></span></span>
+<span class="index-def" title="'margin-top'"><dfn id="propdef-margin-top" class="propdef-title" data-dfn-type="property" data-lt="margin-top"><strong>'margin-top'</strong></dfn></span>, <span class="index-def" title="'margin-bottom'"><dfn id="propdef-margin-bottom" class="propdef-title" data-dfn-type="property" data-lt="margin-bottom"><strong>'margin-bottom'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -283,7 +283,7 @@ elements.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin-right'"><span id="propdef-margin-right" class="propdef-title"><strong>'margin-right'</strong></span></span>, <span class="index-def" title="'margin-left'"><span id="propdef-margin-left" class="propdef-title"><strong>'margin-left'</strong></span></span>
+<span class="index-def" title="'margin-right'"><dfn id="propdef-margin-right" class="propdef-title" data-dfn-type="property" data-lt="margin-right"><strong>'margin-right'</strong></dfn></span>, <span class="index-def" title="'margin-left'"><dfn id="propdef-margin-left" class="propdef-title" data-dfn-type="property" data-lt="margin-left"><strong>'margin-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -310,7 +310,7 @@ h1 { margin-top: 2em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin'"><span id="propdef-margin" class="propdef-title"><strong>'margin'</strong></span></span>
+<span class="index-def" title="'margin'"><dfn id="propdef-margin" class="propdef-title" data-dfn-type="property" data-lt="margin"><strong>'margin'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -539,7 +539,7 @@ properties refer to the width of the generated box's containing block.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'padding-top'"><span id="propdef-padding-top" class="propdef-title"><strong>'padding-top'</strong></span></span>, <span class="index-def" title="'padding-right'"><span id="propdef-padding-right" class="propdef-title"><strong>'padding-right'</strong></span></span>, <span class="index-def" title="'padding-bottom'"><span id="propdef-padding-bottom" class="propdef-title"><strong>'padding-bottom'</strong></span></span>, <span class="index-def" title="'padding-left'"><span id="propdef-padding-left" class="propdef-title"><strong>'padding-left'</strong></span></span>
+<span class="index-def" title="'padding-top'"><dfn id="propdef-padding-top" class="propdef-title" data-dfn-type="property" data-lt="padding-top"><strong>'padding-top'</strong></dfn></span>, <span class="index-def" title="'padding-right'"><dfn id="propdef-padding-right" class="propdef-title" data-dfn-type="property" data-lt="padding-right"><strong>'padding-right'</strong></dfn></span>, <span class="index-def" title="'padding-bottom'"><dfn id="propdef-padding-bottom" class="propdef-title" data-dfn-type="property" data-lt="padding-bottom"><strong>'padding-bottom'</strong></dfn></span>, <span class="index-def" title="'padding-left'"><dfn id="propdef-padding-left" class="propdef-title" data-dfn-type="property" data-lt="padding-left"><strong>'padding-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-padding-width" class="noxref"><span class="value-inst-padding-width">&lt;padding-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -565,7 +565,7 @@ blockquote { padding-top: 0.3em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'padding'"><span id="propdef-padding" class="propdef-title"><strong>'padding'</strong></span></span>
+<span class="index-def" title="'padding'"><dfn id="propdef-padding" class="propdef-title" data-dfn-type="property" data-lt="padding"><strong>'padding'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-padding-width" class="noxref"><span class="value-inst-padding-width">&lt;padding-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -671,7 +671,7 @@ agent. The following relationships must hold, however:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-width'"><span id="propdef-border-top-width" class="propdef-title"><strong>'border-top-width'</strong></span></span>, <span class="index-def" title="'border-right-width'"><span id="propdef-border-right-width" class="propdef-title"><strong>'border-right-width'</strong></span></span>, <span class="index-def" title="'border-bottom-width'"><span id="propdef-border-bottom-width" class="propdef-title"><strong>'border-bottom-width'</strong></span></span>, <span class="index-def" title="'border-left-width'"><span id="propdef-border-left-width" class="propdef-title"><strong>'border-left-width'</strong></span></span>
+<span class="index-def" title="'border-top-width'"><dfn id="propdef-border-top-width" class="propdef-title" data-dfn-type="property" data-lt="border-top-width"><strong>'border-top-width'</strong></dfn></span>, <span class="index-def" title="'border-right-width'"><dfn id="propdef-border-right-width" class="propdef-title" data-dfn-type="property" data-lt="border-right-width"><strong>'border-right-width'</strong></dfn></span>, <span class="index-def" title="'border-bottom-width'"><dfn id="propdef-border-bottom-width" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-width"><strong>'border-bottom-width'</strong></dfn></span>, <span class="index-def" title="'border-left-width'"><dfn id="propdef-border-left-width" class="propdef-title" data-dfn-type="property" data-lt="border-left-width"><strong>'border-left-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -691,7 +691,7 @@ and left border of a box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-width'"><span id="propdef-border-width" class="propdef-title"><strong>'border-width'</strong></span></span>
+<span class="index-def" title="'border-width'"><dfn id="propdef-border-width" class="propdef-title" data-dfn-type="property" data-lt="border-width"><strong>'border-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -746,7 +746,7 @@ h1 { border-width: thin thick medium }      /* thin thick medium thick */
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-color'"><span id="propdef-border-top-color" class="propdef-title"><strong>'border-top-color'</strong></span></span>, <span class="index-def" title="'border-right-color'"><span id="propdef-border-right-color" class="propdef-title"><strong>'border-right-color'</strong></span></span>, <span class="index-def" title="'border-bottom-color'"><span id="propdef-border-bottom-color" class="propdef-title"><strong>'border-bottom-color'</strong></span></span>, <span class="index-def" title="'border-left-color'"><span id="propdef-border-left-color" class="propdef-title"><strong>'border-left-color'</strong></span></span>
+<span class="index-def" title="'border-top-color'"><dfn id="propdef-border-top-color" class="propdef-title" data-dfn-type="property" data-lt="border-top-color"><strong>'border-top-color'</strong></dfn></span>, <span class="index-def" title="'border-right-color'"><dfn id="propdef-border-right-color" class="propdef-title" data-dfn-type="property" data-lt="border-right-color"><strong>'border-right-color'</strong></dfn></span>, <span class="index-def" title="'border-bottom-color'"><dfn id="propdef-border-bottom-color" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-color"><strong>'border-bottom-color'</strong></dfn></span>, <span class="index-def" title="'border-left-color'"><dfn id="propdef-border-left-color" class="propdef-title" data-dfn-type="property" data-lt="border-left-color"><strong>'border-left-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -763,7 +763,7 @@ h1 { border-width: thin thick medium }      /* thin thick medium thick */
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-color'"><span id="propdef-border-color" class="propdef-title"><strong>'border-color'</strong></span></span>
+<span class="index-def" title="'border-color'"><dfn id="propdef-border-color" class="propdef-title" data-dfn-type="property" data-lt="border-color"><strong>'border-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent ]{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -874,7 +874,7 @@ white to dark gray to indicate a sloping border.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-style'"><span id="propdef-border-top-style" class="propdef-title"><strong>'border-top-style'</strong></span></span>, <span class="index-def" title="'border-right-style'"><span id="propdef-border-right-style" class="propdef-title"><strong>'border-right-style'</strong></span></span>, <span class="index-def" title="'border-bottom-style'"><span id="propdef-border-bottom-style" class="propdef-title"><strong>'border-bottom-style'</strong></span></span>, <span class="index-def" title="'border-left-style'"><span id="propdef-border-left-style" class="propdef-title"><strong>'border-left-style'</strong></span></span>
+<span class="index-def" title="'border-top-style'"><dfn id="propdef-border-top-style" class="propdef-title" data-dfn-type="property" data-lt="border-top-style"><strong>'border-top-style'</strong></dfn></span>, <span class="index-def" title="'border-right-style'"><dfn id="propdef-border-right-style" class="propdef-title" data-dfn-type="property" data-lt="border-right-style"><strong>'border-right-style'</strong></dfn></span>, <span class="index-def" title="'border-bottom-style'"><dfn id="propdef-border-bottom-style" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-style"><strong>'border-bottom-style'</strong></dfn></span>, <span class="index-def" title="'border-left-style'"><dfn id="propdef-border-left-style" class="propdef-title" data-dfn-type="property" data-lt="border-left-style"><strong>'border-left-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -890,7 +890,7 @@ white to dark gray to indicate a sloping border.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-style'"><span id="propdef-border-style" class="propdef-title"><strong>'border-style'</strong></span></span>
+<span class="index-def" title="'border-style'"><dfn id="propdef-border-style" class="propdef-title" data-dfn-type="property" data-lt="border-style"><strong>'border-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -930,7 +930,7 @@ will be visible unless the border style is set.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top'"><span id="propdef-border-top" class="propdef-title"><strong>'border-top'</strong></span></span>, <span class="index-def" title="'border-right'"><span id="propdef-border-right" class="propdef-title"><strong>'border-right'</strong></span></span>, <span class="index-def" title="'border-bottom'"><span id="propdef-border-bottom" class="propdef-title"><strong>'border-bottom'</strong></span></span>, <span class="index-def" title="'border-left'"><span id="propdef-border-left" class="propdef-title"><strong>'border-left'</strong></span></span>
+<span class="index-def" title="'border-top'"><dfn id="propdef-border-top" class="propdef-title" data-dfn-type="property" data-lt="border-top"><strong>'border-top'</strong></dfn></span>, <span class="index-def" title="'border-right'"><dfn id="propdef-border-right" class="propdef-title" data-dfn-type="property" data-lt="border-right"><strong>'border-right'</strong></dfn></span>, <span class="index-def" title="'border-bottom'"><dfn id="propdef-border-bottom" class="propdef-title" data-dfn-type="property" data-lt="border-bottom"><strong>'border-bottom'</strong></dfn></span>, <span class="index-def" title="'border-left'"><dfn id="propdef-border-left" class="propdef-title" data-dfn-type="property" data-lt="border-left"><strong>'border-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> || <a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> || <a href="box.html#propdef-border-top-color" class="noxref"><span class="propinst-border-top-color">&lt;'border-top-color'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -967,7 +967,7 @@ H1 { border-bottom: thick solid }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border'"><span id="propdef-border" class="propdef-title"><strong>'border'</strong></span></span>
+<span class="index-def" title="'border'"><dfn id="propdef-border" class="propdef-title" data-dfn-type="property" data-lt="border"><strong>'border'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> || <a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> || <a href="box.html#propdef-border-top-color" class="noxref"><span class="propinst-border-top-color">&lt;'border-top-color'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/box.html
+++ b/css2/box.html
@@ -829,33 +829,33 @@ id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</s
 value type, which may take one of the following values:</p>
 
 <dl>
-<dt><strong><span class="index-def" title="'none'::as border style"><span id="value-def-bo-none" class="value-def">none</span></span></strong>
+<dt><strong><span class="index-def" title="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
 <dd>No border; the computed border width is zero.
-<dt><strong><span class="index-def" title="'hidden'"><span id="value-def-hidden" class="value-def">hidden</span></span></strong>
+<dt><strong><span class="index-def" title="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
 <dd>Same as 'none', except in terms of <a
 href="tables.html#border-conflict-resolution">border conflict
 resolution</a> for <a href="tables.html">table elements</a>.
-<dt><strong><span class="index-def" title="'dotted'"><span id="value-def-dotted" class="value-def">dotted</span></span></strong>
+<dt><strong><span class="index-def" title="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
 <dd>The border is a series of dots.
-<dt><strong><span class="index-def" title="'dashed'"><span id="value-def-dashed" class="value-def">dashed</span></span></strong>
+<dt><strong><span class="index-def" title="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
 <dd>The border is a series of short line segments.
-<dt><strong><span class="index-def" title="'solid'"><span id="value-def-solid" class="value-def">solid</span></span></strong>
+<dt><strong><span class="index-def" title="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
 <dd>The border is a single line segment.
-<dt><strong><span class="index-def" title="'double'"><span id="value-def-double" class="value-def">double</span></span></strong>
+<dt><strong><span class="index-def" title="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
 <dd>The border is two solid lines. The sum of
 the two lines and the space between them
 equals the value of <a href="box.html#propdef-border-width" class="noxref"><span
 class="propinst-border-width">'border-width'</span></a>.
-<dt><strong><span class="index-def" title="'groove'"><span id="value-def-groove" class="value-def">groove</span></span></strong>
+<dt><strong><span class="index-def" title="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
 <dd>The border looks as though it were carved
 into the canvas.
-<dt><strong><span class="index-def" title="'ridge'"><span id="value-def-ridge" class="value-def">ridge</span></span></strong>
+<dt><strong><span class="index-def" title="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
 <dd>The opposite of 'groove': the border
 looks as though it were coming out of the canvas.
-<dt><strong><span class="index-def" title="'inset'"><span id="value-def-inset" class="value-def">inset</span></span></strong>
+<dt><strong><span class="index-def" title="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
 <dd>The border makes the box look as though
 it were embedded in the canvas.
-<dt><strong><span class="index-def" title="'outset'"><span id="value-def-outset" class="value-def">outset</span></span></strong>
+<dt><strong><span class="index-def" title="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
 <dd>The opposite of 'inset': the
 border makes the box look as though
 it were coming out of the canvas.

--- a/css2/box.html
+++ b/css2/box.html
@@ -60,14 +60,14 @@ model</a>.
 <H2><span class="secno">8.1</span> <span id="box-dimensions">Box dimensions</span></H2> 
 
 <P>Each box has a
-<span class="index-def" title="box::content|content::of a box">
+<span class="index-def" data-term="box::content|content::of a box">
 <span id="box-content-area"><dfn>content area</dfn></span></span> (e.g.,
 text, an image, etc.) and optional surrounding 
-<span class="index-def" title="box::padding|padding::of a box">
+<span class="index-def" data-term="box::padding|padding::of a box">
 <span id="box-padding-area"><dfn>padding</dfn></span></span>,
-<span class="index-def" title="box::border|border::of a box">
+<span class="index-def" data-term="box::border|border::of a box">
 <span id="box-border-area"><dfn>border</dfn></span></span>, and 
-<span class="index-def" title="box::margin|margin::of a box">
+<span class="index-def" data-term="box::margin|margin::of a box">
 <span id="box-margin-area"><dfn>margin</dfn></span></span> areas; the size
 of each area is specified by properties defined below.  The following
 diagram shows how these areas relate and the terminology used to refer
@@ -87,8 +87,8 @@ and margin) is called an "edge", so each box has four edges:</P>
 
 <dl>
 <dt><span class="index-def"
-title="content edge"><span id="content-edge"><strong>content edge</strong></span></span>
-or <span class="index-def" title="inner edge"><span id="inner-edge"><strong>inner edge</strong></span></span>
+data-term="content edge"><span id="content-edge"><strong>content edge</strong></span></span>
+or <span class="index-def" data-term="inner edge"><span id="inner-edge"><strong>inner edge</strong></span></span>
 <dd>The content edge surrounds the rectangle given by the <a
 href="visudet.html#Computing_widths_and_margins">width</a> and <a
 href="visudet.html#Computing_heights_and_margins">height</a>
@@ -96,18 +96,18 @@ of the box, which often depend on the element's <a
 href="conform.html#rendered-content">rendered content</a>.
 The four content edges define the
 box's <dfn><span id="x10" class="index-def">content box</span></dfn>.
-<dt><span class="index-def" title="padding edge"><span id="padding-edge"><strong>padding edge</strong></span></span>
+<dt><span class="index-def" data-term="padding edge"><span id="padding-edge"><strong>padding edge</strong></span></span>
 <dd>The padding edge surrounds the box padding. If the padding
 has 0 width, the padding edge is the same as the content edge.
 The four padding edges define the
 box's <dfn><span id="x12" class="index-def">padding box</span></dfn>.
-<dt><span class="index-def" title="border edge"><span id="border-edge"><strong>border edge</strong></span></span>
+<dt><span class="index-def" data-term="border edge"><span id="border-edge"><strong>border edge</strong></span></span>
 <dd>The border edge surrounds the box's border. If the border
 has 0 width, the border edge is the same as the padding edge.
 The four border edges define the box's <dfn><span id="x14" class="index-def">border
 box</span></dfn>.
-<dt><span class="index-def" title="margin edge"><span id="margin-edge"><strong>margin edge</strong></span></span>
-or <span class="index-def" title="outer edge"><span id="outer-edge"><strong>outer
+<dt><span class="index-def" data-term="margin edge"><span id="margin-edge"><strong>margin edge</strong></span></span>
+or <span class="index-def" data-term="outer edge"><span id="outer-edge"><strong>outer
 edge</strong></span></span>
 <dd>The margin edge surrounds the box margin. If the margin
 has 0 width, the margin edge is the same as the border edge.
@@ -119,9 +119,9 @@ box</span></dfn>.
 edge.
 
 <P>The dimensions of the content area of a box &mdash; the <span
-class="index-def" title="box::content width"><span
+class="index-def" data-term="box::content width"><span
 id="content-width"><dfn>content width</dfn></span></span> and <span
-class="index-def" title="box::content height"><span
+class="index-def" data-term="box::content height"><span
 id="content-height"><dfn>content height</dfn></span></span> &mdash; 
 depend on several factors: whether the element generating
 the box has the <a href="visudet.html#propdef-width" class="noxref"><span class="propinst-width">'width'</span></a>
@@ -235,7 +235,7 @@ vertical margins will not have any effect on non-replaced inline
 elements.
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;margin-width&gt;::definition of"><dfn
+class="index-def" data-term="&lt;margin-width&gt;::definition of"><dfn
 id="value-def-margin-width" data-dfn-type="type"><strong>&lt;margin-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
@@ -262,7 +262,7 @@ implementation-specific limits.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin-top'"><dfn id="propdef-margin-top" class="propdef-title" data-dfn-type="property" data-lt="margin-top"><strong>'margin-top'</strong></dfn></span>, <span class="index-def" title="'margin-bottom'"><dfn id="propdef-margin-bottom" class="propdef-title" data-dfn-type="property" data-lt="margin-bottom"><strong>'margin-bottom'</strong></dfn></span>
+<span class="index-def" data-term="'margin-top'"><dfn id="propdef-margin-top" class="propdef-title" data-dfn-type="property" data-lt="margin-top"><strong>'margin-top'</strong></dfn></span>, <span class="index-def" data-term="'margin-bottom'"><dfn id="propdef-margin-bottom" class="propdef-title" data-dfn-type="property" data-lt="margin-bottom"><strong>'margin-bottom'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -283,7 +283,7 @@ elements.</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin-right'"><dfn id="propdef-margin-right" class="propdef-title" data-dfn-type="property" data-lt="margin-right"><strong>'margin-right'</strong></dfn></span>, <span class="index-def" title="'margin-left'"><dfn id="propdef-margin-left" class="propdef-title" data-dfn-type="property" data-lt="margin-left"><strong>'margin-left'</strong></dfn></span>
+<span class="index-def" data-term="'margin-right'"><dfn id="propdef-margin-right" class="propdef-title" data-dfn-type="property" data-lt="margin-right"><strong>'margin-right'</strong></dfn></span>, <span class="index-def" data-term="'margin-left'"><dfn id="propdef-margin-left" class="propdef-title" data-dfn-type="property" data-lt="margin-left"><strong>'margin-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -310,7 +310,7 @@ h1 { margin-top: 2em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'margin'"><dfn id="propdef-margin" class="propdef-title" data-dfn-type="property" data-lt="margin"><strong>'margin'</strong></dfn></span>
+<span class="index-def" data-term="'margin'"><dfn id="propdef-margin" class="propdef-title" data-dfn-type="property" data-lt="margin"><strong>'margin'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-margin-width" class="noxref"><span class="value-inst-margin-width">&lt;margin-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -370,7 +370,7 @@ might not be siblings) can combine to form a single margin. Margins
 that combine this way are said to <dfn><span id="x26"
 class="index-def">collapse</span></dfn>, and the
 resulting combined margin is called a <dfn><span id="x27" class="index-def"
-title="collapsing margin">collapsed margin</span></dfn>.
+data-term="collapsing margin">collapsed margin</span></dfn>.
 
 <P>Adjoining vertical margins collapse, except:
 
@@ -387,7 +387,7 @@ title="collapsing margin">collapsed margin</span></dfn>.
 <P>Horizontal margins never collapse.
 
 <P ID="what-is-adjoining">Two margins are <span id="x28" class="index-def"
-title="adjoining margins"><DFN>adjoining</DFN></span> if and only if:
+data-term="adjoining margins"><DFN>adjoining</DFN></span> if and only if:
 
 <UL>
   <LI>both belong to in-flow <a
@@ -516,7 +516,7 @@ padding for all four sides while the other padding properties only set
 their respective side. 
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;padding-width&gt;::definition of"><dfn
+class="index-def" data-term="&lt;padding-width&gt;::definition of"><dfn
 id="value-def-padding-width" data-dfn-type="type"><strong>&lt;padding-width&gt;</strong>
 </dfn></span> value type, which may take one of the following values:</p>
 
@@ -539,7 +539,7 @@ properties refer to the width of the generated box's containing block.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'padding-top'"><dfn id="propdef-padding-top" class="propdef-title" data-dfn-type="property" data-lt="padding-top"><strong>'padding-top'</strong></dfn></span>, <span class="index-def" title="'padding-right'"><dfn id="propdef-padding-right" class="propdef-title" data-dfn-type="property" data-lt="padding-right"><strong>'padding-right'</strong></dfn></span>, <span class="index-def" title="'padding-bottom'"><dfn id="propdef-padding-bottom" class="propdef-title" data-dfn-type="property" data-lt="padding-bottom"><strong>'padding-bottom'</strong></dfn></span>, <span class="index-def" title="'padding-left'"><dfn id="propdef-padding-left" class="propdef-title" data-dfn-type="property" data-lt="padding-left"><strong>'padding-left'</strong></dfn></span>
+<span class="index-def" data-term="'padding-top'"><dfn id="propdef-padding-top" class="propdef-title" data-dfn-type="property" data-lt="padding-top"><strong>'padding-top'</strong></dfn></span>, <span class="index-def" data-term="'padding-right'"><dfn id="propdef-padding-right" class="propdef-title" data-dfn-type="property" data-lt="padding-right"><strong>'padding-right'</strong></dfn></span>, <span class="index-def" data-term="'padding-bottom'"><dfn id="propdef-padding-bottom" class="propdef-title" data-dfn-type="property" data-lt="padding-bottom"><strong>'padding-bottom'</strong></dfn></span>, <span class="index-def" data-term="'padding-left'"><dfn id="propdef-padding-left" class="propdef-title" data-dfn-type="property" data-lt="padding-left"><strong>'padding-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-padding-width" class="noxref"><span class="value-inst-padding-width">&lt;padding-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -565,7 +565,7 @@ blockquote { padding-top: 0.3em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'padding'"><dfn id="propdef-padding" class="propdef-title" data-dfn-type="property" data-lt="padding"><strong>'padding'</strong></dfn></span>
+<span class="index-def" data-term="'padding'"><dfn id="propdef-padding" class="propdef-title" data-dfn-type="property" data-lt="padding"><strong>'padding'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-padding-width" class="noxref"><span class="value-inst-padding-width">&lt;padding-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -645,7 +645,7 @@ class="propinst-border-bottom-width">'border-bottom-width'</span></a>,
 <P>The border width properties specify the width of the <a
 href="#box-border-area">border area</a>.  The properties
 defined in this section refer to the <span class="index-def"
-title="&lt;border-width&gt;::definition of"><dfn
+data-term="&lt;border-width&gt;::definition of"><dfn
 id="value-def-border-width" data-dfn-type="type"
 class="value-def"><strong>&lt;border-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</P>
@@ -671,7 +671,7 @@ agent. The following relationships must hold, however:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-width'"><dfn id="propdef-border-top-width" class="propdef-title" data-dfn-type="property" data-lt="border-top-width"><strong>'border-top-width'</strong></dfn></span>, <span class="index-def" title="'border-right-width'"><dfn id="propdef-border-right-width" class="propdef-title" data-dfn-type="property" data-lt="border-right-width"><strong>'border-right-width'</strong></dfn></span>, <span class="index-def" title="'border-bottom-width'"><dfn id="propdef-border-bottom-width" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-width"><strong>'border-bottom-width'</strong></dfn></span>, <span class="index-def" title="'border-left-width'"><dfn id="propdef-border-left-width" class="propdef-title" data-dfn-type="property" data-lt="border-left-width"><strong>'border-left-width'</strong></dfn></span>
+<span class="index-def" data-term="'border-top-width'"><dfn id="propdef-border-top-width" class="propdef-title" data-dfn-type="property" data-lt="border-top-width"><strong>'border-top-width'</strong></dfn></span>, <span class="index-def" data-term="'border-right-width'"><dfn id="propdef-border-right-width" class="propdef-title" data-dfn-type="property" data-lt="border-right-width"><strong>'border-right-width'</strong></dfn></span>, <span class="index-def" data-term="'border-bottom-width'"><dfn id="propdef-border-bottom-width" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-width"><strong>'border-bottom-width'</strong></dfn></span>, <span class="index-def" data-term="'border-left-width'"><dfn id="propdef-border-left-width" class="propdef-title" data-dfn-type="property" data-lt="border-left-width"><strong>'border-left-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -691,7 +691,7 @@ and left border of a box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-width'"><dfn id="propdef-border-width" class="propdef-title" data-dfn-type="property" data-lt="border-width"><strong>'border-width'</strong></dfn></span>
+<span class="index-def" data-term="'border-width'"><dfn id="propdef-border-width" class="propdef-title" data-dfn-type="property" data-lt="border-width"><strong>'border-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -746,7 +746,7 @@ h1 { border-width: thin thick medium }      /* thin thick medium thick */
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-color'"><dfn id="propdef-border-top-color" class="propdef-title" data-dfn-type="property" data-lt="border-top-color"><strong>'border-top-color'</strong></dfn></span>, <span class="index-def" title="'border-right-color'"><dfn id="propdef-border-right-color" class="propdef-title" data-dfn-type="property" data-lt="border-right-color"><strong>'border-right-color'</strong></dfn></span>, <span class="index-def" title="'border-bottom-color'"><dfn id="propdef-border-bottom-color" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-color"><strong>'border-bottom-color'</strong></dfn></span>, <span class="index-def" title="'border-left-color'"><dfn id="propdef-border-left-color" class="propdef-title" data-dfn-type="property" data-lt="border-left-color"><strong>'border-left-color'</strong></dfn></span>
+<span class="index-def" data-term="'border-top-color'"><dfn id="propdef-border-top-color" class="propdef-title" data-dfn-type="property" data-lt="border-top-color"><strong>'border-top-color'</strong></dfn></span>, <span class="index-def" data-term="'border-right-color'"><dfn id="propdef-border-right-color" class="propdef-title" data-dfn-type="property" data-lt="border-right-color"><strong>'border-right-color'</strong></dfn></span>, <span class="index-def" data-term="'border-bottom-color'"><dfn id="propdef-border-bottom-color" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-color"><strong>'border-bottom-color'</strong></dfn></span>, <span class="index-def" data-term="'border-left-color'"><dfn id="propdef-border-left-color" class="propdef-title" data-dfn-type="property" data-lt="border-left-color"><strong>'border-left-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -763,7 +763,7 @@ h1 { border-width: thin thick medium }      /* thin thick medium thick */
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-color'"><dfn id="propdef-border-color" class="propdef-title" data-dfn-type="property" data-lt="border-color"><strong>'border-color'</strong></dfn></span>
+<span class="index-def" data-term="'border-color'"><dfn id="propdef-border-color" class="propdef-title" data-dfn-type="property" data-lt="border-color"><strong>'border-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent ]{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -783,7 +783,7 @@ property sets the color of the four borders. Values have the following
 meanings:</p>
 
 <dl>
-<dt><span id="x47" class="index-inst" title="&lt;color&gt;"><a href="syndata.html#value-def-color" class="noxref"><span
+<dt><span id="x47" class="index-inst" data-term="&lt;color&gt;"><a href="syndata.html#value-def-color" class="noxref"><span
 class="value-inst-color"><strong>&lt;color&gt;</strong></span></a></span>
 <dd>Specifies a color value.
 <dt><strong>transparent</strong>
@@ -824,38 +824,38 @@ p {
 <P>The border style properties specify the line style of a box's
 border (solid, double, dashed, etc.). The properties defined in this
 section refer to the <span class="index-def"
-title="&lt;border-style&gt;, definition of"><dfn
+data-term="&lt;border-style&gt;, definition of"><dfn
 id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>
-<dt><strong><span class="index-def" title="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
 <dd>No border; the computed border width is zero.
-<dt><strong><span class="index-def" title="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
 <dd>Same as 'none', except in terms of <a
 href="tables.html#border-conflict-resolution">border conflict
 resolution</a> for <a href="tables.html">table elements</a>.
-<dt><strong><span class="index-def" title="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
 <dd>The border is a series of dots.
-<dt><strong><span class="index-def" title="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
 <dd>The border is a series of short line segments.
-<dt><strong><span class="index-def" title="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
 <dd>The border is a single line segment.
-<dt><strong><span class="index-def" title="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
 <dd>The border is two solid lines. The sum of
 the two lines and the space between them
 equals the value of <a href="box.html#propdef-border-width" class="noxref"><span
 class="propinst-border-width">'border-width'</span></a>.
-<dt><strong><span class="index-def" title="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
 <dd>The border looks as though it were carved
 into the canvas.
-<dt><strong><span class="index-def" title="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
 <dd>The opposite of 'groove': the border
 looks as though it were coming out of the canvas.
-<dt><strong><span class="index-def" title="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
 <dd>The border makes the box look as though
 it were embedded in the canvas.
-<dt><strong><span class="index-def" title="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
 <dd>The opposite of 'inset': the
 border makes the box look as though
 it were coming out of the canvas.
@@ -874,7 +874,7 @@ white to dark gray to indicate a sloping border.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top-style'"><dfn id="propdef-border-top-style" class="propdef-title" data-dfn-type="property" data-lt="border-top-style"><strong>'border-top-style'</strong></dfn></span>, <span class="index-def" title="'border-right-style'"><dfn id="propdef-border-right-style" class="propdef-title" data-dfn-type="property" data-lt="border-right-style"><strong>'border-right-style'</strong></dfn></span>, <span class="index-def" title="'border-bottom-style'"><dfn id="propdef-border-bottom-style" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-style"><strong>'border-bottom-style'</strong></dfn></span>, <span class="index-def" title="'border-left-style'"><dfn id="propdef-border-left-style" class="propdef-title" data-dfn-type="property" data-lt="border-left-style"><strong>'border-left-style'</strong></dfn></span>
+<span class="index-def" data-term="'border-top-style'"><dfn id="propdef-border-top-style" class="propdef-title" data-dfn-type="property" data-lt="border-top-style"><strong>'border-top-style'</strong></dfn></span>, <span class="index-def" data-term="'border-right-style'"><dfn id="propdef-border-right-style" class="propdef-title" data-dfn-type="property" data-lt="border-right-style"><strong>'border-right-style'</strong></dfn></span>, <span class="index-def" data-term="'border-bottom-style'"><dfn id="propdef-border-bottom-style" class="propdef-title" data-dfn-type="property" data-lt="border-bottom-style"><strong>'border-bottom-style'</strong></dfn></span>, <span class="index-def" data-term="'border-left-style'"><dfn id="propdef-border-left-style" class="propdef-title" data-dfn-type="property" data-lt="border-left-style"><strong>'border-left-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -890,7 +890,7 @@ white to dark gray to indicate a sloping border.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-style'"><dfn id="propdef-border-style" class="propdef-title" data-dfn-type="property" data-lt="border-style"><strong>'border-style'</strong></dfn></span>
+<span class="index-def" data-term="'border-style'"><dfn id="propdef-border-style" class="propdef-title" data-dfn-type="property" data-lt="border-style"><strong>'border-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a>{1,4} | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -930,7 +930,7 @@ will be visible unless the border style is set.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-top'"><dfn id="propdef-border-top" class="propdef-title" data-dfn-type="property" data-lt="border-top"><strong>'border-top'</strong></dfn></span>, <span class="index-def" title="'border-right'"><dfn id="propdef-border-right" class="propdef-title" data-dfn-type="property" data-lt="border-right"><strong>'border-right'</strong></dfn></span>, <span class="index-def" title="'border-bottom'"><dfn id="propdef-border-bottom" class="propdef-title" data-dfn-type="property" data-lt="border-bottom"><strong>'border-bottom'</strong></dfn></span>, <span class="index-def" title="'border-left'"><dfn id="propdef-border-left" class="propdef-title" data-dfn-type="property" data-lt="border-left"><strong>'border-left'</strong></dfn></span>
+<span class="index-def" data-term="'border-top'"><dfn id="propdef-border-top" class="propdef-title" data-dfn-type="property" data-lt="border-top"><strong>'border-top'</strong></dfn></span>, <span class="index-def" data-term="'border-right'"><dfn id="propdef-border-right" class="propdef-title" data-dfn-type="property" data-lt="border-right"><strong>'border-right'</strong></dfn></span>, <span class="index-def" data-term="'border-bottom'"><dfn id="propdef-border-bottom" class="propdef-title" data-dfn-type="property" data-lt="border-bottom"><strong>'border-bottom'</strong></dfn></span>, <span class="index-def" data-term="'border-left'"><dfn id="propdef-border-left" class="propdef-title" data-dfn-type="property" data-lt="border-left"><strong>'border-left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> || <a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> || <a href="box.html#propdef-border-top-color" class="noxref"><span class="propinst-border-top-color">&lt;'border-top-color'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -967,7 +967,7 @@ H1 { border-bottom: thick solid }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border'"><dfn id="propdef-border" class="propdef-title" data-dfn-type="property" data-lt="border"><strong>'border'</strong></dfn></span>
+<span class="index-def" data-term="'border'"><dfn id="propdef-border" class="propdef-title" data-dfn-type="property" data-lt="border"><strong>'border'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> || <a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> || <a href="box.html#propdef-border-top-color" class="noxref"><span class="propinst-border-top-color">&lt;'border-top-color'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/box.src
+++ b/css2/box.src
@@ -646,33 +646,33 @@ id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</s
 value type, which may take one of the following values:</p>
 
 <dl>
-<dt><strong><span class="index-def" title="'none'::as border style"><span id="value-def-bo-none" class="value-def">none</span></span></strong>
+<dt><strong><span class="index-def" title="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
 <dd>No border; the computed border width is zero.
-<dt><strong><span class="index-def" title="'hidden'"><span id="value-def-hidden" class="value-def">hidden</span></span></strong>
+<dt><strong><span class="index-def" title="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
 <dd>Same as 'none', except in terms of <a
 href="tables.html#border-conflict-resolution">border conflict
 resolution</a> for <a href="tables.html">table elements</a>.
-<dt><strong><span class="index-def" title="'dotted'"><span id="value-def-dotted" class="value-def">dotted</span></span></strong>
+<dt><strong><span class="index-def" title="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
 <dd>The border is a series of dots.
-<dt><strong><span class="index-def" title="'dashed'"><span id="value-def-dashed" class="value-def">dashed</span></span></strong>
+<dt><strong><span class="index-def" title="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
 <dd>The border is a series of short line segments.
-<dt><strong><span class="index-def" title="'solid'"><span id="value-def-solid" class="value-def">solid</span></span></strong>
+<dt><strong><span class="index-def" title="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
 <dd>The border is a single line segment.
-<dt><strong><span class="index-def" title="'double'"><span id="value-def-double" class="value-def">double</span></span></strong>
+<dt><strong><span class="index-def" title="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
 <dd>The border is two solid lines. The sum of
 the two lines and the space between them
 equals the value of <span
 class="propinst-border-width">'border-width'</span>.
-<dt><strong><span class="index-def" title="'groove'"><span id="value-def-groove" class="value-def">groove</span></span></strong>
+<dt><strong><span class="index-def" title="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
 <dd>The border looks as though it were carved
 into the canvas.
-<dt><strong><span class="index-def" title="'ridge'"><span id="value-def-ridge" class="value-def">ridge</span></span></strong>
+<dt><strong><span class="index-def" title="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
 <dd>The opposite of 'groove': the border
 looks as though it were coming out of the canvas.
-<dt><strong><span class="index-def" title="'inset'"><span id="value-def-inset" class="value-def">inset</span></span></strong>
+<dt><strong><span class="index-def" title="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
 <dd>The border makes the box look as though
 it were embedded in the canvas.
-<dt><strong><span class="index-def" title="'outset'"><span id="value-def-outset" class="value-def">outset</span></span></strong>
+<dt><strong><span class="index-def" title="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
 <dd>The opposite of 'inset': the
 border makes the box look as though
 it were coming out of the canvas.

--- a/css2/box.src
+++ b/css2/box.src
@@ -17,14 +17,14 @@ model</a>.
 <H2><span id="box-dimensions">Box dimensions</span></H2> 
 
 <P>Each box has a
-<span class="index-def" title="box::content|content::of a box">
+<span class="index-def" data-term="box::content|content::of a box">
 <span id="box-content-area"><dfn>content area</dfn></span></span> (e.g.,
 text, an image, etc.) and optional surrounding 
-<span class="index-def" title="box::padding|padding::of a box">
+<span class="index-def" data-term="box::padding|padding::of a box">
 <span id="box-padding-area"><dfn>padding</dfn></span></span>,
-<span class="index-def" title="box::border|border::of a box">
+<span class="index-def" data-term="box::border|border::of a box">
 <span id="box-border-area"><dfn>border</dfn></span></span>, and 
-<span class="index-def" title="box::margin|margin::of a box">
+<span class="index-def" data-term="box::margin|margin::of a box">
 <span id="box-margin-area"><dfn>margin</dfn></span></span> areas; the size
 of each area is specified by properties defined below.  The following
 diagram shows how these areas relate and the terminology used to refer
@@ -44,8 +44,8 @@ and margin) is called an "edge", so each box has four edges:</P>
 
 <dl>
 <dt><span class="index-def"
-title="content edge"><span id="content-edge"><strong>content edge</strong></span></span>
-or <span class="index-def" title="inner edge"><span id="inner-edge"><strong>inner edge</strong></span></span>
+data-term="content edge"><span id="content-edge"><strong>content edge</strong></span></span>
+or <span class="index-def" data-term="inner edge"><span id="inner-edge"><strong>inner edge</strong></span></span>
 <dd>The content edge surrounds the rectangle given by the <a
 href="visudet.html#Computing_widths_and_margins">width</a> and <a
 href="visudet.html#Computing_heights_and_margins">height</a>
@@ -53,18 +53,18 @@ of the box, which often depend on the element's <a
 href="conform.html#rendered-content">rendered content</a>.
 The four content edges define the
 box's <dfn><span class="index-def">content box</span></dfn>.
-<dt><span class="index-def" title="padding edge"><span id="padding-edge"><strong>padding edge</strong></span></span>
+<dt><span class="index-def" data-term="padding edge"><span id="padding-edge"><strong>padding edge</strong></span></span>
 <dd>The padding edge surrounds the box padding. If the padding
 has 0 width, the padding edge is the same as the content edge.
 The four padding edges define the
 box's <dfn><span class="index-def">padding box</span></dfn>.
-<dt><span class="index-def" title="border edge"><span id="border-edge"><strong>border edge</strong></span></span>
+<dt><span class="index-def" data-term="border edge"><span id="border-edge"><strong>border edge</strong></span></span>
 <dd>The border edge surrounds the box's border. If the border
 has 0 width, the border edge is the same as the padding edge.
 The four border edges define the box's <dfn><span class="index-def">border
 box</span></dfn>.
-<dt><span class="index-def" title="margin edge"><span id="margin-edge"><strong>margin edge</strong></span></span>
-or <span class="index-def" title="outer edge"><span id="outer-edge"><strong>outer
+<dt><span class="index-def" data-term="margin edge"><span id="margin-edge"><strong>margin edge</strong></span></span>
+or <span class="index-def" data-term="outer edge"><span id="outer-edge"><strong>outer
 edge</strong></span></span>
 <dd>The margin edge surrounds the box margin. If the margin
 has 0 width, the margin edge is the same as the border edge.
@@ -76,9 +76,9 @@ box</span></dfn>.
 edge.
 
 <P>The dimensions of the content area of a box &mdash; the <span
-class="index-def" title="box::content width"><span
+class="index-def" data-term="box::content width"><span
 id="content-width"><dfn>content width</dfn></span></span> and <span
-class="index-def" title="box::content height"><span
+class="index-def" data-term="box::content height"><span
 id="content-height"><dfn>content height</dfn></span></span> &mdash; 
 depend on several factors: whether the element generating
 the box has the <span class="propinst-width">'width'</span>
@@ -191,7 +191,7 @@ vertical margins will not have any effect on non-replaced inline
 elements.
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;margin-width&gt;::definition of"><dfn
+class="index-def" data-term="&lt;margin-width&gt;::definition of"><dfn
 id="value-def-margin-width" data-dfn-type="type"><strong>&lt;margin-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
@@ -278,7 +278,7 @@ might not be siblings) can combine to form a single margin. Margins
 that combine this way are said to <dfn><span
 class="index-def">collapse</span></dfn>, and the
 resulting combined margin is called a <dfn><span class="index-def"
-title="collapsing margin">collapsed margin</span></dfn>.
+data-term="collapsing margin">collapsed margin</span></dfn>.
 
 <P>Adjoining vertical margins collapse, except:
 
@@ -295,7 +295,7 @@ title="collapsing margin">collapsed margin</span></dfn>.
 <P>Horizontal margins never collapse.
 
 <P ID="what-is-adjoining">Two margins are <span class="index-def"
-title="adjoining margins"><DFN>adjoining</DFN></span> if and only if:
+data-term="adjoining margins"><DFN>adjoining</DFN></span> if and only if:
 
 <UL>
   <LI>both belong to in-flow <a
@@ -424,7 +424,7 @@ padding for all four sides while the other padding properties only set
 their respective side. 
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;padding-width&gt;::definition of"><dfn
+class="index-def" data-term="&lt;padding-width&gt;::definition of"><dfn
 id="value-def-padding-width" data-dfn-type="type"><strong>&lt;padding-width&gt;</strong>
 </dfn></span> value type, which may take one of the following values:</p>
 
@@ -523,7 +523,7 @@ class="propinst-border-bottom-width">'border-bottom-width'</span>,
 <P>The border width properties specify the width of the <a
 href="#box-border-area">border area</a>.  The properties
 defined in this section refer to the <span class="index-def"
-title="&lt;border-width&gt;::definition of"><dfn
+data-term="&lt;border-width&gt;::definition of"><dfn
 id="value-def-border-width" data-dfn-type="type"
 class="value-def"><strong>&lt;border-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</P>
@@ -600,7 +600,7 @@ property sets the color of the four borders. Values have the following
 meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;color&gt;"><span
+<dt><span class="index-inst" data-term="&lt;color&gt;"><span
 class="value-inst-color"><strong>&lt;color&gt;</strong></span></span>
 <dd>Specifies a color value.
 <dt><strong>transparent</strong>
@@ -641,38 +641,38 @@ p {
 <P>The border style properties specify the line style of a box's
 border (solid, double, dashed, etc.). The properties defined in this
 section refer to the <span class="index-def"
-title="&lt;border-style&gt;, definition of"><dfn
+data-term="&lt;border-style&gt;, definition of"><dfn
 id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>
-<dt><strong><span class="index-def" title="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'none'::as border style"><dfn id="value-def-bo-none" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">none</dfn></span></strong>
 <dd>No border; the computed border width is zero.
-<dt><strong><span class="index-def" title="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'hidden'"><dfn id="value-def-hidden" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">hidden</dfn></span></strong>
 <dd>Same as 'none', except in terms of <a
 href="tables.html#border-conflict-resolution">border conflict
 resolution</a> for <a href="tables.html">table elements</a>.
-<dt><strong><span class="index-def" title="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'dotted'"><dfn id="value-def-dotted" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dotted</dfn></span></strong>
 <dd>The border is a series of dots.
-<dt><strong><span class="index-def" title="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'dashed'"><dfn id="value-def-dashed" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">dashed</dfn></span></strong>
 <dd>The border is a series of short line segments.
-<dt><strong><span class="index-def" title="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'solid'"><dfn id="value-def-solid" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">solid</dfn></span></strong>
 <dd>The border is a single line segment.
-<dt><strong><span class="index-def" title="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'double'"><dfn id="value-def-double" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">double</dfn></span></strong>
 <dd>The border is two solid lines. The sum of
 the two lines and the space between them
 equals the value of <span
 class="propinst-border-width">'border-width'</span>.
-<dt><strong><span class="index-def" title="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'groove'"><dfn id="value-def-groove" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">groove</dfn></span></strong>
 <dd>The border looks as though it were carved
 into the canvas.
-<dt><strong><span class="index-def" title="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'ridge'"><dfn id="value-def-ridge" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">ridge</dfn></span></strong>
 <dd>The opposite of 'groove': the border
 looks as though it were coming out of the canvas.
-<dt><strong><span class="index-def" title="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'inset'"><dfn id="value-def-inset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">inset</dfn></span></strong>
 <dd>The border makes the box look as though
 it were embedded in the canvas.
-<dt><strong><span class="index-def" title="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="'outset'"><dfn id="value-def-outset" data-dfn-type="value" data-dfn-for="<border-style>" class="value-def">outset</dfn></span></strong>
 <dd>The opposite of 'inset': the
 border makes the box look as though
 it were coming out of the canvas.
@@ -688,7 +688,7 @@ white to dark gray to indicate a sloping border.
 
 
 <!-- Remove? BB 29 Apr 2003
-<P><span class="index-inst" title="conformance"><a
+<P><span class="index-inst" data-term="conformance"><a
 href="conform.html#conformance">Conforming HTML user agents</a></span> may
 interpret 'dotted', 'dashed', 'double', 'groove', 'ridge',
 'inset', and 'outset' to be 'solid'. 

--- a/css2/box.src
+++ b/css2/box.src
@@ -191,8 +191,8 @@ vertical margins will not have any effect on non-replaced inline
 elements.
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;margin-width&gt;::definition of"><span
-id="value-def-margin-width"><strong>&lt;margin-width&gt;</strong></span></span>
+class="index-def" title="&lt;margin-width&gt;::definition of"><dfn
+id="value-def-margin-width" data-dfn-type="type"><strong>&lt;margin-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>
@@ -424,9 +424,9 @@ padding for all four sides while the other padding properties only set
 their respective side. 
 
 <P>The properties defined in this section refer to the <span
-class="index-def" title="&lt;padding-width&gt;::definition of"><span
-id="value-def-padding-width"><strong>&lt;padding-width&gt;</strong>
-</span></span> value type, which may take one of the following values:</p>
+class="index-def" title="&lt;padding-width&gt;::definition of"><dfn
+id="value-def-padding-width" data-dfn-type="type"><strong>&lt;padding-width&gt;</strong>
+</dfn></span> value type, which may take one of the following values:</p>
 
 <dl>
 <dt><span class="value-inst-length"><strong>&lt;length&gt;</strong></span>
@@ -523,9 +523,9 @@ class="propinst-border-bottom-width">'border-bottom-width'</span>,
 <P>The border width properties specify the width of the <a
 href="#box-border-area">border area</a>.  The properties
 defined in this section refer to the <span class="index-def"
-title="&lt;border-width&gt;::definition of"><span
-id="value-def-border-width"
-class="value-def"><strong>&lt;border-width&gt;</strong></span></span>
+title="&lt;border-width&gt;::definition of"><dfn
+id="value-def-border-width" data-dfn-type="type"
+class="value-def"><strong>&lt;border-width&gt;</strong></dfn></span>
 value type, which may take one of the following values:</P>
 
 <dl>
@@ -641,8 +641,8 @@ p {
 <P>The border style properties specify the line style of a box's
 border (solid, double, dashed, etc.). The properties defined in this
 section refer to the <span class="index-def"
-title="&lt;border-style&gt;, definition of"><span
-id="value-def-border-style"><strong>&lt;border-style&gt;</strong></span></span>
+title="&lt;border-style&gt;, definition of"><dfn
+id="value-def-border-style" data-dfn-type="type"><strong>&lt;border-style&gt;</strong></dfn></span>
 value type, which may take one of the following values:</p>
 
 <dl>

--- a/css2/cascade.html
+++ b/css2/cascade.html
@@ -71,7 +71,7 @@ value if necessary (the "used value"), and finally transformed
 according to the limitations of the local environment (the "actual
 value").
 
-<h3><span class="secno">6.1.1</span> <span class="index-def" title="specified value">
+<h3><span class="secno">6.1.1</span> <span class="index-def" data-term="specified value">
 <span id="specified-value">Specified values</span></span></h3>
 
 <p>User agents must first assign a specified value to each property based
@@ -80,11 +80,11 @@ on the following mechanisms (in order of precedence):</p>
 <ol>
 <li>If the <a href="#cascade">cascade</a> results in a value, use it.
 <li>Otherwise, if the property is <a href="#inheritance">inherited</a> and the element is not the root of the <a>document tree</a>, use the computed value of the parent element.
-<li>Otherwise use the property's <span id="x1" class="index-def" title="initial value">initial value</span>. The initial value of each property is indicated in the property's definition. 
+<li>Otherwise use the property's <span id="x1" class="index-def" data-term="initial value">initial value</span>. The initial value of each property is indicated in the property's definition. 
 </ol>
 
 
-<h3><span class="secno">6.1.2</span> <span class="index-def" title="computed value">
+<h3><span class="secno">6.1.2</span> <span class="index-def" data-term="computed value">
 <span id="computed-value">Computed values</span></span></h3>
 
 <p>Specified values are resolved to computed values during the cascade;
@@ -109,7 +109,7 @@ properties may define the computed value of a property for an element
 to depend on whether the property applies to that element.
 
 
-<h3><span class="secno">6.1.3</span> <span class="index-def" title="used value">
+<h3><span class="secno">6.1.3</span> <span class="index-def" data-term="used value">
 <span id="used-value">Used values</span></span></h3>
 
 <p>Computed values are processed as far as possible without formatting
@@ -121,7 +121,7 @@ determined. The <dfn id="usedValue">used value</dfn> is the result of
 taking the computed value and resolving any remaining dependencies
 into an absolute value.
 
-<h3><span class="secno">6.1.4</span> <span class="index-def" title="actual value">
+<h3><span class="secno">6.1.4</span> <span class="index-def" data-term="actual value">
 <span id="actual-value">Actual values</span></span></h3>
 
 <p>A used value is in principle the value used for rendering, but a
@@ -189,7 +189,7 @@ not intercepted by <span id="x5" class=index-inst><a
 href="visuren.html#box-gen">anonymous boxes.</a></span>
 
 
-<h3><span class="secno">6.2.1</span> The <span class="index-def" title="inherit, definition
+<h3><span class="secno">6.2.1</span> The <span class="index-def" data-term="inherit, definition
 of"><dfn id="value-def-inherit" data-dfn-type="value" data-dfn-for="all" data-lt="inherit">'inherit'</dfn></span>
 value</h3>
 
@@ -230,7 +230,7 @@ body {
 <H2><span class="secno">6.3</span> <span id="at-import">The @import rule</span></h2>
 
 <P>The <span id="x7" class="index-def"
-title="@import"><dfn>'@import'</dfn></span> rule allows users to
+data-term="@import"><dfn>'@import'</dfn></span> rule allows users to
 import style rules from other style sheets. In CSS&nbsp;2, any
 @import rules must precede all other rules (except the @charset rule,
 if present). See the <a href="syndata.html#at-rules">section on
@@ -252,8 +252,8 @@ The following lines are equivalent in meaning and illustrate both
 <p>So that user agents can avoid retrieving resources for unsupported
 <a href="media.html">media types</a>, authors may specify
 media-dependent <span id="x8" class="index-inst"
-title="@import">@import</span> rules.  These <span id="x9" class="index-def"
-title="conditional import|media-dependent import">conditional
+data-term="@import">@import</span> rules.  These <span id="x9" class="index-def"
+data-term="conditional import|media-dependent import">conditional
 imports</span> specify comma-separated media types after the URI.
 
 <div class="example"><P style="display:none">Example(s):</P>
@@ -299,7 +299,7 @@ if it did).
 
 <li><strong>User agent</strong>: <a
 href="conform.html#conformance">Conforming user agents</a> must apply
-a <span class="index-def" title="default style sheet"><span
+a <span class="index-def" data-term="default style sheet"><span
 id="default-style-sheet"><dfn>default style sheet</dfn></span></span>
 (or behave as if they did). A user agent's default style sheet should
 present the
@@ -318,7 +318,7 @@ default style sheet.
 <P>Style sheets from these three origins will overlap in scope, and
 they interact according to the cascade.
 
-<P>The CSS <span id="x12" class="index-def" title="cascade">cascade</span>
+<P>The CSS <span id="x12" class="index-def" data-term="cascade">cascade</span>
 assigns a weight to each style rule. When several rules apply, the one
 with the greatest weight takes precedence.
 
@@ -390,7 +390,7 @@ a normal declaration.  Both author and user style sheets may contain
 of documents by giving users with special requirements (large
 fonts, color combinations, etc.) control over presentation.
 
-<P>Declaring a <span id="x13" class="index-inst" title="shorthand
+<P>Declaring a <span id="x13" class="index-inst" data-term="shorthand
 property">shorthand property</span> (e.g., <a href="colors.html#propdef-background" class="noxref"><span
 class="propinst-background">'background'</span></a>) to be "!important" is
 equivalent to declaring all of its sub-properties to be "!important".

--- a/css2/cascade.html
+++ b/css2/cascade.html
@@ -190,7 +190,7 @@ href="visuren.html#box-gen">anonymous boxes.</a></span>
 
 
 <h3><span class="secno">6.2.1</span> The <span class="index-def" title="inherit, definition
-of"><span id="value-def-inherit">'inherit'</span></span>
+of"><dfn id="value-def-inherit" data-dfn-type="value" data-dfn-for="all" data-lt="inherit">'inherit'</dfn></span>
 value</h3>
 
 <P>Each property may also have a cascaded value of 'inherit', which

--- a/css2/cascade.src
+++ b/css2/cascade.src
@@ -24,7 +24,7 @@ value if necessary (the "used value"), and finally transformed
 according to the limitations of the local environment (the "actual
 value").
 
-<h3><span class="index-def" title="specified value">
+<h3><span class="index-def" data-term="specified value">
 <span id="specified-value">Specified values</span></span></h3>
 
 <p>User agents must first assign a specified value to each property based
@@ -33,11 +33,11 @@ on the following mechanisms (in order of precedence):</p>
 <ol>
 <li>If the <a href="#cascade">cascade</a> results in a value, use it.
 <li>Otherwise, if the property is <a href="#inheritance">inherited</a> and the element is not the root of the <a>document tree</a>, use the computed value of the parent element.
-<li>Otherwise use the property's <span class="index-def" title="initial value">initial value</span>. The initial value of each property is indicated in the property's definition. 
+<li>Otherwise use the property's <span class="index-def" data-term="initial value">initial value</span>. The initial value of each property is indicated in the property's definition. 
 </ol>
 
 
-<h3><span class="index-def" title="computed value">
+<h3><span class="index-def" data-term="computed value">
 <span id="computed-value">Computed values</span></span></h3>
 
 <p>Specified values are resolved to computed values during the cascade;
@@ -62,7 +62,7 @@ properties may define the computed value of a property for an element
 to depend on whether the property applies to that element.
 
 
-<h3><span class="index-def" title="used value">
+<h3><span class="index-def" data-term="used value">
 <span id="used-value">Used values</span></span></h3>
 
 <p>Computed values are processed as far as possible without formatting
@@ -74,7 +74,7 @@ determined. The <dfn id="usedValue">used value</dfn> is the result of
 taking the computed value and resolving any remaining dependencies
 into an absolute value.
 
-<h3><span class="index-def" title="actual value">
+<h3><span class="index-def" data-term="actual value">
 <span id="actual-value">Actual values</span></span></h3>
 
 <p>A used value is in principle the value used for rendering, but a
@@ -142,7 +142,7 @@ not intercepted by <span class=index-inst><a
 href="visuren.html#box-gen">anonymous boxes.</a></span>
 
 
-<h3>The <span class="index-def" title="inherit, definition
+<h3>The <span class="index-def" data-term="inherit, definition
 of"><dfn id="value-def-inherit" data-dfn-type="value" data-dfn-for="all" data-lt="inherit">'inherit'</dfn></span>
 value</h3>
 
@@ -185,7 +185,7 @@ https://lists.w3.org/Archives/Member/w3c-css-wg/1998JanMar/0054.html
 <H2><span id="at-import">The @import rule</span></h2>
 
 <P>The <span class="index-def"
-title="@import"><dfn>'@import'</dfn></span> rule allows users to
+data-term="@import"><dfn>'@import'</dfn></span> rule allows users to
 import style rules from other style sheets. In CSS&nbsp;2, any
 @import rules must precede all other rules (except the @charset rule,
 if present). See the <a href="syndata.html#at-rules">section on
@@ -207,8 +207,8 @@ The following lines are equivalent in meaning and illustrate both
 <p>So that user agents can avoid retrieving resources for unsupported
 <a href="media.html">media types</a>, authors may specify
 media-dependent <span class="index-inst"
-title="@import">@import</span> rules.  These <span class="index-def"
-title="conditional import|media-dependent import">conditional
+data-term="@import">@import</span> rules.  These <span class="index-def"
+data-term="conditional import|media-dependent import">conditional
 imports</span> specify comma-separated media types after the URI.
 
 <div class="example">
@@ -254,7 +254,7 @@ if it did).
 
 <li><strong>User agent</strong>: <a
 href="conform.html#conformance">Conforming user agents</a> must apply
-a <span class="index-def" title="default style sheet"><span
+a <span class="index-def" data-term="default style sheet"><span
 id="default-style-sheet"><dfn>default style sheet</dfn></span></span>
 (or behave as if they did). A user agent's default style sheet should
 present the
@@ -273,7 +273,7 @@ default style sheet.
 <P>Style sheets from these three origins will overlap in scope, and
 they interact according to the cascade.
 
-<P>The CSS <span class="index-def" title="cascade">cascade</span>
+<P>The CSS <span class="index-def" data-term="cascade">cascade</span>
 assigns a weight to each style rule. When several rules apply, the one
 with the greatest weight takes precedence.
 
@@ -345,7 +345,7 @@ a normal declaration.  Both author and user style sheets may contain
 of documents by giving users with special requirements (large
 fonts, color combinations, etc.) control over presentation.
 
-<P>Declaring a <span class="index-inst" title="shorthand
+<P>Declaring a <span class="index-inst" data-term="shorthand
 property">shorthand property</span> (e.g., <span
 class="propinst-background">'background'</span>) to be "!important" is
 equivalent to declaring all of its sub-properties to be "!important".

--- a/css2/cascade.src
+++ b/css2/cascade.src
@@ -143,7 +143,7 @@ href="visuren.html#box-gen">anonymous boxes.</a></span>
 
 
 <h3>The <span class="index-def" title="inherit, definition
-of"><span id="value-def-inherit">'inherit'</span></span>
+of"><dfn id="value-def-inherit" data-dfn-type="value" data-dfn-for="all" data-lt="inherit">'inherit'</dfn></span>
 value</h3>
 
 <P>Each property may also have a cascaded value of 'inherit', which

--- a/css2/colors.html
+++ b/css2/colors.html
@@ -64,7 +64,7 @@ class="propinst-color">'color'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'color'"><dfn id="propdef-color" class="propdef-title" data-dfn-type="property" data-lt="color"><strong>'color'</strong></dfn></span>
+<span class="index-def" data-term="'color'"><dfn id="propdef-color" class="propdef-title" data-dfn-type="property" data-lt="color"><strong>'color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -164,7 +164,7 @@ class="propinst-background-position">'background-position'</span></a>, and
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-color'"><dfn id="propdef-background-color" class="propdef-title" data-dfn-type="property" data-lt="background-color"><strong>'background-color'</strong></dfn></span>
+<span class="index-def" data-term="'background-color'"><dfn id="propdef-background-color" class="propdef-title" data-dfn-type="property" data-lt="background-color"><strong>'background-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -180,7 +180,7 @@ class="propinst-background-position">'background-position'</span></a>, and
 
 
 <p>This property sets the background color of an element, either a
-<span id="x2" class="index-inst" title="&lt;color&gt;"><a href="syndata.html#value-def-color" class="noxref"><span
+<span id="x2" class="index-inst" data-term="&lt;color&gt;"><a href="syndata.html#value-def-color" class="noxref"><span
 class="value-inst-color">&lt;color&gt;</span></a></span> value or the keyword
 'transparent', to make the underlying colors shine through.
 </p>
@@ -193,7 +193,7 @@ h1 { background-color: #F00 }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-image'"><dfn id="propdef-background-image" class="propdef-title" data-dfn-type="property" data-lt="background-image"><strong>'background-image'</strong></dfn></span>
+<span class="index-def" data-term="'background-image'"><dfn id="propdef-background-image" class="propdef-title" data-dfn-type="property" data-lt="background-image"><strong>'background-image'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -215,7 +215,7 @@ is available, it is rendered on top of the background color.  (Thus,
 the color is visible in the transparent parts of the image).
 </p>
 <p>Values for this property are either <span id="x4" class="index-inst"
-title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
+data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
 class="value-inst-uri">&lt;uri&gt;</span></a></span>, to specify the
 image, or 'none', when no image is used.
 </p>
@@ -258,7 +258,7 @@ property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-repeat'"><dfn id="propdef-background-repeat" class="propdef-title" data-dfn-type="property" data-lt="background-repeat"><strong>'background-repeat'</strong></dfn></span>
+<span class="index-def" data-term="'background-repeat'"><dfn id="propdef-background-repeat" class="propdef-title" data-dfn-type="property" data-lt="background-repeat"><strong>'background-repeat'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>repeat | repeat-x | repeat-y | no-repeat | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -318,7 +318,7 @@ the element.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-attachment'"><dfn id="propdef-background-attachment" class="propdef-title" data-dfn-type="property" data-lt="background-attachment"><strong>'background-attachment'</strong></dfn></span>
+<span class="index-def" data-term="'background-attachment'"><dfn id="propdef-background-attachment" class="propdef-title" data-dfn-type="property" data-lt="background-attachment"><strong>'background-attachment'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>scroll | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -381,7 +381,7 @@ href="conform.html#conformance">conformance</a> for details.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-position'"><dfn id="propdef-background-position" class="propdef-title" data-dfn-type="property" data-lt="background-position"><strong>'background-position'</strong></dfn></span>
+<span class="index-def" data-term="'background-position'"><dfn id="propdef-background-position" class="propdef-title" data-dfn-type="property" data-lt="background-position"><strong>'background-position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [ <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | left | center | right ]
@@ -409,7 +409,7 @@ represents the vertical position. Negative &lt;percentage> and
 
 
 <dl>
-  <dt><span id="x8" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
+  <dt><span id="x8" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
   class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 
   <dd>A percentage X aligns the point X% across (for horizontal) or
@@ -422,7 +422,7 @@ represents the vertical position. Negative &lt;percentage> and
   '14% 84%', the point 14% across and 84% down the image is to be
   placed at the point 14% across and 84% down the padding box.
 
-  <dt><span id="x9" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+  <dt><span id="x9" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
   class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 
   <dd>A length L aligns the top left corner of the image a distance L
@@ -495,7 +495,7 @@ corner of the viewport.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background'"><dfn id="propdef-background" class="propdef-title" data-dfn-type="property" data-lt="background"><strong>'background'</strong></dfn></span>
+<span class="index-def" data-term="'background'"><dfn id="propdef-background" class="propdef-title" data-dfn-type="property" data-lt="background"><strong>'background'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[<a href="colors.html#propdef-background-color" class="noxref"><span class="propinst-background-color">&lt;'background-color'&gt;</span></a> || <a href="colors.html#propdef-background-image" class="noxref"><span class="propinst-background-image">&lt;'background-image'&gt;</span></a> || <a href="colors.html#propdef-background-repeat" class="noxref"><span class="propinst-background-repeat">&lt;'background-repeat'&gt;</span></a>

--- a/css2/colors.html
+++ b/css2/colors.html
@@ -64,7 +64,7 @@ class="propinst-color">'color'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'color'"><span id="propdef-color" class="propdef-title"><strong>'color'</strong></span></span>
+<span class="index-def" title="'color'"><dfn id="propdef-color" class="propdef-title" data-dfn-type="property" data-lt="color"><strong>'color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -164,7 +164,7 @@ class="propinst-background-position">'background-position'</span></a>, and
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-color'"><span id="propdef-background-color" class="propdef-title"><strong>'background-color'</strong></span></span>
+<span class="index-def" title="'background-color'"><dfn id="propdef-background-color" class="propdef-title" data-dfn-type="property" data-lt="background-color"><strong>'background-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | transparent | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -193,7 +193,7 @@ h1 { background-color: #F00 }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-image'"><span id="propdef-background-image" class="propdef-title"><strong>'background-image'</strong></span></span>
+<span class="index-def" title="'background-image'"><dfn id="propdef-background-image" class="propdef-title" data-dfn-type="property" data-lt="background-image"><strong>'background-image'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -258,7 +258,7 @@ property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-repeat'"><span id="propdef-background-repeat" class="propdef-title"><strong>'background-repeat'</strong></span></span>
+<span class="index-def" title="'background-repeat'"><dfn id="propdef-background-repeat" class="propdef-title" data-dfn-type="property" data-lt="background-repeat"><strong>'background-repeat'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>repeat | repeat-x | repeat-y | no-repeat | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -318,7 +318,7 @@ the element.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-attachment'"><span id="propdef-background-attachment" class="propdef-title"><strong>'background-attachment'</strong></span></span>
+<span class="index-def" title="'background-attachment'"><dfn id="propdef-background-attachment" class="propdef-title" data-dfn-type="property" data-lt="background-attachment"><strong>'background-attachment'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>scroll | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -381,7 +381,7 @@ href="conform.html#conformance">conformance</a> for details.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background-position'"><span id="propdef-background-position" class="propdef-title"><strong>'background-position'</strong></span></span>
+<span class="index-def" title="'background-position'"><dfn id="propdef-background-position" class="propdef-title" data-dfn-type="property" data-lt="background-position"><strong>'background-position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [ <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | left | center | right ]
@@ -495,7 +495,7 @@ corner of the viewport.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'background'"><span id="propdef-background" class="propdef-title"><strong>'background'</strong></span></span>
+<span class="index-def" title="'background'"><dfn id="propdef-background" class="propdef-title" data-dfn-type="property" data-lt="background"><strong>'background'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[<a href="colors.html#propdef-background-color" class="noxref"><span class="propinst-background-color">&lt;'background-color'&gt;</span></a> || <a href="colors.html#propdef-background-image" class="noxref"><span class="propinst-background-image">&lt;'background-image'&gt;</span></a> || <a href="colors.html#propdef-background-repeat" class="noxref"><span class="propinst-background-repeat">&lt;'background-repeat'&gt;</span></a>

--- a/css2/colors.src
+++ b/css2/colors.src
@@ -117,7 +117,7 @@ class="propinst-background-position">'background-position'</span>, and
 <!-- #include src=properties/background-color.srb -->
 
 <p>This property sets the background color of an element, either a
-<span class="index-inst" title="&lt;color&gt;"><span
+<span class="index-inst" data-term="&lt;color&gt;"><span
 class="value-inst-color">&lt;color&gt;</span></span> value or the keyword
 'transparent', to make the underlying colors shine through.
 </p>
@@ -137,7 +137,7 @@ is available, it is rendered on top of the background color.  (Thus,
 the color is visible in the transparent parts of the image).
 </p>
 <p>Values for this property are either <span class="index-inst"
-title="&lt;uri&gt;"><span
+data-term="&lt;uri&gt;"><span
 class="value-inst-uri">&lt;uri&gt;</span></span>, to specify the
 image, or 'none', when no image is used.
 </p>
@@ -284,7 +284,7 @@ represents the vertical position. Negative &lt;percentage> and
 position. Is that clear from the above? -->
 
 <dl>
-  <dt><span class="index-inst" title="&lt;percentage&gt;"><span
+  <dt><span class="index-inst" data-term="&lt;percentage&gt;"><span
   class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 
   <dd>A percentage X aligns the point X% across (for horizontal) or
@@ -297,7 +297,7 @@ position. Is that clear from the above? -->
   '14% 84%', the point 14% across and 84% down the image is to be
   placed at the point 14% across and 84% down the padding box.
 
-  <dt><span class="index-inst" title="&lt;length&gt;"><span
+  <dt><span class="index-inst" data-term="&lt;length&gt;"><span
   class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 
   <dd>A length L aligns the top left corner of the image a distance L

--- a/css2/conform.html
+++ b/css2/conform.html
@@ -43,16 +43,16 @@
 
 <H2><span class="secno">3.1</span> <span id="defs">Definitions</span></H2>
 
-<P>The key words <span id="x0" class="index-def" title="MUST">"MUST"</span>,
-<span id="x1" class="index-def" title="MUST NOT">"MUST NOT"</span>, <span id="x2"
-class="index-def" title="REQUIRED">"REQUIRED"</span>, <span id="x3"
-class="index-def" title="SHALL">"SHALL"</span>, <span id="x4"
-class="index-def" title="SHALL NOT">"SHALL NOT"</span>, <span id="x5"
-class="index-def" title="SHOULD">"SHOULD"</span>, <span id="x6"
-class="index-def" title="SHOULD NOT">"SHOULD NOT"</span>, <span id="x7"
-class="index-def" title="RECOMMENDED">"RECOMMENDED"</span>, <span id="x8"
-class="index-def" title="MAY">"MAY"</span>, and <span id="x9"
-class="index-def" title="OPTIONAL">"OPTIONAL"</span> in this document
+<P>The key words <span id="x0" class="index-def" data-term="MUST">"MUST"</span>,
+<span id="x1" class="index-def" data-term="MUST NOT">"MUST NOT"</span>, <span id="x2"
+class="index-def" data-term="REQUIRED">"REQUIRED"</span>, <span id="x3"
+class="index-def" data-term="SHALL">"SHALL"</span>, <span id="x4"
+class="index-def" data-term="SHALL NOT">"SHALL NOT"</span>, <span id="x5"
+class="index-def" data-term="SHOULD">"SHOULD"</span>, <span id="x6"
+class="index-def" data-term="SHOULD NOT">"SHOULD NOT"</span>, <span id="x7"
+class="index-def" data-term="RECOMMENDED">"RECOMMENDED"</span>, <span id="x8"
+class="index-def" data-term="MAY">"MAY"</span>, and <span id="x9"
+class="index-def" data-term="OPTIONAL">"OPTIONAL"</span> in this document
 are to be interpreted as described in RFC&nbsp;2119 (see <a href="refs.html#ref-RFC2119" class="noxref"><span class="normref">[RFC2119]</span></a>).
 However, for readability, these words do not appear in all uppercase
 letters in this specification.
@@ -93,7 +93,7 @@ renderings, unless explicitly stated.
 
 
 
-<dt><strong><span class="index-def" title="style
+<dt><strong><span class="index-def" data-term="style
 sheet"><span id="style-sheet">Style sheet</span></span></strong>
 
 <dd>A set of statements that specify presentation of a document.
@@ -104,7 +104,7 @@ href="#user-agent">user agent</a>. The interaction of these sources is
 described in the section on <a href="cascade.html">cascading and
 inheritance</a>.
 
-<dt><strong><span class="index-def" title="valid style
+<dt><strong><span class="index-def" data-term="valid style
 sheet|validity"><span id="valid-style-sheet">Valid style
 sheet</span></span></strong>
 
@@ -124,7 +124,7 @@ class="index-def"><span
 id="illegal">illegal</span></span></strong> (invalid) at-rule,
 property name, or property value is one that is not valid.
 
-<dt><strong><span class="index-def" title="source
+<dt><strong><span class="index-def" data-term="source
 document"><span id="source-document">Source
 document</span></span></strong>
 
@@ -136,7 +136,7 @@ href="#attribute">attributes</a>, and a (possibly empty) <a
 href="#content">content</a>. For example, the source document could be 
 an XML or SGML instance.</dd>
 
-<dt><strong><span class="index-def" title="document language"><span
+<dt><strong><span class="index-def" data-term="document language"><span
 id="doclanguage">Document language</span></span></strong>
 
 <dd>The encoding language of the source document (e.g., HTML, XHTML, or
@@ -144,7 +144,7 @@ SVG). CSS is used to describe the presentation of document languages
 and CSS does not change the underlying semantics of the document
 languages.
 
-<dt><strong><span class="index-def" title="element"><span
+<dt><strong><span class="index-def" data-term="element"><span
 id="element">Element</span></span></strong>
 
 <dd>(An SGML term, see <a href="refs.html#ref-ISO8879" class="noxref"><span class="normref">[ISO8879]</span></a>.) The primary syntactic constructs
@@ -152,7 +152,7 @@ of the document language. Most CSS style sheet rules use the names of
 these elements (such as P, TABLE, and OL in HTML) to specify
 how the elements should be rendered.
 
-<dt><strong><span class="index-def" title="replaced element">
+<dt><strong><span class="index-def" data-term="replaced element">
 <span id="replaced-element">Replaced
 element</span></span></strong>
 
@@ -177,7 +177,7 @@ dimensions.
 <p>The content of replaced elements is not considered in the CSS
 rendering model.
 
-<dt><strong><span class="index-def" title="intrinsic
+<dt><strong><span class="index-def" data-term="intrinsic
 dimensions"><span id="intrinsic">Intrinsic dimensions</span></span></strong>
 
 <dd>The width and height as defined by the element itself, not imposed
@@ -187,27 +187,27 @@ intrinsic dimensions.
 For raster images without reliable resolution information, a size of
 1&nbsp;px unit per image source pixel must be assumed.
 
-<dt><strong><span class="index-def" title="attribute"><span
+<dt><strong><span class="index-def" data-term="attribute"><span
 id="attribute">Attribute</span></span></strong>
 
 <dd>A value associated with an element, consisting of a name, and an
 associated (textual) value.
 
-<dt><strong><span class="index-def" title="content"><span
+<dt><strong><span class="index-def" data-term="content"><span
 id="content">Content</span></span></strong>
 
 <dd>The content associated with an element in the source document.
 Some elements have no content, in which case they are
 called <strong><span class="index-def"
-title="empty"><span id="empty">empty</span></span></strong>. The content
+data-term="empty"><span id="empty">empty</span></span></strong>. The content
 of an element may include text, and it may include a number of
 sub-elements, in which case the element is called
 the <strong><span class="index-def"
-title="parent"><span id="parent">parent</span></span></strong> of those
+data-term="parent"><span id="parent">parent</span></span></strong> of those
 sub-elements.
 
 <dt><strong><span class="index-def"
-title="ignore"><span id="ignore">Ignore</span></span></strong>
+data-term="ignore"><span id="ignore">Ignore</span></span></strong>
 
 <dd>This term has two slightly different meanings in this
 specification. First, a CSS parser must follow certain rules when it
@@ -224,7 +224,7 @@ legal. For example, table-column elements cannot affect the font of the
 column, so the font properties must be ignored.
 
 
-<dt><strong><span class="index-def" title="rendered
+<dt><strong><span class="index-def" data-term="rendered
 content|content::rendered"><span id="rendered-content">Rendered
 content</span></span></strong>
 
@@ -236,50 +236,50 @@ alternate text for an element (e.g., the value of the XHTML "alt"
 attribute), and may include items inserted implicitly or explicitly by
 the style sheet, such as bullets, numbering, etc.
 
-<dt><strong><span class="index-def" title="document tree">
+<dt><strong><span class="index-def" data-term="document tree">
 <span id="doctree">Document
 tree</span></span></strong>
 
 <dd>The tree of elements encoded in the source document. Each element
 in this tree has exactly one parent, with the exception of the
-<strong><span class="index-def" title="root"><span
+<strong><span class="index-def" data-term="root"><span
 id="root">root</span></span></strong> element, which has none.
 
 <dt><strong><span class="index-def"
-title="child"><span id="child">Child</span></span></strong>
+data-term="child"><span id="child">Child</span></span></strong>
 
 <dd>An element A is called the child of element B if and only if B is
 the parent of A.
 
 <dt><strong><span class="index-def"
-title="descendant"><span id="descendant">Descendant</span></span></strong>
+data-term="descendant"><span id="descendant">Descendant</span></span></strong>
 
 <dd>An element A is called a descendant of an element B, if either (1)
 A is a child of B, or (2) A is the child of some element C that is a
 descendant of B.
 
 <dt><strong><span class="index-def"
-title="ancestor"><span id="ancestor">Ancestor</span></span></strong>
+data-term="ancestor"><span id="ancestor">Ancestor</span></span></strong>
 
 <dd>An element A is called an ancestor of an element B, if and only if
 B is a descendant of A.
 
 <dt><strong><span class="index-def"
-title="sibling"><span id="sibling">Sibling</span></span></strong>
+data-term="sibling"><span id="sibling">Sibling</span></span></strong>
 
 <dd>An element A is called a sibling of an element B, if and only if B
 and A share the same parent element. Element A is a preceding sibling
 if it comes before B in the document tree. Element B is a following
 sibling if it comes after A in the document tree.
 
-<dt><strong><span class="index-def" title="preceding
+<dt><strong><span class="index-def" data-term="preceding
 element|element::preceding"><span id="preceding">Preceding element</span></span></strong>
 
 <dd>An element A is called a preceding element of an element B, if and
 only if (1) A is an ancestor of B or (2) A is a preceding sibling of
 B.
 
-<dt><strong><span class="index-def" title="following
+<dt><strong><span class="index-def" data-term="following
 element|element::following"><span id="following">Following
 element</span></span></strong>
 
@@ -307,7 +307,7 @@ preferences.
 <dt><strong><span class="index-def"><span id="user-agent">User agent
 (UA)</span></span></strong>
 
-<dd>A <span class="index-def" title="user agent|UA"><span id="ua">user
+<dd>A <span class="index-def" data-term="user agent|UA"><span id="ua">user
 agent</span></span> is any program that interprets a document written in
 the document language and applies associated style sheets according
 to the terms of this specification. A user agent may display a
@@ -377,7 +377,7 @@ end tags.
 <h2><span class="secno">3.2</span> <span id="conformance">UA Conformance</span></h2>
 
 <P>This section defines <span class="index-def"
-title="conformance"><span id="conformance-term">conformance</span></span> with
+data-term="conformance"><span id="conformance-term">conformance</span></span> with
 the CSS&nbsp;2
 specification only. There may be other levels of CSS in the future
 that may require a user agent to implement a different set of features
@@ -403,9 +403,9 @@ If a user agent encounters a property that applies for a supported
 media type, the user agent must parse the value according to the property
 definition. This means that the user agent must accept all valid
 values and must  
-<span id="x44" class="index-inst" title="ignore">ignore</span> declarations with
+<span id="x44" class="index-inst" data-term="ignore">ignore</span> declarations with
 invalid values. User
-agents must <span id="x45" class="index-inst" title="ignore">ignore</span>
+agents must <span id="x45" class="index-inst" data-term="ignore">ignore</span>
 rules that apply to unsupported <a href="media.html">media
 types</a>.
 
@@ -465,13 +465,13 @@ support as experimental. A future level of CSS may specify this further.
 throughout the specification. For example, see the <a
 href="syndata.html#parsing-errors">rules for handling parsing errors</a>. 
 
-<h2><span class="secno">3.4</span> <span class="index-def" title="text/css"><span
+<h2><span class="secno">3.4</span> <span class="index-def" data-term="text/css"><span
 id="text-css">The text/css content type</span></span></h2>
 
 <p>CSS style sheets that exist in separate files are sent over the
 Internet as a sequence of bytes accompanied by encoding
 information. The structure of the
-transmission, termed a <span class="index-def" title="message
+transmission, termed a <span class="index-def" data-term="message
 entity"><span id="message-entity"><strong>message
 entity,</strong></span></span> is defined by RFC 2045 and RFC 2616 (see
 <a href="refs.html#ref-RFC2045" class="noxref"><span class="normref">[RFC2045]</span></a> and <a href="refs.html#ref-RFC2616" class="noxref"><span class="normref">[RFC2616]</span></a>). A message entity with a content type of

--- a/css2/conform.src
+++ b/css2/conform.src
@@ -11,16 +11,16 @@
 
 <H2><span id="defs">Definitions</span></H2>
 
-<P>The key words <span class="index-def" title="MUST">"MUST"</span>,
-<span class="index-def" title="MUST NOT">"MUST NOT"</span>, <span
-class="index-def" title="REQUIRED">"REQUIRED"</span>, <span
-class="index-def" title="SHALL">"SHALL"</span>, <span
-class="index-def" title="SHALL NOT">"SHALL NOT"</span>, <span
-class="index-def" title="SHOULD">"SHOULD"</span>, <span
-class="index-def" title="SHOULD NOT">"SHOULD NOT"</span>, <span
-class="index-def" title="RECOMMENDED">"RECOMMENDED"</span>, <span
-class="index-def" title="MAY">"MAY"</span>, and <span
-class="index-def" title="OPTIONAL">"OPTIONAL"</span> in this document
+<P>The key words <span class="index-def" data-term="MUST">"MUST"</span>,
+<span class="index-def" data-term="MUST NOT">"MUST NOT"</span>, <span
+class="index-def" data-term="REQUIRED">"REQUIRED"</span>, <span
+class="index-def" data-term="SHALL">"SHALL"</span>, <span
+class="index-def" data-term="SHALL NOT">"SHALL NOT"</span>, <span
+class="index-def" data-term="SHOULD">"SHOULD"</span>, <span
+class="index-def" data-term="SHOULD NOT">"SHOULD NOT"</span>, <span
+class="index-def" data-term="RECOMMENDED">"RECOMMENDED"</span>, <span
+class="index-def" data-term="MAY">"MAY"</span>, and <span
+class="index-def" data-term="OPTIONAL">"OPTIONAL"</span> in this document
 are to be interpreted as described in RFC&nbsp;2119 (see [[RFC2119]]).
 However, for readability, these words do not appear in all uppercase
 letters in this specification.
@@ -61,7 +61,7 @@ renderings, unless explicitly stated.
 
 
 
-<dt><strong><span class="index-def" title="style
+<dt><strong><span class="index-def" data-term="style
 sheet"><span id="style-sheet">Style sheet</span></span></strong>
 
 <dd>A set of statements that specify presentation of a document.
@@ -72,7 +72,7 @@ href="#user-agent">user agent</a>. The interaction of these sources is
 described in the section on <a href="cascade.html">cascading and
 inheritance</a>.
 
-<dt><strong><span class="index-def" title="valid style
+<dt><strong><span class="index-def" data-term="valid style
 sheet|validity"><span id="valid-style-sheet">Valid style
 sheet</span></span></strong>
 
@@ -92,7 +92,7 @@ class="index-def"><span
 id="illegal">illegal</span></span></strong> (invalid) at-rule,
 property name, or property value is one that is not valid.
 
-<dt><strong><span class="index-def" title="source
+<dt><strong><span class="index-def" data-term="source
 document"><span id="source-document">Source
 document</span></span></strong>
 
@@ -104,7 +104,7 @@ href="#attribute">attributes</a>, and a (possibly empty) <a
 href="#content">content</a>. For example, the source document could be 
 an XML or SGML instance.</dd>
 
-<dt><strong><span class="index-def" title="document language"><span
+<dt><strong><span class="index-def" data-term="document language"><span
 id="doclanguage">Document language</span></span></strong>
 
 <dd>The encoding language of the source document (e.g., HTML, XHTML, or
@@ -112,7 +112,7 @@ SVG). CSS is used to describe the presentation of document languages
 and CSS does not change the underlying semantics of the document
 languages.
 
-<dt><strong><span class="index-def" title="element"><span
+<dt><strong><span class="index-def" data-term="element"><span
 id="element">Element</span></span></strong>
 
 <dd>(An SGML term, see [[ISO8879]].) The primary syntactic constructs
@@ -120,7 +120,7 @@ of the document language. Most CSS style sheet rules use the names of
 these elements (such as P, TABLE, and OL in HTML) to specify
 how the elements should be rendered.
 
-<dt><strong><span class="index-def" title="replaced element">
+<dt><strong><span class="index-def" data-term="replaced element">
 <span id="replaced-element">Replaced
 element</span></span></strong>
 
@@ -145,7 +145,7 @@ dimensions.
 <p>The content of replaced elements is not considered in the CSS
 rendering model.
 
-<dt><strong><span class="index-def" title="intrinsic
+<dt><strong><span class="index-def" data-term="intrinsic
 dimensions"><span id="intrinsic">Intrinsic dimensions</span></span></strong>
 
 <dd>The width and height as defined by the element itself, not imposed
@@ -155,27 +155,27 @@ intrinsic dimensions.
 For raster images without reliable resolution information, a size of
 1&nbsp;px unit per image source pixel must be assumed.
 
-<dt><strong><span class="index-def" title="attribute"><span
+<dt><strong><span class="index-def" data-term="attribute"><span
 id="attribute">Attribute</span></span></strong>
 
 <dd>A value associated with an element, consisting of a name, and an
 associated (textual) value.
 
-<dt><strong><span class="index-def" title="content"><span
+<dt><strong><span class="index-def" data-term="content"><span
 id="content">Content</span></span></strong>
 
 <dd>The content associated with an element in the source document.
 Some elements have no content, in which case they are
 called <strong><span class="index-def"
-title="empty"><span id="empty">empty</span></span></strong>. The content
+data-term="empty"><span id="empty">empty</span></span></strong>. The content
 of an element may include text, and it may include a number of
 sub-elements, in which case the element is called
 the <strong><span class="index-def"
-title="parent"><span id="parent">parent</span></span></strong> of those
+data-term="parent"><span id="parent">parent</span></span></strong> of those
 sub-elements.
 
 <dt><strong><span class="index-def"
-title="ignore"><span id="ignore">Ignore</span></span></strong>
+data-term="ignore"><span id="ignore">Ignore</span></span></strong>
 
 <dd>This term has two slightly different meanings in this
 specification. First, a CSS parser must follow certain rules when it
@@ -192,7 +192,7 @@ legal. For example, table-column elements cannot affect the font of the
 column, so the font properties must be ignored.
 
 
-<dt><strong><span class="index-def" title="rendered
+<dt><strong><span class="index-def" data-term="rendered
 content|content::rendered"><span id="rendered-content">Rendered
 content</span></span></strong>
 
@@ -204,50 +204,50 @@ alternate text for an element (e.g., the value of the XHTML "alt"
 attribute), and may include items inserted implicitly or explicitly by
 the style sheet, such as bullets, numbering, etc.
 
-<dt><strong><span class="index-def" title="document tree">
+<dt><strong><span class="index-def" data-term="document tree">
 <span id="doctree">Document
 tree</span></span></strong>
 
 <dd>The tree of elements encoded in the source document. Each element
 in this tree has exactly one parent, with the exception of the
-<strong><span class="index-def" title="root"><span
+<strong><span class="index-def" data-term="root"><span
 id="root">root</span></span></strong> element, which has none.
 
 <dt><strong><span class="index-def"
-title="child"><span id="child">Child</span></span></strong>
+data-term="child"><span id="child">Child</span></span></strong>
 
 <dd>An element A is called the child of element B if and only if B is
 the parent of A.
 
 <dt><strong><span class="index-def"
-title="descendant"><span id="descendant">Descendant</span></span></strong>
+data-term="descendant"><span id="descendant">Descendant</span></span></strong>
 
 <dd>An element A is called a descendant of an element B, if either (1)
 A is a child of B, or (2) A is the child of some element C that is a
 descendant of B.
 
 <dt><strong><span class="index-def"
-title="ancestor"><span id="ancestor">Ancestor</span></span></strong>
+data-term="ancestor"><span id="ancestor">Ancestor</span></span></strong>
 
 <dd>An element A is called an ancestor of an element B, if and only if
 B is a descendant of A.
 
 <dt><strong><span class="index-def"
-title="sibling"><span id="sibling">Sibling</span></span></strong>
+data-term="sibling"><span id="sibling">Sibling</span></span></strong>
 
 <dd>An element A is called a sibling of an element B, if and only if B
 and A share the same parent element. Element A is a preceding sibling
 if it comes before B in the document tree. Element B is a following
 sibling if it comes after A in the document tree.
 
-<dt><strong><span class="index-def" title="preceding
+<dt><strong><span class="index-def" data-term="preceding
 element|element::preceding"><span id="preceding">Preceding element</span></span></strong>
 
 <dd>An element A is called a preceding element of an element B, if and
 only if (1) A is an ancestor of B or (2) A is a preceding sibling of
 B.
 
-<dt><strong><span class="index-def" title="following
+<dt><strong><span class="index-def" data-term="following
 element|element::following"><span id="following">Following
 element</span></span></strong>
 
@@ -275,7 +275,7 @@ preferences.
 <dt><strong><span class="index-def"><span id="user-agent">User agent
 (UA)</span></span></strong>
 
-<dd>A <span class="index-def" title="user agent|UA"><span id="ua">user
+<dd>A <span class="index-def" data-term="user agent|UA"><span id="ua">user
 agent</span></span> is any program that interprets a document written in
 the document language and applies associated style sheets according
 to the terms of this specification. A user agent may display a
@@ -345,7 +345,7 @@ end tags.
 <h2><span id="conformance">UA Conformance</span></h2>
 
 <P>This section defines <span class="index-def"
-title="conformance"><span id="conformance-term">conformance</span></span> with
+data-term="conformance"><span id="conformance-term">conformance</span></span> with
 the CSS&nbsp;2
 specification only. There may be other levels of CSS in the future
 that may require a user agent to implement a different set of features
@@ -371,9 +371,9 @@ If a user agent encounters a property that applies for a supported
 media type, the user agent must parse the value according to the property
 definition. This means that the user agent must accept all valid
 values and must  
-<span class="index-inst" title="ignore">ignore</span> declarations with
+<span class="index-inst" data-term="ignore">ignore</span> declarations with
 invalid values. User
-agents must <span class="index-inst" title="ignore">ignore</span>
+agents must <span class="index-inst" data-term="ignore">ignore</span>
 rules that apply to unsupported <a href="media.html">media
 types</a>.
 
@@ -436,13 +436,13 @@ support as experimental. A future level of CSS may specify this further.
 throughout the specification. For example, see the <a
 href="syndata.html#parsing-errors">rules for handling parsing errors</a>. 
 
-<h2><span class="index-def" title="text/css"><span
+<h2><span class="index-def" data-term="text/css"><span
 id="text-css">The text/css content type</span></span></h2>
 
 <p>CSS style sheets that exist in separate files are sent over the
 Internet as a sequence of bytes accompanied by encoding
 information. The structure of the
-transmission, termed a <span class="index-def" title="message
+transmission, termed a <span class="index-def" data-term="message
 entity"><span id="message-entity"><strong>message
 entity,</strong></span></span> is defined by RFC 2045 and RFC 2616 (see
 [[RFC2045]] and [[RFC2616]]). A message entity with a content type of

--- a/css2/cover.html
+++ b/css2/cover.html
@@ -28,12 +28,12 @@
   <p><a href="https://www.w3.org/"><img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"/></a>
 
   <h1 id="title">Cascading Style Sheets Level 2 Revision 2 (CSS&nbsp;2.2) Specification</h1>
-  <h2 id="W3C-doctype">W3C Editors Draft 17 March 2020</h2>
+  <h2 id="W3C-doctype">W3C Editors Draft 18 March 2020</h2>
 
   <dl>
   <dt>This version:
-  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200317/">
-               https://www.w3.org/TR/2020/ED-CSS2-20200317/</a>
+  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200318/">
+               https://www.w3.org/TR/2020/ED-CSS2-20200318/</a>
   <dt>Latest version:
   <dd><a href="https://www.w3.org/TR/CSS2/">
                https://www.w3.org/TR/CSS2/</a>
@@ -74,7 +74,7 @@
 
   <!--
   <p>Please refer to the <a
-  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200317-errata.html"><strong>
+  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200318-errata.html"><strong>
   errata</strong></a> for this document.
   -->
 

--- a/css2/cover.html
+++ b/css2/cover.html
@@ -515,11 +515,11 @@ in <a href="changes.html">appendix&nbsp;C.</a>
     <ol class="toc">
       <li class="tocline3"><a href="fonts.html#generic-font-families" class="tocxref"><span class="secno">15.3.1</span> Generic font families</a>
       <ol class="toc">
-        <li class="tocline4"><a href="fonts.html#serif-def" class="tocxref"><span class="secno">15.3.1.1</span> <dfn>serif</dfn></a>
-        <li class="tocline4"><a href="fonts.html#sans-serif-def" class="tocxref"><span class="secno">15.3.1.2</span>  <dfn>sans-serif</dfn></a>
-        <li class="tocline4"><a href="fonts.html#cursive-def" class="tocxref"><span class="secno">15.3.1.3</span>  <dfn>cursive</dfn></a>
-        <li class="tocline4"><a href="fonts.html#fantasy-def" class="tocxref"><span class="secno">15.3.1.4</span>  <dfn>fantasy</dfn></a>
-        <li class="tocline4"><a href="fonts.html#monospace-def" class="tocxref"><span class="secno">15.3.1.5</span>  <dfn>monospace</dfn></a>
+        <li class="tocline4"><a href="fonts.html#serif-def" class="tocxref"><span class="secno">15.3.1.1</span> serif</a>
+        <li class="tocline4"><a href="fonts.html#sans-serif-def" class="tocxref"><span class="secno">15.3.1.2</span>  sans-serif</a>
+        <li class="tocline4"><a href="fonts.html#cursive-def" class="tocxref"><span class="secno">15.3.1.3</span>  cursive</a>
+        <li class="tocline4"><a href="fonts.html#fantasy-def" class="tocxref"><span class="secno">15.3.1.4</span>  fantasy</a>
+        <li class="tocline4"><a href="fonts.html#monospace-def" class="tocxref"><span class="secno">15.3.1.5</span>  monospace</a>
       </ol>
     </ol>
     <li class="tocline2"><a href="fonts.html#font-styling" class="tocxref"><span class="secno">15.4</span> Font styling: the 'font-style' property</a>

--- a/css2/cover.html
+++ b/css2/cover.html
@@ -28,12 +28,12 @@
   <p><a href="https://www.w3.org/"><img height="48" width="72" alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"/></a>
 
   <h1 id="title">Cascading Style Sheets Level 2 Revision 2 (CSS&nbsp;2.2) Specification</h1>
-  <h2 id="W3C-doctype">W3C Editors Draft 15 March 2020</h2>
+  <h2 id="W3C-doctype">W3C Editors Draft 17 March 2020</h2>
 
   <dl>
   <dt>This version:
-  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200315/">
-               https://www.w3.org/TR/2020/ED-CSS2-20200315/</a>
+  <dd><a href="https://www.w3.org/TR/2020/ED-CSS2-20200317/">
+               https://www.w3.org/TR/2020/ED-CSS2-20200317/</a>
   <dt>Latest version:
   <dd><a href="https://www.w3.org/TR/CSS2/">
                https://www.w3.org/TR/CSS2/</a>
@@ -74,7 +74,7 @@
 
   <!--
   <p>Please refer to the <a
-  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200315-errata.html"><strong>
+  href="https://www.w3.org/Style/css2-updates/ED-CSS2-20200317-errata.html"><strong>
   errata</strong></a> for this document.
   -->
 

--- a/css2/fonts.html
+++ b/css2/fonts.html
@@ -197,12 +197,12 @@ character's code point).
 </p>
 <dl>
 
-<dt><span id="value-def-family-name">&lt;family-name&gt;</span>
+<dt><dfn id="value-def-family-name" data-dfn-type="type">&lt;family-name&gt;</dfn>
 </dt>
 <dd>The name of a font family of choice. In the last example, "Gill"
 and "Helvetica" are font families.
 </dd>
-<dt><span id="value-def-generic-family">&lt;generic-family&gt;</span>
+<dt><dfn id="value-def-generic-family" data-dfn-type="type">&lt;generic-family&gt;</dfn>
 </dt>
 <dd>In the example above, the last value is a generic family name. The
 following generic families are defined:
@@ -707,7 +707,7 @@ Note that certain glyphs may bleed outside their em squares. Values
 have the following meanings:</p>
 
 <dl>
-<dt><b><span id="value-def-absolute-size">&lt;absolute-size&gt;</span></b>
+<dt><b><dfn id="value-def-absolute-size" data-dfn-type="type">&lt;absolute-size&gt;</dfn></b>
 </dt>
 <dd>An &lt;absolute-size&gt; keyword is an index to a table of font
 sizes computed and kept by the UA. Possible values are:
@@ -765,7 +765,7 @@ problematic, and this specification does <em>not</em> recommend such a
 fixed ratio.</em></p>
 
 </dd>
-<dt><b><span id="value-def-relative-size">&lt;relative-size&gt;</span></b>
+<dt><b><dfn id="value-def-relative-size" data-dfn-type="type">&lt;relative-size&gt;</dfn></b>
 </dt>
 <dd>A &lt;relative-size&gt; keyword is interpreted relative to the
 table of font sizes and the font size of the parent element. Possible

--- a/css2/fonts.html
+++ b/css2/fonts.html
@@ -162,7 +162,7 @@ class="propinst-font-family">'font-family'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-family'"><span id="propdef-font-family" class="propdef-title"><strong>'font-family'</strong></span></span>
+<span class="index-def" title="'font-family'"><dfn id="propdef-font-family" class="propdef-title" data-dfn-type="property" data-lt="font-family"><strong>'font-family'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[[ <a href="fonts.html#value-def-family-name" class="noxref"><span class="value-inst-family-name">&lt;family-name&gt;</span></a> | <a href="fonts.html#value-def-generic-family" class="noxref"><span class="value-inst-generic-family">&lt;generic-family&gt;</span></a> ] [, <a href="fonts.html#value-def-family-name" class="noxref"><span class="value-inst-family-name">&lt;family-name&gt;</span></a>| <a href="fonts.html#value-def-generic-family" class="noxref"><span class="value-inst-generic-family">&lt;generic-family&gt;</span></a>]* ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -423,7 +423,7 @@ typewriter, and is often used to set samples of computer code.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-style'"><span id="propdef-font-style" class="propdef-title"><strong>'font-style'</strong></span></span>
+<span class="index-def" title="'font-style'"><dfn id="propdef-font-style" class="propdef-title" data-dfn-type="property" data-lt="font-style"><strong>'font-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | italic | oblique | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -468,7 +468,7 @@ normal face.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-variant'"><span id="propdef-font-variant" class="propdef-title"><strong>'font-variant'</strong></span></span>
+<span class="index-def" title="'font-variant'"><dfn id="propdef-font-variant" class="propdef-title" data-dfn-type="property" data-lt="font-variant"><strong>'font-variant'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | small-caps | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -517,7 +517,7 @@ class="propinst-text-transform">'text-transform'</span></a> apply.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-weight'"><span id="propdef-font-weight" class="propdef-title"><strong>'font-weight'</strong></span></span>
+<span class="index-def" title="'font-weight'"><dfn id="propdef-font-weight" class="propdef-title" data-dfn-type="property" data-lt="font-weight"><strong>'font-weight'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 |
@@ -687,7 +687,7 @@ property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-size'"><span id="propdef-font-size" class="propdef-title"><strong>'font-size'</strong></span></span>
+<span class="index-def" title="'font-size'"><dfn id="propdef-font-size" class="propdef-title" data-dfn-type="property" data-lt="font-size"><strong>'font-size'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="fonts.html#value-def-absolute-size" class="noxref"><span class="value-inst-absolute-size">&lt;absolute-size&gt;</span></a> | <a href="fonts.html#value-def-relative-size" class="noxref"><span class="value-inst-relative-size">&lt;relative-size&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -808,7 +808,7 @@ em { font-size: 1.5em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font'"><span id="propdef-font" class="propdef-title"><strong>'font'</strong></span></span>
+<span class="index-def" title="'font'"><dfn id="propdef-font" class="propdef-title" data-dfn-type="property" data-lt="font"><strong>'font'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [ <a href="fonts.html#propdef-font-style" class="noxref"><span class="propinst-font-style">&lt;'font-style'&gt;</span></a> || <a href="fonts.html#propdef-font-variant" class="noxref"><span class="propinst-font-variant">&lt;'font-variant'&gt;</span></a> || <a href="fonts.html#propdef-font-weight" class="noxref"><span class="propinst-font-weight">&lt;'font-weight'&gt;</span></a> ]?

--- a/css2/fonts.html
+++ b/css2/fonts.html
@@ -162,7 +162,7 @@ class="propinst-font-family">'font-family'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-family'"><dfn id="propdef-font-family" class="propdef-title" data-dfn-type="property" data-lt="font-family"><strong>'font-family'</strong></dfn></span>
+<span class="index-def" data-term="'font-family'"><dfn id="propdef-font-family" class="propdef-title" data-dfn-type="property" data-lt="font-family"><strong>'font-family'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[[ <a href="fonts.html#value-def-family-name" class="noxref"><span class="value-inst-family-name">&lt;family-name&gt;</span></a> | <a href="fonts.html#value-def-generic-family" class="noxref"><span class="value-inst-generic-family">&lt;generic-family&gt;</span></a> ] [, <a href="fonts.html#value-def-family-name" class="noxref"><span class="value-inst-family-name">&lt;family-name&gt;</span></a>| <a href="fonts.html#value-def-generic-family" class="noxref"><span class="value-inst-generic-family">&lt;generic-family&gt;</span></a>]* ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -288,7 +288,7 @@ allowed by the underlying technology.
 <p>User agents are encouraged to allow users to select alternative
 choices for the generic fonts.
 
-<h4><span class="secno">15.3.1.1</span> <span class="index-def" title="serif, definition of"><span id="serif-def"><dfn>serif</dfn></span></span></h4>
+<h4><span class="secno">15.3.1.1</span> <span class="index-def" data-term="serif, definition of"><span id="serif-def"><dfn>serif</dfn></span></span></h4>
 
 <p>Glyphs of serif fonts, as the term is used in CSS, tend to have finishing
 strokes, flared or tapering ends, or have actual serifed endings
@@ -322,7 +322,7 @@ Monotype Albion 70, Bitstream Cyberbit, ER Bukinist
   <td>Lo Cicero Cherokee
 </table>
 
-<h4><span class="secno">15.3.1.2</span> <span class="index-def" title="sans-serif, definition of">
+<h4><span class="secno">15.3.1.2</span> <span class="index-def" data-term="sans-serif, definition of">
 <span id="sans-serif-def"><dfn>sans-serif</dfn></span></span></h4>
 
 <p>Glyphs in sans-serif fonts, as the term is used in CSS, tend to have stroke
@@ -354,7 +354,7 @@ Futura, ITC Stone Sans, Gill Sans, Akzidenz Grotesk, Helvetica
   <td>MS Tahoma
 </table>
 
-<h4><span class="secno">15.3.1.3</span> <span class="index-def" title="cursive, definition of">
+<h4><span class="secno">15.3.1.3</span> <span class="index-def" data-term="cursive, definition of">
 <span id="cursive-def"><dfn>cursive</dfn></span></span></h4>
 
 <p>Glyphs in cursive fonts, as the term is used in CSS, generally have
@@ -380,7 +380,7 @@ Zapf-Chancery
   <td>DecoType Naskh, Monotype Urdu 507
 </table>
 
-<h4><span class="secno">15.3.1.4</span> <span class="index-def" title="fantasy, definition of">
+<h4><span class="secno">15.3.1.4</span> <span class="index-def" data-term="fantasy, definition of">
 <span id="fantasy-def"><dfn>fantasy</dfn></span></span></h4>
 
 
@@ -394,7 +394,7 @@ Picture fonts, which do not represent characters). Examples include:</p>
 </table>
 
 
-<h4><span class="secno">15.3.1.5</span> <span class="index-def" title="monospace, definition of">
+<h4><span class="secno">15.3.1.5</span> <span class="index-def" data-term="monospace, definition of">
 <span id="monospace-def"><dfn>monospace</dfn></span></span></h4>
 
 
@@ -423,7 +423,7 @@ typewriter, and is often used to set samples of computer code.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-style'"><dfn id="propdef-font-style" class="propdef-title" data-dfn-type="property" data-lt="font-style"><strong>'font-style'</strong></dfn></span>
+<span class="index-def" data-term="'font-style'"><dfn id="propdef-font-style" class="propdef-title" data-dfn-type="property" data-lt="font-style"><strong>'font-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | italic | oblique | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -468,7 +468,7 @@ normal face.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-variant'"><dfn id="propdef-font-variant" class="propdef-title" data-dfn-type="property" data-lt="font-variant"><strong>'font-variant'</strong></dfn></span>
+<span class="index-def" data-term="'font-variant'"><dfn id="propdef-font-variant" class="propdef-title" data-dfn-type="property" data-lt="font-variant"><strong>'font-variant'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | small-caps | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -517,7 +517,7 @@ class="propinst-text-transform">'text-transform'</span></a> apply.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-weight'"><dfn id="propdef-font-weight" class="propdef-title" data-dfn-type="property" data-lt="font-weight"><strong>'font-weight'</strong></dfn></span>
+<span class="index-def" data-term="'font-weight'"><dfn id="propdef-font-weight" class="propdef-title" data-dfn-type="property" data-lt="font-weight"><strong>'font-weight'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | bold | bolder | lighter | 100 | 200 | 300 | 400 | 500 |
@@ -687,7 +687,7 @@ property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font-size'"><dfn id="propdef-font-size" class="propdef-title" data-dfn-type="property" data-lt="font-size"><strong>'font-size'</strong></dfn></span>
+<span class="index-def" data-term="'font-size'"><dfn id="propdef-font-size" class="propdef-title" data-dfn-type="property" data-lt="font-size"><strong>'font-size'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="fonts.html#value-def-absolute-size" class="noxref"><span class="value-inst-absolute-size">&lt;absolute-size&gt;</span></a> | <a href="fonts.html#value-def-relative-size" class="noxref"><span class="value-inst-relative-size">&lt;relative-size&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -808,7 +808,7 @@ em { font-size: 1.5em }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'font'"><dfn id="propdef-font" class="propdef-title" data-dfn-type="property" data-lt="font"><strong>'font'</strong></dfn></span>
+<span class="index-def" data-term="'font'"><dfn id="propdef-font" class="propdef-title" data-dfn-type="property" data-lt="font"><strong>'font'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [ <a href="fonts.html#propdef-font-style" class="noxref"><span class="propinst-font-style">&lt;'font-style'&gt;</span></a> || <a href="fonts.html#propdef-font-variant" class="noxref"><span class="propinst-font-variant">&lt;'font-variant'&gt;</span></a> || <a href="fonts.html#propdef-font-weight" class="noxref"><span class="propinst-font-weight">&lt;'font-weight'&gt;</span></a> ]?
@@ -869,7 +869,7 @@ the font size) and the 'font-family' ('fantasy'). It follows that the
 keyword 'normal' applies to the two remaining properties: 'font-style'
 and 'font-weight'.
 </p>
-<p>The following values refer to <span id="x11" class="index-def" title="system
+<p>The following values refer to <span id="x11" class="index-def" data-term="system
 fonts">system fonts</span>:</p>
 
 <dl>

--- a/css2/fonts.html
+++ b/css2/fonts.html
@@ -48,11 +48,11 @@ body>del,body>ins {display:block}
     <ol class="toc">
       <li class="tocline3"><a href="fonts.html#generic-font-families" class="tocxref"><span class="secno">15.3.1</span> Generic font families</a>
       <ol class="toc">
-        <li class="tocline4"><a href="fonts.html#serif-def" class="tocxref"><span class="secno">15.3.1.1</span> <dfn>serif</dfn></a>
-        <li class="tocline4"><a href="fonts.html#sans-serif-def" class="tocxref"><span class="secno">15.3.1.2</span>  <dfn>sans-serif</dfn></a>
-        <li class="tocline4"><a href="fonts.html#cursive-def" class="tocxref"><span class="secno">15.3.1.3</span>  <dfn>cursive</dfn></a>
-        <li class="tocline4"><a href="fonts.html#fantasy-def" class="tocxref"><span class="secno">15.3.1.4</span>  <dfn>fantasy</dfn></a>
-        <li class="tocline4"><a href="fonts.html#monospace-def" class="tocxref"><span class="secno">15.3.1.5</span>  <dfn>monospace</dfn></a>
+        <li class="tocline4"><a href="fonts.html#serif-def" class="tocxref"><span class="secno">15.3.1.1</span> serif</a>
+        <li class="tocline4"><a href="fonts.html#sans-serif-def" class="tocxref"><span class="secno">15.3.1.2</span>  sans-serif</a>
+        <li class="tocline4"><a href="fonts.html#cursive-def" class="tocxref"><span class="secno">15.3.1.3</span>  cursive</a>
+        <li class="tocline4"><a href="fonts.html#fantasy-def" class="tocxref"><span class="secno">15.3.1.4</span>  fantasy</a>
+        <li class="tocline4"><a href="fonts.html#monospace-def" class="tocxref"><span class="secno">15.3.1.5</span>  monospace</a>
       </ol>
     </ol>
     <li class="tocline2"><a href="fonts.html#font-styling" class="tocxref"><span class="secno">15.4</span> Font styling: the 'font-style' property</a>

--- a/css2/fonts.src
+++ b/css2/fonts.src
@@ -227,7 +227,7 @@ allowed by the underlying technology.
 <p>User agents are encouraged to allow users to select alternative
 choices for the generic fonts.
 
-<h4><span class="index-def" title="serif, definition of"><span id="serif-def"><dfn>serif</dfn></span></span></h4>
+<h4><span class="index-def" data-term="serif, definition of"><span id="serif-def"><dfn>serif</dfn></span></span></h4>
 
 <p>Glyphs of serif fonts, as the term is used in CSS, tend to have finishing
 strokes, flared or tapering ends, or have actual serifed endings
@@ -261,7 +261,7 @@ Monotype Albion 70, Bitstream Cyberbit, ER Bukinist
   <td>Lo Cicero Cherokee
 </table>
 
-<h4><span class="index-def" title="sans-serif, definition of">
+<h4><span class="index-def" data-term="sans-serif, definition of">
 <span id="sans-serif-def"><dfn>sans-serif</dfn></span></span></h4>
 
 <p>Glyphs in sans-serif fonts, as the term is used in CSS, tend to have stroke
@@ -293,7 +293,7 @@ Futura, ITC Stone Sans, Gill Sans, Akzidenz Grotesk, Helvetica
   <td>MS Tahoma
 </table>
 
-<h4><span class="index-def" title="cursive, definition of">
+<h4><span class="index-def" data-term="cursive, definition of">
 <span id="cursive-def"><dfn>cursive</dfn></span></span></h4>
 
 <p>Glyphs in cursive fonts, as the term is used in CSS, generally have
@@ -319,7 +319,7 @@ Zapf-Chancery
   <td>DecoType Naskh, Monotype Urdu 507
 </table>
 
-<h4><span class="index-def" title="fantasy, definition of">
+<h4><span class="index-def" data-term="fantasy, definition of">
 <span id="fantasy-def"><dfn>fantasy</dfn></span></span></h4>
 
 
@@ -333,7 +333,7 @@ Picture fonts, which do not represent characters). Examples include:</p>
 </table>
 
 
-<h4><span class="index-def" title="monospace, definition of">
+<h4><span class="index-def" data-term="monospace, definition of">
 <span id="monospace-def"><dfn>monospace</dfn></span></span></h4>
 
 
@@ -743,7 +743,7 @@ the font size) and the 'font-family' ('fantasy'). It follows that the
 keyword 'normal' applies to the two remaining properties: 'font-style'
 and 'font-weight'.
 </p>
-<p>The following values refer to <span class="index-def" title="system
+<p>The following values refer to <span class="index-def" data-term="system
 fonts">system fonts</span>:</p>
 
 <dl>

--- a/css2/fonts.src
+++ b/css2/fonts.src
@@ -136,12 +136,12 @@ character's code point).
 </p>
 <dl>
 
-<dt><span id="value-def-family-name">&lt;family-name&gt;</span>
+<dt><dfn id="value-def-family-name" data-dfn-type="type">&lt;family-name&gt;</dfn>
 </dt>
 <dd>The name of a font family of choice. In the last example, "Gill"
 and "Helvetica" are font families.
 </dd>
-<dt><span id="value-def-generic-family">&lt;generic-family&gt;</span>
+<dt><dfn id="value-def-generic-family" data-dfn-type="type">&lt;generic-family&gt;</dfn>
 </dt>
 <dd>In the example above, the last value is a generic family name. The
 following generic families are defined:
@@ -597,7 +597,7 @@ Note that certain glyphs may bleed outside their em squares. Values
 have the following meanings:</p>
 
 <dl>
-<dt><b><span id="value-def-absolute-size">&lt;absolute-size&gt;</span></b>
+<dt><b><dfn id="value-def-absolute-size" data-dfn-type="type">&lt;absolute-size&gt;</dfn></b>
 </dt>
 <dd>An &lt;absolute-size&gt; keyword is an index to a table of font
 sizes computed and kept by the UA. Possible values are:
@@ -655,7 +655,7 @@ problematic, and this specification does <em>not</em> recommend such a
 fixed ratio.</em></p>
 
 </dd>
-<dt><b><span id="value-def-relative-size">&lt;relative-size&gt;</span></b>
+<dt><b><dfn id="value-def-relative-size" data-dfn-type="type">&lt;relative-size&gt;</dfn></b>
 </dt>
 <dd>A &lt;relative-size&gt; keyword is interpreted relative to the
 table of font sizes and the font size of the parent element. Possible

--- a/css2/generate.html
+++ b/css2/generate.html
@@ -27,8 +27,8 @@
 
 <h1><span class="secno">12</span> 
 <span id="generated-text">Generated</span> <span id="x0" class="index-def"
-title="generated content">content</span>, automatic <span id="x1"
-class="index-def" title="automatic numbering">numbering</span>,
+data-term="generated content">content</span>, automatic <span id="x1"
+class="index-def" data-term="automatic numbering">numbering</span>,
 and lists</h1>
 <nav id="toc">
 <h2>Table of Contents</h2>
@@ -77,8 +77,8 @@ for the <a href="visuren.html#propdef-display" class="noxref"><span class="propi
 
 
 <h2><span class="secno">12.1</span> <span id="before-after-content">The</span> <span id="x2" class="index-def"
-title=":before|pseudo-elements:::before|before">:before</span> and <span id="x5"
-class="index-def" title=":after|pseudo-elements:::after|after">:after</span>
+data-term=":before|pseudo-elements:::before|before">:before</span> and <span id="x5"
+class="index-def" data-term=":after|pseudo-elements:::after|after">:after</span>
 pseudo-elements</h2>
 
 <p>Authors specify the style and location of generated content with
@@ -192,7 +192,7 @@ class="propinst-content">'content'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'content'"><dfn id="propdef-content" class="propdef-title" data-dfn-type="property" data-lt="content"><strong>'content'</strong></dfn></span>
+<span class="index-def" data-term="'content'"><dfn id="propdef-content" class="propdef-title" data-dfn-type="property" data-lt="content"><strong>'content'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | none | [ <a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a> | <a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | <a href="syndata.html#value-def-counter" class="noxref"><span class="value-inst-counter">&lt;counter&gt;</span></a> | attr(<a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a>) | open-quote | close-quote | no-open-quote | no-close-quote ]+ | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -216,25 +216,25 @@ meanings:</p>
 
 <dl>
 
-<dt><span id="x9" class="index-inst" title="none"><strong>none</strong></span>
+<dt><span id="x9" class="index-inst" data-term="none"><strong>none</strong></span>
 <dd>The pseudo-element is not generated.</dd>
 
-<dt><span id="x10" class="index-inst" title="normal"><strong>normal</strong></span>
+<dt><span id="x10" class="index-inst" data-term="normal"><strong>normal</strong></span>
 <dd>Computes to 'none' for the :before and :after pseudo-elements.</dd>
 
-<dt><span id="x11" class="index-inst" title="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
+<dt><span id="x11" class="index-inst" data-term="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></a></span>
 <dd>Text content 
 (see the section on <a href="syndata.html#strings">strings</a>).
 
-<dt><span id="x12" class="index-inst" title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
+<dt><span id="x12" class="index-inst" data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
 class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></a></span>
 <dd>The value is a URI that designates an external resource (such as an image).
 If  the user agent cannot display the resource it must either leave
 it out as if it were not specified or display some indication that
 the resource cannot be displayed.
 
-<dt><span id="x13" class="index-inst" title="&lt;counter&gt;"><a href="syndata.html#value-def-counter" class="noxref"><span
+<dt><span id="x13" class="index-inst" data-term="&lt;counter&gt;"><a href="syndata.html#value-def-counter" class="noxref"><span
 class="value-inst-counter"><strong>&lt;counter&gt;</strong></span></a></span>
 <dd><a href="syndata.html#counter">Counters</a> may be specified
 with two different functions: 'counter()' or 'counters()'. 
@@ -258,22 +258,22 @@ The name must not be 'none', 'inherit' or 'initial'. Such a name
 causes the declaration to be ignored.
 
 <dt><span id="x14" class="index-inst"
-title="open-quote"><a href="generate.html#value-def-open-quote" class="noxref"><span
+data-term="open-quote"><a href="generate.html#value-def-open-quote" class="noxref"><span
 class="value-inst-open-quote"><strong>open-quote</strong></span></a></span>
-and <span id="x15" class="index-inst" title="close-quote"><a href="generate.html#value-def-close-quote" class="noxref"><span
+and <span id="x15" class="index-inst" data-term="close-quote"><a href="generate.html#value-def-close-quote" class="noxref"><span
 class="value-inst-close-quote"><strong>close-quote</strong></span></a></span>
 
 <dd>These values are replaced by the appropriate string
 from the <a href="generate.html#propdef-quotes" class="noxref"><span class="propinst-quotes"><strong>'quotes'</strong></span></a> property.
 
-<dt><span id="x16" class="index-inst" title="no-open-quote"><a href="generate.html#value-def-no-open-quote" class="noxref"><span
+<dt><span id="x16" class="index-inst" data-term="no-open-quote"><a href="generate.html#value-def-no-open-quote" class="noxref"><span
 class="value-inst-no-open-quote"><strong>no-open-quote</strong></span></a></span>
-and <span id="x17" class="index-inst" title="no-close-quote"><a href="generate.html#value-def-no-close-quote" class="noxref"><span
+and <span id="x17" class="index-inst" data-term="no-close-quote"><a href="generate.html#value-def-no-close-quote" class="noxref"><span
 class="value-inst-no-close-quote"><strong>no-close-quote</strong></span></a></span>
 
 <dd>Introduces no content, but increments (decrements) the level of nesting for quotes.
 
-<dt><span id="x18" class="index-def" title="attr()"><strong>attr(X)</strong></span>
+<dt><span id="x18" class="index-def" data-term="attr()"><strong>attr(X)</strong></span>
 <dd>This function returns as a string the value of attribute X 
 for the subject of the selector. The
 string is not parsed by the CSS processor.  If the subject of the selector
@@ -340,7 +340,7 @@ class="propinst-quotes">'quotes'</span></a> property</H3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'quotes'"><dfn id="propdef-quotes" class="propdef-title" data-dfn-type="property" data-lt="quotes"><strong>'quotes'</strong></dfn></span>
+<span class="index-def" data-term="'quotes'"><dfn id="propdef-quotes" class="propdef-title" data-dfn-type="property" data-lt="quotes"><strong>'quotes'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[<a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a> <a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a>]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -365,9 +365,9 @@ quotations. Values have the following meanings:</p>
 <a href="generate.html#propdef-content" class="noxref"><span class="propinst-content">'content'</span></a> property
 produce no quotation marks.
 
-<dt>[<span id="x20" class="index-inst" title="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
+<dt>[<span id="x20" class="index-inst" data-term="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></a></span>
-&nbsp;<span id="x21" class="index-inst" title="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
+&nbsp;<span id="x21" class="index-inst" data-term="&lt;string&gt;"><a href="syndata.html#value-def-string" class="noxref"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></a></span>]+
 
 <dd>Values for the 'open-quote' and 'close-quote' values of the
@@ -462,9 +462,9 @@ mark characters:</em></p>
 class="propinst-content">'content'</span></a> property</H3>
 
 <p>Quotation marks are inserted in appropriate places in a document
-with the <span class="index-def" title="open-quote"><dfn
+with the <span class="index-def" data-term="open-quote"><dfn
 class="value-def" id="value-def-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="open-quote">'open-quote'</dfn></span>
-and <span class="index-def" title="close-quote"><dfn class="value-def"
+and <span class="index-def" data-term="close-quote"><dfn class="value-def"
 id="value-def-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="close-quote">'close-quote'</dfn></span> values of the
 <a href="generate.html#propdef-content" class="noxref"><span class="propinst-content">'content'</span></a> property. Each
 occurrence of 'open-quote' or 'close-quote' is replaced by one of the
@@ -494,7 +494,7 @@ of the source document or the formatting structure.</em>
 before every paragraph of a quote spanning several paragraphs, but
 only the last paragraph ends with a closing quotation mark. In CSS,
 this can be achieved by inserting "phantom" closing quotes. The
-keyword <span class="index-def" title="no-close-quote"><dfn
+keyword <span class="index-def" data-term="no-close-quote"><dfn
 class="value-def"
 id="value-def-no-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-close-quote">'no-close-quote'</dfn></span> decrements
 the quoting level, but does not insert a quotation mark.
@@ -515,12 +515,12 @@ blockquote p.last:after { content: close-quote }
 </div>
 
 <p>For symmetry, there is also a <span class="index-def"
-title="no-open-quote"><dfn class="value-def"
+data-term="no-open-quote"><dfn class="value-def"
 id="value-def-no-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-open-quote">'no-open-quote'</dfn></span> keyword,
 which inserts nothing, but increments the quotation depth by one.
 
 
-<h2><span class="secno">12.4</span> Automatic <span class="index-def" title="counters"><span
+<h2><span class="secno">12.4</span> Automatic <span class="index-def" data-term="counters"><span
 id="counters">counters</span></span> and numbering</h2>
 
 <p>Automatic numbering in CSS&nbsp;2 is controlled with two properties,
@@ -532,7 +532,7 @@ class="propinst-content">'content'</span></a> property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'counter-reset'"><dfn id="propdef-counter-reset" class="propdef-title" data-dfn-type="property" data-lt="counter-reset"><strong>'counter-reset'</strong></dfn></span>
+<span class="index-def" data-term="'counter-reset'"><dfn id="propdef-counter-reset" class="propdef-title" data-dfn-type="property" data-lt="counter-reset"><strong>'counter-reset'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a> <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a>? ]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -548,7 +548,7 @@ class="propinst-content">'content'</span></a> property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'counter-increment'"><dfn id="propdef-counter-increment" class="propdef-title" data-dfn-type="property" data-lt="counter-increment"><strong>'counter-increment'</strong></dfn></span>
+<span class="index-def" data-term="'counter-increment'"><dfn id="propdef-counter-increment" class="propdef-title" data-dfn-type="property" data-lt="counter-increment"><strong>'counter-increment'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a> <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a>? ]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -672,7 +672,7 @@ LI:before { content: counter(item) ". "; counter-increment: item }
 </pre>
 </div>
 
-<p>The <span id="x29" class="index-def" title="scope"><dfn>scope</dfn></span>
+<p>The <span id="x29" class="index-def" data-term="scope"><dfn>scope</dfn></span>
 of a counter starts at the first element in the document that has a
 <a href="generate.html#propdef-counter-reset" class="noxref"><span class="propinst-counter-reset">'counter-reset'</span></a> for that
 counter and includes the element's descendants and its following
@@ -835,7 +835,7 @@ content and, depending on the values of 'list-style-type' and
 that the
 element is a list item.
 
-<P>The <span id="x30" class="index-def" title="list properties"><dfn>list
+<P>The <span id="x30" class="index-def" data-term="list properties"><dfn>list
 properties</dfn></span> describe basic visual formatting of lists:
 they allow style sheets to specify the marker type (image, glyph, or
 number), and the marker position with respect to the principal box
@@ -858,7 +858,7 @@ class="propinst-list-style-position">'list-style-position'</span></a>, and
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-type'"><dfn id="propdef-list-style-type" class="propdef-title" data-dfn-type="property" data-lt="list-style-type"><strong>'list-style-type'</strong></dfn></span>
+<span class="index-def" data-term="'list-style-type'"><dfn id="propdef-list-style-type" class="propdef-title" data-dfn-type="property" data-lt="list-style-type"><strong>'list-style-type'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>disc | circle | square | decimal | decimal-leading-zero | 
@@ -885,11 +885,11 @@ three types of marker: glyphs, numbering systems, and alphabetic
 systems. 
 
 <P>Glyphs are specified with 
-<strong><span class="index-def" title="disc"><dfn class="value-def"
+<strong><span class="index-def" data-term="disc"><dfn class="value-def"
 id="value-def-disc" data-dfn-type="value" data-dfn-for="list-style-type">disc</dfn></span></strong>, 
-<strong><span class="index-def" title="circle"><dfn class="value-def"
+<strong><span class="index-def" data-term="circle"><dfn class="value-def"
 id="value-def-circle" data-dfn-type="value" data-dfn-for="list-style-type">circle</dfn></span></strong>, and 
-<strong><span class="index-def" title="square"><dfn class="value-def"
+<strong><span class="index-def" data-term="square"><dfn class="value-def"
 id="value-def-square" data-dfn-type="value" data-dfn-for="list-style-type">square</dfn></span></strong>. Their exact
 rendering depends on the user agent.
 
@@ -897,23 +897,23 @@ rendering depends on the user agent.
 
 <dl>
 
-<dt><span class="index-def" title="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
+<dt><span class="index-def" data-term="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
 
-<dt><strong><span class="index-def" title="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
 <dd>Decimal numbers padded by initial zeros (e.g., 01, 02, 03, ..., 98, 99).
 
 
 
-<dt><strong><span class="index-def" title="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
 <dd>Lowercase roman numerals (i, ii, iii, iv, v, etc.).
 
-<dt><strong><span class="index-def" title="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
 <dd>Uppercase roman numerals (I, II, III, IV, V, etc.).
 
-<dt><strong><span class="index-def" title="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
 <dd>Traditional Georgian numbering 
 (an, ban, gan, ..., he, tan, in, in-an, ...).
-<dt><strong><span class="index-def" title="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
 <dd>Traditional uppercase Armenian numbering.
 </dl>
 
@@ -921,11 +921,11 @@ rendering depends on the user agent.
 <P>Alphabetic systems are specified with:</P>
 
 <dl>
-<dt><strong><span class="index-def" title="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
+<dt><strong><span class="index-def" data-term="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
 <dd>Lowercase ascii letters (a, b, c, ... z).
-<dt><strong><span class="index-def" title="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
+<dt><strong><span class="index-def" data-term="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
 <dd>Uppercase ascii letters (A, B, C, ... Z).
-<dt><strong><span class="index-def" title="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
 <dd>Lowercase classical Greek 
 alpha, beta, gamma, ... (&#945;, &#946;, &#947;, ...)
 </dl>
@@ -976,7 +976,7 @@ iii This is the third item.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-image'"><dfn id="propdef-list-style-image" class="propdef-title" data-dfn-type="property" data-lt="list-style-image"><strong>'list-style-image'</strong></dfn></span>
+<span class="index-def" data-term="'list-style-image'"><dfn id="propdef-list-style-image" class="propdef-title" data-dfn-type="property" data-lt="list-style-image"><strong>'list-style-image'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1030,7 +1030,7 @@ ul { list-style-image: url("http://png.com/ellipse.png") }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-position'"><dfn id="propdef-list-style-position" class="propdef-title" data-dfn-type="property" data-lt="list-style-position"><strong>'list-style-position'</strong></dfn></span>
+<span class="index-def" data-term="'list-style-position'"><dfn id="propdef-list-style-position" class="propdef-title" data-dfn-type="property" data-lt="list-style-position"><strong>'list-style-position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>inside | outside | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1124,7 +1124,7 @@ side of the box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style'"><dfn id="propdef-list-style" class="propdef-title" data-dfn-type="property" data-lt="list-style"><strong>'list-style'</strong></dfn></span>
+<span class="index-def" data-term="'list-style'"><dfn id="propdef-list-style" class="propdef-title" data-dfn-type="property" data-lt="list-style"><strong>'list-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="generate.html#propdef-list-style-type" class="noxref"><span class="propinst-list-style-type">&lt;'list-style-type'&gt;</span></a> || <a href="generate.html#propdef-list-style-position" class="noxref"><span class="propinst-list-style-position">&lt;'list-style-position'&gt;</span></a> || <a href="generate.html#propdef-list-style-image" class="noxref"><span class="propinst-list-style-image">&lt;'list-style-image'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/generate.html
+++ b/css2/generate.html
@@ -462,10 +462,10 @@ mark characters:</em></p>
 class="propinst-content">'content'</span></a> property</H3>
 
 <p>Quotation marks are inserted in appropriate places in a document
-with the <span class="index-def" title="open-quote"><span
-class="value-def" id="value-def-open-quote">'open-quote'</span></span>
-and <span class="index-def" title="close-quote"><span class="value-def"
-id="value-def-close-quote">'close-quote'</span></span> values of the
+with the <span class="index-def" title="open-quote"><dfn
+class="value-def" id="value-def-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="open-quote">'open-quote'</dfn></span>
+and <span class="index-def" title="close-quote"><dfn class="value-def"
+id="value-def-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="close-quote">'close-quote'</dfn></span> values of the
 <a href="generate.html#propdef-content" class="noxref"><span class="propinst-content">'content'</span></a> property. Each
 occurrence of 'open-quote' or 'close-quote' is replaced by one of the
 strings from the value of <a href="generate.html#propdef-quotes" class="noxref"><span
@@ -494,9 +494,9 @@ of the source document or the formatting structure.</em>
 before every paragraph of a quote spanning several paragraphs, but
 only the last paragraph ends with a closing quotation mark. In CSS,
 this can be achieved by inserting "phantom" closing quotes. The
-keyword <span class="index-def" title="no-close-quote"><span
+keyword <span class="index-def" title="no-close-quote"><dfn
 class="value-def"
-id="value-def-no-close-quote">'no-close-quote'</span></span> decrements
+id="value-def-no-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-close-quote">'no-close-quote'</dfn></span> decrements
 the quoting level, but does not insert a quotation mark.
 
 
@@ -515,8 +515,8 @@ blockquote p.last:after { content: close-quote }
 </div>
 
 <p>For symmetry, there is also a <span class="index-def"
-title="no-open-quote"><span class="value-def"
-id="value-def-no-open-quote">'no-open-quote'</span></span> keyword,
+title="no-open-quote"><dfn class="value-def"
+id="value-def-no-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-open-quote">'no-open-quote'</dfn></span> keyword,
 which inserts nothing, but increments the quotation depth by one.
 
 
@@ -885,35 +885,35 @@ three types of marker: glyphs, numbering systems, and alphabetic
 systems. 
 
 <P>Glyphs are specified with 
-<strong><span class="index-def" title="disc"><span class="value-def"
-id="value-def-disc">disc</span></span></strong>, 
-<strong><span class="index-def" title="circle"><span class="value-def"
-id="value-def-circle">circle</span></span></strong>, and 
-<strong><span class="index-def" title="square"><span class="value-def"
-id="value-def-square">square</span></span></strong>. Their exact
+<strong><span class="index-def" title="disc"><dfn class="value-def"
+id="value-def-disc" data-dfn-type="value" data-dfn-for="list-style-type">disc</dfn></span></strong>, 
+<strong><span class="index-def" title="circle"><dfn class="value-def"
+id="value-def-circle" data-dfn-type="value" data-dfn-for="list-style-type">circle</dfn></span></strong>, and 
+<strong><span class="index-def" title="square"><dfn class="value-def"
+id="value-def-square" data-dfn-type="value" data-dfn-for="list-style-type">square</dfn></span></strong>. Their exact
 rendering depends on the user agent.
 
 <P>Numbering systems are specified with:</P>
 
 <dl>
 
-<dt><span class="index-def" title="decimal"><span class="value-def" id="value-def-decimal"><strong>decimal</strong></span></span><dd>Decimal numbers, beginning with 1.
+<dt><span class="index-def" title="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
 
-<dt><strong><span class="index-def" title="decimal-leading-zero"><span class="value-def" id="value-def-decimal-leading-zero">decimal-leading-zero</span></span></strong>
+<dt><strong><span class="index-def" title="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
 <dd>Decimal numbers padded by initial zeros (e.g., 01, 02, 03, ..., 98, 99).
 
 
 
-<dt><strong><span class="index-def" title="lower-roman"><span class="value-def" id="value-def-lower-roman">lower-roman</span></span></strong>
+<dt><strong><span class="index-def" title="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
 <dd>Lowercase roman numerals (i, ii, iii, iv, v, etc.).
 
-<dt><strong><span class="index-def" title="upper-roman"><span class="value-def" id="value-def-upper-roman">upper-roman</span></span></strong>
+<dt><strong><span class="index-def" title="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
 <dd>Uppercase roman numerals (I, II, III, IV, V, etc.).
 
-<dt><strong><span class="index-def" title="georgian"><span class="value-def" id="value-def-georgian">georgian</span></span></strong>
+<dt><strong><span class="index-def" title="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
 <dd>Traditional Georgian numbering 
 (an, ban, gan, ..., he, tan, in, in-an, ...).
-<dt><strong><span class="index-def" title="armenian"><span class="value-def" id="value-def-armenian">armenian</span></span></strong>
+<dt><strong><span class="index-def" title="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
 <dd>Traditional uppercase Armenian numbering.
 </dl>
 
@@ -921,11 +921,11 @@ rendering depends on the user agent.
 <P>Alphabetic systems are specified with:</P>
 
 <dl>
-<dt><strong><span class="index-def" title="lower-latin"><span class="value-def" id="value-def-lower-latin">lower-latin</span></span></strong> or <strong>lower-alpha</strong>
+<dt><strong><span class="index-def" title="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
 <dd>Lowercase ascii letters (a, b, c, ... z).
-<dt><strong><span class="index-def" title="upper-latin"><span class="value-def" id="value-def-upper-latin">upper-latin</span></span></strong> or <strong>upper-alpha</strong>
+<dt><strong><span class="index-def" title="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
 <dd>Uppercase ascii letters (A, B, C, ... Z).
-<dt><strong><span class="index-def" title="lower-greek"><span class="value-def" id="value-def-lower-greek">lower-greek</span></span></strong>
+<dt><strong><span class="index-def" title="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
 <dd>Lowercase classical Greek 
 alpha, beta, gamma, ... (&#945;, &#946;, &#947;, ...)
 </dl>

--- a/css2/generate.html
+++ b/css2/generate.html
@@ -192,7 +192,7 @@ class="propinst-content">'content'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'content'"><span id="propdef-content" class="propdef-title"><strong>'content'</strong></span></span>
+<span class="index-def" title="'content'"><dfn id="propdef-content" class="propdef-title" data-dfn-type="property" data-lt="content"><strong>'content'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | none | [ <a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a> | <a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | <a href="syndata.html#value-def-counter" class="noxref"><span class="value-inst-counter">&lt;counter&gt;</span></a> | attr(<a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a>) | open-quote | close-quote | no-open-quote | no-close-quote ]+ | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -340,7 +340,7 @@ class="propinst-quotes">'quotes'</span></a> property</H3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'quotes'"><span id="propdef-quotes" class="propdef-title"><strong>'quotes'</strong></span></span>
+<span class="index-def" title="'quotes'"><dfn id="propdef-quotes" class="propdef-title" data-dfn-type="property" data-lt="quotes"><strong>'quotes'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[<a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a> <a href="syndata.html#value-def-string" class="noxref"><span class="value-inst-string">&lt;string&gt;</span></a>]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -532,7 +532,7 @@ class="propinst-content">'content'</span></a> property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'counter-reset'"><span id="propdef-counter-reset" class="propdef-title"><strong>'counter-reset'</strong></span></span>
+<span class="index-def" title="'counter-reset'"><dfn id="propdef-counter-reset" class="propdef-title" data-dfn-type="property" data-lt="counter-reset"><strong>'counter-reset'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a> <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a>? ]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -548,7 +548,7 @@ class="propinst-content">'content'</span></a> property.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'counter-increment'"><span id="propdef-counter-increment" class="propdef-title"><strong>'counter-increment'</strong></span></span>
+<span class="index-def" title="'counter-increment'"><dfn id="propdef-counter-increment" class="propdef-title" data-dfn-type="property" data-lt="counter-increment"><strong>'counter-increment'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="syndata.html#value-def-identifier" class="noxref"><span class="value-inst-identifier">&lt;identifier&gt;</span></a> <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a>? ]+ | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -858,7 +858,7 @@ class="propinst-list-style-position">'list-style-position'</span></a>, and
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-type'"><span id="propdef-list-style-type" class="propdef-title"><strong>'list-style-type'</strong></span></span>
+<span class="index-def" title="'list-style-type'"><dfn id="propdef-list-style-type" class="propdef-title" data-dfn-type="property" data-lt="list-style-type"><strong>'list-style-type'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>disc | circle | square | decimal | decimal-leading-zero | 
@@ -976,7 +976,7 @@ iii This is the third item.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-image'"><span id="propdef-list-style-image" class="propdef-title"><strong>'list-style-image'</strong></span></span>
+<span class="index-def" title="'list-style-image'"><dfn id="propdef-list-style-image" class="propdef-title" data-dfn-type="property" data-lt="list-style-image"><strong>'list-style-image'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1030,7 +1030,7 @@ ul { list-style-image: url("http://png.com/ellipse.png") }
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style-position'"><span id="propdef-list-style-position" class="propdef-title"><strong>'list-style-position'</strong></span></span>
+<span class="index-def" title="'list-style-position'"><dfn id="propdef-list-style-position" class="propdef-title" data-dfn-type="property" data-lt="list-style-position"><strong>'list-style-position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>inside | outside | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1124,7 +1124,7 @@ side of the box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'list-style'"><span id="propdef-list-style" class="propdef-title"><strong>'list-style'</strong></span></span>
+<span class="index-def" title="'list-style'"><dfn id="propdef-list-style" class="propdef-title" data-dfn-type="property" data-lt="list-style"><strong>'list-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="generate.html#propdef-list-style-type" class="noxref"><span class="propinst-list-style-type">&lt;'list-style-type'&gt;</span></a> || <a href="generate.html#propdef-list-style-position" class="noxref"><span class="propinst-list-style-position">&lt;'list-style-position'&gt;</span></a> || <a href="generate.html#propdef-list-style-image" class="noxref"><span class="propinst-list-style-image">&lt;'list-style-image'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/generate.src
+++ b/css2/generate.src
@@ -384,10 +384,10 @@ mark characters:</em></p>
 class="propinst-content">'content'</span> property</H3>
 
 <p>Quotation marks are inserted in appropriate places in a document
-with the <span class="index-def" title="open-quote"><span
-class="value-def" id="value-def-open-quote">'open-quote'</span></span>
-and <span class="index-def" title="close-quote"><span class="value-def"
-id="value-def-close-quote">'close-quote'</span></span> values of the
+with the <span class="index-def" title="open-quote"><dfn
+class="value-def" id="value-def-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="open-quote">'open-quote'</dfn></span>
+and <span class="index-def" title="close-quote"><dfn class="value-def"
+id="value-def-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="close-quote">'close-quote'</dfn></span> values of the
 <span class="propinst-content">'content'</span> property. Each
 occurrence of 'open-quote' or 'close-quote' is replaced by one of the
 strings from the value of <span
@@ -416,9 +416,9 @@ of the source document or the formatting structure.</em>
 before every paragraph of a quote spanning several paragraphs, but
 only the last paragraph ends with a closing quotation mark. In CSS,
 this can be achieved by inserting "phantom" closing quotes. The
-keyword <span class="index-def" title="no-close-quote"><span
+keyword <span class="index-def" title="no-close-quote"><dfn
 class="value-def"
-id="value-def-no-close-quote">'no-close-quote'</span></span> decrements
+id="value-def-no-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-close-quote">'no-close-quote'</dfn></span> decrements
 the quoting level, but does not insert a quotation mark.
 
 
@@ -437,8 +437,8 @@ blockquote p.last:after { content: close-quote }
 </div>
 
 <p>For symmetry, there is also a <span class="index-def"
-title="no-open-quote"><span class="value-def"
-id="value-def-no-open-quote">'no-open-quote'</span></span> keyword,
+title="no-open-quote"><dfn class="value-def"
+id="value-def-no-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-open-quote">'no-open-quote'</dfn></span> keyword,
 which inserts nothing, but increments the quotation depth by one.
 
 
@@ -758,35 +758,35 @@ three types of marker: glyphs, numbering systems, and alphabetic
 systems. 
 
 <P>Glyphs are specified with 
-<strong><span class="index-def" title="disc"><span class="value-def"
-id="value-def-disc">disc</span></span></strong>, 
-<strong><span class="index-def" title="circle"><span class="value-def"
-id="value-def-circle">circle</span></span></strong>, and 
-<strong><span class="index-def" title="square"><span class="value-def"
-id="value-def-square">square</span></span></strong>. Their exact
+<strong><span class="index-def" title="disc"><dfn class="value-def"
+id="value-def-disc" data-dfn-type="value" data-dfn-for="list-style-type">disc</dfn></span></strong>, 
+<strong><span class="index-def" title="circle"><dfn class="value-def"
+id="value-def-circle" data-dfn-type="value" data-dfn-for="list-style-type">circle</dfn></span></strong>, and 
+<strong><span class="index-def" title="square"><dfn class="value-def"
+id="value-def-square" data-dfn-type="value" data-dfn-for="list-style-type">square</dfn></span></strong>. Their exact
 rendering depends on the user agent.
 
 <P>Numbering systems are specified with:</P>
 
 <dl>
 
-<dt><span class="index-def" title="decimal"><span class="value-def" id="value-def-decimal"><strong>decimal</strong></span></span><dd>Decimal numbers, beginning with 1.
+<dt><span class="index-def" title="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
 
-<dt><strong><span class="index-def" title="decimal-leading-zero"><span class="value-def" id="value-def-decimal-leading-zero">decimal-leading-zero</span></span></strong>
+<dt><strong><span class="index-def" title="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
 <dd>Decimal numbers padded by initial zeros (e.g., 01, 02, 03, ..., 98, 99).
 
 <!-- should this be included -->
 
-<dt><strong><span class="index-def" title="lower-roman"><span class="value-def" id="value-def-lower-roman">lower-roman</span></span></strong>
+<dt><strong><span class="index-def" title="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
 <dd>Lowercase roman numerals (i, ii, iii, iv, v, etc.).
 
-<dt><strong><span class="index-def" title="upper-roman"><span class="value-def" id="value-def-upper-roman">upper-roman</span></span></strong>
+<dt><strong><span class="index-def" title="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
 <dd>Uppercase roman numerals (I, II, III, IV, V, etc.).
 
-<dt><strong><span class="index-def" title="georgian"><span class="value-def" id="value-def-georgian">georgian</span></span></strong>
+<dt><strong><span class="index-def" title="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
 <dd>Traditional Georgian numbering 
 (an, ban, gan, ..., he, tan, in, in-an, ...).
-<dt><strong><span class="index-def" title="armenian"><span class="value-def" id="value-def-armenian">armenian</span></span></strong>
+<dt><strong><span class="index-def" title="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
 <dd>Traditional uppercase Armenian numbering.
 </dl>
 
@@ -794,11 +794,11 @@ rendering depends on the user agent.
 <P>Alphabetic systems are specified with:</P>
 
 <dl>
-<dt><strong><span class="index-def" title="lower-latin"><span class="value-def" id="value-def-lower-latin">lower-latin</span></span></strong> or <strong>lower-alpha</strong>
+<dt><strong><span class="index-def" title="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
 <dd>Lowercase ascii letters (a, b, c, ... z).
-<dt><strong><span class="index-def" title="upper-latin"><span class="value-def" id="value-def-upper-latin">upper-latin</span></span></strong> or <strong>upper-alpha</strong>
+<dt><strong><span class="index-def" title="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
 <dd>Uppercase ascii letters (A, B, C, ... Z).
-<dt><strong><span class="index-def" title="lower-greek"><span class="value-def" id="value-def-lower-greek">lower-greek</span></span></strong>
+<dt><strong><span class="index-def" title="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
 <dd>Lowercase classical Greek 
 alpha, beta, gamma, ... (&#945;, &#946;, &#947;, ...)
 </dl>

--- a/css2/generate.src
+++ b/css2/generate.src
@@ -7,8 +7,8 @@
 <body>
 <h1>
 <span id="generated-text">Generated</span> <span class="index-def"
-title="generated content">content</span>, automatic <span
-class="index-def" title="automatic numbering">numbering</span>,
+data-term="generated content">content</span>, automatic <span
+class="index-def" data-term="automatic numbering">numbering</span>,
 and lists</h1>
 
 <p>In some cases, authors may want user agents to render content
@@ -32,8 +32,8 @@ for the <span class="propinst-display">'display'</span> property.
 
 
 <h2><span id="before-after-content">The</span> <span class="index-def"
-title=":before|pseudo-elements:::before|before">:before</span> and <span
-class="index-def" title=":after|pseudo-elements:::after|after">:after</span>
+data-term=":before|pseudo-elements:::before|before">:before</span> and <span
+class="index-def" data-term=":after|pseudo-elements:::after|after">:after</span>
 pseudo-elements</h2>
 
 <p>Authors specify the style and location of generated content with
@@ -153,25 +153,25 @@ meanings:</p>
 
 <dl>
 
-<dt><span class="index-inst" title="none"><strong>none</strong></span>
+<dt><span class="index-inst" data-term="none"><strong>none</strong></span>
 <dd>The pseudo-element is not generated.</dd>
 
-<dt><span class="index-inst" title="normal"><strong>normal</strong></span>
+<dt><span class="index-inst" data-term="normal"><strong>normal</strong></span>
 <dd>Computes to 'none' for the :before and :after pseudo-elements.</dd>
 
-<dt><span class="index-inst" title="&lt;string&gt;"><span
+<dt><span class="index-inst" data-term="&lt;string&gt;"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></span>
 <dd>Text content 
 (see the section on <a href="syndata.html#strings">strings</a>).
 
-<dt><span class="index-inst" title="&lt;uri&gt;"><span
+<dt><span class="index-inst" data-term="&lt;uri&gt;"><span
 class="value-inst-uri"><strong>&lt;uri&gt;</strong></span></span>
 <dd>The value is a URI that designates an external resource (such as an image).
 If  the user agent cannot display the resource it must either leave
 it out as if it were not specified or display some indication that
 the resource cannot be displayed.
 
-<dt><span class="index-inst" title="&lt;counter&gt;"><span
+<dt><span class="index-inst" data-term="&lt;counter&gt;"><span
 class="value-inst-counter"><strong>&lt;counter&gt;</strong></span></span>
 <dd><a href="syndata.html#counter">Counters</a> may be specified
 with two different functions: 'counter()' or 'counters()'. 
@@ -195,22 +195,22 @@ The name must not be 'none', 'inherit' or 'initial'. Such a name
 causes the declaration to be ignored.
 
 <dt><span class="index-inst"
-title="open-quote"><span
+data-term="open-quote"><span
 class="value-inst-open-quote"><strong>open-quote</strong></span></span>
-and <span class="index-inst" title="close-quote"><span
+and <span class="index-inst" data-term="close-quote"><span
 class="value-inst-close-quote"><strong>close-quote</strong></span></span>
 
 <dd>These values are replaced by the appropriate string
 from the <span class="propinst-quotes"><strong>'quotes'</strong></span> property.
 
-<dt><span class="index-inst" title="no-open-quote"><span
+<dt><span class="index-inst" data-term="no-open-quote"><span
 class="value-inst-no-open-quote"><strong>no-open-quote</strong></span></span>
-and <span class="index-inst" title="no-close-quote"><span
+and <span class="index-inst" data-term="no-close-quote"><span
 class="value-inst-no-close-quote"><strong>no-close-quote</strong></span></span>
 
 <dd>Introduces no content, but increments (decrements) the level of nesting for quotes.
 
-<dt><span class="index-def" title="attr()"><strong>attr(X)</strong></span>
+<dt><span class="index-def" data-term="attr()"><strong>attr(X)</strong></span>
 <dd>This function returns as a string the value of attribute X 
 for the subject of the selector. The
 string is not parsed by the CSS processor.  If the subject of the selector
@@ -287,9 +287,9 @@ quotations. Values have the following meanings:</p>
 <span class="propinst-content">'content'</span> property
 produce no quotation marks.
 
-<dt>[<span class="index-inst" title="&lt;string&gt;"><span
+<dt>[<span class="index-inst" data-term="&lt;string&gt;"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></span>
-&nbsp;<span class="index-inst" title="&lt;string&gt;"><span
+&nbsp;<span class="index-inst" data-term="&lt;string&gt;"><span
 class="value-inst-string"><strong>&lt;string&gt;</strong></span></span>]+
 
 <dd>Values for the 'open-quote' and 'close-quote' values of the
@@ -384,9 +384,9 @@ mark characters:</em></p>
 class="propinst-content">'content'</span> property</H3>
 
 <p>Quotation marks are inserted in appropriate places in a document
-with the <span class="index-def" title="open-quote"><dfn
+with the <span class="index-def" data-term="open-quote"><dfn
 class="value-def" id="value-def-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="open-quote">'open-quote'</dfn></span>
-and <span class="index-def" title="close-quote"><dfn class="value-def"
+and <span class="index-def" data-term="close-quote"><dfn class="value-def"
 id="value-def-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="close-quote">'close-quote'</dfn></span> values of the
 <span class="propinst-content">'content'</span> property. Each
 occurrence of 'open-quote' or 'close-quote' is replaced by one of the
@@ -416,7 +416,7 @@ of the source document or the formatting structure.</em>
 before every paragraph of a quote spanning several paragraphs, but
 only the last paragraph ends with a closing quotation mark. In CSS,
 this can be achieved by inserting "phantom" closing quotes. The
-keyword <span class="index-def" title="no-close-quote"><dfn
+keyword <span class="index-def" data-term="no-close-quote"><dfn
 class="value-def"
 id="value-def-no-close-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-close-quote">'no-close-quote'</dfn></span> decrements
 the quoting level, but does not insert a quotation mark.
@@ -437,12 +437,12 @@ blockquote p.last:after { content: close-quote }
 </div>
 
 <p>For symmetry, there is also a <span class="index-def"
-title="no-open-quote"><dfn class="value-def"
+data-term="no-open-quote"><dfn class="value-def"
 id="value-def-no-open-quote" data-dfn-type="value" data-dfn-for="content" data-lt="no-open-quote">'no-open-quote'</dfn></span> keyword,
 which inserts nothing, but increments the quotation depth by one.
 
 
-<h2>Automatic <span class="index-def" title="counters"><span
+<h2>Automatic <span class="index-def" data-term="counters"><span
 id="counters">counters</span></span> and numbering</h2>
 
 <p>Automatic numbering in CSS&nbsp;2 is controlled with two properties,
@@ -564,7 +564,7 @@ LI:before { content: counter(item) ". "; counter-increment: item }
 </pre>
 </div>
 
-<p>The <span class="index-def" title="scope"><dfn>scope</dfn></span>
+<p>The <span class="index-def" data-term="scope"><dfn>scope</dfn></span>
 of a counter starts at the first element in the document that has a
 <span class="propinst-counter-reset">'counter-reset'</span> for that
 counter and includes the element's descendants and its following
@@ -727,7 +727,7 @@ content and, depending on the values of 'list-style-type' and
 that the
 element is a list item.
 
-<P>The <span class="index-def" title="list properties"><dfn>list
+<P>The <span class="index-def" data-term="list properties"><dfn>list
 properties</dfn></span> describe basic visual formatting of lists:
 they allow style sheets to specify the marker type (image, glyph, or
 number), and the marker position with respect to the principal box
@@ -758,11 +758,11 @@ three types of marker: glyphs, numbering systems, and alphabetic
 systems. 
 
 <P>Glyphs are specified with 
-<strong><span class="index-def" title="disc"><dfn class="value-def"
+<strong><span class="index-def" data-term="disc"><dfn class="value-def"
 id="value-def-disc" data-dfn-type="value" data-dfn-for="list-style-type">disc</dfn></span></strong>, 
-<strong><span class="index-def" title="circle"><dfn class="value-def"
+<strong><span class="index-def" data-term="circle"><dfn class="value-def"
 id="value-def-circle" data-dfn-type="value" data-dfn-for="list-style-type">circle</dfn></span></strong>, and 
-<strong><span class="index-def" title="square"><dfn class="value-def"
+<strong><span class="index-def" data-term="square"><dfn class="value-def"
 id="value-def-square" data-dfn-type="value" data-dfn-for="list-style-type">square</dfn></span></strong>. Their exact
 rendering depends on the user agent.
 
@@ -770,23 +770,23 @@ rendering depends on the user agent.
 
 <dl>
 
-<dt><span class="index-def" title="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
+<dt><span class="index-def" data-term="decimal"><dfn class="value-def" id="value-def-decimal" data-dfn-type="value" data-dfn-for="list-style-type"><strong>decimal</strong></dfn></span><dd>Decimal numbers, beginning with 1.
 
-<dt><strong><span class="index-def" title="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="decimal-leading-zero"><dfn class="value-def" id="value-def-decimal-leading-zero" data-dfn-type="value" data-dfn-for="list-style-type">decimal-leading-zero</dfn></span></strong>
 <dd>Decimal numbers padded by initial zeros (e.g., 01, 02, 03, ..., 98, 99).
 
 <!-- should this be included -->
 
-<dt><strong><span class="index-def" title="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="lower-roman"><dfn class="value-def" id="value-def-lower-roman" data-dfn-type="value" data-dfn-for="list-style-type">lower-roman</dfn></span></strong>
 <dd>Lowercase roman numerals (i, ii, iii, iv, v, etc.).
 
-<dt><strong><span class="index-def" title="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="upper-roman"><dfn class="value-def" id="value-def-upper-roman" data-dfn-type="value" data-dfn-for="list-style-type">upper-roman</dfn></span></strong>
 <dd>Uppercase roman numerals (I, II, III, IV, V, etc.).
 
-<dt><strong><span class="index-def" title="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="georgian"><dfn class="value-def" id="value-def-georgian" data-dfn-type="value" data-dfn-for="list-style-type">georgian</dfn></span></strong>
 <dd>Traditional Georgian numbering 
 (an, ban, gan, ..., he, tan, in, in-an, ...).
-<dt><strong><span class="index-def" title="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="armenian"><dfn class="value-def" id="value-def-armenian" data-dfn-type="value" data-dfn-for="list-style-type">armenian</dfn></span></strong>
 <dd>Traditional uppercase Armenian numbering.
 </dl>
 
@@ -794,11 +794,11 @@ rendering depends on the user agent.
 <P>Alphabetic systems are specified with:</P>
 
 <dl>
-<dt><strong><span class="index-def" title="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
+<dt><strong><span class="index-def" data-term="lower-latin"><dfn class="value-def" id="value-def-lower-latin" data-dfn-type="value" data-dfn-for="list-style-type">lower-latin</dfn></span></strong> or <strong>lower-alpha</strong>
 <dd>Lowercase ascii letters (a, b, c, ... z).
-<dt><strong><span class="index-def" title="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
+<dt><strong><span class="index-def" data-term="upper-latin"><dfn class="value-def" id="value-def-upper-latin" data-dfn-type="value" data-dfn-for="list-style-type">upper-latin</dfn></span></strong> or <strong>upper-alpha</strong>
 <dd>Uppercase ascii letters (A, B, C, ... Z).
-<dt><strong><span class="index-def" title="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
+<dt><strong><span class="index-def" data-term="lower-greek"><dfn class="value-def" id="value-def-lower-greek" data-dfn-type="value" data-dfn-for="list-style-type">lower-greek</dfn></span></strong>
 <dd>Lowercase classical Greek 
 alpha, beta, gamma, ... (&#945;, &#946;, &#947;, ...)
 </dl>

--- a/css2/grammar.html
+++ b/css2/grammar.html
@@ -56,7 +56,7 @@ the "class" attribute.
 <h2><span class="secno">G.1</span> <span id="grammar">Grammar</span></h2>
 
 <P> The grammar below is <span id="x0" class="index-inst"
-title="LALR(1)">LALR(1)</span> (but note that most UA's should not use it
+data-term="LALR(1)">LALR(1)</span> (but note that most UA's should not use it
 directly, since it does not express the <a
 href="syndata.html#parsing-errors">parsing conventions</a>, only the
 CSS&nbsp;2 syntax). The format of the productions is optimized for human
@@ -116,7 +116,7 @@ ruleset
   : selector [ ',' S* selector ]*
     '{' S* declaration? [ ';' S* declaration? ]* '}' S*
   ;
-<span id="x1" class="index-inst" title="selector">selector</span>
+<span id="x1" class="index-inst" data-term="selector">selector</span>
   : simple_selector [ combinator selector | S+ [ combinator? selector ]? ]?
   ;
 simple_selector
@@ -155,7 +155,7 @@ function
   : FUNCTION S* expr ')' S*
   ;
 /*
- * There is a constraint on the <span id="x2" class="index-inst" title="color">color</span> that it must
+ * There is a constraint on the <span id="x2" class="index-inst" data-term="color">color</span> that it must
  * have either 3 or 6 hex-digits (i.e., [0-9a-fA-F])
  * after the "#"; e.g., "#000" is OK, but "#abcd" is not.
  */
@@ -167,15 +167,15 @@ hexcolor
 <h2><span class="secno">G.2</span> <span id="scanner">Lexical scanner</span></h2>
 
 <p> The following is the <span id="x3" class="index-def"
-title="tokenizer">tokenizer</span>, written in Flex (see <a href="refs.html#ref-FLEX" class="noxref"><span class="normref">[FLEX]</span></a>)
+data-term="tokenizer">tokenizer</span>, written in Flex (see <a href="refs.html#ref-FLEX" class="noxref"><span class="normref">[FLEX]</span></a>)
 notation. The tokenizer is case-insensitive.
 
 <p>The "\377" represents the highest character
 number that current versions of Flex can deal with (decimal 255). It
 should be read as "\4177777" (decimal 1114111), which is the highest
 possible code point in <span id="x4" class="index-inst"
-title="unicode">Unicode</span>/<span id="x5" class="index-inst"
-title="iso-10646">ISO-10646</span>.
+data-term="unicode">Unicode</span>/<span id="x5" class="index-inst"
+data-term="iso-10646">ISO-10646</span>.
 
 <pre>
 %option case-insensitive

--- a/css2/grammar.src
+++ b/css2/grammar.src
@@ -24,7 +24,7 @@ the "class" attribute.
 <h2><span id="grammar">Grammar</span></h2>
 
 <P> The grammar below is <span class="index-inst"
-title="LALR(1)">LALR(1)</span> (but note that most UA's should not use it
+data-term="LALR(1)">LALR(1)</span> (but note that most UA's should not use it
 directly, since it does not express the <a
 href="syndata.html#parsing-errors">parsing conventions</a>, only the
 CSS&nbsp;2 syntax). The format of the productions is optimized for human
@@ -84,7 +84,7 @@ ruleset
   : selector [ ',' S* selector ]*
     '{' S* declaration? [ ';' S* declaration? ]* '}' S*
   ;
-<span class="index-inst" title="selector">selector</span>
+<span class="index-inst" data-term="selector">selector</span>
   : simple_selector [ combinator selector | S+ [ combinator? selector ]? ]?
   ;
 simple_selector
@@ -123,7 +123,7 @@ function
   : FUNCTION S* expr ')' S*
   ;
 /*
- * There is a constraint on the <span class="index-inst" title="color">color</span> that it must
+ * There is a constraint on the <span class="index-inst" data-term="color">color</span> that it must
  * have either 3 or 6 hex-digits (i.e., [0-9a-fA-F])
  * after the "#"; e.g., "#000" is OK, but "#abcd" is not.
  */
@@ -135,15 +135,15 @@ hexcolor
 <h2><span id="scanner">Lexical scanner</span></h2>
 
 <p> The following is the <span class="index-def"
-title="tokenizer">tokenizer</span>, written in Flex (see [[FLEX]])
+data-term="tokenizer">tokenizer</span>, written in Flex (see [[FLEX]])
 notation. The tokenizer is case-insensitive.
 
 <p>The "\377" represents the highest character
 number that current versions of Flex can deal with (decimal 255). It
 should be read as "\4177777" (decimal 1114111), which is the highest
 possible code point in <span class="index-inst"
-title="unicode">Unicode</span>/<span class="index-inst"
-title="iso-10646">ISO-10646</span>.
+data-term="unicode">Unicode</span>/<span class="index-inst"
+data-term="iso-10646">ISO-10646</span>.
 
 <pre>
 %option case-insensitive

--- a/css2/indexlist.html
+++ b/css2/indexlist.html
@@ -354,7 +354,7 @@
   </ul>
   <li class="tocline0">'interactive media group, <a href="media.html#interactive-media-group" title="'interactive media group" class="index-def"><strong>1</strong></a>
   <li class="tocline0">internal table box, <a href="tables.html#x19" title="internal table box" class="index-def"><strong>1</strong></a>
-  <li class="tocline0">internal table element, <a href="tables.html#x3" title="internal table element" class="index-def"><strong>1</strong></a>
+  <li class="tocline0">internal table element, <a href="tables.html#internal-table-element" title="internal table element" class="index-def"><strong>1</strong></a>
   <li class="tocline0">intrinsic dimensions, <a href="conform.html#intrinsic" title="intrinsic dimensions" class="index-def"><strong>1</strong></a>
   <li class="tocline0">invert, <a href="ui.html#value-def-invert" title="invert" class="index-def"><strong>1</strong></a>
   <li class="tocline0">iso-10646, <a href="grammar.html#x5" title="iso-10646" class="index-inst"><span>1</span></a>
@@ -609,7 +609,7 @@
   <li class="tocline0">table, <a href="tables.html#value-def-table" title="table" class="index-def"><strong>1</strong></a>
   <li class="tocline0">table element, <a href="tables.html#x2" title="table element" class="index-def"><strong>1</strong></a>
   <ul class="index">
-    <li class="tocline0">internal, <a href="tables.html#x3" title="table element, internal" class="index-def"><strong>1</strong></a>
+    <li class="tocline0">internal, <a href="tables.html#internal-table-element" title="table element, internal" class="index-def"><strong>1</strong></a>
   </ul>
   <li class="tocline0">table-caption, <a href="tables.html#value-def-table-caption" title="table-caption" class="index-def"><strong>1</strong></a>
   <li class="tocline0">table-cell, <a href="tables.html#value-def-table-cell" title="table-cell" class="index-def"><strong>1</strong></a>

--- a/css2/intro.html
+++ b/css2/intro.html
@@ -333,7 +333,7 @@ type</a>. For example, if the target medium is the screen, user agents
 apply the <a href="visuren.html">visual formatting model</a>. 
 
 <li>From the annotated document tree, generate a 
-<span class="index-def" title="formatting structure">
+<span class="index-def" data-term="formatting structure">
 <span id="formatting-structure"><dfn>formatting
 structure</dfn></span></span>.  Often, the formatting structure closely
 resembles the document tree, but it may also differ significantly,
@@ -361,7 +361,7 @@ etc.).
 
 <h3><span class="secno">2.3.1</span> <span id="the-canvas">The canvas</span></h3>
 
-<P>For all media, the term <span class="index-def" title="canvas"> <span
+<P>For all media, the term <span class="index-def" data-term="canvas"> <span
 id="canvas"><dfn>canvas</dfn></span></span> describes "the space where
 the formatting structure is rendered."  The canvas is infinite for each
 dimension of the space, but rendering generally occurs within

--- a/css2/intro.src
+++ b/css2/intro.src
@@ -297,7 +297,7 @@ type</a>. For example, if the target medium is the screen, user agents
 apply the <a href="visuren.html">visual formatting model</a>. 
 
 <li>From the annotated document tree, generate a 
-<span class="index-def" title="formatting structure">
+<span class="index-def" data-term="formatting structure">
 <span id="formatting-structure"><dfn>formatting
 structure</dfn></span></span>.  Often, the formatting structure closely
 resembles the document tree, but it may also differ significantly,
@@ -325,7 +325,7 @@ etc.).
 
 <h3><span id="the-canvas">The canvas</span></h3>
 
-<P>For all media, the term <span class="index-def" title="canvas"> <span
+<P>For all media, the term <span class="index-def" data-term="canvas"> <span
 id="canvas"><dfn>canvas</dfn></span></span> describes "the space where
 the formatting structure is rendered."  The canvas is infinite for each
 dimension of the space, but rendering generally occurs within

--- a/css2/media.html
+++ b/css2/media.html
@@ -72,8 +72,8 @@ style sheets:</p>
 <UL>
 
 <LI>Specify the target medium from a style sheet with the <span id="x0"
-	    class="index-inst" title="@media">@media</span> or <span id="x1"
-	    class="index-inst" title="@import">@import</span> at-rules.
+	    class="index-inst" data-term="@media">@media</span> or <span id="x1"
+	    class="index-inst" data-term="@import">@import</span> at-rules.
 
 <div class="example"><P style="display:none">Example(s):</P>
 <PRE>
@@ -112,7 +112,7 @@ the <a href="cascade.html">chapter on the cascade</a>.
 
 <H3><span class="secno">7.2.1</span> <span id="at-media-rule">The @media rule</span></H3> 
 
-<P>An <span id="x2" class="index-def" title="media">@media</span> rule
+<P>An <span id="x2" class="index-def" data-term="media">@media</span> rule
 specifies the target <a href="#media-types">media types</a> (separated
 by commas) of a set of <a
 href="syndata.html#tokenization">statements</a> (delimited by curly
@@ -120,7 +120,7 @@ braces). Invalid statements must be ignored per <a
 href="syndata.html#rule-sets">4.1.7 "Rule sets, declaration blocks,
 and selectors"</a> and <a href="syndata.html#parsing-errors">4.2
 "Rules for handling parsing errors."</a> The <span id="x3"
-class="index-inst" title="@media">@media</span> construct allows style
+class="index-inst" data-term="@media">@media</span> construct allows style
 sheet rules for various media in the same style sheet:</P>
 
 <pre class="example">
@@ -243,46 +243,46 @@ by a CSS specification.
 <P>Each CSS property definition specifies which media types the
 property applies to. Since properties generally apply to several media
 types, the "Applies to media" section of each property definition
-lists <span id="x4" class="index-def" title="media group">media groups</span>
+lists <span id="x4" class="index-def" data-term="media group">media groups</span>
 rather than individual media types. Each property applies to all media
 types in the media groups listed in its definition.
 
 <P>CSS&nbsp;2 defines the following media groups: </P>
 <ul>
 <li>
-<span class="index-def" title="'continuous' media group"><span
+<span class="index-def" data-term="'continuous' media group"><span
 id="continuous-media-group"><strong>continuous</strong></span></span>
-or <span class="index-def" title="'paged' media group"><span
+or <span class="index-def" data-term="'paged' media group"><span
 id="paged-media-group"><strong>paged</strong></span></span>.
 
 <li><span
-class="index-def" title="'visual' media group"><span
+class="index-def" data-term="'visual' media group"><span
 id="visual-media-group"> <strong>visual</strong></span>,</span> 
-<span class="index-def" title="'audio' media group"><span
+<span class="index-def" data-term="'audio' media group"><span
 id="audio-media-group"><strong>audio</strong></span>,</span> 
-<span class="index-def" title="'speech' media group"><span
+<span class="index-def" data-term="'speech' media group"><span
 id="speech-media-group"><strong>speech</strong></span>,</span> 
 or <span
-class="index-def" title="'tactile' media group"><span
+class="index-def" data-term="'tactile' media group"><span
 id="tactile-media-group"><strong>tactile</strong></span></span>.
 <li><span
-class="index-def" title="'grid' media group"><span
+class="index-def" data-term="'grid' media group"><span
 id="grid-media-group"><strong>grid</strong></span></span> (for
 character grid devices), or
 <span
-class="index-def" title="'bitmap' media group"><span
+class="index-def" data-term="'bitmap' media group"><span
 id="bitmap-media-group"><strong>bitmap</strong></span></span>.
 
 <li><span
-class="index-def" title="'interactive media group"><span
+class="index-def" data-term="'interactive media group"><span
 id="interactive-media-group"><strong>interactive</strong></span></span> (for
 devices that allow user interaction), or
 <span
-class="index-def" title="'static' media group"><span
+class="index-def" data-term="'static' media group"><span
 id="static-media-group"><strong>static</strong></span></span> (for
 those that do not).
 
-<li><span class="index-def" title="'all'
+<li><span class="index-def" data-term="'all'
 media group"> <span id="all-media-group"><strong>all</strong></span></span>
 (includes all media types)
 </ul>

--- a/css2/media.src
+++ b/css2/media.src
@@ -35,8 +35,8 @@ style sheets:</p>
 <UL>
 
 <LI>Specify the target medium from a style sheet with the <span
-	    class="index-inst" title="@media">@media</span> or <span
-	    class="index-inst" title="@import">@import</span> at-rules.
+	    class="index-inst" data-term="@media">@media</span> or <span
+	    class="index-inst" data-term="@import">@import</span> at-rules.
 
 <div class="example">
 <PRE>
@@ -75,7 +75,7 @@ the <a href="cascade.html">chapter on the cascade</a>.
 
 <H3><span id="at-media-rule">The @media rule</span></H3> 
 
-<P>An <span class="index-def" title="media">@media</span> rule
+<P>An <span class="index-def" data-term="media">@media</span> rule
 specifies the target <a href="#media-types">media types</a> (separated
 by commas) of a set of <a
 href="syndata.html#tokenization">statements</a> (delimited by curly
@@ -83,7 +83,7 @@ braces). Invalid statements must be ignored per <a
 href="syndata.html#rule-sets">4.1.7 "Rule sets, declaration blocks,
 and selectors"</a> and <a href="syndata.html#parsing-errors">4.2
 "Rules for handling parsing errors."</a> The <span
-class="index-inst" title="@media">@media</span> construct allows style
+class="index-inst" data-term="@media">@media</span> construct allows style
 sheet rules for various media in the same style sheet:</P>
 
 <pre class="example">
@@ -111,7 +111,7 @@ line in each property is likewise informative. We expect profiles to
 eventually define what properties apply where. Also explain this in
 1.3.2.]
 
-<P>A CSS <span class="index-def" title="media type"><dfn>media
+<P>A CSS <span class="index-def" data-term="media type"><dfn>media
 type</dfn></span> names a set of CSS properties.  A user agent that
 claims to support a media type by name must implement all of the
 properties that apply to that media type.
@@ -222,46 +222,46 @@ by a CSS specification.
 <P>Each CSS property definition specifies which media types the
 property applies to. Since properties generally apply to several media
 types, the "Applies to media" section of each property definition
-lists <span class="index-def" title="media group">media groups</span>
+lists <span class="index-def" data-term="media group">media groups</span>
 rather than individual media types. Each property applies to all media
 types in the media groups listed in its definition.
 
 <P>CSS&nbsp;2 defines the following media groups: </P>
 <ul>
 <li>
-<span class="index-def" title="'continuous' media group"><span
+<span class="index-def" data-term="'continuous' media group"><span
 id="continuous-media-group"><strong>continuous</strong></span></span>
-or <span class="index-def" title="'paged' media group"><span
+or <span class="index-def" data-term="'paged' media group"><span
 id="paged-media-group"><strong>paged</strong></span></span>.
 
 <li><span
-class="index-def" title="'visual' media group"><span
+class="index-def" data-term="'visual' media group"><span
 id="visual-media-group"> <strong>visual</strong></span>,</span> 
-<span class="index-def" title="'audio' media group"><span
+<span class="index-def" data-term="'audio' media group"><span
 id="audio-media-group"><strong>audio</strong></span>,</span> 
-<span class="index-def" title="'speech' media group"><span
+<span class="index-def" data-term="'speech' media group"><span
 id="speech-media-group"><strong>speech</strong></span>,</span> 
 or <span
-class="index-def" title="'tactile' media group"><span
+class="index-def" data-term="'tactile' media group"><span
 id="tactile-media-group"><strong>tactile</strong></span></span>.
 <li><span
-class="index-def" title="'grid' media group"><span
+class="index-def" data-term="'grid' media group"><span
 id="grid-media-group"><strong>grid</strong></span></span> (for
 character grid devices), or
 <span
-class="index-def" title="'bitmap' media group"><span
+class="index-def" data-term="'bitmap' media group"><span
 id="bitmap-media-group"><strong>bitmap</strong></span></span>.
 
 <li><span
-class="index-def" title="'interactive media group"><span
+class="index-def" data-term="'interactive media group"><span
 id="interactive-media-group"><strong>interactive</strong></span></span> (for
 devices that allow user interaction), or
 <span
-class="index-def" title="'static' media group"><span
+class="index-def" data-term="'static' media group"><span
 id="static-media-group"><strong>static</strong></span></span> (for
 those that do not).
 
-<li><span class="index-def" title="'all'
+<li><span class="index-def" data-term="'all'
 media group"> <span id="all-media-group"><strong>all</strong></span></span>
 (includes all media types)
 </ul>

--- a/css2/page.html
+++ b/css2/page.html
@@ -302,7 +302,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-before'"><span id="propdef-page-break-before" class="propdef-title"><strong>'page-break-before'</strong></span></span>
+<span class="index-def" title="'page-break-before'"><dfn id="propdef-page-break-before" class="propdef-title" data-dfn-type="property" data-lt="page-break-before"><strong>'page-break-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | always | avoid | left | right | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -319,7 +319,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-after'"><span id="propdef-page-break-after" class="propdef-title"><strong>'page-break-after'</strong></span></span>
+<span class="index-def" title="'page-break-after'"><dfn id="propdef-page-break-after" class="propdef-title" data-dfn-type="property" data-lt="page-break-after"><strong>'page-break-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | always | avoid | left | right | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -336,7 +336,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-inside'"><span id="propdef-page-break-inside" class="propdef-title"><strong>'page-break-inside'</strong></span></span>
+<span class="index-def" title="'page-break-inside'"><dfn id="propdef-page-break-inside" class="propdef-title" data-dfn-type="property" data-lt="page-break-inside"><strong>'page-break-inside'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>avoid | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -401,7 +401,7 @@ class="propinst-widows">'widows'</span></a></h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'orphans'"><span id="propdef-orphans" class="propdef-title"><strong>'orphans'</strong></span></span>
+<span class="index-def" title="'orphans'"><dfn id="propdef-orphans" class="propdef-title" data-dfn-type="property" data-lt="orphans"><strong>'orphans'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -418,7 +418,7 @@ class="propinst-widows">'widows'</span></a></h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'widows'"><span id="propdef-widows" class="propdef-title"><strong>'widows'</strong></span></span>
+<span class="index-def" title="'widows'"><dfn id="propdef-widows" class="propdef-title" data-dfn-type="property" data-lt="widows"><strong>'widows'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/page.html
+++ b/css2/page.html
@@ -64,7 +64,7 @@ on <a href="#page-box">page boxes</a>, and how <a href="#page-breaks">page break
 
 <p>The user agent is responsible for transferring the page boxes of a
 document onto the real <span id="x0" class="index-def"
-title="sheet"><dfn>sheets</dfn></span> where the document will
+data-term="sheet"><dfn>sheets</dfn></span> where the document will
 ultimately be rendered (paper, transparency, screen, etc.). There is
 often a 1-to-1 relationship between a page box and a sheet, but this
 is not always the case. Transfer possibilities include:</P>
@@ -85,12 +85,12 @@ proper sequence.
 
 <h2><span class="secno">13.2</span> <span id="page-box">Page boxes</span>: the @page rule</h2>
 
-<p>The <span id="x1" class="index-def" title="page box"><dfn>page
+<p>The <span id="x1" class="index-def" data-term="page box"><dfn>page
 box</dfn></span> is a rectangular region that contains two areas:</p>
 
 <ul>
 
-<li>The <span class="index-def" title="page area"><span
+<li>The <span class="index-def" data-term="page area"><span
 id="page-area"><dfn>page area</dfn></span></span>. The page area
 includes the boxes laid out on that page. The edges of the first page
 area establish the rectangle that is the initial <a
@@ -106,21 +106,21 @@ The page margin area is transparent.
 <p>The size of a page box cannot be specified in CSS&nbsp;2.
 
 <P>Authors can specify the margins of a page box inside an <span id="x3"
-class="index-def" title="@page">@page</span> rule. An @page rule
+class="index-def" data-term="@page">@page</span> rule. An @page rule
 consists of the keyword "@page", followed by an optional page
 selector, followed by a block containing declarations and
 at-rules. Comments and white space are allowed, but optional, between
 the @page token and the page selector and between the page selector
 and the block. The declarations in an
 @page rule are said to be in the <span class="index-def"
-title="page-context"><span id="page-context"><dfn>page
+data-term="page-context"><span id="page-context"><dfn>page
 context</dfn></span></span>.</p>
 
 <p class=note>Note: CSS level&nbsp;2 has no at-rules that may appear
 inside @page, but such at-rules are expected to be defined in
 level&nbsp;3.
 
-<P>The <span id="x5" class="index-def" title="page selector"><dfn>page
+<P>The <span id="x5" class="index-def" data-term="page selector"><dfn>page
 selector</dfn></span> specifies for which pages the declarations
 apply. In CSS&nbsp;2, page selectors may designate the first page,
 all left pages, or all right pages</p>
@@ -190,8 +190,8 @@ expressed through two CSS pseudo-classes that may be used in page selectors.
 
 <P>All pages are automatically classified by user agents into either
 the <span id="x6" class="index-def"
-title=":left|pseudo-class:::left">:left</span> or <span id="x8"
-class="index-def" title=":right|pseudo-class:::right">:right</span>
+data-term=":left|pseudo-class:::left">:left</span> or <span id="x8"
+class="index-def" data-term=":right|pseudo-class:::right">:right</span>
 pseudo-class.
 Whether the first page of a document is :left or :right depends on the
 major writing direction of the root element. For example, the first
@@ -223,7 +223,7 @@ printer that only prints single-sided).
 
 <P>Authors may also specify style for the first page of a document
 with the <span id="x10" class="index-def"
-title=":first|pseudo-class:::first">:first</span> pseudo-class:
+data-term=":first|pseudo-class:::first">:first</span> pseudo-class:
 
 <div class="example"><P style="display:none">Example(s):</P><P>
 <PRE>
@@ -302,7 +302,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-before'"><dfn id="propdef-page-break-before" class="propdef-title" data-dfn-type="property" data-lt="page-break-before"><strong>'page-break-before'</strong></dfn></span>
+<span class="index-def" data-term="'page-break-before'"><dfn id="propdef-page-break-before" class="propdef-title" data-dfn-type="property" data-lt="page-break-before"><strong>'page-break-before'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | always | avoid | left | right | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -319,7 +319,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-after'"><dfn id="propdef-page-break-after" class="propdef-title" data-dfn-type="property" data-lt="page-break-after"><strong>'page-break-after'</strong></dfn></span>
+<span class="index-def" data-term="'page-break-after'"><dfn id="propdef-page-break-after" class="propdef-title" data-dfn-type="property" data-lt="page-break-after"><strong>'page-break-after'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | always | avoid | left | right | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -336,7 +336,7 @@ class="propinst-page-break-before">'page-break-before'</span></a>,
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'page-break-inside'"><dfn id="propdef-page-break-inside" class="propdef-title" data-dfn-type="property" data-lt="page-break-inside"><strong>'page-break-inside'</strong></dfn></span>
+<span class="index-def" data-term="'page-break-inside'"><dfn id="propdef-page-break-inside" class="propdef-title" data-dfn-type="property" data-lt="page-break-inside"><strong>'page-break-inside'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>avoid | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -401,7 +401,7 @@ class="propinst-widows">'widows'</span></a></h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'orphans'"><dfn id="propdef-orphans" class="propdef-title" data-dfn-type="property" data-lt="orphans"><strong>'orphans'</strong></dfn></span>
+<span class="index-def" data-term="'orphans'"><dfn id="propdef-orphans" class="propdef-title" data-dfn-type="property" data-lt="orphans"><strong>'orphans'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -418,7 +418,7 @@ class="propinst-widows">'widows'</span></a></h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'widows'"><dfn id="propdef-widows" class="propdef-title" data-dfn-type="property" data-lt="widows"><strong>'widows'</strong></dfn></span>
+<span class="index-def" data-term="'widows'"><dfn id="propdef-widows" class="propdef-title" data-dfn-type="property" data-lt="widows"><strong>'widows'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/page.src
+++ b/css2/page.src
@@ -20,7 +20,7 @@ on <a href="#page-box">page boxes</a>, and how <a href="#page-breaks">page break
 
 <p>The user agent is responsible for transferring the page boxes of a
 document onto the real <span class="index-def"
-title="sheet"><dfn>sheets</dfn></span> where the document will
+data-term="sheet"><dfn>sheets</dfn></span> where the document will
 ultimately be rendered (paper, transparency, screen, etc.). There is
 often a 1-to-1 relationship between a page box and a sheet, but this
 is not always the case. Transfer possibilities include:</P>
@@ -41,12 +41,12 @@ proper sequence.
 
 <h2><span id="page-box">Page boxes</span>: the @page rule</h2>
 
-<p>The <span class="index-def" title="page box"><dfn>page
+<p>The <span class="index-def" data-term="page box"><dfn>page
 box</dfn></span> is a rectangular region that contains two areas:</p>
 
 <ul>
 
-<li>The <span class="index-def" title="page area"><span
+<li>The <span class="index-def" data-term="page area"><span
 id="page-area"><dfn>page area</dfn></span></span>. The page area
 includes the boxes laid out on that page. The edges of the first page
 area establish the rectangle that is the initial <a
@@ -62,21 +62,21 @@ The page margin area is transparent.
 <p>The size of a page box cannot be specified in CSS&nbsp;2.
 
 <P>Authors can specify the margins of a page box inside an <span
-class="index-def" title="@page">@page</span> rule. An @page rule
+class="index-def" data-term="@page">@page</span> rule. An @page rule
 consists of the keyword "@page", followed by an optional page
 selector, followed by a block containing declarations and
 at-rules. Comments and white space are allowed, but optional, between
 the @page token and the page selector and between the page selector
 and the block. The declarations in an
 @page rule are said to be in the <span class="index-def"
-title="page-context"><span id="page-context"><dfn>page
+data-term="page-context"><span id="page-context"><dfn>page
 context</dfn></span></span>.</p>
 
 <p class=note>Note: CSS level&nbsp;2 has no at-rules that may appear
 inside @page, but such at-rules are expected to be defined in
 level&nbsp;3.
 
-<P>The <span class="index-def" title="page selector"><dfn>page
+<P>The <span class="index-def" data-term="page selector"><dfn>page
 selector</dfn></span> specifies for which pages the declarations
 apply. In CSS&nbsp;2, page selectors may designate the first page,
 all left pages, or all right pages</p>
@@ -150,8 +150,8 @@ expressed through two CSS pseudo-classes that may be used in page selectors.
 
 <P>All pages are automatically classified by user agents into either
 the <span class="index-def"
-title=":left|pseudo-class:::left">:left</span> or <span
-class="index-def" title=":right|pseudo-class:::right">:right</span>
+data-term=":left|pseudo-class:::left">:left</span> or <span
+class="index-def" data-term=":right|pseudo-class:::right">:right</span>
 pseudo-class.
 Whether the first page of a document is :left or :right depends on the
 major writing direction of the root element. For example, the first
@@ -183,7 +183,7 @@ printer that only prints single-sided).
 
 <P>Authors may also specify style for the first page of a document
 with the <span class="index-def"
-title=":first|pseudo-class:::first">:first</span> pseudo-class:
+data-term=":first|pseudo-class:::first">:first</span> pseudo-class:
 
 <div class="example"><P>
 <PRE>

--- a/css2/selector.html
+++ b/css2/selector.html
@@ -72,10 +72,10 @@
 <p>In CSS, pattern matching rules determine which style rules apply to
 elements in the <a href="conform.html#doctree">document
 tree</a>. These patterns, called <span id="x0" class="index-inst"
-title="selector">selectors,</span> may range from simple element names
+data-term="selector">selectors,</span> may range from simple element names
 to rich contextual patterns. If all conditions in the pattern are true
 for a certain element, the selector <span id="x1" class="index-def"
-title="match|selector::match"><dfn>matches</dfn></span> the element.
+data-term="match|selector::match"><dfn>matches</dfn></span> the element.
 
 <P>The case-sensitivity of document language element names in
 selectors depends on the document language. For example, in HTML,
@@ -140,7 +140,7 @@ equal to "myid".<TD><a href="#id-selectors">ID selectors</a></TR>
 
 <h2><span class="secno">5.2</span> <span id="selector-syntax">Selector syntax</span></h2>
 
-<P>A <span class="index-def" title="simple selector"><span
+<P>A <span class="index-def" data-term="simple selector"><span
 id="simple-selector"><dfn>simple selector</dfn></span></span> is either
 a <a href="#type-selectors">type selector</a> or <a
 href="#universal-selector">universal selector</a> followed immediately
@@ -155,15 +155,15 @@ refers to a smaller part of a selector in CSS3 than in CSS&nbsp;2.
 See the CSS3 Selectors module <a href="refs.html#ref-CSS3SEL" class="noxref"><span class="informref">[SELECTORS-3]</span></a>.
 
 <P>A <span id="x4" class="index-def"
-title="selector"><dfn>selector</dfn></span> is a chain of one or more
+data-term="selector"><dfn>selector</dfn></span> is a chain of one or more
 simple selectors separated by combinators.  <span class="index-def"
-title="combinator"><span
+data-term="combinator"><span
 id="combinator"><dfn>Combinators</dfn></span></span> are: white space,
 "&gt;", and "+". White space may appear between a combinator and the
 simple selectors around it.
 
 <P>The elements of the document tree that match a selector are called
-<span class="index-def" title="subject (of selector)|selector::subject
+<span class="index-def" data-term="subject (of selector)|selector::subject
 of"><span id="subject"><dfn>subjects</dfn></span></span> of the selector.
 A selector consisting of a single simple selector matches any element
 satisfying its requirements.  Prepending a simple selector and
@@ -198,14 +198,14 @@ h1, h2, h3 { font-family: sans-serif }
 </div>
 
 <P>CSS offers other "shorthand" mechanisms as well, including 
-<span id="x8" class="index-def" title="multiple declarations">
+<span id="x8" class="index-def" data-term="multiple declarations">
 <a href="syndata.html#declaration">multiple declarations</a></span>
-and <span id="x9" class="index-inst" title="shorthand property"><a
+and <span id="x9" class="index-inst" data-term="shorthand property"><a
 href="about.html#shorthand">shorthand properties</a></span>.
 
 <h2><span class="secno">5.3</span> <span id="universal-selector">Universal selector</span></h2>
 
-<P>The <span id="x10" class="index-def" title="universal selector">universal
+<P>The <span id="x10" class="index-def" data-term="universal selector">universal
 selector</span>, written "*", matches the name of any element
 type. It matches any single element in the <a
 href="conform.html#doctree">document tree.</a>
@@ -223,7 +223,7 @@ omitted. For example:</P>
 
 <h2><span class="secno">5.4</span> <span id="type-selectors">Type selectors</span></h2>
 
-<p>A <span id="x11" class="index-def" title="type selector"><em>type
+<p>A <span id="x11" class="index-def" data-term="type selector"><em>type
 selector</em></span> matches the name of a document language element
 type. A type selector matches every instance of the element type in
 the document tree.
@@ -242,7 +242,7 @@ h1 { font-family: sans-serif }
 <p>At times, authors may want selectors to match an element that is
 the descendant of another element in the document tree (e.g., "Match
 those EM elements that are contained by an H1 element").  <span id="x12"
-class="index-def" title="descendant-selectors">Descendant
+class="index-def" data-term="descendant-selectors">Descendant
 selectors</span> express such a relationship in a pattern. A
 descendant selector is made up of two or more selectors separated by
 <a href="syndata.html#whitespace">white space</a>. A descendant
@@ -311,7 +311,7 @@ div p *[href]
 
 <h2><span class="secno">5.6</span> <span id="child-selectors">Child selectors</span></h2>
 
-<p>A <span id="x13" class="index-def" title="child selector"><em>child
+<p>A <span id="x13" class="index-def" data-term="child selector"><em>child
 selector</em></span> matches when an element is the <a
 href="conform.html#doctree">child</a> of some element. A child
 selector is made up of two or more selectors separated by "&gt;".
@@ -389,22 +389,22 @@ in the source document.
 <dt><code>[att]</code>
 <dd>Match when the element sets the "att" attribute, whatever
 the value of the attribute.
-<dt><span id="x14" class="index-def" title="exact
+<dt><span id="x14" class="index-def" data-term="exact
 matching|="><code>[att=val]</code></span>
 <dd>Match when the element's "att" attribute value is exactly "val".
-<dt><span id="x16" class="index-def" title="space-separated
+<dt><span id="x16" class="index-def" data-term="space-separated
 matching|~="><code>[att~=val]</code></span>
 <dd>Represents an element with the <code>att</code> attribute whose
 value is a white space-separated list of words, one of which is exactly
 "val". If "val" contains white space, it will never represent anything
 (since the words are <em>separated</em> by spaces).
 If "val" is the empty string, it will never represent anything either.
-<dt><span id="x18" class="index-def" title="hyphen-separated
+<dt><span id="x18" class="index-def" data-term="hyphen-separated
 matching|&#124;="><code>[att|=val]</code></span>
 <dd>Represents an element with the <code>att</code> attribute, its
 value either being exactly "val" or beginning with "val" immediately
 followed by "-" (U+002D). This is primarily intended to allow <span id="x20"
-class="index-inst" title="language code">language subcode</span>
+class="index-inst" data-term="language code">language subcode</span>
 matches (e.g., the <code>hreflang</code> attribute on the
 <code>a</code> element in HTML) as described in BCP&nbsp;47
 (<a href="refs.html#ref-BCP47" class="noxref"><span class="informref">[BCP47]</span></a>) or its successor. For <code>lang</code> (or
@@ -497,7 +497,7 @@ DIALOGUE[character=juliet]
 
 <P>Matching takes place on attribute values in the document tree.
 Default attribute values may be defined in a <span id="x21" class="index-inst"
-title="DTD">DTD</span> or elsewhere, but cannot always be selected by
+data-term="DTD">DTD</span> or elsewhere, but cannot always be selected by
 attribute selectors. Style sheets should be designed so that they work
 even if the default values are not included in the document tree.
 
@@ -736,9 +736,9 @@ href="conform.html#doctree">document tree</a>. For instance, in HTML
 paragraph, and therefore no simple CSS selector may refer to it.</p>
 
 <p>CSS introduces the concepts of <span id="x22" class="index-def"
-title="pseudo-elements"><dfn>pseudo-elements</dfn></span> and <span id="x23"
+data-term="pseudo-elements"><dfn>pseudo-elements</dfn></span> and <span id="x23"
 class="index-def"
-title="pseudo-classes"><dfn>pseudo-classes</dfn></span> to permit
+data-term="pseudo-classes"><dfn>pseudo-classes</dfn></span> to permit
 formatting based on information that lies outside the document
 tree. </p>
 
@@ -786,7 +786,7 @@ order</A> determines the outcome.
 <h3><span class="secno">5.11.1</span> <span id="first-child">:first-child</span> pseudo-class</h3>
 
 <P>The <span id="x24" class="index-def"
-title="first-child|:first-child">:first-child</span> pseudo-class
+data-term="first-child|:first-child">:first-child</span> pseudo-class
 matches an element that is the first child element of some other element.
 
 <div class="example"><P style="display:none">Example(s):</P><P>
@@ -853,9 +853,9 @@ a:first-child       /* Same */
 
 
 <h3><span class="secno">5.11.2</span> <span id="link-pseudo-classes">The link pseudo-classes</span>: <span id="x26"
-class="index-def" title="pseudo-classes:::link|:link|link
+class="index-def" data-term="pseudo-classes:::link|:link|link
 (pseudo-class)">:link</span> and <span id="x29" class="index-def"
-title="pseudo-classes:::visited|:visited|visited
+data-term="pseudo-classes:::visited|:visited|visited
 (pseudo-class)">:visited</span></h3>
 
 <p>User agents commonly display unvisited links differently from
@@ -911,11 +911,11 @@ and unvisited links differently. See <a href="refs.html#ref-P3P" class="noxref">
 about handling privacy.
 
 <h3><span class="secno">5.11.3</span> <span id="dynamic-pseudo-classes">The dynamic pseudo-classes:</span>
-<span id="x32" class="index-def" title="pseudo-classes:::hover|:hover|hover
+<span id="x32" class="index-def" data-term="pseudo-classes:::hover|:hover|hover
 (pseudo-class)">:hover</span>, <span id="x35" class="index-def"
-title="pseudo-classes:::active|:active|active
+data-term="pseudo-classes:::active|:active|active
 (pseudo-class)">:active</span>, and <span id="x38" class="index-def"
-title="pseudo-classes:::focus|:focus|focus
+data-term="pseudo-classes:::focus|:focus|focus
 (pseudo-class)">:focus</span></h3>
 
 <p>Interactive user agents sometimes change the rendering in response
@@ -1013,11 +1013,11 @@ links.</em>
 </div>
 
 <h3><span class="secno">5.11.4</span> <span id="lang">The language pseudo-class:</span> <span id="x41"
-class="index-def" title="pseudo-classes:::lang|:lang|lang
+class="index-def" data-term="pseudo-classes:::lang|:lang|lang
 (pseudo-class)">:lang</span></h3>
 
 <p>If the document language specifies how the <span id="x44" class="index-inst"
-title="language (human)">human language</span> of an element is
+data-term="language (human)">human language</span> of an element is
 determined, it is possible to write selectors in CSS that match an
 element based on its language. For example, in HTML <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]</span></a>, the
 language is determined by a combination of the "lang" attribute, the
@@ -1084,7 +1084,7 @@ exact rendering of ':first-line' and ':first-letter' in all cases. A
 future level of CSS may define them more precisely.</em>
 
 <h3><span class="secno">5.12.1</span> The <span class="index-def"
-title="pseudo-elements:::first-line|:first-line|first-line"><span
+data-term="pseudo-elements:::first-line|:first-line|first-line"><span
 id="first-line-pseudo">:first-line</span></span> pseudo-element</h3>
 
 <p>The :first-line pseudo-element applies special styles to the
@@ -1125,7 +1125,7 @@ ordinary lines in the paragraph.
 </pre>
 
 <p>might be "rewritten" by user agents to include the <em><span id="x48"
-class="index-def" title="fictional tag sequence">fictional tag
+class="index-def" data-term="fictional tag sequence">fictional tag
 sequence</span></em> for :first-line. This fictional tag sequence helps
 to show how properties are inherited.
 
@@ -1167,7 +1167,7 @@ paragraph.&lt;/P&gt;
 </pre>
 
 <p> The <span id="x49" class="index-inst"
-title="pseudo-elements:::first-line">:first-line</span> pseudo-element
+data-term="pseudo-elements:::first-line">:first-line</span> pseudo-element
 can only be attached to a <a href="visuren.html#block-boxes">block
 container element.</a>
 
@@ -1227,13 +1227,13 @@ class="propinst-line-height">'line-height'</span></a>. UAs may apply
 other properties as well.</p>
 
 
-<h3><span class="secno">5.12.2</span> <span id="first-letter">The</span> <span id="x50" class="index-def" title="pseudo-elements:::first-letter|:first-letter|first-letter">:first-letter</span> pseudo-element</h3>
+<h3><span class="secno">5.12.2</span> <span id="first-letter">The</span> <span id="x50" class="index-def" data-term="pseudo-elements:::first-letter|:first-letter|first-letter">:first-letter</span> pseudo-element</h3>
 
 <p>The :first-letter pseudo-element must select the first letter of
 the first line of a block, if it is not preceded by any other content
 (such as images or inline tables) on its line. The :first-letter
-pseudo-element may be used for <span id="x53" class="index-inst" title="initial
-caps">"initial caps"</span> and <span id="x54" class="index-inst" title="drop
+pseudo-element may be used for <span id="x53" class="index-inst" data-term="initial
+caps">"initial caps"</span> and <span id="x54" class="index-inst" data-term="drop
 caps">"drop caps"</span>, which are common typographical effects. This
 type of initial letter is similar to an inline-level element if its
 <a href="visuren.html#propdef-float" class="noxref"><span class="propinst-float">'float'</span></a> property is 'none',
@@ -1311,7 +1311,7 @@ En dagelix geschrey de bange stad ontzet.
 <P><img src="./images/first-letter.png" alt="Image illustrating the combined effect of the :first-letter and :first-line pseudo-elements"><SPAN class="dlink">&nbsp;&nbsp;&nbsp;<A id="img-first-letter" href="images/longdesc/first-letter-desc.html" title="Long description for drop cap example">[D]</A></SPAN></p>
 </div>
 
-<p>The <span id="x55" class="index-inst" title="fictional tag
+<p>The <span id="x55" class="index-inst" data-term="fictional tag
 sequence">fictional tag sequence</span> is:</p>
 
 <pre>
@@ -1426,7 +1426,7 @@ p:first-line { color: blue }
 </pre>
 
 <p>Assuming that a line break will occur before the word "ends", the
-<span id="x56" class="index-inst" title="fictional tag sequence">fictional tag
+<span id="x56" class="index-inst" data-term="fictional tag sequence">fictional tag
 sequence</span> for this fragment might be:</p>
 
 <pre>
@@ -1447,8 +1447,8 @@ element.  Properties set on :first-line are inherited by
 </div>
 
 <h3><span class="secno">5.12.3</span> <span id="before-and-after">The</span> <span id="x57" class="index-def"
-title="pseudo-elements:::before|:before">:before</span> and <span id="x59"
-class="index-def" title="pseudo-elements:::after|:after">:after</span>
+data-term="pseudo-elements:::before|:before">:before</span> and <span id="x59"
+class="index-def" data-term="pseudo-elements:::after|:after">:after</span>
 pseudo-elements</h3>
 
 <p>The ':before' and ':after' pseudo-elements can be used to insert

--- a/css2/selector.src
+++ b/css2/selector.src
@@ -13,10 +13,10 @@
 <p>In CSS, pattern matching rules determine which style rules apply to
 elements in the <a href="conform.html#doctree">document
 tree</a>. These patterns, called <span class="index-inst"
-title="selector">selectors,</span> may range from simple element names
+data-term="selector">selectors,</span> may range from simple element names
 to rich contextual patterns. If all conditions in the pattern are true
 for a certain element, the selector <span class="index-def"
-title="match|selector::match"><dfn>matches</dfn></span> the element.
+data-term="match|selector::match"><dfn>matches</dfn></span> the element.
 
 <P>The case-sensitivity of document language element names in
 selectors depends on the document language. For example, in HTML,
@@ -81,7 +81,7 @@ equal to "myid".<TD><a href="#id-selectors">ID selectors</a></TR>
 
 <h2><span id="selector-syntax">Selector syntax</span></h2>
 
-<P>A <span class="index-def" title="simple selector"><span
+<P>A <span class="index-def" data-term="simple selector"><span
 id="simple-selector"><dfn>simple selector</dfn></span></span> is either
 a <a href="#type-selectors">type selector</a> or <a
 href="#universal-selector">universal selector</a> followed immediately
@@ -96,15 +96,15 @@ refers to a smaller part of a selector in CSS3 than in CSS&nbsp;2.
 See the CSS3 Selectors module [[-SELECTORS-3]].
 
 <P>A <span class="index-def"
-title="selector"><dfn>selector</dfn></span> is a chain of one or more
+data-term="selector"><dfn>selector</dfn></span> is a chain of one or more
 simple selectors separated by combinators.  <span class="index-def"
-title="combinator"><span
+data-term="combinator"><span
 id="combinator"><dfn>Combinators</dfn></span></span> are: white space,
 "&gt;", and "+". White space may appear between a combinator and the
 simple selectors around it.
 
 <P>The elements of the document tree that match a selector are called
-<span class="index-def" title="subject (of selector)|selector::subject
+<span class="index-def" data-term="subject (of selector)|selector::subject
 of"><span id="subject"><dfn>subjects</dfn></span></span> of the selector.
 A selector consisting of a single simple selector matches any element
 satisfying its requirements.  Prepending a simple selector and
@@ -139,14 +139,14 @@ h1, h2, h3 { font-family: sans-serif }
 </div>
 
 <P>CSS offers other "shorthand" mechanisms as well, including 
-<span class="index-def" title="multiple declarations">
+<span class="index-def" data-term="multiple declarations">
 <a href="syndata.html#declaration">multiple declarations</a></span>
-and <span class="index-inst" title="shorthand property"><a
+and <span class="index-inst" data-term="shorthand property"><a
 href="about.html#shorthand">shorthand properties</a></span>.
 
 <h2><span id="universal-selector">Universal selector</span></h2>
 
-<P>The <span class="index-def" title="universal selector">universal
+<P>The <span class="index-def" data-term="universal selector">universal
 selector</span>, written "*", matches the name of any element
 type. It matches any single element in the <a
 href="conform.html#doctree">document tree.</a>
@@ -164,7 +164,7 @@ omitted. For example:</P>
 
 <h2><span id="type-selectors">Type selectors</span></h2>
 
-<p>A <span class="index-def" title="type selector"><em>type
+<p>A <span class="index-def" data-term="type selector"><em>type
 selector</em></span> matches the name of a document language element
 type. A type selector matches every instance of the element type in
 the document tree.
@@ -183,7 +183,7 @@ h1 { font-family: sans-serif }
 <p>At times, authors may want selectors to match an element that is
 the descendant of another element in the document tree (e.g., "Match
 those EM elements that are contained by an H1 element").  <span
-class="index-def" title="descendant-selectors">Descendant
+class="index-def" data-term="descendant-selectors">Descendant
 selectors</span> express such a relationship in a pattern. A
 descendant selector is made up of two or more selectors separated by
 <a href="syndata.html#whitespace">white space</a>. A descendant
@@ -252,7 +252,7 @@ div p *[href]
 
 <h2><span id="child-selectors">Child selectors</span></h2>
 
-<p>A <span class="index-def" title="child selector"><em>child
+<p>A <span class="index-def" data-term="child selector"><em>child
 selector</em></span> matches when an element is the <a
 href="conform.html#doctree">child</a> of some element. A child
 selector is made up of two or more selectors separated by "&gt;".
@@ -330,22 +330,22 @@ in the source document.
 <dt><code>[att]</code>
 <dd>Match when the element sets the "att" attribute, whatever
 the value of the attribute.
-<dt><span class="index-def" title="exact
+<dt><span class="index-def" data-term="exact
 matching|="><code>[att=val]</code></span>
 <dd>Match when the element's "att" attribute value is exactly "val".
-<dt><span class="index-def" title="space-separated
+<dt><span class="index-def" data-term="space-separated
 matching|~="><code>[att~=val]</code></span>
 <dd>Represents an element with the <code>att</code> attribute whose
 value is a white space-separated list of words, one of which is exactly
 "val". If "val" contains white space, it will never represent anything
 (since the words are <em>separated</em> by spaces).
 If "val" is the empty string, it will never represent anything either.
-<dt><span class="index-def" title="hyphen-separated
+<dt><span class="index-def" data-term="hyphen-separated
 matching|&#124;="><code>[att|=val]</code></span>
 <dd>Represents an element with the <code>att</code> attribute, its
 value either being exactly "val" or beginning with "val" immediately
 followed by "-" (U+002D). This is primarily intended to allow <span
-class="index-inst" title="language code">language subcode</span>
+class="index-inst" data-term="language code">language subcode</span>
 matches (e.g., the <code>hreflang</code> attribute on the
 <code>a</code> element in HTML) as described in BCP&nbsp;47
 ([[-BCP47]]) or its successor. For <code>lang</code> (or
@@ -438,7 +438,7 @@ DIALOGUE[character=juliet]
 
 <P>Matching takes place on attribute values in the document tree.
 Default attribute values may be defined in a <span class="index-inst"
-title="DTD">DTD</span> or elsewhere, but cannot always be selected by
+data-term="DTD">DTD</span> or elsewhere, but cannot always be selected by
 attribute selectors. Style sheets should be designed so that they work
 even if the default values are not included in the document tree.
 
@@ -677,9 +677,9 @@ href="conform.html#doctree">document tree</a>. For instance, in HTML
 paragraph, and therefore no simple CSS selector may refer to it.</p>
 
 <p>CSS introduces the concepts of <span class="index-def"
-title="pseudo-elements"><dfn>pseudo-elements</dfn></span> and <span
+data-term="pseudo-elements"><dfn>pseudo-elements</dfn></span> and <span
 class="index-def"
-title="pseudo-classes"><dfn>pseudo-classes</dfn></span> to permit
+data-term="pseudo-classes"><dfn>pseudo-classes</dfn></span> to permit
 formatting based on information that lies outside the document
 tree. </p>
 
@@ -727,7 +727,7 @@ order</A> determines the outcome.
 <h3><span id="first-child">:first-child</span> pseudo-class</h3>
 
 <P>The <span class="index-def"
-title="first-child|:first-child">:first-child</span> pseudo-class
+data-term="first-child|:first-child">:first-child</span> pseudo-class
 matches an element that is the first child element of some other element.
 
 <div class="example"><P>
@@ -794,9 +794,9 @@ a:first-child       /* Same */
 
 
 <h3><span id="link-pseudo-classes">The link pseudo-classes</span>: <span
-class="index-def" title="pseudo-classes:::link|:link|link
+class="index-def" data-term="pseudo-classes:::link|:link|link
 (pseudo-class)">:link</span> and <span class="index-def"
-title="pseudo-classes:::visited|:visited|visited
+data-term="pseudo-classes:::visited|:visited|visited
 (pseudo-class)">:visited</span></h3>
 
 <p>User agents commonly display unvisited links differently from
@@ -852,11 +852,11 @@ and unvisited links differently. See [[-P3P]] for more information
 about handling privacy.
 
 <h3><span id="dynamic-pseudo-classes">The dynamic pseudo-classes:</span>
-<span class="index-def" title="pseudo-classes:::hover|:hover|hover
+<span class="index-def" data-term="pseudo-classes:::hover|:hover|hover
 (pseudo-class)">:hover</span>, <span class="index-def"
-title="pseudo-classes:::active|:active|active
+data-term="pseudo-classes:::active|:active|active
 (pseudo-class)">:active</span>, and <span class="index-def"
-title="pseudo-classes:::focus|:focus|focus
+data-term="pseudo-classes:::focus|:focus|focus
 (pseudo-class)">:focus</span></h3>
 
 <p>Interactive user agents sometimes change the rendering in response
@@ -956,11 +956,11 @@ links.</em>
 </div>
 
 <h3><span id="lang">The language pseudo-class:</span> <span
-class="index-def" title="pseudo-classes:::lang|:lang|lang
+class="index-def" data-term="pseudo-classes:::lang|:lang|lang
 (pseudo-class)">:lang</span></h3>
 
 <p>If the document language specifies how the <span class="index-inst"
-title="language (human)">human language</span> of an element is
+data-term="language (human)">human language</span> of an element is
 determined, it is possible to write selectors in CSS that match an
 element based on its language. For example, in HTML [[HTML401]], the
 language is determined by a combination of the "lang" attribute, the
@@ -1027,7 +1027,7 @@ exact rendering of ':first-line' and ':first-letter' in all cases. A
 future level of CSS may define them more precisely.</em>
 
 <h3>The <span class="index-def"
-title="pseudo-elements:::first-line|:first-line|first-line"><span
+data-term="pseudo-elements:::first-line|:first-line|first-line"><span
 id="first-line-pseudo">:first-line</span></span> pseudo-element</h3>
 
 <p>The :first-line pseudo-element applies special styles to the
@@ -1068,7 +1068,7 @@ ordinary lines in the paragraph.
 </pre>
 
 <p>might be "rewritten" by user agents to include the <em><span
-class="index-def" title="fictional tag sequence">fictional tag
+class="index-def" data-term="fictional tag sequence">fictional tag
 sequence</span></em> for :first-line. This fictional tag sequence helps
 to show how properties are inherited.
 
@@ -1110,7 +1110,7 @@ paragraph.&lt;/P&gt;
 </pre>
 
 <p> The <span class="index-inst"
-title="pseudo-elements:::first-line">:first-line</span> pseudo-element
+data-term="pseudo-elements:::first-line">:first-line</span> pseudo-element
 can only be attached to a <a href="visuren.html#block-boxes">block
 container element.</a>
 
@@ -1170,13 +1170,13 @@ class="propinst-line-height">'line-height'</span>. UAs may apply
 other properties as well.</p>
 
 
-<h3><span id="first-letter">The</span> <span class="index-def" title="pseudo-elements:::first-letter|:first-letter|first-letter">:first-letter</span> pseudo-element</h3>
+<h3><span id="first-letter">The</span> <span class="index-def" data-term="pseudo-elements:::first-letter|:first-letter|first-letter">:first-letter</span> pseudo-element</h3>
 
 <p>The :first-letter pseudo-element must select the first letter of
 the first line of a block, if it is not preceded by any other content
 (such as images or inline tables) on its line. The :first-letter
-pseudo-element may be used for <span class="index-inst" title="initial
-caps">"initial caps"</span> and <span class="index-inst" title="drop
+pseudo-element may be used for <span class="index-inst" data-term="initial
+caps">"initial caps"</span> and <span class="index-inst" data-term="drop
 caps">"drop caps"</span>, which are common typographical effects. This
 type of initial letter is similar to an inline-level element if its
 <span class="propinst-float">'float'</span> property is 'none',
@@ -1254,7 +1254,7 @@ En dagelix geschrey de bange stad ontzet.
 <P><img src="./images/first-letter.png" alt="Image illustrating the combined effect of the :first-letter and :first-line pseudo-elements"></p>
 </div>
 
-<p>The <span class="index-inst" title="fictional tag
+<p>The <span class="index-inst" data-term="fictional tag
 sequence">fictional tag sequence</span> is:</p>
 
 <pre>
@@ -1369,7 +1369,7 @@ p:first-line { color: blue }
 </pre>
 
 <p>Assuming that a line break will occur before the word "ends", the
-<span class="index-inst" title="fictional tag sequence">fictional tag
+<span class="index-inst" data-term="fictional tag sequence">fictional tag
 sequence</span> for this fragment might be:</p>
 
 <pre>
@@ -1390,8 +1390,8 @@ element.  Properties set on :first-line are inherited by
 </div>
 
 <h3><span id="before-and-after">The</span> <span class="index-def"
-title="pseudo-elements:::before|:before">:before</span> and <span
-class="index-def" title="pseudo-elements:::after|:after">:after</span>
+data-term="pseudo-elements:::before|:before">:before</span> and <span
+class="index-def" data-term="pseudo-elements:::after|:after">:after</span>
 pseudo-elements</h3>
 
 <p>The ':before' and ':after' pseudo-elements can be used to insert

--- a/css2/syndata.html
+++ b/css2/syndata.html
@@ -84,7 +84,7 @@ body>del,body>ins {display:block}
 <h2><span class="secno">4.1</span> <span id="syntax">Syntax</span></h2>
 
 <p>This section describes a grammar (and <span id="x0" class="index-def"
-title="forward-compatible parsing"><dfn>forward-compatible
+data-term="forward-compatible parsing"><dfn>forward-compatible
 parsing</dfn></span> rules) common to any level of CSS (including
 CSS&nbsp;2). Future updates of CSS will adhere to this core syntax,
 although they may add additional syntactic constraints.
@@ -318,7 +318,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
 <p>  The following rules always hold:</p>
 
 <ul>
-    <li> All CSS syntax is <span id="x1" class="index-inst" title="case
+    <li> All CSS syntax is <span id="x1" class="index-inst" data-term="case
     sensitivity">case-insensitive</span> within the ASCII
     range (i.e., [a-z] and [A-Z] are equivalent), except for parts that are
     not under the control of CSS. For example, the case-sensitivity of
@@ -329,7 +329,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </li>
 
     <li> In CSS, <span class="index-def"
-    title="identifier|identifier, definition of"><dfn
+    data-term="identifier|identifier, definition of"><dfn
     id="value-def-identifier" data-dfn-type="type" data-lt="<identifier>"><dfn>identifiers</dfn></dfn></span>
     (including element names, classes, and IDs in <a
     href="selector.html">selectors</a>) can contain only the
@@ -345,7 +345,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </p>
 	</li>
     <li> In CSS&nbsp;2, a backslash (\) character can indicate one
-    of three types of <span class="index-def" title="backslash
+    of three types of <span class="index-def" data-term="backslash
     escapes"> <span id="escaped-characters">character
     escape.</span></span> Inside a CSS comment, a backslash stands for
     itself, and if a backslash is immediately followed by the end of
@@ -411,16 +411,16 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
 <h3><span class="secno">4.1.4</span> <span id="statements">Statements</span></h3>
 
 <p> A CSS style sheet, for any level of CSS, consists of a list of
-<span id="x5" class="index-inst" title="statements"><em>statements</em></span>
+<span id="x5" class="index-inst" data-term="statements"><em>statements</em></span>
 (see the <a href="#tokenization">grammar</a> above). There are two
 kinds of statements: <span id="x6"
-class="index-inst" title="at-rules"><em>at-rules</em></span>
-and <span id="x7" class="index-inst" title="rule sets"><em>rule
+class="index-inst" data-term="at-rules"><em>at-rules</em></span>
+and <span id="x7" class="index-inst" data-term="rule sets"><em>rule
 sets.</em></span> There may be <a href="#whitespace">white space</a>
 around the statements.
 </p>
 
-<h3><span class="secno">4.1.5</span> <span class="index-def" title="at-rule">
+<h3><span class="secno">4.1.5</span> <span class="index-def" data-term="at-rule">
 <span id="at-rules">At-rules</span></span></h3>
 
 <p> At-rules start with an <dfn>at-keyword</dfn>, an '@' character
@@ -433,7 +433,7 @@ semicolon (;) or the next <a href="#block">block,</a> whichever comes
 first.
 </p>
 
-<p>CSS&nbsp;2 user agents must <span id="x9" class="index-inst" title="ignore"><a
+<p>CSS&nbsp;2 user agents must <span id="x9" class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> any <a
 href="cascade.html#at-import">'@import'</a> rule that occurs inside a <a
 href="#block">block</a> or after any non-ignored statement other than an <span id="x10"
@@ -450,7 +450,7 @@ h1 { color: blue }
 </code></pre>
 
 <p> The second '@import' is illegal according to CSS&nbsp;2. The CSS&nbsp;2 parser
-<span id="x11" class="index-inst" title="ignore"><a href="#ignore">ignores</a></span>
+<span id="x11" class="index-inst" data-term="ignore"><a href="#ignore">ignores</a></span>
 the whole at-rule, effectively reducing the style sheet to:
 </p>
 <pre class="lang-css">
@@ -487,14 +487,14 @@ h1 {color: blue }
 
 <h3><span class="secno">4.1.6</span> <span id="block">Blocks</span></h3>
 
-<p> A <span id="x12" class="index-inst" title="block"><em>block</em></span>
+<p> A <span id="x12" class="index-inst" data-term="block"><em>block</em></span>
 starts with a left curly brace ({) and ends with the matching right
 curly brace (}). In between there may be any tokens, except that
 parentheses ((&nbsp;)), brackets ([&nbsp;]), and braces ({&nbsp;}) must
 always occur in
 matching pairs and may be nested. Single (') and double quotes (")
  must also occur in matching pairs, and characters between them
-are parsed as a <span id="x13" class="index-inst" title="string">string</span>.
+are parsed as a <span id="x13" class="index-inst" data-term="string">string</span>.
 See <a href="#tokenization">Tokenization</a> above for the definition
 of a string.
 </p>
@@ -520,25 +520,25 @@ a block as defined above.
 a declaration block.
 </p>
 <p> A <span id="x14" class="index-def"
-title="declaration block"><dfn>declaration block</dfn></span>
+data-term="declaration block"><dfn>declaration block</dfn></span>
 starts with a left curly
 brace ({) and ends with the matching right curly brace (}). In between
 there must be a list of zero or more semicolon-separated (;)
 declarations.
 </p>
 <p>The <span id="x15" class="index-def"
-title="selector"><em>selector</em></span> (see also the section on <a
+data-term="selector"><em>selector</em></span> (see also the section on <a
 href="selector.html">selectors</a>) consists of everything up to (but
 not including) the first left curly brace ({).  A selector always goes
 together with a declaration block. When a user agent cannot parse the selector (i.e., it
-is not valid CSS&nbsp;2), it must <span id="x16" class="index-inst" title="ignore"><a
+is not valid CSS&nbsp;2), it must <span id="x16" class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> the selector and the following
 declaration block (if any) as well.
 </p>
 <p>CSS&nbsp;2 gives a special meaning to the comma (,) in
 selectors. However, since it is not known if the comma may acquire
 other meanings in future updates of CSS, the whole statement should
-be <span id="x17" class="index-inst" title="ignore"><a
+be <span id="x17" class="index-inst" data-term="ignore"><a
 href="#ignore">ignored</a></span> if there is an error anywhere in the
 selector, even though the rest of the selector may look reasonable in
 CSS&nbsp;2.
@@ -546,7 +546,7 @@ CSS&nbsp;2.
 <div class="illegal example"><P style="display:none">Illegal example(s):</P>
 <p>For example, since the "&amp;" is not a valid token in a CSS&nbsp;2
 selector, a CSS&nbsp;2 user agent must
-<span id="x18" class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+<span id="x18" class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 the whole second line, and not set the color of H3 to red:
 </p>
 <pre><code>
@@ -578,9 +578,9 @@ p[example="public class foo\
 id="properties">properties</span></h3>
 
 <p> A <span id="x19" class="index-def"
-title="declaration"><dfn>declaration</dfn></span> is either empty or
+data-term="declaration"><dfn>declaration</dfn></span> is either empty or
 consists of a <span id="x20" class="index-inst"
-title="property">property name</span>, followed by a colon (:), followed by
+data-term="property">property name</span>, followed by a colon (:), followed by
 a property value. Around each of these there may be <a
 href="#whitespace">white space</a>.
 </p>
@@ -623,12 +623,12 @@ href="#escaped-characters">escaped</a>. Parentheses, brackets, and
 braces may be nested. Inside the quotes, characters are parsed as a
 string.
 </p>
-<p>The syntax of <span id="x21" class="index-def" title="value">values</span>
+<p>The syntax of <span id="x21" class="index-def" data-term="value">values</span>
 is specified separately for each property, but in any case, values are
 built from identifiers, strings, numbers, lengths, percentages, URIs,
 colors, etc.
 </p>
-<p>A user agent must <span id="x22" class="index-inst" title="ignore"><a
+<p>A user agent must <span id="x22" class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> a declaration with an invalid property
 name or an invalid value. Every CSS property has its own syntactic
 and semantic restrictions on the values it accepts.
@@ -646,7 +646,7 @@ em em { font-style: normal }
 <p> The second declaration on the first line has an invalid value
 '12pt'. The second declaration on the second line contains an
 undefined property 'font-vendor'. The CSS&nbsp;2 parser will <span id="x23"
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span> these
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span> these
 declarations, effectively reducing the style sheet to:
 </p>
 <pre class="example"><code class="css">
@@ -658,7 +658,7 @@ em em { font-style: normal }
 
 <h3><span class="secno">4.1.9</span> <span id="comments">Comments</span></h3>
 
-<p><span id="x24" class="index-inst" title="comments">Comments </span> begin
+<p><span id="x24" class="index-inst" data-term="comments">Comments </span> begin
 with the characters "/*" and end with the characters "*/". They may
 occur anywhere outside other tokens,
 and their contents have no influence on the rendering.  Comments may
@@ -677,7 +677,7 @@ errors</span></h2>
 
 <p>In some cases, user agents must ignore part of an illegal style
 sheet. This specification defines <span class="index-def"
-title="ignore"><span id="ignore"><dfn>ignore</dfn></span></span> to mean
+data-term="ignore"><span id="ignore"><dfn>ignore</dfn></span></span> to mean
 that the user agent parses the illegal part (in order to find its
 beginning and end), but otherwise acts as if it had not been there. 
 CSS&nbsp;2 reserves for future updates of CSS all property:value combinations 
@@ -694,7 +694,7 @@ scenarios:</p>
 
 <ul>
 <li><strong>Unknown properties.</strong> User agents must <span id="x26"
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span> a <a
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span> a <a
 href="syndata.html#declaration">declaration</a> with an unknown
 property. For example, if the style sheet is:
 
@@ -719,7 +719,7 @@ img { border-width: 3 }   /* a unit must be specified for length values */
 </code></pre>
 
 A CSS&nbsp;2 parser would honor the first rule and
-<span id="x27" class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+<span id="x27" class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 the rest, as if the style sheet had been:
 
 <pre class="example"><code class="css">
@@ -772,7 +772,7 @@ p @here {color: red}     /* ruleset with unexpected at-keyword "@here" */
 
 
 <li><strong>At-rules with unknown at-keywords.</strong> User agents must <span id="x28"
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 an invalid at-keyword together with everything following it, up to the
 end of the block that contains the invalid at-keyword, or up to and
 including the next semicolon (;), or up to and including the next
@@ -792,8 +792,8 @@ h1 { color: blue }
 
 <p> The '@three-dee' at-rule is not part of CSS&nbsp;2. Therefore, the whole
 at-rule (up to, and including, the third right curly brace) is <span id="x29"
-class="index-inst" title="ignore"><a href="#ignore">ignored.</a></span> A
-CSS&nbsp;2 user agent <span id="x30" class="index-inst" title="ignore"><a
+class="index-inst" data-term="ignore"><a href="#ignore">ignored.</a></span> A
+CSS&nbsp;2 user agent <span id="x30" class="index-inst" data-term="ignore"><a
 href="#ignore">ignores</a></span> it, effectively reducing the style sheet
 to:</p>
 
@@ -868,10 +868,10 @@ selectors</a> for parsing rules for declaration blocks.
 <h3><span class="secno">4.3.1</span> <span id="numbers">Integers and real numbers</span></h3>
 
 <p>Some value types may have integer values (denoted by <span
-class="index-def" title="&lt;integer&gt;::definition of"><dfn
+class="index-def" data-term="&lt;integer&gt;::definition of"><dfn
 id="value-def-integer" data-dfn-type="type" class="value-def">&lt;integer&gt;</dfn></span>)
 or real number values (denoted by <span class="index-def"
-title="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
+data-term="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
 class="value-def">&lt;number&gt;</dfn></span>).  Real numbers and
 integers are specified in decimal notation only. An &lt;integer&gt;
 consists of one or more digits "0" to "9". A &lt;number&gt; can either
@@ -890,7 +890,7 @@ non-negative value.
 <p>Lengths refer to distance measurements.</p>
 
 <p> The format of a length value (denoted by <span class="index-def"
-title="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
+data-term="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
 class="value-def">&lt;length&gt;</dfn></span> in this specification) is
 a <a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a> (with or without a
@@ -912,7 +912,7 @@ length cannot be supported, user agents must approximate it in the
 <a href="cascade.html#actual-value">actual value.</a>
 
 <p><span id="absrel-units">There are two types of length units:
-relative and absolute.</span> <span id="x34" class="index-def" title="relative
+relative and absolute.</span> <span id="x34" class="index-def" data-term="relative
 units"><em>Relative length</em></span> units specify a length relative
 
 to another length property. Style sheets that use relative units
@@ -933,7 +933,7 @@ h1 { margin: 1ex }        /* ex */
 </pre>
 </div>
 
-<p>The <span class="index-def" title="em (unit)|quad width"><span
+<p>The <span class="index-def" data-term="em (unit)|quad width"><span
 id="em-width">'em'</span></span> unit is equal to the computed value of
 the <a href="fonts.html#propdef-font-size" class="noxref"><span class="propinst-font-size">'font-size'</span></a> property of
 the element on which it is used. The exception is when 'em' occurs in
@@ -942,7 +942,7 @@ to the font size of the parent element. It may be used for vertical or
 horizontal measurement. (This unit is also sometimes called the
 quad-width in typographic texts.)
 </p>
-<p>The <span class="index-def" title="x-height|ex (unit)"><span
+<p>The <span class="index-def" data-term="x-height|ex (unit)"><span
 id="ex">'ex'</span></span> unit is defined by the element's first available
 font.
 The exception is when 'ex' occurs in the value of the <a href="fonts.html#propdef-font-size" class="noxref"><span
@@ -1000,7 +1000,7 @@ h1 { font-size: 15px }
 </pre>
 </div>
 
-<p><span id="x39" class="index-def" title="absolute length"><em> Absolute
+<p><span id="x39" class="index-def" data-term="absolute length"><em> Absolute
 
 length</em></span>
 
@@ -1049,7 +1049,7 @@ pixel unit would vary to most closely match the reference pixel.
 on the assumption of 96dpi, and breaking that assumption breaks
 the content.)
 
-<p>The <span id="x40" class="index-def" title="reference pixel|pixel"><em>reference pixel</em></span> is the
+<p>The <span id="x40" class="index-def" data-term="reference pixel|pixel"><em>reference pixel</em></span> is the
 visual angle of one pixel on a device with a pixel density of 96dpi
 and a distance from the reader of an arm's length. For a nominal arm's
 length of 28 inches, the visual angle is therefore about 0.0213
@@ -1098,11 +1098,11 @@ p  { font-size: 12px }    /* px */
 <h3><span class="secno">4.3.3</span>  <span id="percentage-units">Percentages</span></h3>
 
 <p> The format of a percentage value (denoted by <span
-class="index-def" title="&lt;percentage&gt;::definition of"><dfn
+class="index-def" data-term="&lt;percentage&gt;::definition of"><dfn
 id="value-def-percentage" data-dfn-type="type"
 class="value-def">&lt;percentage&gt;</dfn></span> in this specification)
 is a <span id="x43" class="index-inst"
-title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
 followed by '%'.
 </p>
@@ -1136,7 +1136,7 @@ p { line-height: 120% }  /* 120% of 'font-size' */
 
 <p>URI values (Uniform Resource Identifiers, see <a href="refs.html#ref-RFC3986" class="noxref"><span class="normref">[RFC3986]</span></a>, which
 includes URLs, URNs, etc) in this specification are denoted by <span
-class="index-def" title="&lt;uri&gt;::definition of"><dfn
+class="index-def" data-term="&lt;uri&gt;::definition of"><dfn
 id="value-def-uri" data-dfn-type="type" class="value-def">&lt;uri&gt;</dfn></span>.  The
 functional notation used to designate URIs in property values is
 "url()", as in:
@@ -1208,13 +1208,13 @@ unavailable or inapplicable resources.
 </p>
 <h3><span class="secno">4.3.5</span> <span id="counter">Counters</span></h3>
 
-<p><span class="index-def" title="&lt;counter&gt;, definition of"><dfn
+<p><span class="index-def" data-term="&lt;counter&gt;, definition of"><dfn
 id="value-def-counter" data-dfn-type="type" data-lt="<counter>">Counters</dfn></span> are denoted by
 case-sensitive identifiers (see the <a href="generate.html#propdef-counter-increment" class="noxref"><span
 class="propinst-counter-increment">'counter-increment'</span></a> and
 <a href="generate.html#propdef-counter-reset" class="noxref"><span class="propinst-counter-reset">'counter-reset'</span></a>
 properties). To refer to the value of a counter, the notation
-<span id="x46" class="index-def" title="counter()">
+<span id="x46" class="index-def" data-term="counter()">
 'counter(&lt;identifier&gt;)'</span> or 'counter(&lt;identifier&gt;,
 &lt;'list-style-type'&gt;)', with optional white space separating the tokens,
 is used. The default style is 'decimal'.
@@ -1251,7 +1251,7 @@ p:before {content: counter(par-num, upper-roman) ". "}
 
 <h3><span class="secno">4.3.6</span> <span id="color-units">Colors</span></h3>
 <p>
-A <span class="index-def" title="&lt;color&gt;::definition of"><dfn
+A <span class="index-def" data-term="&lt;color&gt;::definition of"><dfn
 id="value-def-color" data-dfn-type="type" class="value-def">&lt;color&gt;</dfn></span>
 is either a keyword or a numerical RGB specification.
 </p>
@@ -1373,7 +1373,7 @@ may be larger or smaller than 0..255).</em>
 
 <h3><span class="secno">4.3.7</span> <span id="strings">Strings</span></h3>
 
-<p><span class="index-def" title="&lt;string&gt;, definition of"><dfn
+<p><span class="index-def" data-term="&lt;string&gt;, definition of"><dfn
 id="value-def-string" data-dfn-type="type" data-lt="<string>">Strings</dfn></span> can either be written
 with double quotes or with single quotes. Double quotes cannot occur
 inside double quotes, unless escaped (e.g., as '\"' or as
@@ -1389,7 +1389,7 @@ inside double quotes, unless escaped (e.g., as '\"' or as
 </div>
 
 <p>A string cannot directly contain a <span id="x49" class="index-inst"
-title="newline">newline</span>. 
+data-term="newline">newline</span>. 
 To include a newline in a string, use an escape representing the line feed 
 character in ISO-10646 (U+000A), such as "\A" or "\00000a". 
 This character represents the generic notion of "newline" in CSS.
@@ -1437,7 +1437,7 @@ display declaration.
 <p>A CSS style sheet is a sequence of characters from the Universal
 Character Set (see <a href="refs.html#ref-ISO10646" class="noxref"><span class="normref">[ISO10646]</span></a>). For transmission and
 storage, these characters must be <span id="x50" class="index-def"
-title="character encoding">encoded</span> by a character encoding that
+data-term="character encoding">encoded</span> by a character encoding that
 supports the set of characters available in US-ASCII (e.g., UTF-8, ISO
 8859-x, SHIFT JIS, etc.).  For a good introduction to character sets
 and character encodings, please consult the HTML 4
@@ -1449,9 +1449,9 @@ STYLE element or "style" attribute of HTML, the style sheet shares the
 character encoding of the whole document.
 </p>
 <p>When a style sheet resides in a separate file, user agents must
-observe the following <span id="x51" class="index-inst" title="character
+observe the following <span id="x51" class="index-inst" data-term="character
 encoding::user agent's determination of">priorities</span> when
-determining a style sheet's <span id="x52" class="index-inst" title="character
+determining a style sheet's <span id="x52" class="index-inst" data-term="character
 encoding::default|default::character encoding">character
 encoding</span> (from highest priority to lowest):
 </p>

--- a/css2/syndata.html
+++ b/css2/syndata.html
@@ -329,8 +329,8 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </li>
 
     <li> In CSS, <span class="index-def"
-    title="identifier|identifier, definition of"><span
-    id="value-def-identifier"><dfn>identifiers</dfn></span></span>
+    title="identifier|identifier, definition of"><dfn
+    id="value-def-identifier" data-dfn-type="type" data-lt="<identifier>"><dfn>identifiers</dfn></dfn></span>
     (including element names, classes, and IDs in <a
     href="selector.html">selectors</a>) can contain only the
     characters [a-zA-Z0-9] and ISO 10646 characters  U+00A0 and higher,
@@ -868,11 +868,11 @@ selectors</a> for parsing rules for declaration blocks.
 <h3><span class="secno">4.3.1</span> <span id="numbers">Integers and real numbers</span></h3>
 
 <p>Some value types may have integer values (denoted by <span
-class="index-def" title="&lt;integer&gt;::definition of"><span
-id="value-def-integer" class="value-def">&lt;integer&gt;</span></span>)
+class="index-def" title="&lt;integer&gt;::definition of"><dfn
+id="value-def-integer" data-dfn-type="type" class="value-def">&lt;integer&gt;</dfn></span>)
 or real number values (denoted by <span class="index-def"
-title="&lt;number&gt;::definition of"><span id="value-def-number"
-class="value-def">&lt;number&gt;</span></span>).  Real numbers and
+title="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
+class="value-def">&lt;number&gt;</dfn></span>).  Real numbers and
 integers are specified in decimal notation only. An &lt;integer&gt;
 consists of one or more digits "0" to "9". A &lt;number&gt; can either
 be an &lt;integer&gt;, or it can be zero or more digits followed by a
@@ -890,8 +890,8 @@ non-negative value.
 <p>Lengths refer to distance measurements.</p>
 
 <p> The format of a length value (denoted by <span class="index-def"
-title="&lt;length&gt;::definition of"><span id="value-def-length"
-class="value-def">&lt;length&gt;</span></span> in this specification) is
+title="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
+class="value-def">&lt;length&gt;</dfn></span> in this specification) is
 a <a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a> (with or without a
 decimal point) immediately followed by a unit identifier (e.g., px,
@@ -1098,9 +1098,9 @@ p  { font-size: 12px }    /* px */
 <h3><span class="secno">4.3.3</span>  <span id="percentage-units">Percentages</span></h3>
 
 <p> The format of a percentage value (denoted by <span
-class="index-def" title="&lt;percentage&gt;::definition of"><span
-id="value-def-percentage"
-class="value-def">&lt;percentage&gt;</span></span> in this specification)
+class="index-def" title="&lt;percentage&gt;::definition of"><dfn
+id="value-def-percentage" data-dfn-type="type"
+class="value-def">&lt;percentage&gt;</dfn></span> in this specification)
 is a <span id="x43" class="index-inst"
 title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span> immediately
@@ -1136,8 +1136,8 @@ p { line-height: 120% }  /* 120% of 'font-size' */
 
 <p>URI values (Uniform Resource Identifiers, see <a href="refs.html#ref-RFC3986" class="noxref"><span class="normref">[RFC3986]</span></a>, which
 includes URLs, URNs, etc) in this specification are denoted by <span
-class="index-def" title="&lt;uri&gt;::definition of"><span
-id="value-def-uri" class="value-def">&lt;uri&gt;</span></span>.  The
+class="index-def" title="&lt;uri&gt;::definition of"><dfn
+id="value-def-uri" data-dfn-type="type" class="value-def">&lt;uri&gt;</dfn></span>.  The
 functional notation used to designate URIs in property values is
 "url()", as in:
 </p>
@@ -1208,8 +1208,8 @@ unavailable or inapplicable resources.
 </p>
 <h3><span class="secno">4.3.5</span> <span id="counter">Counters</span></h3>
 
-<p><span class="index-def" title="&lt;counter&gt;, definition of"><span
-id="value-def-counter">Counters</span></span> are denoted by
+<p><span class="index-def" title="&lt;counter&gt;, definition of"><dfn
+id="value-def-counter" data-dfn-type="type" data-lt="<counter>">Counters</dfn></span> are denoted by
 case-sensitive identifiers (see the <a href="generate.html#propdef-counter-increment" class="noxref"><span
 class="propinst-counter-increment">'counter-increment'</span></a> and
 <a href="generate.html#propdef-counter-reset" class="noxref"><span class="propinst-counter-reset">'counter-reset'</span></a>
@@ -1251,8 +1251,8 @@ p:before {content: counter(par-num, upper-roman) ". "}
 
 <h3><span class="secno">4.3.6</span> <span id="color-units">Colors</span></h3>
 <p>
-A <span class="index-def" title="&lt;color&gt;::definition of"><span
-id="value-def-color" class="value-def">&lt;color&gt;</span></span>
+A <span class="index-def" title="&lt;color&gt;::definition of"><dfn
+id="value-def-color" data-dfn-type="type" class="value-def">&lt;color&gt;</dfn></span>
 is either a keyword or a numerical RGB specification.
 </p>
 <p> The list of color keywords is: aqua, black, blue, fuchsia,
@@ -1373,8 +1373,8 @@ may be larger or smaller than 0..255).</em>
 
 <h3><span class="secno">4.3.7</span> <span id="strings">Strings</span></h3>
 
-<p><span class="index-def" title="&lt;string&gt;, definition of"><span
-id="value-def-string">Strings</span></span> can either be written
+<p><span class="index-def" title="&lt;string&gt;, definition of"><dfn
+id="value-def-string" data-dfn-type="type" data-lt="<string>">Strings</dfn></span> can either be written
 with double quotes or with single quotes. Double quotes cannot occur
 inside double quotes, unless escaped (e.g., as '\"' or as
 '\22'). Analogously for single quotes (e.g., "\'" or "\27"). 

--- a/css2/syndata.src
+++ b/css2/syndata.src
@@ -24,7 +24,7 @@ body>del,body>ins {display:block}
 <h2><span id="syntax">Syntax</span></h2>
 
 <p>This section describes a grammar (and <span class="index-def"
-title="forward-compatible parsing"><dfn>forward-compatible
+data-term="forward-compatible parsing"><dfn>forward-compatible
 parsing</dfn></span> rules) common to any level of CSS (including
 CSS&nbsp;2). Future updates of CSS will adhere to this core syntax,
 although they may add additional syntactic constraints.
@@ -260,7 +260,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
 <p>  The following rules always hold:</p>
 
 <ul>
-    <li> All CSS syntax is <span class="index-inst" title="case
+    <li> All CSS syntax is <span class="index-inst" data-term="case
     sensitivity">case-insensitive</span> within the ASCII
     range (i.e., [a-z] and [A-Z] are equivalent), except for parts that are
     not under the control of CSS. For example, the case-sensitivity of
@@ -271,7 +271,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </li>
 
     <li> In CSS, <span class="index-def"
-    title="identifier|identifier, definition of"><dfn
+    data-term="identifier|identifier, definition of"><dfn
     id="value-def-identifier" data-dfn-type="type" data-lt="<identifier>"><dfn>identifiers</dfn></dfn></span>
     (including element names, classes, and IDs in <a
     href="selector.html">selectors</a>) can contain only the
@@ -287,7 +287,7 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </p>
 	</li>
     <li> In CSS&nbsp;2, a backslash (\) character can indicate one
-    of three types of <span class="index-def" title="backslash
+    of three types of <span class="index-def" data-term="backslash
     escapes"> <span id="escaped-characters">character
     escape.</span></span> Inside a CSS comment, a backslash stands for
     itself, and if a backslash is immediately followed by the end of
@@ -353,16 +353,16 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
 <h3><span id="statements">Statements</span></h3>
 
 <p> A CSS style sheet, for any level of CSS, consists of a list of
-<span class="index-inst" title="statements"><em>statements</em></span>
+<span class="index-inst" data-term="statements"><em>statements</em></span>
 (see the <a href="#tokenization">grammar</a> above). There are two
 kinds of statements: <span
-class="index-inst" title="at-rules"><em>at-rules</em></span>
-and <span class="index-inst" title="rule sets"><em>rule
+class="index-inst" data-term="at-rules"><em>at-rules</em></span>
+and <span class="index-inst" data-term="rule sets"><em>rule
 sets.</em></span> There may be <a href="#whitespace">white space</a>
 around the statements.
 </p>
 
-<h3><span class="index-def" title="at-rule">
+<h3><span class="index-def" data-term="at-rule">
 <span id="at-rules">At-rules</span></span></h3>
 
 <p> At-rules start with an <dfn>at-keyword</dfn>, an '@' character
@@ -375,7 +375,7 @@ semicolon (;) or the next <a href="#block">block,</a> whichever comes
 first.
 </p>
 
-<p>CSS&nbsp;2 user agents must <span class="index-inst" title="ignore"><a
+<p>CSS&nbsp;2 user agents must <span class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> any <a
 href="cascade.html#at-import">'@import'</a> rule that occurs inside a <a
 href="#block">block</a> or after any non-ignored statement other than an <span
@@ -392,7 +392,7 @@ h1 { color: blue }
 </code></pre>
 
 <p> The second '@import' is illegal according to CSS&nbsp;2. The CSS&nbsp;2 parser
-<span class="index-inst" title="ignore"><a href="#ignore">ignores</a></span>
+<span class="index-inst" data-term="ignore"><a href="#ignore">ignores</a></span>
 the whole at-rule, effectively reducing the style sheet to:
 </p>
 <pre class="lang-css">
@@ -429,14 +429,14 @@ h1 {color: blue }
 
 <h3><span id="block">Blocks</span></h3>
 
-<p> A <span class="index-inst" title="block"><em>block</em></span>
+<p> A <span class="index-inst" data-term="block"><em>block</em></span>
 starts with a left curly brace ({) and ends with the matching right
 curly brace (}). In between there may be any tokens, except that
 parentheses ((&nbsp;)), brackets ([&nbsp;]), and braces ({&nbsp;}) must
 always occur in
 matching pairs and may be nested. Single (') and double quotes (")
 <!-- " --> must also occur in matching pairs, and characters between them
-are parsed as a <span class="index-inst" title="string">string</span>.
+are parsed as a <span class="index-inst" data-term="string">string</span>.
 See <a href="#tokenization">Tokenization</a> above for the definition
 of a string.
 </p>
@@ -462,25 +462,25 @@ a block as defined above.
 a declaration block.
 </p>
 <p> A <span class="index-def"
-title="declaration block"><dfn>declaration block</dfn></span>
+data-term="declaration block"><dfn>declaration block</dfn></span>
 starts with a left curly
 brace ({) and ends with the matching right curly brace (}). In between
 there must be a list of zero or more semicolon-separated (;)
 declarations.
 </p>
 <p>The <span class="index-def"
-title="selector"><em>selector</em></span> (see also the section on <a
+data-term="selector"><em>selector</em></span> (see also the section on <a
 href="selector.html">selectors</a>) consists of everything up to (but
 not including) the first left curly brace ({).  A selector always goes
 together with a declaration block. When a user agent cannot parse the selector (i.e., it
-is not valid CSS&nbsp;2), it must <span class="index-inst" title="ignore"><a
+is not valid CSS&nbsp;2), it must <span class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> the selector and the following
 declaration block (if any) as well.
 </p>
 <p>CSS&nbsp;2 gives a special meaning to the comma (,) in
 selectors. However, since it is not known if the comma may acquire
 other meanings in future updates of CSS, the whole statement should
-be <span class="index-inst" title="ignore"><a
+be <span class="index-inst" data-term="ignore"><a
 href="#ignore">ignored</a></span> if there is an error anywhere in the
 selector, even though the rest of the selector may look reasonable in
 CSS&nbsp;2.
@@ -488,7 +488,7 @@ CSS&nbsp;2.
 <div class="illegal example">
 <p>For example, since the "&amp;" is not a valid token in a CSS&nbsp;2
 selector, a CSS&nbsp;2 user agent must
-<span class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+<span class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 the whole second line, and not set the color of H3 to red:
 </p>
 <pre><code>
@@ -520,9 +520,9 @@ p[example="public class foo\
 id="properties">properties</span></h3>
 
 <p> A <span class="index-def"
-title="declaration"><dfn>declaration</dfn></span> is either empty or
+data-term="declaration"><dfn>declaration</dfn></span> is either empty or
 consists of a <span class="index-inst"
-title="property">property name</span>, followed by a colon (:), followed by
+data-term="property">property name</span>, followed by a colon (:), followed by
 a property value. Around each of these there may be <a
 href="#whitespace">white space</a>.
 </p>
@@ -565,12 +565,12 @@ href="#escaped-characters">escaped</a>. Parentheses, brackets, and
 braces may be nested. Inside the quotes, characters are parsed as a
 string.
 </p>
-<p>The syntax of <span class="index-def" title="value">values</span>
+<p>The syntax of <span class="index-def" data-term="value">values</span>
 is specified separately for each property, but in any case, values are
 built from identifiers, strings, numbers, lengths, percentages, URIs,
 colors, etc.
 </p>
-<p>A user agent must <span class="index-inst" title="ignore"><a
+<p>A user agent must <span class="index-inst" data-term="ignore"><a
 href="#ignore">ignore</a></span> a declaration with an invalid property
 name or an invalid value. Every CSS property has its own syntactic
 and semantic restrictions on the values it accepts.
@@ -588,7 +588,7 @@ em em { font-style: normal }
 <p> The second declaration on the first line has an invalid value
 '12pt'. The second declaration on the second line contains an
 undefined property 'font-vendor'. The CSS&nbsp;2 parser will <span
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span> these
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span> these
 declarations, effectively reducing the style sheet to:
 </p>
 <pre class="example"><code class="css">
@@ -600,7 +600,7 @@ em em { font-style: normal }
 
 <h3><span id="comments">Comments</span></h3>
 
-<p><span class="index-inst" title="comments">Comments </span> begin
+<p><span class="index-inst" data-term="comments">Comments </span> begin
 with the characters "/*" and end with the characters "*/". They may
 occur anywhere outside other tokens,
 and their contents have no influence on the rendering.  Comments may
@@ -619,7 +619,7 @@ errors</span></h2>
 
 <p>In some cases, user agents must ignore part of an illegal style
 sheet. This specification defines <span class="index-def"
-title="ignore"><span id="ignore"><dfn>ignore</dfn></span></span> to mean
+data-term="ignore"><span id="ignore"><dfn>ignore</dfn></span></span> to mean
 that the user agent parses the illegal part (in order to find its
 beginning and end), but otherwise acts as if it had not been there. 
 CSS&nbsp;2 reserves for future updates of CSS all property:value combinations 
@@ -636,7 +636,7 @@ scenarios:</p>
 
 <ul>
 <li><strong>Unknown properties.</strong> User agents must <span
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span> a <a
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span> a <a
 href="syndata.html#declaration">declaration</a> with an unknown
 property. For example, if the style sheet is:
 
@@ -661,7 +661,7 @@ img { border-width: 3 }   /* a unit must be specified for length values */
 </code></pre>
 
 A CSS&nbsp;2 parser would honor the first rule and
-<span class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+<span class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 the rest, as if the style sheet had been:
 
 <pre class="example"><code class="css">
@@ -717,7 +717,7 @@ p @here {color: red}     /* ruleset with unexpected at-keyword "@here" */
 pair. -->
 
 <li><strong>At-rules with unknown at-keywords.</strong> User agents must <span
-class="index-inst" title="ignore"><a href="#ignore">ignore</a></span>
+class="index-inst" data-term="ignore"><a href="#ignore">ignore</a></span>
 an invalid at-keyword together with everything following it, up to the
 end of the block that contains the invalid at-keyword, or up to and
 including the next semicolon (;), or up to and including the next
@@ -737,8 +737,8 @@ h1 { color: blue }
 
 <p> The '@three-dee' at-rule is not part of CSS&nbsp;2. Therefore, the whole
 at-rule (up to, and including, the third right curly brace) is <span
-class="index-inst" title="ignore"><a href="#ignore">ignored.</a></span> A
-CSS&nbsp;2 user agent <span class="index-inst" title="ignore"><a
+class="index-inst" data-term="ignore"><a href="#ignore">ignored.</a></span> A
+CSS&nbsp;2 user agent <span class="index-inst" data-term="ignore"><a
 href="#ignore">ignores</a></span> it, effectively reducing the style sheet
 to:</p>
 
@@ -817,10 +817,10 @@ undefined in CSS&nbsp;2
 <h3><span id="numbers">Integers and real numbers</span></h3>
 
 <p>Some value types may have integer values (denoted by <span
-class="index-def" title="&lt;integer&gt;::definition of"><dfn
+class="index-def" data-term="&lt;integer&gt;::definition of"><dfn
 id="value-def-integer" data-dfn-type="type" class="value-def">&lt;integer&gt;</dfn></span>)
 or real number values (denoted by <span class="index-def"
-title="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
+data-term="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
 class="value-def">&lt;number&gt;</dfn></span>).  Real numbers and
 integers are specified in decimal notation only. An &lt;integer&gt;
 consists of one or more digits "0" to "9". A &lt;number&gt; can either
@@ -839,7 +839,7 @@ non-negative value.
 <p>Lengths refer to distance measurements.</p>
 
 <p> The format of a length value (denoted by <span class="index-def"
-title="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
+data-term="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
 class="value-def">&lt;length&gt;</dfn></span> in this specification) is
 a <span
 class="value-inst-number">&lt;number&gt;</span> (with or without a
@@ -861,7 +861,7 @@ length cannot be supported, user agents must approximate it in the
 <a href="cascade.html#actual-value">actual value.</a>
 
 <p><span id="absrel-units">There are two types of length units:
-relative and absolute.</span> <span class="index-def" title="relative
+relative and absolute.</span> <span class="index-def" data-term="relative
 units"><em>Relative length</em></span> units specify a length relative
 
 to another length property. Style sheets that use relative units
@@ -882,7 +882,7 @@ h1 { margin: 1ex }        /* ex */
 </pre>
 </div>
 
-<p>The <span class="index-def" title="em (unit)|quad width"><span
+<p>The <span class="index-def" data-term="em (unit)|quad width"><span
 id="em-width">'em'</span></span> unit is equal to the computed value of
 the <span class="propinst-font-size">'font-size'</span> property of
 the element on which it is used. The exception is when 'em' occurs in
@@ -891,7 +891,7 @@ to the font size of the parent element. It may be used for vertical or
 horizontal measurement. (This unit is also sometimes called the
 quad-width in typographic texts.)
 </p>
-<p>The <span class="index-def" title="x-height|ex (unit)"><span
+<p>The <span class="index-def" data-term="x-height|ex (unit)"><span
 id="ex">'ex'</span></span> unit is defined by the element's first available
 font.
 The exception is when 'ex' occurs in the value of the <span
@@ -949,7 +949,7 @@ h1 { font-size: 15px }
 </pre>
 </div>
 
-<p><span class="index-def" title="absolute length"><em> Absolute
+<p><span class="index-def" data-term="absolute length"><em> Absolute
 
 length</em></span>
 
@@ -998,7 +998,7 @@ pixel unit would vary to most closely match the reference pixel.
 on the assumption of 96dpi, and breaking that assumption breaks
 the content.)
 
-<p>The <span class="index-def" title="reference pixel|pixel"><em>reference pixel</em></span> is the
+<p>The <span class="index-def" data-term="reference pixel|pixel"><em>reference pixel</em></span> is the
 visual angle of one pixel on a device with a pixel density of 96dpi
 and a distance from the reader of an arm's length. For a nominal arm's
 length of 28 inches, the visual angle is therefore about 0.0213
@@ -1046,11 +1046,11 @@ p  { font-size: 12px }    /* px */
 <h3> <span id="percentage-units">Percentages</span></h3>
 
 <p> The format of a percentage value (denoted by <span
-class="index-def" title="&lt;percentage&gt;::definition of"><dfn
+class="index-def" data-term="&lt;percentage&gt;::definition of"><dfn
 id="value-def-percentage" data-dfn-type="type"
 class="value-def">&lt;percentage&gt;</dfn></span> in this specification)
 is a <span class="index-inst"
-title="&lt;number&gt;"><span
+data-term="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
 followed by '%'.
 </p>
@@ -1084,7 +1084,7 @@ p { line-height: 120% }  /* 120% of 'font-size' */
 
 <p>URI values (Uniform Resource Identifiers, see [[RFC3986]], which
 includes URLs, URNs, etc) in this specification are denoted by <span
-class="index-def" title="&lt;uri&gt;::definition of"><dfn
+class="index-def" data-term="&lt;uri&gt;::definition of"><dfn
 id="value-def-uri" data-dfn-type="type" class="value-def">&lt;uri&gt;</dfn></span>.  The
 functional notation used to designate URIs in property values is
 "url()", as in:
@@ -1156,13 +1156,13 @@ unavailable or inapplicable resources.
 </p>
 <h3><span id="counter">Counters</span></h3>
 
-<p><span class="index-def" title="&lt;counter&gt;, definition of"><dfn
+<p><span class="index-def" data-term="&lt;counter&gt;, definition of"><dfn
 id="value-def-counter" data-dfn-type="type" data-lt="<counter>">Counters</dfn></span> are denoted by
 case-sensitive identifiers (see the <span
 class="propinst-counter-increment">'counter-increment'</span> and
 <span class="propinst-counter-reset">'counter-reset'</span>
 properties). To refer to the value of a counter, the notation
-<span class="index-def" title="counter()">
+<span class="index-def" data-term="counter()">
 'counter(&lt;identifier&gt;)'</span> or 'counter(&lt;identifier&gt;,
 &lt;'list-style-type'&gt;)', with optional white space separating the tokens,
 is used. The default style is 'decimal'.
@@ -1199,7 +1199,7 @@ p:before {content: counter(par-num, upper-roman) ". "}
 
 <h3><span id="color-units">Colors</span></h3>
 <p>
-A <span class="index-def" title="&lt;color&gt;::definition of"><dfn
+A <span class="index-def" data-term="&lt;color&gt;::definition of"><dfn
 id="value-def-color" data-dfn-type="type" class="value-def">&lt;color&gt;</dfn></span>
 is either a keyword or a numerical RGB specification.
 </p>
@@ -1323,7 +1323,7 @@ may be larger or smaller than 0..255).</em>
 
 <h3><span id="strings">Strings</span></h3>
 
-<p><span class="index-def" title="&lt;string&gt;, definition of"><dfn
+<p><span class="index-def" data-term="&lt;string&gt;, definition of"><dfn
 id="value-def-string" data-dfn-type="type" data-lt="<string>">Strings</dfn></span> can either be written
 with double quotes or with single quotes. Double quotes cannot occur
 inside double quotes, unless escaped (e.g., as '\"' or as
@@ -1339,7 +1339,7 @@ inside double quotes, unless escaped (e.g., as '\"' or as
 </div>
 
 <p>A string cannot directly contain a <span class="index-inst"
-title="newline">newline</span>. 
+data-term="newline">newline</span>. 
 To include a newline in a string, use an escape representing the line feed 
 character in ISO-10646 (U+000A), such as "\A" or "\00000a". 
 This character represents the generic notion of "newline" in CSS.
@@ -1387,7 +1387,7 @@ display declaration.
 <p>A CSS style sheet is a sequence of characters from the Universal
 Character Set (see [[ISO10646]]). For transmission and
 storage, these characters must be <span class="index-def"
-title="character encoding">encoded</span> by a character encoding that
+data-term="character encoding">encoded</span> by a character encoding that
 supports the set of characters available in US-ASCII (e.g., UTF-8, ISO
 8859-x, SHIFT JIS, etc.).  For a good introduction to character sets
 and character encodings, please consult the HTML 4
@@ -1399,9 +1399,9 @@ STYLE element or "style" attribute of HTML, the style sheet shares the
 character encoding of the whole document.
 </p>
 <p>When a style sheet resides in a separate file, user agents must
-observe the following <span class="index-inst" title="character
+observe the following <span class="index-inst" data-term="character
 encoding::user agent's determination of">priorities</span> when
-determining a style sheet's <span class="index-inst" title="character
+determining a style sheet's <span class="index-inst" data-term="character
 encoding::default|default::character encoding">character
 encoding</span> (from highest priority to lowest):
 </p>

--- a/css2/syndata.src
+++ b/css2/syndata.src
@@ -271,8 +271,8 @@ href="#parsing-errors">rules for handling parsing errors</a>. However, because t
     </li>
 
     <li> In CSS, <span class="index-def"
-    title="identifier|identifier, definition of"><span
-    id="value-def-identifier"><dfn>identifiers</dfn></span></span>
+    title="identifier|identifier, definition of"><dfn
+    id="value-def-identifier" data-dfn-type="type" data-lt="<identifier>"><dfn>identifiers</dfn></dfn></span>
     (including element names, classes, and IDs in <a
     href="selector.html">selectors</a>) can contain only the
     characters [a-zA-Z0-9] and ISO 10646 characters  U+00A0 and higher,
@@ -817,11 +817,11 @@ undefined in CSS&nbsp;2
 <h3><span id="numbers">Integers and real numbers</span></h3>
 
 <p>Some value types may have integer values (denoted by <span
-class="index-def" title="&lt;integer&gt;::definition of"><span
-id="value-def-integer" class="value-def">&lt;integer&gt;</span></span>)
+class="index-def" title="&lt;integer&gt;::definition of"><dfn
+id="value-def-integer" data-dfn-type="type" class="value-def">&lt;integer&gt;</dfn></span>)
 or real number values (denoted by <span class="index-def"
-title="&lt;number&gt;::definition of"><span id="value-def-number"
-class="value-def">&lt;number&gt;</span></span>).  Real numbers and
+title="&lt;number&gt;::definition of"><dfn id="value-def-number" data-dfn-type="type"
+class="value-def">&lt;number&gt;</dfn></span>).  Real numbers and
 integers are specified in decimal notation only. An &lt;integer&gt;
 consists of one or more digits "0" to "9". A &lt;number&gt; can either
 be an &lt;integer&gt;, or it can be zero or more digits followed by a
@@ -839,8 +839,8 @@ non-negative value.
 <p>Lengths refer to distance measurements.</p>
 
 <p> The format of a length value (denoted by <span class="index-def"
-title="&lt;length&gt;::definition of"><span id="value-def-length"
-class="value-def">&lt;length&gt;</span></span> in this specification) is
+title="&lt;length&gt;::definition of"><dfn id="value-def-length" data-dfn-type="type"
+class="value-def">&lt;length&gt;</dfn></span> in this specification) is
 a <span
 class="value-inst-number">&lt;number&gt;</span> (with or without a
 decimal point) immediately followed by a unit identifier (e.g., px,
@@ -1046,9 +1046,9 @@ p  { font-size: 12px }    /* px */
 <h3> <span id="percentage-units">Percentages</span></h3>
 
 <p> The format of a percentage value (denoted by <span
-class="index-def" title="&lt;percentage&gt;::definition of"><span
-id="value-def-percentage"
-class="value-def">&lt;percentage&gt;</span></span> in this specification)
+class="index-def" title="&lt;percentage&gt;::definition of"><dfn
+id="value-def-percentage" data-dfn-type="type"
+class="value-def">&lt;percentage&gt;</dfn></span> in this specification)
 is a <span class="index-inst"
 title="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span> immediately
@@ -1084,8 +1084,8 @@ p { line-height: 120% }  /* 120% of 'font-size' */
 
 <p>URI values (Uniform Resource Identifiers, see [[RFC3986]], which
 includes URLs, URNs, etc) in this specification are denoted by <span
-class="index-def" title="&lt;uri&gt;::definition of"><span
-id="value-def-uri" class="value-def">&lt;uri&gt;</span></span>.  The
+class="index-def" title="&lt;uri&gt;::definition of"><dfn
+id="value-def-uri" data-dfn-type="type" class="value-def">&lt;uri&gt;</dfn></span>.  The
 functional notation used to designate URIs in property values is
 "url()", as in:
 </p>
@@ -1156,8 +1156,8 @@ unavailable or inapplicable resources.
 </p>
 <h3><span id="counter">Counters</span></h3>
 
-<p><span class="index-def" title="&lt;counter&gt;, definition of"><span
-id="value-def-counter">Counters</span></span> are denoted by
+<p><span class="index-def" title="&lt;counter&gt;, definition of"><dfn
+id="value-def-counter" data-dfn-type="type" data-lt="<counter>">Counters</dfn></span> are denoted by
 case-sensitive identifiers (see the <span
 class="propinst-counter-increment">'counter-increment'</span> and
 <span class="propinst-counter-reset">'counter-reset'</span>
@@ -1199,8 +1199,8 @@ p:before {content: counter(par-num, upper-roman) ". "}
 
 <h3><span id="color-units">Colors</span></h3>
 <p>
-A <span class="index-def" title="&lt;color&gt;::definition of"><span
-id="value-def-color" class="value-def">&lt;color&gt;</span></span>
+A <span class="index-def" title="&lt;color&gt;::definition of"><dfn
+id="value-def-color" data-dfn-type="type" class="value-def">&lt;color&gt;</dfn></span>
 is either a keyword or a numerical RGB specification.
 </p>
 <p> The list of color keywords is: aqua, black, blue, fuchsia,
@@ -1323,8 +1323,8 @@ may be larger or smaller than 0..255).</em>
 
 <h3><span id="strings">Strings</span></h3>
 
-<p><span class="index-def" title="&lt;string&gt;, definition of"><span
-id="value-def-string">Strings</span></span> can either be written
+<p><span class="index-def" title="&lt;string&gt;, definition of"><dfn
+id="value-def-string" data-dfn-type="type" data-lt="<string>">Strings</dfn></span> can either be written
 with double quotes or with single quotes. Double quotes cannot occur
 inside double quotes, unless escaped (e.g., as '\"' or as
 '\22'). Analogously for single quotes (e.g., "\'" or "\27"). 

--- a/css2/tables.html
+++ b/css2/tables.html
@@ -214,36 +214,36 @@ class="propinst-display">'display'</span></a> property. The following
 formatting rules to an arbitrary element:
 
 <dl>
-  <dt><strong><span class="index-def" title="table"><span
-  class="value-def" id="value-def-table">table</span></span></strong>
+  <dt><strong><span class="index-def" title="table"><dfn
+  class="value-def" id="value-def-table" data-dfn-type="value" data-dfn-for="display">table</dfn></span></strong>
   (In HTML: TABLE) <dd>Specifies that an element defines a <a
   href="visuren.html#block-level">block-level</a> table: it is a
   rectangular block that participates in a <a
   href="visuren.html#block-formatting">block formatting context</a>.
 
-  <dt><strong><span class="index-def" title="inline-table"><span
+  <dt><strong><span class="index-def" title="inline-table"><dfn
   class="value-def"
-  id="value-def-inline-table">inline-table</span></span></strong> (In
+  id="value-def-inline-table" data-dfn-type="value" data-dfn-for="display">inline-table</dfn></span></strong> (In
   HTML: TABLE) <dd>Specifies that an element defines an <a
   href="visuren.html#inline-level">inline-level</a> table: it is a
   rectangular block that participates in an <a
   href="visuren.html#inline-formatting">inline formatting
   context</a>).
 
-  <dt><strong><span class="index-def" title="table-row"><span
+  <dt><strong><span class="index-def" title="table-row"><dfn
   class="value-def"
-  id="value-def-table-row">table-row</span></span></strong> (In HTML:
+  id="value-def-table-row" data-dfn-type="value" data-dfn-for="display">table-row</dfn></span></strong> (In HTML:
   TR) <dd>Specifies that an element is a row of cells.
 
-  <dt><strong><span class="index-def" title="table-row-group"><span
+  <dt><strong><span class="index-def" title="table-row-group"><dfn
   class="value-def"
-  id="value-def-table-row-group">table-row-group</span></span></strong>
+  id="value-def-table-row-group" data-dfn-type="value" data-dfn-for="display">table-row-group</dfn></span></strong>
   (In HTML: TBODY) <dd>Specifies that an element groups one or more
   rows.
 
-  <dt><strong><span class="index-def" title="table-header-group"><span
+  <dt><strong><span class="index-def" title="table-header-group"><dfn
   class="value-def"
-  id="value-def-table-header-group">table-header-group</span></span></strong>
+  id="value-def-table-header-group" data-dfn-type="value" data-dfn-for="display">table-header-group</dfn></span></strong>
   (In HTML: THEAD) <dd>Like 'table-row-group', but for visual
   formatting, the row group is always displayed before all other rows
   and row groups and after any top captions. Print user agents may
@@ -252,9 +252,9 @@ formatting rules to an arbitrary element:
   the first is rendered as a header; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-footer-group"><span
+  <dt><strong><span class="index-def" title="table-footer-group"><dfn
   class="value-def"
-  id="value-def-table-footer-group">table-footer-group</span></span></strong>
+  id="value-def-table-footer-group" data-dfn-type="value" data-dfn-for="display">table-footer-group</dfn></span></strong>
   (In HTML: TFOOT) <dd>Like 'table-row-group', but for visual
   formatting, the row group is always displayed after all other rows
   and row groups and before any bottom captions. Print user agents may
@@ -263,26 +263,26 @@ formatting rules to an arbitrary element:
   the first is rendered as a footer; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-column"><span
+  <dt><strong><span class="index-def" title="table-column"><dfn
   class="value-def"
-  id="value-def-table-column">table-column</span></span></strong> (In
+  id="value-def-table-column" data-dfn-type="value" data-dfn-for="display">table-column</dfn></span></strong> (In
   HTML: COL) <dd>Specifies that an element describes a column of
   cells.
 
-  <dt><strong><span class="index-def" title="table-column-group"><span
+  <dt><strong><span class="index-def" title="table-column-group"><dfn
   class="value-def"
-  id="value-def-table-column-group">table-column-group</span></span></strong>
+  id="value-def-table-column-group" data-dfn-type="value" data-dfn-for="display">table-column-group</dfn></span></strong>
   (In HTML: COLGROUP) <dd>Specifies that an element groups one or more
   columns.
 
-  <dt><strong><span class="index-def" title="table-cell"><span
+  <dt><strong><span class="index-def" title="table-cell"><dfn
   class="value-def"
-  id="value-def-table-cell">table-cell</span></span></strong> (In HTML:
+  id="value-def-table-cell" data-dfn-type="value" data-dfn-for="display">table-cell</dfn></span></strong> (In HTML:
   TD, TH) <dd>Specifies that an element represents a table cell.
 
-  <dt><strong><span class="index-def" title="table-caption"><span
+  <dt><strong><span class="index-def" title="table-caption"><dfn
   class="value-def"
-  id="value-def-table-caption">table-caption</span></span></strong> (In
+  id="value-def-table-caption" data-dfn-type="value" data-dfn-for="display">table-caption</dfn></span></strong> (In
   HTML: CAPTION) <dd>Specifies a caption for the table. All elements
   with 'display: table-caption' must be rendered, as described in
   <a href="#model">section 17.4.</a>

--- a/css2/tables.html
+++ b/css2/tables.html
@@ -591,7 +591,7 @@ it">
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'caption-side'"><span id="propdef-caption-side" class="propdef-title"><strong>'caption-side'</strong></span></span>
+<span class="index-def" title="'caption-side'"><dfn id="propdef-caption-side" class="propdef-title" data-dfn-type="property" data-lt="caption-side"><strong>'caption-side'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>top | bottom | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -876,7 +876,7 @@ automatically fit their containing blocks.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'table-layout'"><span id="propdef-table-layout" class="propdef-title"><strong>'table-layout'</strong></span></span>
+<span class="index-def" title="'table-layout'"><dfn id="propdef-table-layout" class="propdef-title" data-dfn-type="property" data-lt="table-layout"><strong>'table-layout'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1250,7 +1250,7 @@ either model, so it is often a matter of taste which one is used.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-collapse'"><span id="propdef-border-collapse" class="propdef-title"><strong>'border-collapse'</strong></span></span>
+<span class="index-def" title="'border-collapse'"><dfn id="propdef-border-collapse" class="propdef-title" data-dfn-type="property" data-lt="border-collapse"><strong>'border-collapse'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>collapse | separate | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1273,7 +1273,7 @@ selects the collapsing borders model. The models are described below.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-spacing'"><span id="propdef-border-spacing" class="propdef-title"><strong>'border-spacing'</strong></span></span>
+<span class="index-def" title="'border-spacing'"><dfn id="propdef-border-spacing" class="propdef-title" data-dfn-type="property" data-lt="border-spacing"><strong>'border-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a>? | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1359,7 +1359,7 @@ class="propinst-empty-cells">'empty-cells'</span></a> property</h4>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'empty-cells'"><span id="propdef-empty-cells" class="propdef-title"><strong>'empty-cells'</strong></span></span>
+<span class="index-def" title="'empty-cells'"><dfn id="propdef-empty-cells" class="propdef-title" data-dfn-type="property" data-lt="empty-cells"><strong>'empty-cells'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>show | hide | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/tables.html
+++ b/css2/tables.html
@@ -80,7 +80,7 @@ algorithm, is not fully defined by this specification.
 <p>For the automatic table layout algorithm, some widely deployed
 implementations have achieved relatively close interoperability.
 
-<p><span id="x0" class="index-def" title="tables">Table</span> layout can be
+<p><span id="x0" class="index-def" data-term="tables">Table</span> layout can be
 used to represent tabular relationships between data. Authors specify
 these relationships in the <a href="conform.html#doclanguage">document
 language</a> and can specify their <em>presentation</em> using
@@ -166,7 +166,7 @@ in HTML 4, the semantics of the various table elements (TABLE,
 CAPTION, THEAD, TBODY, TFOOT, COL, COLGROUP, TH, and TD) are
 well-defined. In other document languages (such as XML applications),
 there may not be pre-defined table elements. Therefore, CSS&nbsp;2 allows
-authors to <span id="x1" class="index-inst" title="mapping elements to table
+authors to <span id="x1" class="index-inst" data-term="mapping elements to table
 parts">"map"</span> document language elements to table elements via
 the <a href="visuren.html#propdef-display" class="noxref"><span class="propinst-display">'display'</span></a> property. For
 example, the following rule makes the FOO element act like an HTML
@@ -179,10 +179,10 @@ BAR { display : table-caption }
 
 <p><span id="internal"></span> We discuss the various table elements in the
 following section. In
-this specification, the term <span id="x2" class="index-def" title="table
+this specification, the term <span id="x2" class="index-def" data-term="table
 element"><dfn>table element</dfn></span> refers to any element
 involved in the creation of a table. An <span class="index-def"
-title="internal table element|table element::internal"><dfn id="internal-table-element">internal
+data-term="internal table element|table element::internal"><dfn id="internal-table-element">internal
 table element</dfn></span> is one that produces a row, row group, column,
 column group, or cell.
 
@@ -214,14 +214,14 @@ class="propinst-display">'display'</span></a> property. The following
 formatting rules to an arbitrary element:
 
 <dl>
-  <dt><strong><span class="index-def" title="table"><dfn
+  <dt><strong><span class="index-def" data-term="table"><dfn
   class="value-def" id="value-def-table" data-dfn-type="value" data-dfn-for="display">table</dfn></span></strong>
   (In HTML: TABLE) <dd>Specifies that an element defines a <a
   href="visuren.html#block-level">block-level</a> table: it is a
   rectangular block that participates in a <a
   href="visuren.html#block-formatting">block formatting context</a>.
 
-  <dt><strong><span class="index-def" title="inline-table"><dfn
+  <dt><strong><span class="index-def" data-term="inline-table"><dfn
   class="value-def"
   id="value-def-inline-table" data-dfn-type="value" data-dfn-for="display">inline-table</dfn></span></strong> (In
   HTML: TABLE) <dd>Specifies that an element defines an <a
@@ -230,18 +230,18 @@ formatting rules to an arbitrary element:
   href="visuren.html#inline-formatting">inline formatting
   context</a>).
 
-  <dt><strong><span class="index-def" title="table-row"><dfn
+  <dt><strong><span class="index-def" data-term="table-row"><dfn
   class="value-def"
   id="value-def-table-row" data-dfn-type="value" data-dfn-for="display">table-row</dfn></span></strong> (In HTML:
   TR) <dd>Specifies that an element is a row of cells.
 
-  <dt><strong><span class="index-def" title="table-row-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-row-group"><dfn
   class="value-def"
   id="value-def-table-row-group" data-dfn-type="value" data-dfn-for="display">table-row-group</dfn></span></strong>
   (In HTML: TBODY) <dd>Specifies that an element groups one or more
   rows.
 
-  <dt><strong><span class="index-def" title="table-header-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-header-group"><dfn
   class="value-def"
   id="value-def-table-header-group" data-dfn-type="value" data-dfn-for="display">table-header-group</dfn></span></strong>
   (In HTML: THEAD) <dd>Like 'table-row-group', but for visual
@@ -252,7 +252,7 @@ formatting rules to an arbitrary element:
   the first is rendered as a header; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-footer-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-footer-group"><dfn
   class="value-def"
   id="value-def-table-footer-group" data-dfn-type="value" data-dfn-for="display">table-footer-group</dfn></span></strong>
   (In HTML: TFOOT) <dd>Like 'table-row-group', but for visual
@@ -263,24 +263,24 @@ formatting rules to an arbitrary element:
   the first is rendered as a footer; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-column"><dfn
+  <dt><strong><span class="index-def" data-term="table-column"><dfn
   class="value-def"
   id="value-def-table-column" data-dfn-type="value" data-dfn-for="display">table-column</dfn></span></strong> (In
   HTML: COL) <dd>Specifies that an element describes a column of
   cells.
 
-  <dt><strong><span class="index-def" title="table-column-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-column-group"><dfn
   class="value-def"
   id="value-def-table-column-group" data-dfn-type="value" data-dfn-for="display">table-column-group</dfn></span></strong>
   (In HTML: COLGROUP) <dd>Specifies that an element groups one or more
   columns.
 
-  <dt><strong><span class="index-def" title="table-cell"><dfn
+  <dt><strong><span class="index-def" data-term="table-cell"><dfn
   class="value-def"
   id="value-def-table-cell" data-dfn-type="value" data-dfn-for="display">table-cell</dfn></span></strong> (In HTML:
   TD, TH) <dd>Specifies that an element represents a table cell.
 
-  <dt><strong><span class="index-def" title="table-caption"><dfn
+  <dt><strong><span class="index-def" data-term="table-caption"><dfn
   class="value-def"
   id="value-def-table-caption" data-dfn-type="value" data-dfn-for="display">table-caption</dfn></span></strong> (In
   HTML: CAPTION) <dd>Specifies a caption for the table. All elements
@@ -591,7 +591,7 @@ it">
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'caption-side'"><dfn id="propdef-caption-side" class="propdef-title" data-dfn-type="property" data-lt="caption-side"><strong>'caption-side'</strong></dfn></span>
+<span class="index-def" data-term="'caption-side'"><dfn id="propdef-caption-side" class="propdef-title" data-dfn-type="property" data-lt="caption-side"><strong>'caption-side'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>top | bottom | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -876,7 +876,7 @@ automatically fit their containing blocks.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'table-layout'"><dfn id="propdef-table-layout" class="propdef-title" data-dfn-type="property" data-lt="table-layout"><strong>'table-layout'</strong></dfn></span>
+<span class="index-def" data-term="'table-layout'"><dfn id="propdef-table-layout" class="propdef-title" data-dfn-type="property" data-lt="table-layout"><strong>'table-layout'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1243,14 +1243,14 @@ constraints.
 
 <p>There are two distinct models for setting borders on table cells in
 CSS. One is most suitable for so-called <span id="x24" class="index-inst"
-title="separated borders">separated borders</span> around individual
+data-term="separated borders">separated borders</span> around individual
 cells, the other is suitable for borders that are continuous from one
 end of the table to the other. Many border styles can be achieved with
 either model, so it is often a matter of taste which one is used.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-collapse'"><dfn id="propdef-border-collapse" class="propdef-title" data-dfn-type="property" data-lt="border-collapse"><strong>'border-collapse'</strong></dfn></span>
+<span class="index-def" data-term="'border-collapse'"><dfn id="propdef-border-collapse" class="propdef-title" data-dfn-type="property" data-lt="border-collapse"><strong>'border-collapse'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>collapse | separate | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1273,7 +1273,7 @@ selects the collapsing borders model. The models are described below.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'border-spacing'"><dfn id="propdef-border-spacing" class="propdef-title" data-dfn-type="property" data-lt="border-spacing"><strong>'border-spacing'</strong></dfn></span>
+<span class="index-def" data-term="'border-spacing'"><dfn id="propdef-border-spacing" class="propdef-title" data-dfn-type="property" data-lt="border-spacing"><strong>'border-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a>? | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1326,7 +1326,7 @@ specifies the distance between the borders of adjoining cells. In this
 space, the row, column, row group, and column group backgrounds are
 invisible, allowing the table background to show through. Rows,
 columns, row groups, and column groups cannot have borders (i.e., user
-agents must <span id="x27" class="index-inst" title="ignore"><a
+agents must <span id="x27" class="index-inst" data-term="ignore"><a
 href="syndata.html#ignore">ignore</a></span> the border properties for
 those elements).
 
@@ -1359,7 +1359,7 @@ class="propinst-empty-cells">'empty-cells'</span></a> property</h4>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'empty-cells'"><dfn id="propdef-empty-cells" class="propdef-title" data-dfn-type="property" data-lt="empty-cells"><strong>'empty-cells'</strong></dfn></span>
+<span class="index-def" data-term="'empty-cells'"><dfn id="propdef-empty-cells" class="propdef-title" data-dfn-type="property" data-lt="empty-cells"><strong>'empty-cells'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>show | hide | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1597,7 +1597,7 @@ borders">[D]</A></SPAN>
 <h3><span class="secno">17.6.3</span> <span id="table-border-styles">Border styles</span></h3>
 
 <p>Some of the values of the <span id="x29" class="index-inst"
-title="&lt;border-style&gt;"><a href="box.html#propdef-border-style" class="noxref"><span
+data-term="&lt;border-style&gt;"><a href="box.html#propdef-border-style" class="noxref"><span
 class="propinst-border-style">'border-style'</span></a></span> have
 different meanings in tables than for other elements. In the list
 below they are marked with an asterisk.
@@ -1605,10 +1605,10 @@ below they are marked with an asterisk.
 <dl>
   <dt><a href="box.html#value-def-bo-none" class="noxref"><span class="value-inst-bo-none"><strong>none</strong></span></a>
 
-    <dd><span id="x30" class="index-inst" title="'none'::as border style">No
+    <dd><span id="x30" class="index-inst" data-term="'none'::as border style">No
     border.</span>
 
-  <dt><strong>*<span id="x31" class="index-inst" title="'hidden"><a href="box.html#value-def-hidden" class="noxref"><span
+  <dt><strong>*<span id="x31" class="index-inst" data-term="'hidden"><a href="box.html#value-def-hidden" class="noxref"><span
   class="value-inst-hidden">hidden</span></a></span></strong>
 
     <dd>Same as 'none', but in the <a
@@ -1616,40 +1616,40 @@ below they are marked with an asterisk.
     inhibits any other border (see the section on <a
     href="#border-conflict-resolution">border conflicts</a>).
 
-  <dt><strong><span id="x32" class="index-inst" title="'dotted'"><a href="box.html#value-def-dotted" class="noxref"><span
+  <dt><strong><span id="x32" class="index-inst" data-term="'dotted'"><a href="box.html#value-def-dotted" class="noxref"><span
   class="value-inst-dotted">dotted</span></a></span></strong>
 
     <dd>The border is a series of dots.
 
-  <dt><strong><span id="x33" class="index-inst" title="'dashed'"><a href="box.html#value-def-dashed" class="noxref"><span
+  <dt><strong><span id="x33" class="index-inst" data-term="'dashed'"><a href="box.html#value-def-dashed" class="noxref"><span
   class="value-inst-dashed">dashed</span></a></span></strong>
 
     <dd>The border is a series of short line segments.
 
-  <dt><strong><span id="x34" class="index-inst" title="'solid'"><a href="box.html#value-def-solid" class="noxref"><span
+  <dt><strong><span id="x34" class="index-inst" data-term="'solid'"><a href="box.html#value-def-solid" class="noxref"><span
   class="value-inst-solid">solid</span></a></span></strong>
 
     <dd>The border is a single line segment.
 
-   <dt><strong><span id="x35" class="index-inst" title="'double'"><a href="box.html#value-def-double" class="noxref"><span
+   <dt><strong><span id="x35" class="index-inst" data-term="'double'"><a href="box.html#value-def-double" class="noxref"><span
    class="value-inst-double">double</span></a></span></strong>
 
     <dd>The border is two solid lines. The sum of the two lines and
     the space between them equals the value of <a href="box.html#propdef-border-width" class="noxref"><span
     class="propinst-border-width">'border-width'</span></a>.
 
-  <dt><strong><span id="x36" class="index-inst" title="'groove'"><a href="box.html#value-def-groove" class="noxref"><span
+  <dt><strong><span id="x36" class="index-inst" data-term="'groove'"><a href="box.html#value-def-groove" class="noxref"><span
   class="value-inst-groove">groove</span></a></span></strong>
 
     <dd>The border looks as though it were carved into the canvas.
 
-  <dt><strong><span id="x37" class="index-inst" title="'ridge'"><a href="box.html#value-def-ridge" class="noxref"><span
+  <dt><strong><span id="x37" class="index-inst" data-term="'ridge'"><a href="box.html#value-def-ridge" class="noxref"><span
   class="value-inst-ridge">ridge</span></a></span></strong>
 
     <dd>The opposite of 'groove': the border looks as though it were
     coming out of the canvas.
 
-  <dt><strong>*<span id="x38" class="index-inst" title="'inset'"><a href="box.html#value-def-inset" class="noxref"><span
+  <dt><strong>*<span id="x38" class="index-inst" data-term="'inset'"><a href="box.html#value-def-inset" class="noxref"><span
   class="value-inst-inset">inset</span></a></span></strong>
 
     <dd>In the <a href="#separated-borders">separated borders
@@ -1658,7 +1658,7 @@ below they are marked with an asterisk.
     href="#collapsing-borders">collapsing border model</a>, drawn the same as
     'ridge'.
 
-  <dt><strong>*<span id="x39" class="index-inst" title="'outset'"><a href="box.html#value-def-outset" class="noxref"><span
+  <dt><strong>*<span id="x39" class="index-inst" data-term="'outset'"><a href="box.html#value-def-outset" class="noxref"><span
   class="value-inst-outset">outset</span></a></span></strong>
 
     <dd>In the <a href="#separated-borders">separated borders

--- a/css2/tables.html
+++ b/css2/tables.html
@@ -181,7 +181,7 @@ BAR { display : table-caption }
 following section. In
 this specification, the term <span id="x2" class="index-def" title="table
 element"><dfn>table element</dfn></span> refers to any element
-involved in the creation of a table. An <span id="x3" class="index-def"
+involved in the creation of a table. An <span class="index-def"
 title="internal table element|table element::internal"><dfn id="internal-table-element">internal
 table element</dfn></span> is one that produces a row, row group, column,
 column group, or cell.

--- a/css2/tables.src
+++ b/css2/tables.src
@@ -152,36 +152,36 @@ class="propinst-display">'display'</span> property. The following
 formatting rules to an arbitrary element:
 
 <dl>
-  <dt><strong><span class="index-def" title="table"><span
-  class="value-def" id="value-def-table">table</span></span></strong>
+  <dt><strong><span class="index-def" title="table"><dfn
+  class="value-def" id="value-def-table" data-dfn-type="value" data-dfn-for="display">table</dfn></span></strong>
   (In HTML: TABLE) <dd>Specifies that an element defines a <a
   href="visuren.html#block-level">block-level</a> table: it is a
   rectangular block that participates in a <a
   href="visuren.html#block-formatting">block formatting context</a>.
 
-  <dt><strong><span class="index-def" title="inline-table"><span
+  <dt><strong><span class="index-def" title="inline-table"><dfn
   class="value-def"
-  id="value-def-inline-table">inline-table</span></span></strong> (In
+  id="value-def-inline-table" data-dfn-type="value" data-dfn-for="display">inline-table</dfn></span></strong> (In
   HTML: TABLE) <dd>Specifies that an element defines an <a
   href="visuren.html#inline-level">inline-level</a> table: it is a
   rectangular block that participates in an <a
   href="visuren.html#inline-formatting">inline formatting
   context</a>).
 
-  <dt><strong><span class="index-def" title="table-row"><span
+  <dt><strong><span class="index-def" title="table-row"><dfn
   class="value-def"
-  id="value-def-table-row">table-row</span></span></strong> (In HTML:
+  id="value-def-table-row" data-dfn-type="value" data-dfn-for="display">table-row</dfn></span></strong> (In HTML:
   TR) <dd>Specifies that an element is a row of cells.
 
-  <dt><strong><span class="index-def" title="table-row-group"><span
+  <dt><strong><span class="index-def" title="table-row-group"><dfn
   class="value-def"
-  id="value-def-table-row-group">table-row-group</span></span></strong>
+  id="value-def-table-row-group" data-dfn-type="value" data-dfn-for="display">table-row-group</dfn></span></strong>
   (In HTML: TBODY) <dd>Specifies that an element groups one or more
   rows.
 
-  <dt><strong><span class="index-def" title="table-header-group"><span
+  <dt><strong><span class="index-def" title="table-header-group"><dfn
   class="value-def"
-  id="value-def-table-header-group">table-header-group</span></span></strong>
+  id="value-def-table-header-group" data-dfn-type="value" data-dfn-for="display">table-header-group</dfn></span></strong>
   (In HTML: THEAD) <dd>Like 'table-row-group', but for visual
   formatting, the row group is always displayed before all other rows
   and row groups and after any top captions. Print user agents may
@@ -190,9 +190,9 @@ formatting rules to an arbitrary element:
   the first is rendered as a header; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-footer-group"><span
+  <dt><strong><span class="index-def" title="table-footer-group"><dfn
   class="value-def"
-  id="value-def-table-footer-group">table-footer-group</span></span></strong>
+  id="value-def-table-footer-group" data-dfn-type="value" data-dfn-for="display">table-footer-group</dfn></span></strong>
   (In HTML: TFOOT) <dd>Like 'table-row-group', but for visual
   formatting, the row group is always displayed after all other rows
   and row groups and before any bottom captions. Print user agents may
@@ -201,26 +201,26 @@ formatting rules to an arbitrary element:
   the first is rendered as a footer; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-column"><span
+  <dt><strong><span class="index-def" title="table-column"><dfn
   class="value-def"
-  id="value-def-table-column">table-column</span></span></strong> (In
+  id="value-def-table-column" data-dfn-type="value" data-dfn-for="display">table-column</dfn></span></strong> (In
   HTML: COL) <dd>Specifies that an element describes a column of
   cells.
 
-  <dt><strong><span class="index-def" title="table-column-group"><span
+  <dt><strong><span class="index-def" title="table-column-group"><dfn
   class="value-def"
-  id="value-def-table-column-group">table-column-group</span></span></strong>
+  id="value-def-table-column-group" data-dfn-type="value" data-dfn-for="display">table-column-group</dfn></span></strong>
   (In HTML: COLGROUP) <dd>Specifies that an element groups one or more
   columns.
 
-  <dt><strong><span class="index-def" title="table-cell"><span
+  <dt><strong><span class="index-def" title="table-cell"><dfn
   class="value-def"
-  id="value-def-table-cell">table-cell</span></span></strong> (In HTML:
+  id="value-def-table-cell" data-dfn-type="value" data-dfn-for="display">table-cell</dfn></span></strong> (In HTML:
   TD, TH) <dd>Specifies that an element represents a table cell.
 
-  <dt><strong><span class="index-def" title="table-caption"><span
+  <dt><strong><span class="index-def" title="table-caption"><dfn
   class="value-def"
-  id="value-def-table-caption">table-caption</span></span></strong> (In
+  id="value-def-table-caption" data-dfn-type="value" data-dfn-for="display">table-caption</dfn></span></strong> (In
   HTML: CAPTION) <dd>Specifies a caption for the table. All elements
   with 'display: table-caption' must be rendered, as described in
   <a href="#model">section 17.4.</a>

--- a/css2/tables.src
+++ b/css2/tables.src
@@ -18,7 +18,7 @@ algorithm, is not fully defined by this specification.
 <p>For the automatic table layout algorithm, some widely deployed
 implementations have achieved relatively close interoperability.
 
-<p><span class="index-def" title="tables">Table</span> layout can be
+<p><span class="index-def" data-term="tables">Table</span> layout can be
 used to represent tabular relationships between data. Authors specify
 these relationships in the <a href="conform.html#doclanguage">document
 language</a> and can specify their <em>presentation</em> using
@@ -104,7 +104,7 @@ in HTML 4, the semantics of the various table elements (TABLE,
 CAPTION, THEAD, TBODY, TFOOT, COL, COLGROUP, TH, and TD) are
 well-defined. In other document languages (such as XML applications),
 there may not be pre-defined table elements. Therefore, CSS&nbsp;2 allows
-authors to <span class="index-inst" title="mapping elements to table
+authors to <span class="index-inst" data-term="mapping elements to table
 parts">"map"</span> document language elements to table elements via
 the <span class="propinst-display">'display'</span> property. For
 example, the following rule makes the FOO element act like an HTML
@@ -117,10 +117,10 @@ BAR { display : table-caption }
 
 <p><span id="internal"></span> We discuss the various table elements in the
 following section. In
-this specification, the term <span class="index-def" title="table
+this specification, the term <span class="index-def" data-term="table
 element"><dfn>table element</dfn></span> refers to any element
 involved in the creation of a table. An <span class="index-def"
-title="internal table element|table element::internal"><dfn id="internal-table-element">internal
+data-term="internal table element|table element::internal"><dfn id="internal-table-element">internal
 table element</dfn></span> is one that produces a row, row group, column,
 column group, or cell.
 
@@ -152,14 +152,14 @@ class="propinst-display">'display'</span> property. The following
 formatting rules to an arbitrary element:
 
 <dl>
-  <dt><strong><span class="index-def" title="table"><dfn
+  <dt><strong><span class="index-def" data-term="table"><dfn
   class="value-def" id="value-def-table" data-dfn-type="value" data-dfn-for="display">table</dfn></span></strong>
   (In HTML: TABLE) <dd>Specifies that an element defines a <a
   href="visuren.html#block-level">block-level</a> table: it is a
   rectangular block that participates in a <a
   href="visuren.html#block-formatting">block formatting context</a>.
 
-  <dt><strong><span class="index-def" title="inline-table"><dfn
+  <dt><strong><span class="index-def" data-term="inline-table"><dfn
   class="value-def"
   id="value-def-inline-table" data-dfn-type="value" data-dfn-for="display">inline-table</dfn></span></strong> (In
   HTML: TABLE) <dd>Specifies that an element defines an <a
@@ -168,18 +168,18 @@ formatting rules to an arbitrary element:
   href="visuren.html#inline-formatting">inline formatting
   context</a>).
 
-  <dt><strong><span class="index-def" title="table-row"><dfn
+  <dt><strong><span class="index-def" data-term="table-row"><dfn
   class="value-def"
   id="value-def-table-row" data-dfn-type="value" data-dfn-for="display">table-row</dfn></span></strong> (In HTML:
   TR) <dd>Specifies that an element is a row of cells.
 
-  <dt><strong><span class="index-def" title="table-row-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-row-group"><dfn
   class="value-def"
   id="value-def-table-row-group" data-dfn-type="value" data-dfn-for="display">table-row-group</dfn></span></strong>
   (In HTML: TBODY) <dd>Specifies that an element groups one or more
   rows.
 
-  <dt><strong><span class="index-def" title="table-header-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-header-group"><dfn
   class="value-def"
   id="value-def-table-header-group" data-dfn-type="value" data-dfn-for="display">table-header-group</dfn></span></strong>
   (In HTML: THEAD) <dd>Like 'table-row-group', but for visual
@@ -190,7 +190,7 @@ formatting rules to an arbitrary element:
   the first is rendered as a header; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-footer-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-footer-group"><dfn
   class="value-def"
   id="value-def-table-footer-group" data-dfn-type="value" data-dfn-for="display">table-footer-group</dfn></span></strong>
   (In HTML: TFOOT) <dd>Like 'table-row-group', but for visual
@@ -201,24 +201,24 @@ formatting rules to an arbitrary element:
   the first is rendered as a footer; the others are treated as if they
   had 'display: table-row-group'.
 
-  <dt><strong><span class="index-def" title="table-column"><dfn
+  <dt><strong><span class="index-def" data-term="table-column"><dfn
   class="value-def"
   id="value-def-table-column" data-dfn-type="value" data-dfn-for="display">table-column</dfn></span></strong> (In
   HTML: COL) <dd>Specifies that an element describes a column of
   cells.
 
-  <dt><strong><span class="index-def" title="table-column-group"><dfn
+  <dt><strong><span class="index-def" data-term="table-column-group"><dfn
   class="value-def"
   id="value-def-table-column-group" data-dfn-type="value" data-dfn-for="display">table-column-group</dfn></span></strong>
   (In HTML: COLGROUP) <dd>Specifies that an element groups one or more
   columns.
 
-  <dt><strong><span class="index-def" title="table-cell"><dfn
+  <dt><strong><span class="index-def" data-term="table-cell"><dfn
   class="value-def"
   id="value-def-table-cell" data-dfn-type="value" data-dfn-for="display">table-cell</dfn></span></strong> (In HTML:
   TD, TH) <dd>Specifies that an element represents a table cell.
 
-  <dt><strong><span class="index-def" title="table-caption"><dfn
+  <dt><strong><span class="index-def" data-term="table-caption"><dfn
   class="value-def"
   id="value-def-table-caption" data-dfn-type="value" data-dfn-for="display">table-caption</dfn></span></strong> (In
   HTML: CAPTION) <dd>Specifies a caption for the table. All elements
@@ -1148,7 +1148,7 @@ constraints.
 
 <p>There are two distinct models for setting borders on table cells in
 CSS. One is most suitable for so-called <span class="index-inst"
-title="separated borders">separated borders</span> around individual
+data-term="separated borders">separated borders</span> around individual
 cells, the other is suitable for borders that are continuous from one
 end of the table to the other. Many border styles can be achieved with
 either model, so it is often a matter of taste which one is used.
@@ -1201,7 +1201,7 @@ specifies the distance between the borders of adjoining cells. In this
 space, the row, column, row group, and column group backgrounds are
 invisible, allowing the table background to show through. Rows,
 columns, row groups, and column groups cannot have borders (i.e., user
-agents must <span class="index-inst" title="ignore"><a
+agents must <span class="index-inst" data-term="ignore"><a
 href="syndata.html#ignore">ignore</a></span> the border properties for
 those elements).
 
@@ -1453,7 +1453,7 @@ td.cell6       { border: 5px solid green; }
 <h3><span id="table-border-styles">Border styles</span></h3>
 
 <p>Some of the values of the <span class="index-inst"
-title="&lt;border-style&gt;"><span
+data-term="&lt;border-style&gt;"><span
 class="propinst-border-style">'border-style'</span></span> have
 different meanings in tables than for other elements. In the list
 below they are marked with an asterisk.
@@ -1461,10 +1461,10 @@ below they are marked with an asterisk.
 <dl>
   <dt><span class="value-inst-bo-none"><strong>none</strong></span>
 
-    <dd><span class="index-inst" title="'none'::as border style">No
+    <dd><span class="index-inst" data-term="'none'::as border style">No
     border.</span>
 
-  <dt><strong>*<span class="index-inst" title="'hidden"><span
+  <dt><strong>*<span class="index-inst" data-term="'hidden"><span
   class="value-inst-hidden">hidden</span></span></strong>
 
     <dd>Same as 'none', but in the <a
@@ -1472,40 +1472,40 @@ below they are marked with an asterisk.
     inhibits any other border (see the section on <a
     href="#border-conflict-resolution">border conflicts</a>).
 
-  <dt><strong><span class="index-inst" title="'dotted'"><span
+  <dt><strong><span class="index-inst" data-term="'dotted'"><span
   class="value-inst-dotted">dotted</span></span></strong>
 
     <dd>The border is a series of dots.
 
-  <dt><strong><span class="index-inst" title="'dashed'"><span
+  <dt><strong><span class="index-inst" data-term="'dashed'"><span
   class="value-inst-dashed">dashed</span></span></strong>
 
     <dd>The border is a series of short line segments.
 
-  <dt><strong><span class="index-inst" title="'solid'"><span
+  <dt><strong><span class="index-inst" data-term="'solid'"><span
   class="value-inst-solid">solid</span></span></strong>
 
     <dd>The border is a single line segment.
 
-   <dt><strong><span class="index-inst" title="'double'"><span
+   <dt><strong><span class="index-inst" data-term="'double'"><span
    class="value-inst-double">double</span></span></strong>
 
     <dd>The border is two solid lines. The sum of the two lines and
     the space between them equals the value of <span
     class="propinst-border-width">'border-width'</span>.
 
-  <dt><strong><span class="index-inst" title="'groove'"><span
+  <dt><strong><span class="index-inst" data-term="'groove'"><span
   class="value-inst-groove">groove</span></span></strong>
 
     <dd>The border looks as though it were carved into the canvas.
 
-  <dt><strong><span class="index-inst" title="'ridge'"><span
+  <dt><strong><span class="index-inst" data-term="'ridge'"><span
   class="value-inst-ridge">ridge</span></span></strong>
 
     <dd>The opposite of 'groove': the border looks as though it were
     coming out of the canvas.
 
-  <dt><strong>*<span class="index-inst" title="'inset'"><span
+  <dt><strong>*<span class="index-inst" data-term="'inset'"><span
   class="value-inst-inset">inset</span></span></strong>
 
     <dd>In the <a href="#separated-borders">separated borders
@@ -1514,7 +1514,7 @@ below they are marked with an asterisk.
     href="#collapsing-borders">collapsing border model</a>, drawn the same as
     'ridge'.
 
-  <dt><strong>*<span class="index-inst" title="'outset'"><span
+  <dt><strong>*<span class="index-inst" data-term="'outset'"><span
   class="value-inst-outset">outset</span></span></strong>
 
     <dd>In the <a href="#separated-borders">separated borders

--- a/css2/text.html
+++ b/css2/text.html
@@ -75,7 +75,7 @@ class="propinst-text-indent">'text-indent'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-indent'"><dfn id="propdef-text-indent" class="propdef-title" data-dfn-type="property" data-lt="text-indent"><strong>'text-indent'</strong></dfn></span>
+<span class="index-def" data-term="'text-indent'"><dfn id="propdef-text-indent" class="propdef-title" data-dfn-type="property" data-lt="text-indent"><strong>'text-indent'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -106,10 +106,10 @@ affected if it is the first child of its parent element.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x1" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+<dt><span id="x1" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
 class="value-inst-length">&lt;length&gt;</span></a></span></dt>
 <dd>The indentation is a fixed length.</dd>
-<dt><span id="x2" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
+<dt><span id="x2" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
 class="value-inst-percentage">&lt;percentage&gt;
 </span></a></span></dt>
 <dd>The indentation is a percentage of the containing
@@ -148,7 +148,7 @@ class="propinst-text-align">'text-align'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-align'"><dfn id="propdef-text-align" class="propdef-title" data-dfn-type="property" data-lt="text-align"><strong>'text-align'</strong></dfn></span>
+<span class="index-def" data-term="'text-align'"><dfn id="propdef-text-align" class="propdef-title" data-dfn-type="property" data-lt="text-align"><strong>'text-align'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>left | right | center | justify | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -211,7 +211,7 @@ The actual justification algorithm used depends on the user-agent and the langua
 of the text.</em>
 </p>
 </div>
-<p><em><span id="x4" class="index-inst" title="conformance"><a
+<p><em><span id="x4" class="index-inst" data-term="conformance"><a
 href="conform.html#conformance">Conforming user agents</a></span> may
 interpret the value 'justify' as 'left' or 'right', depending on
 whether the element's default writing direction is left-to-right or
@@ -227,7 +227,7 @@ property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-decoration'"><dfn id="propdef-text-decoration" class="propdef-title" data-dfn-type="property" data-lt="text-decoration"><strong>'text-decoration'</strong></dfn></span>
+<span class="index-def" data-term="'text-decoration'"><dfn id="propdef-text-decoration" class="propdef-title" data-dfn-type="property" data-lt="text-decoration"><strong>'text-decoration'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>none | [ underline || overline || line-through || blink ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -383,7 +383,7 @@ class="propinst-word-spacing">'word-spacing'</span></a> properties</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'letter-spacing'"><dfn id="propdef-letter-spacing" class="propdef-title" data-dfn-type="property" data-lt="letter-spacing"><strong>'letter-spacing'</strong></dfn></span>
+<span class="index-def" data-term="'letter-spacing'"><dfn id="propdef-letter-spacing" class="propdef-title" data-dfn-type="property" data-lt="letter-spacing"><strong>'letter-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -406,7 +406,7 @@ text characters. Values have the following meanings:</p>
 <dd>The spacing is the normal spacing for the current font.
 This value allows the user agent to alter the space
 between characters in order to justify text.</dd>
-<dt><span id="x7" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+<dt><span id="x7" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
 class="value-inst-length">&lt;length&gt;</span></a></span></dt>
 <dd>This value indicates inter-character space <em>in
 addition to</em> the default space between
@@ -436,12 +436,12 @@ blockquote { letter-spacing: 0cm }   /* Same as '0' */
 
 <p> When the resultant space between two characters is not the same as
 the default space, user agents should not use 
-<span id="x8" class="index-inst" title="ligatures">ligatures.</span>
+<span id="x8" class="index-inst" data-term="ligatures">ligatures.</span>
 </p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'word-spacing'"><dfn id="propdef-word-spacing" class="propdef-title" data-dfn-type="property" data-lt="word-spacing"><strong>'word-spacing'</strong></dfn></span>
+<span class="index-def" data-term="'word-spacing'"><dfn id="propdef-word-spacing" class="propdef-title" data-dfn-type="property" data-lt="word-spacing"><strong>'word-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -463,7 +463,7 @@ Values have the following meanings:</p>
 <dt>normal</dt>
 <dd>The normal inter-word space, as defined by the current font and/or
 the <abbr title="user agent">UA</abbr>.</dd>
-<dt><span id="x10" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+<dt><span id="x10" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
 class="value-inst-length">&lt;length&gt;</span></a></span></dt>
 <dd>This value indicates inter-word space <em>in
 addition to</em> the default space between
@@ -496,7 +496,7 @@ class="propinst-text-transform">'text-transform'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-transform'"><dfn id="propdef-text-transform" class="propdef-title" data-dfn-type="property" data-lt="text-transform"><strong>'text-transform'</strong></dfn></span>
+<span class="index-def" data-term="'text-transform'"><dfn id="propdef-text-transform" class="propdef-title" data-dfn-type="property" data-lt="text-transform"><strong>'text-transform'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>capitalize | uppercase | lowercase | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -546,7 +546,7 @@ class="propinst-white-space">'white-space'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'white-space'"><dfn id="propdef-white-space" class="propdef-title" data-dfn-type="property" data-lt="white-space"><strong>'white-space'</strong></dfn></span>
+<span class="index-def" data-term="'white-space'"><dfn id="propdef-white-space" class="propdef-title" data-dfn-type="property" data-lt="white-space"><strong>'white-space'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | pre | nowrap | pre-wrap | pre-line | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/text.html
+++ b/css2/text.html
@@ -75,7 +75,7 @@ class="propinst-text-indent">'text-indent'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-indent'"><span id="propdef-text-indent" class="propdef-title"><strong>'text-indent'</strong></span></span>
+<span class="index-def" title="'text-indent'"><dfn id="propdef-text-indent" class="propdef-title" data-dfn-type="property" data-lt="text-indent"><strong>'text-indent'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -148,7 +148,7 @@ class="propinst-text-align">'text-align'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-align'"><span id="propdef-text-align" class="propdef-title"><strong>'text-align'</strong></span></span>
+<span class="index-def" title="'text-align'"><dfn id="propdef-text-align" class="propdef-title" data-dfn-type="property" data-lt="text-align"><strong>'text-align'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>left | right | center | justify | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -227,7 +227,7 @@ property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-decoration'"><span id="propdef-text-decoration" class="propdef-title"><strong>'text-decoration'</strong></span></span>
+<span class="index-def" title="'text-decoration'"><dfn id="propdef-text-decoration" class="propdef-title" data-dfn-type="property" data-lt="text-decoration"><strong>'text-decoration'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>none | [ underline || overline || line-through || blink ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -383,7 +383,7 @@ class="propinst-word-spacing">'word-spacing'</span></a> properties</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'letter-spacing'"><span id="propdef-letter-spacing" class="propdef-title"><strong>'letter-spacing'</strong></span></span>
+<span class="index-def" title="'letter-spacing'"><dfn id="propdef-letter-spacing" class="propdef-title" data-dfn-type="property" data-lt="letter-spacing"><strong>'letter-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -441,7 +441,7 @@ the default space, user agents should not use
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'word-spacing'"><span id="propdef-word-spacing" class="propdef-title"><strong>'word-spacing'</strong></span></span>
+<span class="index-def" title="'word-spacing'"><dfn id="propdef-word-spacing" class="propdef-title" data-dfn-type="property" data-lt="word-spacing"><strong>'word-spacing'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -496,7 +496,7 @@ class="propinst-text-transform">'text-transform'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'text-transform'"><span id="propdef-text-transform" class="propdef-title"><strong>'text-transform'</strong></span></span>
+<span class="index-def" title="'text-transform'"><dfn id="propdef-text-transform" class="propdef-title" data-dfn-type="property" data-lt="text-transform"><strong>'text-transform'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>capitalize | uppercase | lowercase | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -546,7 +546,7 @@ class="propinst-white-space">'white-space'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'white-space'"><span id="propdef-white-space" class="propdef-title"><strong>'white-space'</strong></span></span>
+<span class="index-def" title="'white-space'"><dfn id="propdef-white-space" class="propdef-title" data-dfn-type="property" data-lt="white-space"><strong>'white-space'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | pre | nowrap | pre-wrap | pre-line | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/text.src
+++ b/css2/text.src
@@ -49,10 +49,10 @@ affected if it is the first child of its parent element.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;length&gt;"><span
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span
 class="value-inst-length">&lt;length&gt;</span></span></dt>
 <dd>The indentation is a fixed length.</dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span
 class="value-inst-percentage">&lt;percentage&gt;
 </span></span></dt>
 <dd>The indentation is a percentage of the containing
@@ -138,7 +138,7 @@ The actual justification algorithm used depends on the user-agent and the langua
 of the text.</em>
 </p>
 </div>
-<p><em><span class="index-inst" title="conformance"><a
+<p><em><span class="index-inst" data-term="conformance"><a
 href="conform.html#conformance">Conforming user agents</a></span> may
 interpret the value 'justify' as 'left' or 'right', depending on
 whether the element's default writing direction is left-to-right or
@@ -303,7 +303,7 @@ text characters. Values have the following meanings:</p>
 <dd>The spacing is the normal spacing for the current font.
 This value allows the user agent to alter the space
 between characters in order to justify text.</dd>
-<dt><span class="index-inst" title="&lt;length&gt;"><span
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span
 class="value-inst-length">&lt;length&gt;</span></span></dt>
 <dd>This value indicates inter-character space <em>in
 addition to</em> the default space between
@@ -333,7 +333,7 @@ blockquote { letter-spacing: 0cm }   /* Same as '0' */
 
 <p> When the resultant space between two characters is not the same as
 the default space, user agents should not use 
-<span class="index-inst" title="ligatures">ligatures.</span>
+<span class="index-inst" data-term="ligatures">ligatures.</span>
 </p>
 
 <!-- #include src=properties/word-spacing.srb -->
@@ -345,7 +345,7 @@ Values have the following meanings:</p>
 <dt>normal</dt>
 <dd>The normal inter-word space, as defined by the current font and/or
 the <abbr title="user agent">UA</abbr>.</dd>
-<dt><span class="index-inst" title="&lt;length&gt;"><span
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span
 class="value-inst-length">&lt;length&gt;</span></span></dt>
 <dd>This value indicates inter-word space <em>in
 addition to</em> the default space between

--- a/css2/ui.html
+++ b/css2/ui.html
@@ -356,8 +356,8 @@ except that 'hidden' is not a legal outline style.
 </p>
 <p>The <a href="ui.html#propdef-outline-color" class="noxref"><span class="propinst-outline-color">'outline-color'</span></a>
 accepts all colors, as well as the keyword <span class="index-def"
-title="invert"><span class="value-def"
-id="value-def-invert">'invert'</span></span>. 'invert' is expected to
+title="invert"><dfn class="value-def"
+id="value-def-invert" data-dfn-type="value" data-dfn-for="outline-color" data-lt="invert">'invert'</dfn></span>. 'invert' is expected to
 perform a color inversion on the pixels on the screen. This is a
 common trick to ensure the focus border is visible, regardless of
 color background.

--- a/css2/ui.html
+++ b/css2/ui.html
@@ -57,7 +57,7 @@ class="propinst-cursor">'cursor'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cursor'"><span id="propdef-cursor" class="propdef-title"><strong>'cursor'</strong></span></span>
+<span class="index-def" title="'cursor'"><dfn id="propdef-cursor" class="propdef-title" data-dfn-type="property" data-lt="cursor"><strong>'cursor'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [<a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> ,]* [ auto | crosshair | default | pointer | move | e-resize
@@ -268,7 +268,7 @@ ways:</p>
 </p>
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline'"><span id="propdef-outline" class="propdef-title"><strong>'outline'</strong></span></span>
+<span class="index-def" title="'outline'"><dfn id="propdef-outline" class="propdef-title" data-dfn-type="property" data-lt="outline"><strong>'outline'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="ui.html#propdef-outline-color" class="noxref"><span class="propinst-outline-color">&lt;'outline-color'&gt;</span></a> || <a href="ui.html#propdef-outline-style" class="noxref"><span class="propinst-outline-style">&lt;'outline-style'&gt;</span></a> || <a href="ui.html#propdef-outline-width" class="noxref"><span class="propinst-outline-width">&lt;'outline-width'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -284,7 +284,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-width'"><span id="propdef-outline-width" class="propdef-title"><strong>'outline-width'</strong></span></span>
+<span class="index-def" title="'outline-width'"><dfn id="propdef-outline-width" class="propdef-title" data-dfn-type="property" data-lt="outline-width"><strong>'outline-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -300,7 +300,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-style'"><span id="propdef-outline-style" class="propdef-title"><strong>'outline-style'</strong></span></span>
+<span class="index-def" title="'outline-style'"><dfn id="propdef-outline-style" class="propdef-title" data-dfn-type="property" data-lt="outline-style"><strong>'outline-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -316,7 +316,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-color'"><span id="propdef-outline-color" class="propdef-title"><strong>'outline-color'</strong></span></span>
+<span class="index-def" title="'outline-color'"><dfn id="propdef-outline-color" class="propdef-title" data-dfn-type="property" data-lt="outline-color"><strong>'outline-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | invert | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/ui.html
+++ b/css2/ui.html
@@ -57,7 +57,7 @@ class="propinst-cursor">'cursor'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'cursor'"><dfn id="propdef-cursor" class="propdef-title" data-dfn-type="property" data-lt="cursor"><strong>'cursor'</strong></dfn></span>
+<span class="index-def" data-term="'cursor'"><dfn id="propdef-cursor" class="propdef-title" data-dfn-type="property" data-lt="cursor"><strong>'cursor'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ [<a href="syndata.html#value-def-uri" class="noxref"><span class="value-inst-uri">&lt;uri&gt;</span></a> ,]* [ auto | crosshair | default | pointer | move | e-resize
@@ -119,7 +119,7 @@ or an arrow with a watch or hourglass.
 <dd>Help is available for the object under the cursor. Often rendered
 	  as a question mark or a balloon.
 </dd>
-<dt><span id="x1" class="index-inst" title="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
+<dt><span id="x1" class="index-inst" data-term="&lt;uri&gt;"><a href="syndata.html#value-def-uri" class="noxref"><span
 class="value-inst-uri">&lt;uri&gt;</span></a></span></dt>
 <dd>The user agent retrieves the cursor from the resource
 designated by the URI. If the user agent cannot handle 
@@ -251,7 +251,7 @@ a user's system resources. Please consult the <a href="fonts.html#propdef-font" 
 class="propinst-font">'font'</span></a> property for details.
 </p>
 <h2><span class="secno">18.4</span> <span id="dynamic-outlines">Dynamic outlines:</span> the <span id="x2"
-class="index-def" title="outline">'outline'</span> property</h2>
+class="index-def" data-term="outline">'outline'</span> property</h2>
 
 <p>At times, style sheet authors may want to create outlines around
 visual objects such as buttons, active form fields, image maps, etc.,
@@ -268,7 +268,7 @@ ways:</p>
 </p>
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline'"><dfn id="propdef-outline" class="propdef-title" data-dfn-type="property" data-lt="outline"><strong>'outline'</strong></dfn></span>
+<span class="index-def" data-term="'outline'"><dfn id="propdef-outline" class="propdef-title" data-dfn-type="property" data-lt="outline"><strong>'outline'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>[ <a href="ui.html#propdef-outline-color" class="noxref"><span class="propinst-outline-color">&lt;'outline-color'&gt;</span></a> || <a href="ui.html#propdef-outline-style" class="noxref"><span class="propinst-outline-style">&lt;'outline-style'&gt;</span></a> || <a href="ui.html#propdef-outline-width" class="noxref"><span class="propinst-outline-width">&lt;'outline-width'&gt;</span></a> ] | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -284,7 +284,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-width'"><dfn id="propdef-outline-width" class="propdef-title" data-dfn-type="property" data-lt="outline-width"><strong>'outline-width'</strong></dfn></span>
+<span class="index-def" data-term="'outline-width'"><dfn id="propdef-outline-width" class="propdef-title" data-dfn-type="property" data-lt="outline-width"><strong>'outline-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-width" class="noxref"><span class="value-inst-border-width">&lt;border-width&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -300,7 +300,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-style'"><dfn id="propdef-outline-style" class="propdef-title" data-dfn-type="property" data-lt="outline-style"><strong>'outline-style'</strong></dfn></span>
+<span class="index-def" data-term="'outline-style'"><dfn id="propdef-outline-style" class="propdef-title" data-dfn-type="property" data-lt="outline-style"><strong>'outline-style'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="box.html#value-def-border-style" class="noxref"><span class="value-inst-border-style">&lt;border-style&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -316,7 +316,7 @@ ways:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'outline-color'"><dfn id="propdef-outline-color" class="propdef-title" data-dfn-type="property" data-lt="outline-color"><strong>'outline-color'</strong></dfn></span>
+<span class="index-def" data-term="'outline-color'"><dfn id="propdef-outline-color" class="propdef-title" data-dfn-type="property" data-lt="outline-color"><strong>'outline-color'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-color" class="noxref"><span class="value-inst-color">&lt;color&gt;</span></a> | invert | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -356,7 +356,7 @@ except that 'hidden' is not a legal outline style.
 </p>
 <p>The <a href="ui.html#propdef-outline-color" class="noxref"><span class="propinst-outline-color">'outline-color'</span></a>
 accepts all colors, as well as the keyword <span class="index-def"
-title="invert"><dfn class="value-def"
+data-term="invert"><dfn class="value-def"
 id="value-def-invert" data-dfn-type="value" data-dfn-for="outline-color" data-lt="invert">'invert'</dfn></span>. 'invert' is expected to
 perform a color inversion on the pixels on the screen. This is a
 common trick to ensure the focus border is visible, regardless of
@@ -410,7 +410,7 @@ of the outline, without provoking a reflow.
 
 <p>Graphical user interfaces may use outlines around elements to tell
 the user which element on the page has the <span id="x8" class="index-def"
-title="focus"><dfn>focus</dfn></span>. These outlines are in addition
+data-term="focus"><dfn>focus</dfn></span>. These outlines are in addition
 to any borders, and switching outlines on and off should not cause
 the document to reflow. The focus is the subject of user interaction
 in a document (e.g., for entering text, selecting a button,

--- a/css2/ui.src
+++ b/css2/ui.src
@@ -243,8 +243,8 @@ except that 'hidden' is not a legal outline style.
 </p>
 <p>The <span class="propinst-outline-color">'outline-color'</span>
 accepts all colors, as well as the keyword <span class="index-def"
-title="invert"><span class="value-def"
-id="value-def-invert">'invert'</span></span>. 'invert' is expected to
+title="invert"><dfn class="value-def"
+id="value-def-invert" data-dfn-type="value" data-dfn-for="outline-color" data-lt="invert">'invert'</dfn></span>. 'invert' is expected to
 perform a color inversion on the pixels on the screen. This is a
 common trick to ensure the focus border is visible, regardless of
 color background.

--- a/css2/ui.src
+++ b/css2/ui.src
@@ -66,7 +66,7 @@ or an arrow with a watch or hourglass.
 <dd>Help is available for the object under the cursor. Often rendered
 	  as a question mark or a balloon.
 </dd>
-<dt><span class="index-inst" title="&lt;uri&gt;"><span
+<dt><span class="index-inst" data-term="&lt;uri&gt;"><span
 class="value-inst-uri">&lt;uri&gt;</span></span></dt>
 <dd>The user agent retrieves the cursor from the resource
 designated by the URI. If the user agent cannot handle 
@@ -198,7 +198,7 @@ a user's system resources. Please consult the <span
 class="propinst-font">'font'</span> property for details.
 </p>
 <h2><span id="dynamic-outlines">Dynamic outlines:</span> the <span
-class="index-def" title="outline">'outline'</span> property</h2>
+class="index-def" data-term="outline">'outline'</span> property</h2>
 
 <p>At times, style sheet authors may want to create outlines around
 visual objects such as buttons, active form fields, image maps, etc.,
@@ -243,7 +243,7 @@ except that 'hidden' is not a legal outline style.
 </p>
 <p>The <span class="propinst-outline-color">'outline-color'</span>
 accepts all colors, as well as the keyword <span class="index-def"
-title="invert"><dfn class="value-def"
+data-term="invert"><dfn class="value-def"
 id="value-def-invert" data-dfn-type="value" data-dfn-for="outline-color" data-lt="invert">'invert'</dfn></span>. 'invert' is expected to
 perform a color inversion on the pixels on the screen. This is a
 common trick to ensure the focus border is visible, regardless of
@@ -297,7 +297,7 @@ of the outline, without provoking a reflow.
 
 <p>Graphical user interfaces may use outlines around elements to tell
 the user which element on the page has the <span class="index-def"
-title="focus"><dfn>focus</dfn></span>. These outlines are in addition
+data-term="focus"><dfn>focus</dfn></span>. These outlines are in addition
 to any borders, and switching outlines on and off should not cause
 the document to reflow. The focus is the subject of user interaction
 in a document (e.g., for entering text, selecting a button,

--- a/css2/visudet.html
+++ b/css2/visudet.html
@@ -81,14 +81,14 @@ block"</span></h2>
 
 <p>The position and size of an element's box(es) are sometimes
 calculated relative to a certain rectangle, called the <dfn><span id="x0"
-class="index-def" title="containing block">containing
+class="index-def" data-term="containing block">containing
 block</span></dfn> of the element. The containing block of an element
 is defined as follows:</p>
 
 <ol>
 <li>The containing block in which the <a href="conform.html#root">root
 element</a> lives is a rectangle called the <dfn><span id="x1"
-class="index-def" title="initial containing block|containing
+class="index-def" data-term="initial containing block|containing
 block::initial">initial containing block</span></dfn>. For continuous
 media, it has the dimensions of the <a
 href="visuren.html#viewport">viewport</a> and is anchored at the
@@ -227,7 +227,7 @@ class="propinst-width">'width'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'width'"><dfn id="propdef-width" class="propdef-title" data-dfn-type="property" data-lt="width"><strong>'width'</strong></dfn></span>
+<span class="index-def" data-term="'width'"><dfn id="propdef-width" class="propdef-title" data-dfn-type="property" data-lt="width"><strong>'width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -259,11 +259,11 @@ shorted by the presence of <a href="visuren.html#floats">floats</a>.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x4" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
+<dt><span id="x4" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies the width of the content area using a length unit.
 </dd>
-<dt><span id="x5" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x5" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a percentage width. The percentage is calculated
 with respect to the width of the generated box's 
@@ -682,7 +682,7 @@ class="propinst-max-width">'max-width'</span></a></h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'min-width'"><dfn id="propdef-min-width" class="propdef-title" data-dfn-type="property" data-lt="min-width"><strong>'min-width'</strong></dfn></span>
+<span class="index-def" data-term="'min-width'"><dfn id="propdef-min-width" class="propdef-title" data-dfn-type="property" data-lt="min-width"><strong>'min-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -698,7 +698,7 @@ class="propinst-max-width">'max-width'</span></a></h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'max-width'"><dfn id="propdef-max-width" class="propdef-title" data-dfn-type="property" data-lt="max-width"><strong>'max-width'</strong></dfn></span>
+<span class="index-def" data-term="'max-width'"><dfn id="propdef-max-width" class="propdef-title" data-dfn-type="property" data-lt="max-width"><strong>'max-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -717,11 +717,11 @@ class="propinst-max-width">'max-width'</span></a></h2>
 certain range. Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x8" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
+<dt><span id="x8" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a fixed minimum or maximum used width.
 </dd>
-<dt><span id="x9" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x9" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a percentage for determining the used value. The
 percentage is calculated with respect to the width of the generated
@@ -869,7 +869,7 @@ class="propinst-height">'height'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'height'"><dfn id="propdef-height" class="propdef-title" data-dfn-type="property" data-lt="height"><strong>'height'</strong></dfn></span>
+<span class="index-def" data-term="'height'"><dfn id="propdef-height" class="propdef-title" data-dfn-type="property" data-lt="height"><strong>'height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -895,11 +895,11 @@ for non-replaced inline elements</a> for the rules used instead.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x11" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
+<dt><span id="x11" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies the height of the content area using a length value.
 </dd>
-<dt><span id="x12" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x12" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a percentage height. The percentage is calculated with
 respect to the height of the generated box's <a
@@ -1271,7 +1271,7 @@ certain range. Two properties offer this functionality:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'min-height'"><dfn id="propdef-min-height" class="propdef-title" data-dfn-type="property" data-lt="min-height"><strong>'min-height'</strong></dfn></span>
+<span class="index-def" data-term="'min-height'"><dfn id="propdef-min-height" class="propdef-title" data-dfn-type="property" data-lt="min-height"><strong>'min-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1287,7 +1287,7 @@ certain range. Two properties offer this functionality:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'max-height'"><dfn id="propdef-max-height" class="propdef-title" data-dfn-type="property" data-lt="max-height"><strong>'max-height'</strong></dfn></span>
+<span class="index-def" data-term="'max-height'"><dfn id="propdef-max-height" class="propdef-title" data-dfn-type="property" data-lt="max-height"><strong>'max-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1306,11 +1306,11 @@ certain range. Two properties offer this functionality:
 certain range. Values have the following meanings:</p>
 
 <dl>
-<dt><span id="x15" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
+<dt><span id="x15" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a fixed minimum or maximum computed height.
 </dd>
-<dt><span id="x16" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
+<dt><span id="x16" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 </dt>
 <dd>Specifies a percentage for determining the used value.
 The percentage is calculated with respect to the height of the
@@ -1487,7 +1487,7 @@ metrics from the HHEA table should be used.</em>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'line-height'"><dfn id="propdef-line-height" class="propdef-title" data-dfn-type="property" data-lt="line-height"><strong>'line-height'</strong></dfn></span>
+<span class="index-def" data-term="'line-height'"><dfn id="propdef-line-height" class="propdef-title" data-dfn-type="property" data-lt="line-height"><strong>'line-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1529,18 +1529,18 @@ height.
 <dd>Tells user agents to set the used
 value to a "reasonable" value based on the font of the element. The
 value has the same meaning as <span id="x18" class="index-inst"
-title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number">&lt;number&gt;</span></a></span>. We recommend a
 used value for 'normal' between 1.0 to 1.2. The <a
 href="cascade.html#computed-value">computed value</a> is 'normal'.
 </dd>
-<dt><span id="x19" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+<dt><span id="x19" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
 class="value-inst-length"><strong>&lt;length&gt;</strong></span></a></span>
 </dt>
 <dd>The specified length is used in the calculation of the line box
 height. Negative values are illegal.
 </dd>
-<dt><span id="x20" class="index-inst" title="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
+<dt><span id="x20" class="index-inst" data-term="&lt;number&gt;"><a href="syndata.html#value-def-number" class="noxref"><span
 class="value-inst-number"><strong>&lt;number&gt;</strong></span></a></span>
 </dt>
 <dd>The used value of the property is this number multiplied by the
@@ -1548,7 +1548,7 @@ element's font size. Negative values are illegal. The <a
 href="cascade.html#computed-value">computed value</a> is the same as
 the specified value.
 </dd>
-<dt><span id="x21" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
+<dt><span id="x21" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
 class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></a></span>
 </dt>
 <dd>The <a href="cascade.html#computed-value">computed value</a> of the
@@ -1584,7 +1584,7 @@ for example in a table.</em>
 </p>
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'vertical-align'"><dfn id="propdef-vertical-align" class="propdef-title" data-dfn-type="property" data-lt="vertical-align"><strong>'vertical-align'</strong></dfn></span>
+<span class="index-def" data-term="'vertical-align'"><dfn id="propdef-vertical-align" class="propdef-title" data-dfn-type="property" data-lt="vertical-align"><strong>'vertical-align'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>baseline | sub | super | top | text-top | middle | 
@@ -1645,14 +1645,14 @@ used for alignment is the margin box.
   <dd>Align the bottom of the box with the bottom of the parent's
       content area (see <a
       href="#inline-non-replaced">10.6.1</a>).</dd>
-  <dt><span id="x23" class="index-inst" title="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
+  <dt><span id="x23" class="index-inst" data-term="&lt;percentage&gt;"><a href="syndata.html#value-def-percentage" class="noxref"><span
   class="value-inst-percentage"><strong>&lt;percentage&gt;
   </strong></span></a></span></dt>
   <dd>Raise (positive value) or lower (negative value) the box
       by this distance (a percentage of the <a href="visudet.html#propdef-line-height" class="noxref"><span
       class="propinst-line-height">'line-height'</span></a> value).
       The value '0%' means the same as 'baseline'.</dd>
-  <dt><span id="x24" class="index-inst" title="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
+  <dt><span id="x24" class="index-inst" data-term="&lt;length&gt;"><a href="syndata.html#value-def-length" class="noxref"><span
   class="value-inst-length"><strong>&lt;length&gt;
   </strong></span></a></span></dt>
   <dd>Raise (positive value) or lower (negative value) the box

--- a/css2/visudet.html
+++ b/css2/visudet.html
@@ -227,7 +227,7 @@ class="propinst-width">'width'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'width'"><span id="propdef-width" class="propdef-title"><strong>'width'</strong></span></span>
+<span class="index-def" title="'width'"><dfn id="propdef-width" class="propdef-title" data-dfn-type="property" data-lt="width"><strong>'width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -682,7 +682,7 @@ class="propinst-max-width">'max-width'</span></a></h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'min-width'"><span id="propdef-min-width" class="propdef-title"><strong>'min-width'</strong></span></span>
+<span class="index-def" title="'min-width'"><dfn id="propdef-min-width" class="propdef-title" data-dfn-type="property" data-lt="min-width"><strong>'min-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -698,7 +698,7 @@ class="propinst-max-width">'max-width'</span></a></h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'max-width'"><span id="propdef-max-width" class="propdef-title"><strong>'max-width'</strong></span></span>
+<span class="index-def" title="'max-width'"><dfn id="propdef-max-width" class="propdef-title" data-dfn-type="property" data-lt="max-width"><strong>'max-width'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -869,7 +869,7 @@ class="propinst-height">'height'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'height'"><span id="propdef-height" class="propdef-title"><strong>'height'</strong></span></span>
+<span class="index-def" title="'height'"><dfn id="propdef-height" class="propdef-title" data-dfn-type="property" data-lt="height"><strong>'height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1271,7 +1271,7 @@ certain range. Two properties offer this functionality:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'min-height'"><span id="propdef-min-height" class="propdef-title"><strong>'min-height'</strong></span></span>
+<span class="index-def" title="'min-height'"><dfn id="propdef-min-height" class="propdef-title" data-dfn-type="property" data-lt="min-height"><strong>'min-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1287,7 +1287,7 @@ certain range. Two properties offer this functionality:
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'max-height'"><span id="propdef-max-height" class="propdef-title"><strong>'max-height'</strong></span></span>
+<span class="index-def" title="'max-height'"><dfn id="propdef-max-height" class="propdef-title" data-dfn-type="property" data-lt="max-height"><strong>'max-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1487,7 +1487,7 @@ metrics from the HHEA table should be used.</em>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'line-height'"><span id="propdef-line-height" class="propdef-title"><strong>'line-height'</strong></span></span>
+<span class="index-def" title="'line-height'"><dfn id="propdef-line-height" class="propdef-title" data-dfn-type="property" data-lt="line-height"><strong>'line-height'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | <a href="syndata.html#value-def-number" class="noxref"><span class="value-inst-number">&lt;number&gt;</span></a> | <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1584,7 +1584,7 @@ for example in a table.</em>
 </p>
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'vertical-align'"><span id="propdef-vertical-align" class="propdef-title"><strong>'vertical-align'</strong></span></span>
+<span class="index-def" title="'vertical-align'"><dfn id="propdef-vertical-align" class="propdef-title" data-dfn-type="property" data-lt="vertical-align"><strong>'vertical-align'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>baseline | sub | super | top | text-top | middle | 

--- a/css2/visudet.src
+++ b/css2/visudet.src
@@ -21,14 +21,14 @@ block"</span></h2>
 
 <p>The position and size of an element's box(es) are sometimes
 calculated relative to a certain rectangle, called the <dfn><span
-class="index-def" title="containing block">containing
+class="index-def" data-term="containing block">containing
 block</span></dfn> of the element. The containing block of an element
 is defined as follows:</p>
 
 <ol>
 <li>The containing block in which the <a href="conform.html#root">root
 element</a> lives is a rectangle called the <dfn><span
-class="index-def" title="initial containing block|containing
+class="index-def" data-term="initial containing block|containing
 block::initial">initial containing block</span></dfn>. For continuous
 media, it has the dimensions of the <a
 href="visuren.html#viewport">viewport</a> and is anchored at the
@@ -184,11 +184,11 @@ shorted by the presence of <a href="visuren.html#floats">floats</a>.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 </dt>
 <dd>Specifies the width of the content area using a length unit.
 </dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 </dt>
 <dd>Specifies a percentage width. The percentage is calculated
 with respect to the width of the generated box's 
@@ -612,11 +612,11 @@ class="propinst-max-width">'max-width'</span></h2>
 certain range. Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 </dt>
 <dd>Specifies a fixed minimum or maximum used width.
 </dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 </dt>
 <dd>Specifies a percentage for determining the used value. The
 percentage is calculated with respect to the width of the generated
@@ -801,11 +801,11 @@ for non-replaced inline elements</a> for the rules used instead.
 <p>Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 </dt>
 <dd>Specifies the height of the content area using a length value.
 </dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 </dt>
 <dd>Specifies a percentage height. The percentage is calculated with
 respect to the height of the generated box's <a
@@ -1183,11 +1183,11 @@ certain range. Two properties offer this functionality:
 certain range. Values have the following meanings:</p>
 
 <dl>
-<dt><span class="index-inst" title="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 </dt>
 <dd>Specifies a fixed minimum or maximum computed height.
 </dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 </dt>
 <dd>Specifies a percentage for determining the used value.
 The percentage is calculated with respect to the height of the
@@ -1391,18 +1391,18 @@ height.
 <dd>Tells user agents to set the used
 value to a "reasonable" value based on the font of the element. The
 value has the same meaning as <span class="index-inst"
-title="&lt;number&gt;"><span
+data-term="&lt;number&gt;"><span
 class="value-inst-number">&lt;number&gt;</span></span>. We recommend a
 used value for 'normal' between 1.0 to 1.2. The <a
 href="cascade.html#computed-value">computed value</a> is 'normal'.
 </dd>
-<dt><span class="index-inst" title="&lt;length&gt;"><span
+<dt><span class="index-inst" data-term="&lt;length&gt;"><span
 class="value-inst-length"><strong>&lt;length&gt;</strong></span></span>
 </dt>
 <dd>The specified length is used in the calculation of the line box
 height. Negative values are illegal.
 </dd>
-<dt><span class="index-inst" title="&lt;number&gt;"><span
+<dt><span class="index-inst" data-term="&lt;number&gt;"><span
 class="value-inst-number"><strong>&lt;number&gt;</strong></span></span>
 </dt>
 <dd>The used value of the property is this number multiplied by the
@@ -1410,7 +1410,7 @@ element's font size. Negative values are illegal. The <a
 href="cascade.html#computed-value">computed value</a> is the same as
 the specified value.
 </dd>
-<dt><span class="index-inst" title="&lt;percentage&gt;"><span
+<dt><span class="index-inst" data-term="&lt;percentage&gt;"><span
 class="value-inst-percentage"><strong>&lt;percentage&gt;</strong></span></span>
 </dt>
 <dd>The <a href="cascade.html#computed-value">computed value</a> of the
@@ -1491,14 +1491,14 @@ used for alignment is the margin box.
   <dd>Align the bottom of the box with the bottom of the parent's
       content area (see <a
       href="#inline-non-replaced">10.6.1</a>).</dd>
-  <dt><span class="index-inst" title="&lt;percentage&gt;"><span
+  <dt><span class="index-inst" data-term="&lt;percentage&gt;"><span
   class="value-inst-percentage"><strong>&lt;percentage&gt;
   </strong></span></span></dt>
   <dd>Raise (positive value) or lower (negative value) the box
       by this distance (a percentage of the <span
       class="propinst-line-height">'line-height'</span> value).
       The value '0%' means the same as 'baseline'.</dd>
-  <dt><span class="index-inst" title="&lt;length&gt;"><span
+  <dt><span class="index-inst" data-term="&lt;length&gt;"><span
   class="value-inst-length"><strong>&lt;length&gt;
   </strong></span></span></dt>
   <dd>Raise (positive value) or lower (negative value) the box

--- a/css2/visufx.html
+++ b/css2/visufx.html
@@ -54,7 +54,7 @@ body>del,body>ins {display:block}
 <p>Generally, the content of a block box is confined to the
 content edges of the box. In certain cases, a box may <span id="x0"
 class="index-def"
-title="overflow|box::overflow"><dfn>overflow</dfn></span>, meaning its
+data-term="overflow|box::overflow"><dfn>overflow</dfn></span>, meaning its
 content lies partly or entirely outside of the box, e.g.:</p>
 
 <ul>
@@ -96,7 +96,7 @@ class="propinst-overflow">'overflow'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'overflow'"><dfn id="propdef-overflow" class="propdef-title" data-dfn-type="property" data-lt="overflow"><strong>'overflow'</strong></dfn></span>
+<span class="index-def" data-term="'overflow'"><dfn id="propdef-overflow" class="propdef-title" data-dfn-type="property" data-lt="overflow"><strong>'overflow'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>visible | hidden | scroll | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -276,7 +276,7 @@ class="propinst-clip">'clip'</span></a> property</h3>
 
 
 
-<p>A <span id="x3" class="index-def" title="clipping region"><dfn>clipping
+<p>A <span id="x3" class="index-def" data-term="clipping region"><dfn>clipping
 region</dfn></span> defines what portion of an element's 
 border box 
  
@@ -285,7 +285,7 @@ is visible. By default, the element is not clipped. However, the clipping region
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'clip'"><dfn id="propdef-clip" class="propdef-title" data-dfn-type="property" data-lt="clip"><strong>'clip'</strong></dfn></span>
+<span class="index-def" data-term="'clip'"><dfn id="propdef-clip" class="propdef-title" data-dfn-type="property" data-lt="clip"><strong>'clip'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="visufx.html#value-def-shape" class="noxref"><span class="value-inst-shape">&lt;shape&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -309,7 +309,7 @@ Values have the following meanings:</p>
 <dt><strong>auto</strong></dt>
 <dd>The element does not clip.</dd>
 
-<dt><span class="index-def" title="&lt;shape&gt;::definition of"><dfn
+<dt><span class="index-def" data-term="&lt;shape&gt;::definition of"><dfn
 id="value-def-shape" data-dfn-type="type"
 class="value-def"><strong>&lt;shape&gt;</strong></dfn></span></dt>
 <dd>In CSS&nbsp;2, the only valid &lt;shape&gt; value is:
@@ -330,13 +330,13 @@ commas, but may also support separation without commas (but not a
 combination), because a
 previous revision of this specification was ambiguous in this respect.
 
-<p><span class="index-def" title="&lt;top&gt;::definition of"><dfn
+<p><span class="index-def" data-term="&lt;top&gt;::definition of"><dfn
 id="value-def-top" data-dfn-type="type" class="value-def">&lt;top&gt;</dfn></span>, <span
-class="index-def" title="&lt;right&gt;::definition of"><dfn
+class="index-def" data-term="&lt;right&gt;::definition of"><dfn
 id="value-def-right" data-dfn-type="type" class="value-def">&lt;right&gt;</dfn></span>,
-<span class="index-def" title="&lt;bottom&gt;::definition of"><dfn
+<span class="index-def" data-term="&lt;bottom&gt;::definition of"><dfn
 id="value-def-bottom" data-dfn-type="type" class="value-def">&lt;bottom&gt;</dfn></span>,
-and <span class="index-def" title="&lt;left&gt;::definition of"><dfn
+and <span class="index-def" data-term="&lt;left&gt;::definition of"><dfn
 id="value-def-left" data-dfn-type="type" class="value-def">&lt;left&gt;</dfn></span> may
 either have a <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a>
 value or 'auto'. Negative lengths are permitted. The value 'auto'
@@ -396,7 +396,7 @@ class="propinst-visibility">'visibility'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'visibility'"><dfn id="propdef-visibility" class="propdef-title" data-dfn-type="property" data-lt="visibility"><strong>'visibility'</strong></dfn></span>
+<span class="index-def" data-term="'visibility'"><dfn id="propdef-visibility" class="propdef-title" data-dfn-type="property" data-lt="visibility"><strong>'visibility'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>visible | hidden | collapse | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/visufx.html
+++ b/css2/visufx.html
@@ -96,7 +96,7 @@ class="propinst-overflow">'overflow'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'overflow'"><span id="propdef-overflow" class="propdef-title"><strong>'overflow'</strong></span></span>
+<span class="index-def" title="'overflow'"><dfn id="propdef-overflow" class="propdef-title" data-dfn-type="property" data-lt="overflow"><strong>'overflow'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>visible | hidden | scroll | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -285,7 +285,7 @@ is visible. By default, the element is not clipped. However, the clipping region
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'clip'"><span id="propdef-clip" class="propdef-title"><strong>'clip'</strong></span></span>
+<span class="index-def" title="'clip'"><dfn id="propdef-clip" class="propdef-title" data-dfn-type="property" data-lt="clip"><strong>'clip'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="visufx.html#value-def-shape" class="noxref"><span class="value-inst-shape">&lt;shape&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -396,7 +396,7 @@ class="propinst-visibility">'visibility'</span></a> property</h2>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'visibility'"><span id="propdef-visibility" class="propdef-title"><strong>'visibility'</strong></span></span>
+<span class="index-def" title="'visibility'"><dfn id="propdef-visibility" class="propdef-title" data-dfn-type="property" data-lt="visibility"><strong>'visibility'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>visible | hidden | collapse | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/visufx.html
+++ b/css2/visufx.html
@@ -309,9 +309,9 @@ Values have the following meanings:</p>
 <dt><strong>auto</strong></dt>
 <dd>The element does not clip.</dd>
 
-<dt><span class="index-def" title="&lt;shape&gt;::definition of"><span
-id="value-def-shape"
-class="value-def"><strong>&lt;shape&gt;</strong></span></span></dt>
+<dt><span class="index-def" title="&lt;shape&gt;::definition of"><dfn
+id="value-def-shape" data-dfn-type="type"
+class="value-def"><strong>&lt;shape&gt;</strong></dfn></span></dt>
 <dd>In CSS&nbsp;2, the only valid &lt;shape&gt; value is:
 rect(<a href="visufx.html#value-def-top" class="noxref"><span
 class="value-inst-top">&lt;top&gt;</span></a>, <a href="visufx.html#value-def-right" class="noxref"><span
@@ -330,14 +330,14 @@ commas, but may also support separation without commas (but not a
 combination), because a
 previous revision of this specification was ambiguous in this respect.
 
-<p><span class="index-def" title="&lt;top&gt;::definition of"><span
-id="value-def-top" class="value-def">&lt;top&gt;</span></span>, <span
-class="index-def" title="&lt;right&gt;::definition of"><span
-id="value-def-right" class="value-def">&lt;right&gt;</span></span>,
-<span class="index-def" title="&lt;bottom&gt;::definition of"><span
-id="value-def-bottom" class="value-def">&lt;bottom&gt;</span></span>,
-and <span class="index-def" title="&lt;left&gt;::definition of"><span
-id="value-def-left" class="value-def">&lt;left&gt;</span></span> may
+<p><span class="index-def" title="&lt;top&gt;::definition of"><dfn
+id="value-def-top" data-dfn-type="type" class="value-def">&lt;top&gt;</dfn></span>, <span
+class="index-def" title="&lt;right&gt;::definition of"><dfn
+id="value-def-right" data-dfn-type="type" class="value-def">&lt;right&gt;</dfn></span>,
+<span class="index-def" title="&lt;bottom&gt;::definition of"><dfn
+id="value-def-bottom" data-dfn-type="type" class="value-def">&lt;bottom&gt;</dfn></span>,
+and <span class="index-def" title="&lt;left&gt;::definition of"><dfn
+id="value-def-left" data-dfn-type="type" class="value-def">&lt;left&gt;</dfn></span> may
 either have a <a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a>
 value or 'auto'. Negative lengths are permitted. The value 'auto'
 means that a given edge of the clipping region will be the same as the

--- a/css2/visufx.src
+++ b/css2/visufx.src
@@ -250,9 +250,9 @@ Values have the following meanings:</p>
 <dt><strong>auto</strong></dt>
 <dd>The element does not clip.</dd>
 
-<dt><span class="index-def" title="&lt;shape&gt;::definition of"><span
-id="value-def-shape"
-class="value-def"><strong>&lt;shape&gt;</strong></span></span></dt>
+<dt><span class="index-def" title="&lt;shape&gt;::definition of"><dfn
+id="value-def-shape" data-dfn-type="type"
+class="value-def"><strong>&lt;shape&gt;</strong></dfn></span></dt>
 <dd>In CSS&nbsp;2, the only valid &lt;shape&gt; value is:
 rect(<span
 class="value-inst-top">&lt;top&gt;</span>, <span
@@ -271,14 +271,14 @@ commas, but may also support separation without commas (but not a
 combination), because a
 previous revision of this specification was ambiguous in this respect.
 
-<p><span class="index-def" title="&lt;top&gt;::definition of"><span
-id="value-def-top" class="value-def">&lt;top&gt;</span></span>, <span
-class="index-def" title="&lt;right&gt;::definition of"><span
-id="value-def-right" class="value-def">&lt;right&gt;</span></span>,
-<span class="index-def" title="&lt;bottom&gt;::definition of"><span
-id="value-def-bottom" class="value-def">&lt;bottom&gt;</span></span>,
-and <span class="index-def" title="&lt;left&gt;::definition of"><span
-id="value-def-left" class="value-def">&lt;left&gt;</span></span> may
+<p><span class="index-def" title="&lt;top&gt;::definition of"><dfn
+id="value-def-top" data-dfn-type="type" class="value-def">&lt;top&gt;</dfn></span>, <span
+class="index-def" title="&lt;right&gt;::definition of"><dfn
+id="value-def-right" data-dfn-type="type" class="value-def">&lt;right&gt;</dfn></span>,
+<span class="index-def" title="&lt;bottom&gt;::definition of"><dfn
+id="value-def-bottom" data-dfn-type="type" class="value-def">&lt;bottom&gt;</dfn></span>,
+and <span class="index-def" title="&lt;left&gt;::definition of"><dfn
+id="value-def-left" data-dfn-type="type" class="value-def">&lt;left&gt;</dfn></span> may
 either have a <span class="value-inst-length">&lt;length&gt;</span>
 value or 'auto'. Negative lengths are permitted. The value 'auto'
 means that a given edge of the clipping region will be the same as the

--- a/css2/visufx.src
+++ b/css2/visufx.src
@@ -20,7 +20,7 @@ body>del,body>ins {display:block}
 <p>Generally, the content of a block box is confined to the
 content edges of the box. In certain cases, a box may <span
 class="index-def"
-title="overflow|box::overflow"><dfn>overflow</dfn></span>, meaning its
+data-term="overflow|box::overflow"><dfn>overflow</dfn></span>, meaning its
 content lies partly or entirely outside of the box, e.g.:</p>
 
 <ul>
@@ -233,7 +233,7 @@ and
 BB]
 -->
 
-<p>A <span class="index-def" title="clipping region"><dfn>clipping
+<p>A <span class="index-def" data-term="clipping region"><dfn>clipping
 region</dfn></span> defines what portion of an element's 
 border box 
 <!--<a
@@ -250,7 +250,7 @@ Values have the following meanings:</p>
 <dt><strong>auto</strong></dt>
 <dd>The element does not clip.</dd>
 
-<dt><span class="index-def" title="&lt;shape&gt;::definition of"><dfn
+<dt><span class="index-def" data-term="&lt;shape&gt;::definition of"><dfn
 id="value-def-shape" data-dfn-type="type"
 class="value-def"><strong>&lt;shape&gt;</strong></dfn></span></dt>
 <dd>In CSS&nbsp;2, the only valid &lt;shape&gt; value is:
@@ -271,13 +271,13 @@ commas, but may also support separation without commas (but not a
 combination), because a
 previous revision of this specification was ambiguous in this respect.
 
-<p><span class="index-def" title="&lt;top&gt;::definition of"><dfn
+<p><span class="index-def" data-term="&lt;top&gt;::definition of"><dfn
 id="value-def-top" data-dfn-type="type" class="value-def">&lt;top&gt;</dfn></span>, <span
-class="index-def" title="&lt;right&gt;::definition of"><dfn
+class="index-def" data-term="&lt;right&gt;::definition of"><dfn
 id="value-def-right" data-dfn-type="type" class="value-def">&lt;right&gt;</dfn></span>,
-<span class="index-def" title="&lt;bottom&gt;::definition of"><dfn
+<span class="index-def" data-term="&lt;bottom&gt;::definition of"><dfn
 id="value-def-bottom" data-dfn-type="type" class="value-def">&lt;bottom&gt;</dfn></span>,
-and <span class="index-def" title="&lt;left&gt;::definition of"><dfn
+and <span class="index-def" data-term="&lt;left&gt;::definition of"><dfn
 id="value-def-left" data-dfn-type="type" class="value-def">&lt;left&gt;</dfn></span> may
 either have a <span class="value-inst-length">&lt;length&gt;</span>
 value or 'auto'. Negative lengths are permitted. The value 'auto'

--- a/css2/visuren.html
+++ b/css2/visuren.html
@@ -102,7 +102,7 @@ blockquote.math span:first-child {text-align: right}
 <h2><span class="secno">9.1</span> <span id="visual-model-intro">Introduction to the visual formatting model</span></h2>
 
 <p>This chapter and the next describe the <span id="x0" class="index-def"
-title="visual formatting model">visual formatting model</span>: how user
+data-term="visual formatting model">visual formatting model</span>: how user
 agents process the <a href="conform.html#doctree">document tree</a>
 for visual <a href="media.html">media</a>.
 </p>
@@ -143,7 +143,7 @@ specification.
 
 <p>User agents for <a
 href="media.html#continuous-media-group">continuous media</a>
-generally offer users a <span id="x1" class="index-def" title="viewport">
+generally offer users a <span id="x1" class="index-def" data-term="viewport">
 <dfn>viewport</dfn></span> (a window or other
 viewing area on the screen) through which users consult a
 document. User agents may change the document's layout when the
@@ -161,14 +161,14 @@ agents may render to more than one canvas (i.e., provide different
 views of the same document).
 </p>
 
-<h3><span class="secno">9.1.2</span> <span class="index-def" title="containing block">
+<h3><span class="secno">9.1.2</span> <span class="index-def" data-term="containing block">
 <span id="containing-block">Containing blocks</span></span>
 </h3>
 
 <p>In CSS&nbsp;2, many box positions and sizes are calculated with respect
 to the edges
 of a rectangular box called a <span id="x3" class="index-def"
-title="containing block"><dfn>containing block</dfn></span>.  In
+data-term="containing block"><dfn>containing block</dfn></span>.  In
 general, generated boxes act as containing blocks for descendant
 boxes; we say that a box "establishes" the containing block for its
 descendants. The phrase "a box's containing block" means "the
@@ -194,18 +194,18 @@ specifies a box's type.
 
 <h3><span class="secno">9.2.1</span> <span id="block-boxes">Block-level elements and block boxes</span></h3>
 
-<p><span class="index-def" title="block-level
+<p><span class="index-def" data-term="block-level
 element"><span id="block-level"><dfn>Block-level elements</dfn></span></span> are those elements of the source document that are formatted visually as
 blocks (e.g., paragraphs). The following values of the <a href="visuren.html#propdef-display" class="noxref"><span
 class="propinst-display">'display'</span></a> property make an element
 block-level: 'block', 'list-item', and 'table'.
 </p>
 
-<p><span id="x5" class="index-def" title="block-level box"><dfn>Block-level
+<p><span id="x5" class="index-def" data-term="block-level box"><dfn>Block-level
 boxes</dfn></span> are boxes that participate in
 a <a href="#block-formatting">block formatting context.</a> Each
 block-level element generates a <span class="index-def"
-title="principal block-level
+data-term="principal block-level
 box"><span id="principal-box"><dfn>principal block-level
 box</dfn></span></span> that contains descendant boxes and generated
 content and is also the box involved in any positioning scheme.
@@ -217,7 +217,7 @@ placed with respect to the principal box.
 
 <p>Except for table boxes, which are described in a later chapter, and
 replaced elements, a block-level box is also a block container box.
-A <span class="index-def" title="block container box"><span
+A <span class="index-def" data-term="block container box"><span
 id="block-container-box"><dfn >block
 container box</dfn></span></span> either
 contains only block-level boxes or establishes an inline formatting
@@ -225,7 +225,7 @@ context and thus contains only inline-level boxes. Not all block
 container boxes are block-level boxes: non-replaced inline blocks
 and non-replaced table cells are block containers but not block-level
 boxes. Block-level boxes that are also block containers are
-called <span id="x8" class="index-def" title="block box"><dfn>block
+called <span id="x8" class="index-def" data-term="block box"><dfn>block
 boxes</dfn></span>.
 
 <p>The three terms "block-level box," "block container box," and
@@ -245,7 +245,7 @@ boxes</dfn></span>.
 (and assuming the DIV and the P both have 'display: block'), the
 DIV appears to have both inline content and block content. To make it
 easier to define the formatting, we assume that there is an <em><span id="x9"
-class="index-def" title="anonymous">anonymous block box</span></em>
+class="index-def" data-term="anonymous">anonymous block box</span></em>
 around "Some text".
 </p>
 <div class="figure">
@@ -336,7 +336,7 @@ containing block formed by the DIV, not of the anonymous block box.
 
 <h3><span class="secno">9.2.2</span> <span id="inline-boxes">Inline-level elements and inline boxes</span></h3>
 
-<p><span class="index-def" title="inline-level element">
+<p><span class="index-def" data-term="inline-level element">
 <span id="inline-level"><dfn>Inline-level
 elements</dfn></span></span> are those elements of the source document that
 do not form new blocks of content; the content is distributed in lines
@@ -347,11 +347,11 @@ class="propinst-display">'display'</span></a> property make an element
 inline-level: 'inline', 'inline-table', and 'inline-block'. 
 
 Inline-level elements generate <span id="x11" class="index-def"
-title="inline-level box"><dfn>inline-level
+data-term="inline-level box"><dfn>inline-level
 boxes</dfn></span>, which are boxes that participate in an inline
 formatting context.
 
-<p>An <span class="index-def" title="inline box"><span
+<p>An <span class="index-def" data-term="inline box"><span
 id="inline-box"><dfn>inline
 box</dfn></span></span> is one that is both inline-level and whose
 contents participate in its containing inline formatting context. A
@@ -359,7 +359,7 @@ non-replaced element with a 'display' value of 'inline' generates an
 inline box.
 Inline-level boxes that are not inline boxes (such as replaced
 inline-level elements, inline-block elements, and inline-table
-elements) are called <span id="x13" class="index-def" title="atomic
+elements) are called <span id="x13" class="index-def" data-term="atomic
 inline-level box"><dfn>atomic inline-level boxes</dfn></span> because
 they participate in their inline formatting context as a single opaque
 box.
@@ -381,7 +381,7 @@ element.
 <p>the <code>&lt;p&gt;</code> generates a block box, with several inline boxes inside
 it. The box for "emphasized" is an inline box generated by an inline
 element (<code>&lt;em&gt;</code>), but the other boxes ("Some" and "text") are inline boxes generated by a block-level element (<code>&lt;p&gt;</code>). The latter are called <span id="x14"
-class="index-def" title="anonymous inline boxes">anonymous inline
+class="index-def" data-term="anonymous inline boxes">anonymous inline
 boxes</span>, because they do not have an associated inline-level element.
 </p>
 <p>Such anonymous inline boxes inherit inheritable properties from
@@ -404,7 +404,7 @@ simply called anonymous boxes in this specification.
 <h3><span class="secno">9.2.3</span> <span id="run-in">Run-in boxes</span></h3>
 
 <p>[This section exists so that the section numbers are the same as in
-previous drafts. <span id="x15" class="index-def" title="run-in">'display:
+previous drafts. <span id="x15" class="index-def" data-term="run-in">'display:
 run-in'</span> is now defined in CSS level&nbsp;3 (see <a
 href="/TR/css3-box">CSS basic box model</a>).]
 
@@ -413,7 +413,7 @@ class="propinst-display">'display'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'display'"><dfn id="propdef-display" class="propdef-title" data-dfn-type="property" data-lt="display"><strong>'display'</strong></dfn></span>
+<span class="index-def" data-term="'display'"><dfn id="propdef-display" class="propdef-title" data-dfn-type="property" data-lt="display"><strong>'display'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>inline | block | list-item | inline-block |
@@ -434,12 +434,12 @@ table-cell | table-caption | none | <a href="cascade.html#value-def-inherit" cla
 <p>The values of this property have the following meanings:</p>
 
 <dl>
-<dt><span class="index-def" title="'block', definition of"><dfn
+<dt><span class="index-def" data-term="'block', definition of"><dfn
 id="value-def-block" data-dfn-type="value" data-dfn-for="display"><strong>block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate a block box.
 </dd>
-<dt><span class="index-def" title="'inline-block', definition of"><dfn
+<dt><span class="index-def" data-term="'inline-block', definition of"><dfn
 id="value-def-inline-block" data-dfn-type="value" data-dfn-for="display"><strong>inline-block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate an inline-level block
@@ -447,12 +447,12 @@ container.
 The inside of an inline-block is formatted as a block box, and the 
 element itself is formatted as an atomic inline-level box.
 </dd>
-<dt><span class="index-def" title="'inline', definition of"><dfn
+<dt><span class="index-def" data-term="'inline', definition of"><dfn
 id="value-def-inline" data-dfn-type="value" data-dfn-for="display"><strong>inline</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate one or more inline boxes.
 </dd>
-<dt><span class="index-def" title="'list-item', definition of"><dfn
+<dt><span class="index-def" data-term="'list-item', definition of"><dfn
 id="value-def-list-item" data-dfn-type="value" data-dfn-for="display"><strong>list-item</strong></dfn></span>
 </dt>
 <dd>This value causes an element (e.g., LI in HTML) to generate a
@@ -462,7 +462,7 @@ lists and examples of list formatting, please consult the section on
 </dd>
 <dt><strong>none</strong></dt>
 
-<dd><span id="x21" class="index-def" title="'none'::as display value">This
+<dd><span id="x21" class="index-def" data-term="'none'::as display value">This
 value</span> causes an element to not appear in the <a
 href="intro.html#formatting-structure">formatting structure</a> (i.e.,
 in visual media the element generates no boxes and has no effect on
@@ -530,7 +530,7 @@ img { display: none }      /* Do not display images */
 <h2><span class="secno">9.3</span> <span id="positioning-scheme">Positioning schemes</span></h2>
 
 <p>In CSS&nbsp;2, a box may be laid out according to three <span id="x22"
-class="index-def" title="positioning scheme"><dfn>positioning
+class="index-def" data-term="positioning scheme"><dfn>positioning
 schemes:</dfn></span></p>
 
 <ol>
@@ -582,7 +582,7 @@ the position of a box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'position'"><dfn id="propdef-position" class="propdef-title" data-dfn-type="property" data-lt="position"><strong>'position'</strong></dfn></span>
+<span class="index-def" data-term="'position'"><dfn id="propdef-position" class="propdef-title" data-dfn-type="property" data-lt="position"><strong>'position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>static | relative | absolute | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -679,7 +679,7 @@ class="propinst-right">'right'</span></a>, <a href="visuren.html#propdef-bottom"
 class="propinst-bottom">'bottom'</span></a>, <a href="visuren.html#propdef-left" class="noxref"><span
 class="propinst-left">'left'</span></a></h3>
 
-<p>An element is said to be <span class="index-def" title="positioned
+<p>An element is said to be <span class="index-def" data-term="positioned
 element/box"><span id="positioned-element"><dfn>positioned</dfn></span></span>
 if its <a href="visuren.html#propdef-position" class="noxref"><span class="propinst-position">'position'</span></a> property has
 a value other than 'static'. Positioned elements generate
@@ -687,7 +687,7 @@ positioned boxes, laid out according to four properties:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'top'"><dfn id="propdef-top" class="propdef-title" data-dfn-type="property" data-lt="top"><strong>'top'</strong></dfn></span>
+<span class="index-def" data-term="'top'"><dfn id="propdef-top" class="propdef-title" data-dfn-type="property" data-lt="top"><strong>'top'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -715,7 +715,7 @@ offset from that position according to these properties).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'right'"><dfn id="propdef-right" class="propdef-title" data-dfn-type="property" data-lt="right"><strong>'right'</strong></dfn></span>
+<span class="index-def" data-term="'right'"><dfn id="propdef-right" class="propdef-title" data-dfn-type="property" data-lt="right"><strong>'right'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -742,7 +742,7 @@ box itself.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'bottom'"><dfn id="propdef-bottom" class="propdef-title" data-dfn-type="property" data-lt="bottom"><strong>'bottom'</strong></dfn></span>
+<span class="index-def" data-term="'bottom'"><dfn id="propdef-bottom" class="propdef-title" data-dfn-type="property" data-lt="bottom"><strong>'bottom'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -768,7 +768,7 @@ box itself.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'left'"><dfn id="propdef-left" class="propdef-title" data-dfn-type="property" data-lt="left"><strong>'left'</strong></dfn></span>
+<span class="index-def" data-term="'left'"><dfn id="propdef-left" class="propdef-title" data-dfn-type="property" data-lt="left"><strong>'left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -825,7 +825,7 @@ positioned, replaced elements for details.
 <h2><span class="secno">9.4</span> <span id="normal-flow">Normal flow</span></h2> 
 
 <p>Boxes in the normal flow belong to a <span id="x32" class="index-def"
-title="formatting context">formatting context</span>, which may be
+data-term="formatting context">formatting context</span>, which may be
 block or inline, but not both simultaneously.  <a
 href="#block-level">Block-level</a> boxes participate in a <a
 href="#block-formatting">block formatting</a> context.  <a
@@ -871,7 +871,7 @@ block. Horizontal margins, borders, and padding are respected between
 these boxes. The boxes may be aligned vertically in different ways: their
 bottoms or tops may be aligned, or the baselines of text within them
 may be aligned. The rectangular area that contains the boxes that form
-a line is called a <span class="index-def" title="line box"><span
+a line is called a <span class="index-def" data-term="line box"><span
 id="line-box"><dfn>line box</dfn></span></span>. 
 </p>
 <p>The width of a line box is determined by a <a
@@ -1036,7 +1036,7 @@ dashed border is rendered on three sides in each case.</li>
 
 <p>Once a box has been laid out according to the <a
 href="#normal-flow">normal flow</a> or floated, it may be shifted relative to
-this position. This is called <span id="x34" class="index-def" title="relative
+this position. This is called <span id="x34" class="index-def" data-term="relative
 positioning"><dfn>relative positioning</dfn></span>. Offsetting a box
 (B1) in this way has no effect on the box (B2) that follows: B2 is
 given a position as if B1 were not offset and B2 is not re-positioned
@@ -1337,7 +1337,7 @@ class="propinst-clear">'clear'</span></a> property).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'float'"><dfn id="propdef-float" class="propdef-title" data-dfn-type="property" data-lt="float"><strong>'float'</strong></dfn></span>
+<span class="index-def" data-term="'float'"><dfn id="propdef-float" class="propdef-title" data-dfn-type="property" data-lt="float"><strong>'float'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>left | right | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1381,7 +1381,7 @@ User agents may treat float as 'none' on the root element.
 </p>
 
 
-<p><span class="index-def" title="float rules"><span
+<p><span class="index-def" data-term="float rules"><span
 id="float-rules">Here are the precise rules</span></span> that
 govern the behavior of floats:</p>
 
@@ -1423,7 +1423,7 @@ earlier in the source document.
 </li>
 <li>The <a href="box.html#outer-edge">outer top</a> of an element's
 floating box may not be higher than the top of any <span id="x37"
-class="index-inst" title="line-box"><a
+class="index-inst" data-term="line-box"><a
 href="#line-box">line-box</a></span> containing a box
 generated by an element earlier in the source document.
 </li>
@@ -1470,7 +1470,7 @@ the <a href="visuren.html#propdef-clear" class="noxref"><span class="propinst-cl
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'clear'"><dfn id="propdef-clear" class="propdef-title" data-dfn-type="property" data-lt="clear"><strong>'clear'</strong></dfn></span>
+<span class="index-def" data-term="'clear'"><dfn id="propdef-clear" class="propdef-title" data-dfn-type="property" data-lt="clear"><strong>'clear'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>none | left | right | both | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1694,7 +1694,7 @@ depending on the
 <a href="#stack-level">stack levels</a> of the overlapping boxes.
 </p>
 <p>References in this specification to an <span class="index-def"
-title="absolutely positioned element">
+data-term="absolutely positioned element">
 <span id="absolutely-positioned"><dfn>absolutely positioned
 element</dfn></span></span> (or its box) imply that the element's <a href="visuren.html#propdef-position" class="noxref"><span
 class="propinst-position">'position'</span></a> property has the value
@@ -2142,7 +2142,7 @@ class="propinst-z-index">'z-index'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'z-index'"><dfn id="propdef-z-index" class="propdef-title" data-dfn-type="property" data-lt="z-index"><strong>'z-index'</strong></dfn></span>
+<span class="index-def" data-term="'z-index'"><dfn id="propdef-z-index" class="propdef-title" data-dfn-type="property" data-lt="z-index"><strong>'z-index'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2169,7 +2169,7 @@ class="propinst-z-index">'z-index'</span></a> property specifies:
 <p>Values have the following meanings:
 
 <dl>
-  <dt><span id="x42" class="index-inst" title="&lt;integer&gt;"><a href="syndata.html#value-def-integer" class="noxref"><span
+  <dt><span id="x42" class="index-inst" data-term="&lt;integer&gt;"><a href="syndata.html#value-def-integer" class="noxref"><span
   class="value-inst-integer"><strong>&lt;integer&gt;</strong></span></a></span>
 
   <dd>This integer is the stack level of the generated box in the
@@ -2199,10 +2199,10 @@ contain further stacking contexts. A stacking context is atomic from
 the point of view of its parent stacking context; boxes in other 
 stacking contexts may not come between any of its boxes.
 </p>
-<p>Each box belongs to one <span id="x43" class="index-def" title="stacking
+<p>Each box belongs to one <span id="x43" class="index-def" data-term="stacking
 context"><dfn>stacking context</dfn></span>. Each positioned box in a
 given stacking context has an integer <span class="index-def"
-title="stack level"><span id="stack-level"><dfn>stack
+data-term="stack level"><span id="stack-level"><dfn>stack
 level</dfn></span></span>, which is its position on the z-axis relative
 other stack levels within the same stacking context. Boxes with
 greater stack levels are always formatted
@@ -2333,7 +2333,7 @@ left. In some documents, in particular those written with the Arabic
 or Hebrew script, and in some mixed-language contexts, text in a
 single (visually displayed) block may appear with mixed
 directionality. This phenomenon is called <span id="x45" class="index-def"
-title="bidirectionality (bidi)"><dfn>bidirectionality</dfn></span>, or
+data-term="bidirectionality (bidi)"><dfn>bidirectionality</dfn></span>, or
 "bidi" for short.
 </p>
 <p>The Unicode standard (<a href="refs.html#ref-UNICODE" class="noxref"><span class="normref">[UNICODE]</span></a>, <a href="refs.html#ref-UAX9" class="noxref"><span class="normref">[UAX9]</span></a>) defines a complex
@@ -2373,7 +2373,7 @@ bidirectionality issues.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'direction'"><dfn id="propdef-direction" class="propdef-title" data-dfn-type="property" data-lt="direction"><strong>'direction'</strong></dfn></span>
+<span class="index-def" data-term="'direction'"><dfn id="propdef-direction" class="propdef-title" data-dfn-type="property" data-lt="direction"><strong>'direction'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>ltr | rtl | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2424,7 +2424,7 @@ in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]<
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'unicode-bidi'"><dfn id="propdef-unicode-bidi" class="propdef-title" data-dfn-type="property" data-lt="unicode-bidi"><strong>'unicode-bidi'</strong></dfn></span>
+<span class="index-def" data-term="'unicode-bidi'"><dfn id="propdef-unicode-bidi" class="propdef-title" data-dfn-type="property" data-lt="unicode-bidi"><strong>'unicode-bidi'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | embed | bidi-override | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2516,7 +2516,7 @@ case display is changed to inline (see example below).
 </p>
 <p>The following example shows an XML document with bidirectional
 text. It illustrates an important design principle: <span id="x48"
-class="index-inst" title="DTD">DTD</span> designers should take bidi
+class="index-inst" data-term="DTD">DTD</span> designers should take bidi
 into account both in the language proper (elements and attributes) and
 in any accompanying style sheets. The style sheets should be designed
 so that bidi rules are separate from other style rules. The bidi rules

--- a/css2/visuren.html
+++ b/css2/visuren.html
@@ -413,7 +413,7 @@ class="propinst-display">'display'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'display'"><span id="propdef-display" class="propdef-title"><strong>'display'</strong></span></span>
+<span class="index-def" title="'display'"><dfn id="propdef-display" class="propdef-title" data-dfn-type="property" data-lt="display"><strong>'display'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>inline | block | list-item | inline-block |
@@ -582,7 +582,7 @@ the position of a box.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'position'"><span id="propdef-position" class="propdef-title"><strong>'position'</strong></span></span>
+<span class="index-def" title="'position'"><dfn id="propdef-position" class="propdef-title" data-dfn-type="property" data-lt="position"><strong>'position'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>static | relative | absolute | fixed | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -687,7 +687,7 @@ positioned boxes, laid out according to four properties:</p>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'top'"><span id="propdef-top" class="propdef-title"><strong>'top'</strong></span></span>
+<span class="index-def" title="'top'"><dfn id="propdef-top" class="propdef-title" data-dfn-type="property" data-lt="top"><strong>'top'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -715,7 +715,7 @@ offset from that position according to these properties).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'right'"><span id="propdef-right" class="propdef-title"><strong>'right'</strong></span></span>
+<span class="index-def" title="'right'"><dfn id="propdef-right" class="propdef-title" data-dfn-type="property" data-lt="right"><strong>'right'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -742,7 +742,7 @@ box itself.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'bottom'"><span id="propdef-bottom" class="propdef-title"><strong>'bottom'</strong></span></span>
+<span class="index-def" title="'bottom'"><dfn id="propdef-bottom" class="propdef-title" data-dfn-type="property" data-lt="bottom"><strong>'bottom'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -768,7 +768,7 @@ box itself.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'left'"><span id="propdef-left" class="propdef-title"><strong>'left'</strong></span></span>
+<span class="index-def" title="'left'"><dfn id="propdef-left" class="propdef-title" data-dfn-type="property" data-lt="left"><strong>'left'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td><a href="syndata.html#value-def-length" class="noxref"><span class="value-inst-length">&lt;length&gt;</span></a> | <a href="syndata.html#value-def-percentage" class="noxref"><span class="value-inst-percentage">&lt;percentage&gt;</span></a> | auto | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1337,7 +1337,7 @@ class="propinst-clear">'clear'</span></a> property).
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'float'"><span id="propdef-float" class="propdef-title"><strong>'float'</strong></span></span>
+<span class="index-def" title="'float'"><dfn id="propdef-float" class="propdef-title" data-dfn-type="property" data-lt="float"><strong>'float'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>left | right | none | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -1470,7 +1470,7 @@ the <a href="visuren.html#propdef-clear" class="noxref"><span class="propinst-cl
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'clear'"><span id="propdef-clear" class="propdef-title"><strong>'clear'</strong></span></span>
+<span class="index-def" title="'clear'"><dfn id="propdef-clear" class="propdef-title" data-dfn-type="property" data-lt="clear"><strong>'clear'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>none | left | right | both | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2142,7 +2142,7 @@ class="propinst-z-index">'z-index'</span></a> property</h3>
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'z-index'"><span id="propdef-z-index" class="propdef-title"><strong>'z-index'</strong></span></span>
+<span class="index-def" title="'z-index'"><dfn id="propdef-z-index" class="propdef-title" data-dfn-type="property" data-lt="z-index"><strong>'z-index'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>auto | <a href="syndata.html#value-def-integer" class="noxref"><span class="value-inst-integer">&lt;integer&gt;</span></a> | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2373,7 +2373,7 @@ bidirectionality issues.
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'direction'"><span id="propdef-direction" class="propdef-title"><strong>'direction'</strong></span></span>
+<span class="index-def" title="'direction'"><dfn id="propdef-direction" class="propdef-title" data-dfn-type="property" data-lt="direction"><strong>'direction'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>ltr | rtl | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>
@@ -2424,7 +2424,7 @@ in <a href="refs.html#ref-HTML4" class="noxref"><span class="normref">[HTML401]<
 
 <div class="propdef">
 <dl><dt>
-<span class="index-def" title="'unicode-bidi'"><span id="propdef-unicode-bidi" class="propdef-title"><strong>'unicode-bidi'</strong></span></span>
+<span class="index-def" title="'unicode-bidi'"><dfn id="propdef-unicode-bidi" class="propdef-title" data-dfn-type="property" data-lt="unicode-bidi"><strong>'unicode-bidi'</strong></dfn></span>
 <dd>
 <table class="propinfo def">
 <tr><td><em>Value:</em>&nbsp;&nbsp;<td>normal | embed | bidi-override | <a href="cascade.html#value-def-inherit" class="noxref"><span class="value-inst-inherit">inherit</span></a>

--- a/css2/visuren.html
+++ b/css2/visuren.html
@@ -434,26 +434,26 @@ table-cell | table-caption | none | <a href="cascade.html#value-def-inherit" cla
 <p>The values of this property have the following meanings:</p>
 
 <dl>
-<dt><span class="index-def" title="'block', definition of"><span
-id="value-def-block"><strong>block</strong></span></span>
+<dt><span class="index-def" title="'block', definition of"><dfn
+id="value-def-block" data-dfn-type="value" data-dfn-for="display"><strong>block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate a block box.
 </dd>
-<dt><span class="index-def" title="'inline-block', definition of"><span
-id="value-def-inline-block"><strong>inline-block</strong></span></span>
+<dt><span class="index-def" title="'inline-block', definition of"><dfn
+id="value-def-inline-block" data-dfn-type="value" data-dfn-for="display"><strong>inline-block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate an inline-level block
 container.
 The inside of an inline-block is formatted as a block box, and the 
 element itself is formatted as an atomic inline-level box.
 </dd>
-<dt><span class="index-def" title="'inline', definition of"><span
-id="value-def-inline"><strong>inline</strong></span></span>
+<dt><span class="index-def" title="'inline', definition of"><dfn
+id="value-def-inline" data-dfn-type="value" data-dfn-for="display"><strong>inline</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate one or more inline boxes.
 </dd>
-<dt><span class="index-def" title="'list-item', definition of"><span
-id="value-def-list-item"><strong>list-item</strong></span></span>
+<dt><span class="index-def" title="'list-item', definition of"><dfn
+id="value-def-list-item" data-dfn-type="value" data-dfn-for="display"><strong>list-item</strong></dfn></span>
 </dt>
 <dd>This value causes an element (e.g., LI in HTML) to generate a
 principal block box and a marker box. For information about

--- a/css2/visuren.src
+++ b/css2/visuren.src
@@ -23,7 +23,7 @@ blockquote.math span:first-child {text-align: right}
 <h2><span id="visual-model-intro">Introduction to the visual formatting model</span></h2>
 
 <p>This chapter and the next describe the <span class="index-def"
-title="visual formatting model">visual formatting model</span>: how user
+data-term="visual formatting model">visual formatting model</span>: how user
 agents process the <a href="conform.html#doctree">document tree</a>
 for visual <a href="media.html">media</a>.
 </p>
@@ -64,7 +64,7 @@ specification.
 
 <p>User agents for <a
 href="media.html#continuous-media-group">continuous media</a>
-generally offer users a <span class="index-def" title="viewport">
+generally offer users a <span class="index-def" data-term="viewport">
 <dfn>viewport</dfn></span> (a window or other
 viewing area on the screen) through which users consult a
 document. User agents may change the document's layout when the
@@ -82,14 +82,14 @@ agents may render to more than one canvas (i.e., provide different
 views of the same document).
 </p>
 
-<h3><span class="index-def" title="containing block">
+<h3><span class="index-def" data-term="containing block">
 <span id="containing-block">Containing blocks</span></span>
 </h3>
 
 <p>In CSS&nbsp;2, many box positions and sizes are calculated with respect
 to the edges
 of a rectangular box called a <span class="index-def"
-title="containing block"><dfn>containing block</dfn></span>.  In
+data-term="containing block"><dfn>containing block</dfn></span>.  In
 general, generated boxes act as containing blocks for descendant
 boxes; we say that a box "establishes" the containing block for its
 descendants. The phrase "a box's containing block" means "the
@@ -115,18 +115,18 @@ specifies a box's type.
 
 <h3><span id="block-boxes">Block-level elements and block boxes</span></h3>
 
-<p><span class="index-def" title="block-level
+<p><span class="index-def" data-term="block-level
 element"><span id="block-level"><dfn>Block-level elements</dfn></span></span> are those elements of the source document that are formatted visually as
 blocks (e.g., paragraphs). The following values of the <span
 class="propinst-display">'display'</span> property make an element
 block-level: 'block', 'list-item', and 'table'.
 </p>
 
-<p><span class="index-def" title="block-level box"><dfn>Block-level
+<p><span class="index-def" data-term="block-level box"><dfn>Block-level
 boxes</dfn></span> are boxes that participate in
 a <a href="#block-formatting">block formatting context.</a> Each
 block-level element generates a <span class="index-def"
-title="principal block-level
+data-term="principal block-level
 box"><span id="principal-box"><dfn>principal block-level
 box</dfn></span></span> that contains descendant boxes and generated
 content and is also the box involved in any positioning scheme.
@@ -138,7 +138,7 @@ placed with respect to the principal box.
 
 <p>Except for table boxes, which are described in a later chapter, and
 replaced elements, a block-level box is also a block container box.
-A <span class="index-def" title="block container box"><span
+A <span class="index-def" data-term="block container box"><span
 id="block-container-box"><dfn >block
 container box</dfn></span></span> either
 contains only block-level boxes or establishes an inline formatting
@@ -146,7 +146,7 @@ context and thus contains only inline-level boxes. Not all block
 container boxes are block-level boxes: non-replaced inline blocks
 and non-replaced table cells are block containers but not block-level
 boxes. Block-level boxes that are also block containers are
-called <span class="index-def" title="block box"><dfn>block
+called <span class="index-def" data-term="block box"><dfn>block
 boxes</dfn></span>.
 
 <p>The three terms "block-level box," "block container box," and
@@ -166,7 +166,7 @@ boxes</dfn></span>.
 (and assuming the DIV and the P both have 'display: block'), the
 DIV appears to have both inline content and block content. To make it
 easier to define the formatting, we assume that there is an <em><span
-class="index-def" title="anonymous">anonymous block box</span></em>
+class="index-def" data-term="anonymous">anonymous block box</span></em>
 around "Some text".
 </p>
 <div class="figure">
@@ -257,7 +257,7 @@ containing block formed by the DIV, not of the anonymous block box.
 
 <h3><span id="inline-boxes">Inline-level elements and inline boxes</span></h3>
 
-<p><span class="index-def" title="inline-level element">
+<p><span class="index-def" data-term="inline-level element">
 <span id="inline-level"><dfn>Inline-level
 elements</dfn></span></span> are those elements of the source document that
 do not form new blocks of content; the content is distributed in lines
@@ -268,11 +268,11 @@ class="propinst-display">'display'</span> property make an element
 inline-level: 'inline', 'inline-table', and 'inline-block'. 
 
 Inline-level elements generate <span class="index-def"
-title="inline-level box"><dfn>inline-level
+data-term="inline-level box"><dfn>inline-level
 boxes</dfn></span>, which are boxes that participate in an inline
 formatting context.
 
-<p>An <span class="index-def" title="inline box"><span
+<p>An <span class="index-def" data-term="inline box"><span
 id="inline-box"><dfn>inline
 box</dfn></span></span> is one that is both inline-level and whose
 contents participate in its containing inline formatting context. A
@@ -280,7 +280,7 @@ non-replaced element with a 'display' value of 'inline' generates an
 inline box.
 Inline-level boxes that are not inline boxes (such as replaced
 inline-level elements, inline-block elements, and inline-table
-elements) are called <span class="index-def" title="atomic
+elements) are called <span class="index-def" data-term="atomic
 inline-level box"><dfn>atomic inline-level boxes</dfn></span> because
 they participate in their inline formatting context as a single opaque
 box.
@@ -302,7 +302,7 @@ element.
 <p>the <code>&lt;p&gt;</code> generates a block box, with several inline boxes inside
 it. The box for "emphasized" is an inline box generated by an inline
 element (<code>&lt;em&gt;</code>), but the other boxes ("Some" and "text") are inline boxes generated by a block-level element (<code>&lt;p&gt;</code>). The latter are called <span
-class="index-def" title="anonymous inline boxes">anonymous inline
+class="index-def" data-term="anonymous inline boxes">anonymous inline
 boxes</span>, because they do not have an associated inline-level element.
 </p>
 <p>Such anonymous inline boxes inherit inheritable properties from
@@ -325,7 +325,7 @@ simply called anonymous boxes in this specification.
 <h3><span id="run-in">Run-in boxes</span></h3>
 
 <p>[This section exists so that the section numbers are the same as in
-previous drafts. <span class="index-def" title="run-in">'display:
+previous drafts. <span class="index-def" data-term="run-in">'display:
 run-in'</span> is now defined in CSS level&nbsp;3 (see <a
 href="/TR/css3-box">CSS basic box model</a>).]
 
@@ -337,12 +337,12 @@ class="propinst-display">'display'</span> property</h3>
 <p>The values of this property have the following meanings:</p>
 
 <dl>
-<dt><span class="index-def" title="'block', definition of"><dfn
+<dt><span class="index-def" data-term="'block', definition of"><dfn
 id="value-def-block" data-dfn-type="value" data-dfn-for="display"><strong>block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate a block box.
 </dd>
-<dt><span class="index-def" title="'inline-block', definition of"><dfn
+<dt><span class="index-def" data-term="'inline-block', definition of"><dfn
 id="value-def-inline-block" data-dfn-type="value" data-dfn-for="display"><strong>inline-block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate an inline-level block
@@ -350,12 +350,12 @@ container.
 The inside of an inline-block is formatted as a block box, and the 
 element itself is formatted as an atomic inline-level box.
 </dd>
-<dt><span class="index-def" title="'inline', definition of"><dfn
+<dt><span class="index-def" data-term="'inline', definition of"><dfn
 id="value-def-inline" data-dfn-type="value" data-dfn-for="display"><strong>inline</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate one or more inline boxes.
 </dd>
-<dt><span class="index-def" title="'list-item', definition of"><dfn
+<dt><span class="index-def" data-term="'list-item', definition of"><dfn
 id="value-def-list-item" data-dfn-type="value" data-dfn-for="display"><strong>list-item</strong></dfn></span>
 </dt>
 <dd>This value causes an element (e.g., LI in HTML) to generate a
@@ -365,7 +365,7 @@ lists and examples of list formatting, please consult the section on
 </dd>
 <dt><strong>none</strong></dt>
 
-<dd><span class="index-def" title="'none'::as display value">This
+<dd><span class="index-def" data-term="'none'::as display value">This
 value</span> causes an element to not appear in the <a
 href="intro.html#formatting-structure">formatting structure</a> (i.e.,
 in visual media the element generates no boxes and has no effect on
@@ -437,7 +437,7 @@ img { display: none }      /* Do not display images */
 <h2><span id="positioning-scheme">Positioning schemes</span></h2>
 
 <p>In CSS&nbsp;2, a box may be laid out according to three <span
-class="index-def" title="positioning scheme"><dfn>positioning
+class="index-def" data-term="positioning scheme"><dfn>positioning
 schemes:</dfn></span></p>
 
 <ol>
@@ -571,7 +571,7 @@ class="propinst-right">'right'</span>, <span
 class="propinst-bottom">'bottom'</span>, <span
 class="propinst-left">'left'</span></h3>
 
-<p>An element is said to be <span class="index-def" title="positioned
+<p>An element is said to be <span class="index-def" data-term="positioned
 element/box"><span id="positioned-element"><dfn>positioned</dfn></span></span>
 if its <span class="propinst-position">'position'</span> property has
 a value other than 'static'. Positioned elements generate
@@ -647,7 +647,7 @@ positioned, replaced elements for details.
 <h2><span id="normal-flow">Normal flow</span></h2> 
 
 <p>Boxes in the normal flow belong to a <span class="index-def"
-title="formatting context">formatting context</span>, which may be
+data-term="formatting context">formatting context</span>, which may be
 block or inline, but not both simultaneously.  <a
 href="#block-level">Block-level</a> boxes participate in a <a
 href="#block-formatting">block formatting</a> context.  <a
@@ -693,7 +693,7 @@ block. Horizontal margins, borders, and padding are respected between
 these boxes. The boxes may be aligned vertically in different ways: their
 bottoms or tops may be aligned, or the baselines of text within them
 may be aligned. The rectangular area that contains the boxes that form
-a line is called a <span class="index-def" title="line box"><span
+a line is called a <span class="index-def" data-term="line box"><span
 id="line-box"><dfn>line box</dfn></span></span>. 
 </p>
 <p>The width of a line box is determined by a <a
@@ -857,7 +857,7 @@ dashed border is rendered on three sides in each case.</li>
 
 <p>Once a box has been laid out according to the <a
 href="#normal-flow">normal flow</a> or floated, it may be shifted relative to
-this position. This is called <span class="index-def" title="relative
+this position. This is called <span class="index-def" data-term="relative
 positioning"><dfn>relative positioning</dfn></span>. Offsetting a box
 (B1) in this way has no effect on the box (B2) that follows: B2 is
 given a position as if B1 were not offset and B2 is not re-positioned
@@ -1185,7 +1185,7 @@ User agents may treat float as 'none' on the root element.
 </p>
 
 
-<p><span class="index-def" title="float rules"><span
+<p><span class="index-def" data-term="float rules"><span
 id="float-rules">Here are the precise rules</span></span> that
 govern the behavior of floats:</p>
 
@@ -1227,7 +1227,7 @@ earlier in the source document.
 </li>
 <li>The <a href="box.html#outer-edge">outer top</a> of an element's
 floating box may not be higher than the top of any <span
-class="index-inst" title="line-box"><a
+class="index-inst" data-term="line-box"><a
 href="#line-box">line-box</a></span> containing a box
 generated by an element earlier in the source document.
 </li>
@@ -1483,7 +1483,7 @@ depending on the
 <a href="#stack-level">stack levels</a> of the overlapping boxes.
 </p>
 <p>References in this specification to an <span class="index-def"
-title="absolutely positioned element">
+data-term="absolutely positioned element">
 <span id="absolutely-positioned"><dfn>absolutely positioned
 element</dfn></span></span> (or its box) imply that the element's <span
 class="propinst-position">'position'</span> property has the value
@@ -1939,7 +1939,7 @@ class="propinst-z-index">'z-index'</span> property specifies:
 <p>Values have the following meanings:
 
 <dl>
-  <dt><span class="index-inst" title="&lt;integer&gt;"><span
+  <dt><span class="index-inst" data-term="&lt;integer&gt;"><span
   class="value-inst-integer"><strong>&lt;integer&gt;</strong></span></span>
 
   <dd>This integer is the stack level of the generated box in the
@@ -1969,10 +1969,10 @@ contain further stacking contexts. A stacking context is atomic from
 the point of view of its parent stacking context; boxes in other 
 stacking contexts may not come between any of its boxes.
 </p>
-<p>Each box belongs to one <span class="index-def" title="stacking
+<p>Each box belongs to one <span class="index-def" data-term="stacking
 context"><dfn>stacking context</dfn></span>. Each positioned box in a
 given stacking context has an integer <span class="index-def"
-title="stack level"><span id="stack-level"><dfn>stack
+data-term="stack level"><span id="stack-level"><dfn>stack
 level</dfn></span></span>, which is its position on the z-axis relative
 other stack levels within the same stacking context. Boxes with
 greater stack levels are always formatted
@@ -2103,7 +2103,7 @@ left. In some documents, in particular those written with the Arabic
 or Hebrew script, and in some mixed-language contexts, text in a
 single (visually displayed) block may appear with mixed
 directionality. This phenomenon is called <span class="index-def"
-title="bidirectionality (bidi)"><dfn>bidirectionality</dfn></span>, or
+data-term="bidirectionality (bidi)"><dfn>bidirectionality</dfn></span>, or
 "bidi" for short.
 </p>
 <p>The Unicode standard ([[UNICODE]], [[UAX9]]) defines a complex
@@ -2256,7 +2256,7 @@ case display is changed to inline (see example below).
 </p>
 <p>The following example shows an XML document with bidirectional
 text. It illustrates an important design principle: <span
-class="index-inst" title="DTD">DTD</span> designers should take bidi
+class="index-inst" data-term="DTD">DTD</span> designers should take bidi
 into account both in the language proper (elements and attributes) and
 in any accompanying style sheets. The style sheets should be designed
 so that bidi rules are separate from other style rules. The bidi rules

--- a/css2/visuren.src
+++ b/css2/visuren.src
@@ -337,26 +337,26 @@ class="propinst-display">'display'</span> property</h3>
 <p>The values of this property have the following meanings:</p>
 
 <dl>
-<dt><span class="index-def" title="'block', definition of"><span
-id="value-def-block"><strong>block</strong></span></span>
+<dt><span class="index-def" title="'block', definition of"><dfn
+id="value-def-block" data-dfn-type="value" data-dfn-for="display"><strong>block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate a block box.
 </dd>
-<dt><span class="index-def" title="'inline-block', definition of"><span
-id="value-def-inline-block"><strong>inline-block</strong></span></span>
+<dt><span class="index-def" title="'inline-block', definition of"><dfn
+id="value-def-inline-block" data-dfn-type="value" data-dfn-for="display"><strong>inline-block</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate an inline-level block
 container.
 The inside of an inline-block is formatted as a block box, and the 
 element itself is formatted as an atomic inline-level box.
 </dd>
-<dt><span class="index-def" title="'inline', definition of"><span
-id="value-def-inline"><strong>inline</strong></span></span>
+<dt><span class="index-def" title="'inline', definition of"><dfn
+id="value-def-inline" data-dfn-type="value" data-dfn-for="display"><strong>inline</strong></dfn></span>
 </dt>
 <dd>This value causes an element to generate one or more inline boxes.
 </dd>
-<dt><span class="index-def" title="'list-item', definition of"><span
-id="value-def-list-item"><strong>list-item</strong></span></span>
+<dt><span class="index-def" title="'list-item', definition of"><dfn
+id="value-def-list-item" data-dfn-type="value" data-dfn-for="display"><strong>list-item</strong></dfn></span>
 </dt>
 <dd>This value causes an element (e.g., LI in HTML) to generate a
 principal block box and a marker box. For information about


### PR DESCRIPTION
Fixes #4880.

(Tab, not expecting you to do a detailed review, but please do look quickly at the "add data-dfn-type" commits and check the *.html files look sane!)