### PR TITLE
Ruby cleanup

### DIFF
--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -70,8 +70,9 @@ Diagram conventions</h3>
 
 	<dl>
 		<dt><img alt="Symbolic wide-cell glyph representation" width="39" height="39" src="images/fullwidth.gif">
-		<dd>Wide-cell glyph (e.g. Han) that is the <var>n</var>th character in the text run.
-		They are typically sized to 50% when used as annotations.
+		<dd>
+			Wide-cell glyph (e.g. Han) that is the <var>n</var>th character in the text run.
+			They are typically sized to 50% when used as annotations.
 		<dt><img alt="Symbolic narrow-cell glyph representation" width="19" height="39" src="images/halfwidth.gif">
 		<dd>Narrow-cell glyph (e.g. Roman) which is the <var>n</var>th glyph in the text run.
 	</dl>
@@ -96,7 +97,7 @@ What is ruby?</h3>
 		In this first example, a single annotation is used to annotate the base text.
 		<div class="figure">
 			<img src="images/licence.png"
-			        alt="Example of ruby applied on top of a Japanese expression">
+			     alt="Example of ruby applied on top of a Japanese expression">
 			<p class="caption">Example of ruby used in Japanese (simple case)
 		</div>
 
@@ -113,7 +114,7 @@ What is ruby?</h3>
 		while the words “Keio” and “University” on the bottom are annotations describing the English translation.
 		<div class="figure">
 			<img src="images/ruby-univ.gif"
-			        alt="Example showing complex ruby with annotation text over and under the base characters">
+			     alt="Example showing complex ruby with annotation text over and under the base characters">
 			<p class="caption">Complex ruby with annotation text over and under the base characters
 		</div>
 
@@ -171,19 +172,24 @@ Ruby-specific 'display' Values</h3>
 
 	<dl dfn-type=value export dfn-for=display>
 		<dt><dfn>ruby</dfn>
-			<dd>Specifies that an element generates a <dfn dfn for lt="ruby container | ruby container box">ruby container box</dfn>.
+		<dd>
+			Specifies that an element generates a <dfn dfn for lt="ruby container | ruby container box">ruby container box</dfn>.
 			(Corresponds to HTML/XHTML <code>&lt;ruby&gt;</code> elements.)
 		<dt><dfn>ruby-base</dfn>
-			<dd>Specifies that an element generates a <dfn dfn for lt="ruby base box | ruby base">ruby base box</dfn>.
+		<dd>
+			Specifies that an element generates a <dfn dfn for lt="ruby base box | ruby base">ruby base box</dfn>.
 			(Corresponds to HTML/XHTML <code>&lt;rb&gt;</code> elements.)
 		<dt><dfn>ruby-text</dfn>
-			<dd>Specifies that an element generates a <dfn dfn for lt="ruby annotation box | ruby annotation | annotation">ruby annotation box</dfn>.
+		<dd>
+			Specifies that an element generates a <dfn dfn for lt="ruby annotation box | ruby annotation | annotation">ruby annotation box</dfn>.
 			(Corresponds to HTML/XHTML <code>&lt;rt&gt;</code> elements.)
 		<dt><dfn>ruby-base-container</dfn>
-			<dd>Specifies that an element generates a <dfn dfn for lt="ruby base container box | ruby base container">ruby base container box</dfn>.
+		<dd>
+			Specifies that an element generates a <dfn dfn for lt="ruby base container box | ruby base container">ruby base container box</dfn>.
 			(Corresponds to XHTML <code>&lt;rbc&gt;</code> elements; generated as an anonymous box in HTML.)
 		<dt><dfn>ruby-text-container</dfn>
-			<dd>Specifies that an element generates a <dfn dfn for lt="ruby annotation container box | ruby annotation container">ruby annotation container box</dfn>.
+		<dd>
+			Specifies that an element generates a <dfn dfn for lt="ruby annotation container box | ruby annotation container">ruby annotation container box</dfn>.
 			(Corresponds to HTML/XHTML <code>&lt;rtc&gt;</code> elements.)
 	</dl>
 
@@ -249,7 +255,6 @@ Anonymous Ruby Box Generation</h3>
 	<a href="https://www.w3.org/TR/CSS2/tables.html#anonymous-boxes">similar to those used to normalize tables</a>. [[!CSS2]]
 
 	<ol>
-
 		<li id="anon-gen-inlinize"><strong>[=Inlinify=] block-level boxes:</strong>
 			Any in-flow boxes directly contained by a
 			[=ruby container=],
@@ -265,7 +270,7 @@ Anonymous Ruby Box Generation</h3>
 			parented by an element with ''display: ruby-text''
 			computes to ''inline-block''.
 
-		<li id="anon-gen-anon-ruby"><strong>Generate anonymous ruby containers</strong>:
+		<li id="anon-gen-anon-ruby"><strong>Generate anonymous ruby containers:</strong>
 			Any <a href="https://www.w3.org/TR/CSS2/tables.html#anonymous-boxes">consecutive</a> sequence of
 			improperly-contained
 			[=ruby base containers=],
@@ -279,8 +284,9 @@ Anonymous Ruby Box Generation</h3>
 			<ul>
 				<li>an improperly-contained [=ruby base=] is one not parented by a [=ruby base container=] or [=ruby container=]
 				<li>an improperly-contained [=ruby annotation=] is one not parented by a [=ruby annotation container=] or [=ruby container=]
-				<li>an improperly-contained [=ruby base container=] or [=ruby annotation container=]
-				    is one not parented by a [=ruby container=]
+				<li>
+					an improperly-contained [=ruby base container=] or [=ruby annotation container=]
+					is one not parented by a [=ruby container=]
 			</ul>
 
 		<li id="anon-gen-bare-inlines"><strong>Wrap misparented inline-level content:</strong>
@@ -364,8 +370,9 @@ Anonymous Ruby Box Generation</h3>
 				<tr><td>[=ruby base container=]
 				    <td>[=ruby base=] or [=ruby base container=]
 			</table>
-			The <dfn>intra-level white space</dfn> boxes defined above are
-			treated specially for [=pairing=] and layout. See below.
+			The <dfn>intra-level white space</dfn> boxes defined above
+			are treated specially for [=pairing=] and layout.
+			See below.
 
 		<li id="anon-gen-unbreak"><strong>Suppress line breaks:</strong>
 			Convert all forced line breaks inside [=ruby annotations=] (regardless of 'white-space' value)
@@ -414,7 +421,6 @@ Annotation Pairing</h3>
 	and one [=ruby annotation=] (possibly an empty, anonymous one)
 	from each [=annotation level=] in its [=ruby segment=].
 
-
 <h4 id="segment-pairing">
 Segment Pairing and Annotation Levels</h4>
 
@@ -432,10 +438,12 @@ Segment Pairing and Annotation Levels</h4>
 
 	In order to handle degenerate cases, some empty anonymous containers are assumed:
 	<ul>
-		<li>If the first child of a [=ruby container=] is a [=ruby annotation container=],
-		an anonymous, empty [=ruby base container=] is assumed to exist before it.
-		<li>Similarly, if the [=ruby container=] contains consecutive [=ruby base containers=],
-		anonymous, empty [=ruby annotation containers=] are assumed to exist between them.
+		<li>
+			If the first child of a [=ruby container=] is a [=ruby annotation container=],
+			an anonymous, empty [=ruby base container=] is assumed to exist before it.
+		<li>
+			Similarly, if the [=ruby container=] contains consecutive [=ruby base containers=],
+			anonymous, empty [=ruby annotation containers=] are assumed to exist between them.
 	</ul>
 
 	[=Inter-segment white space=] is effectively a [=ruby segment=] of its own.
@@ -454,7 +462,7 @@ Unit Pairing and Spanning Annotations</h4>
 	all of the [=ruby bases=] in its [=ruby segment=].
 
 	Otherwise, each [=ruby annotation=] is paired,
-	in order, with the corresponding [=ruby base=] in that segment</i>.
+	in order, with the corresponding [=ruby base=] in that segment.
 	If there are not enough [=ruby annotations=] in a [=ruby annotation container=],
 	the remaining [=ruby bases=] are paired with anonymous empty annotations
 	inserted at the end of the [=ruby annotation container=].
@@ -471,15 +479,18 @@ Unit Pairing and Spanning Annotations</h4>
 	However, if the immediately-adjacent [=ruby bases=] or [=ruby annotations=]
 	are paired
 	<ul>
-		<li>with two [=ruby bases=] or [=ruby annotations|annotations=]
-		that surround corresponding [=intra-level white space=] in another level,
-		then the so-corresponding [=intra-level white space=] boxes are also paired.
-		<li>with a single spanning [=ruby annotation=],
-		then the [=intra-level white space=] is also paired to that [=ruby annotation=]
-		<li>with two [=ruby bases=] or [=ruby annotations|annotations=]
-		with no intervening [=intra-level white space=],
-		then the [=intra-level white space=] box pairs with
-		an anonymous empty [=intra-level white space=] box assumed to exist between them.
+		<li>
+			with two [=ruby bases=] or [=ruby annotations|annotations=]
+			that surround corresponding [=intra-level white space=] in another level,
+			then the so-corresponding [=intra-level white space=] boxes are also paired.
+		<li>
+			with a single spanning [=ruby annotation=],
+			then the [=intra-level white space=] is also paired to that [=ruby annotation=]
+		<li>
+			with two [=ruby bases=] or [=ruby annotations|annotations=]
+			with no intervening [=intra-level white space=],
+			then the [=intra-level white space=] box pairs with
+			an anonymous empty [=intra-level white space=] box assumed to exist between them.
 	</ul>
 
 	Issue: Insert diagram
@@ -538,7 +549,7 @@ Autohiding Base-identical Annotations</h3>
 		However, when displayed as ruby, the “り” should be hidden
 		<div class="figure">
 			<img src="images/furigana-separate.png"
-			        alt="Hiragana annotations for 振り仮名 appear, each pronunciation above its kanji base character.">
+			     alt="Hiragana annotations for 振り仮名 appear, each pronunciation above its kanji base character.">
 			<p class="caption">Hiragana ruby for 振り仮名. Notice there is no hiragana annotation above り,  since it is already in hiragana.
 		</div>
 	</div>
@@ -876,10 +887,10 @@ Line Spacing</h3>
 
 	<div class="figure">
 		<img src="images/rlh-a.gif"
-		        alt="The content of each line sits in the middle of its line height;
-		             the additional space on each side is called half-leading.
-		             Ruby fits between lines if it is smaller than twice the half-leading,
-		             but this means that it occupies space belonging to the half-leading of the previous line.">
+		     alt="The content of each line sits in the middle of its line height;
+		          the additional space on each side is called half-leading.
+		          Ruby fits between lines if it is smaller than twice the half-leading,
+		          but this means that it occupies space belonging to the half-leading of the previous line.">
 		<p class="caption">Ruby annotations will often overflow the line;
 		authors should ensure content over/under a ruby-annotated line
 		is adequately spaced to leave room for the ruby.
@@ -918,16 +929,17 @@ Ruby Positioning: the 'ruby-position' property</h3>
 
 	<dl dfn-for=ruby-position dfn-type=value>
 		<dt><dfn>over</dfn>
-		<dd>The ruby text appears [=line-over=] the base.
+		<dd>
+			The ruby text appears [=line-over=] the base.
 
 			<div class="figure">
 				<img src="images/shinkansen-top.gif"
-				        alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing above the base">
+				     alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing above the base">
 				<p class="caption">Ruby over Japanese base text in horizontal layout
 			</div>
 			<div class="figure">
 				<img src="images/shinkansen-right.gif" width="33"
-				        alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the right of the base">
+				     alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the right of the base">
 				<p class="caption">Ruby to the right of Japanese base text in vertical layout
 			</div>
 		</dd>
@@ -940,12 +952,12 @@ Ruby Positioning: the 'ruby-position' property</h3>
 
 			<div class="figure">
 				<img src="images/shinkansen-bottom.gif"
-				        alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing below the base">
+				     alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing below the base">
 				<p class="caption">Ruby under Japanese base text in horizontal layout
 			</div>
 			<div class="figure">
 				<img src="images/shinkansen-left.gif"
-				        alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the left of the base">
+				     alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the left of the base">
 				<p class="caption">Ruby to the left of Japanese base text in vertical layout
 			</div>
 		</dd>
@@ -963,7 +975,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 
 				<div class="figure">
 					<img src="images/bopomofo.gif"
-					        alt="Example of Taiwanese-style ruby">
+					     alt="Example of Taiwanese-style ruby">
 					<p class="caption">“Bopomofo” ruby in traditional Chinese
 					(ruby text shown in blue for clarity) in horizontal layout
 				</div>
@@ -1035,14 +1047,15 @@ Sharing Annotation Space: the 'ruby-merge' property</h3>
 				but if some annotations are wider than their bases
 				the space is shared in some way
 				to avoid imposing space between bases.
-			<div class="example">
-				One possible algorithm is described as “jukugo ruby” in [[JLREQ]].
 
-				Another, more simplified algorithm of “jukugo ruby” is
-				to render as ''separate'' if all ruby annotation boxes fit
-				within the advances of their corresponding base boxes,
-				and render as ''collapse'' otherwise.
-			</div>
+				<div class="example">
+					One possible algorithm is described as “jukugo ruby” in [[JLREQ]].
+
+					Another, more simplified algorithm of “jukugo ruby” is
+					to render as ''separate'' if all ruby annotation boxes fit
+					within the advances of their corresponding base boxes,
+					and render as ''collapse'' otherwise.
+				</div>
 		</dd>
 	</dl>
 
@@ -1070,12 +1083,11 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dd>
 			The ruby content is aligned with the start edge of its box.
 			<div class="figure">
-				<img
-					alt="Diagram of glyph layout in left aligned ruby when ruby text is shorter than base"
-					width="145" height="91" src="images/ra-l.gif" /><img
-					width="145" height="91"
-					alt="Diagram of glyph layout in left aligned ruby when ruby text is longer than base"
-					src="images/ra-l-rb.gif" />
+				<img width="145" height="91" src="images/ra-l.gif"
+				     alt="Diagram of glyph layout in left aligned ruby when ruby text is shorter than base" >
+				<img width="145" height="91"
+				     alt="Diagram of glyph layout in left aligned ruby when ruby text is longer than base"
+				     src="images/ra-l-rb.gif" >
 				<p class="caption">''ruby-align/start'' ruby distribution
 			</div>
 		</dd>
@@ -1084,10 +1096,11 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dd>The ruby content is centered within its box.
 			<div class="figure">
 				<img width="145" height="91"
-					alt="Diagram of glyph layout in center aligned ruby when ruby text is shorter than base"
-					src="images/ra-c.gif" /><img width="145" height="91"
-					alt="Diagram of glyph layout in center aligned ruby when ruby text is longer than base"
-					src="images/ra-c-rb.gif" />
+				     alt="Diagram of glyph layout in center aligned ruby when ruby text is shorter than base"
+				     src="images/ra-c.gif" >
+				<img width="145" height="91"
+				     alt="Diagram of glyph layout in center aligned ruby when ruby text is longer than base"
+				     src="images/ra-c-rb.gif" >
 				<p class="caption">''ruby-align/center'' ruby distribution
 			</div>
 		</dd>
@@ -1095,15 +1108,16 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dt><dfn>space-between</dfn></dt>
 		<dd>
 			The ruby content expands as defined for normal text justification
-				(as defined by 'text-justify'),
-				except that if there are no [=justification opportunities=]
-				the content is centered.
+			(as defined by 'text-justify'),
+			except that if there are no [=justification opportunities=]
+			the content is centered.
 			<div class="figure">
 				<img width="145" height="91"
-				alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is shorter than base"
-				src="images/ra-dl.gif" /><img width="145" height="91"
-				alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is longer than base"
-				src="images/ra-dl-rb.gif" />
+				     alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is shorter than base"
+				     src="images/ra-dl.gif" >
+				<img width="145" height="91"
+				     alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is longer than base"
+				     src="images/ra-dl-rb.gif" >
 				<p class="caption">''ruby-align/space-between'' ruby distribution
 			</div>
 		</dd>
@@ -1121,22 +1135,22 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 				for wide-cell ruby content to be distributed...
 				<div class="figure">
 					<img width="145" height="91"
-					alt="Diagram of glyph layout in auto aligned ruby when ruby text is shorter than base"
-					src="images/ra-ds.gif" /><img width="145" height="91"
-					alt="Diagram of glyph layout in auto aligned ruby when ruby text is longer than base"
-					src="images/ra-ds-rb.gif" />
+					     alt="Diagram of glyph layout in auto aligned ruby when ruby text is shorter than base"
+					     src="images/ra-ds.gif" >
+					<img width="145" height="91"
+					     alt="Diagram of glyph layout in auto aligned ruby when ruby text is longer than base"
+					     src="images/ra-ds-rb.gif" >
 					<p class="caption">Wide-cell text in ''ruby-align/space-around'' ruby distribution is spaced apart
 				</div>
 
 				... and narrow-cell glyph ruby to be centered.
 				<div class="figure">
-					<img
-					alt="Diagram of glyph layout in auto aligned ruby when halfwidth ruby text is shorter than base"
-					width="145" height="91"
-					src="images/ra-c-h.gif" /><img
-					alt="Diagram of character layout in auto aligned ruby when ruby text is longer than narrow-width base"
-					width="145" height="91"
-					src="images/ra-c-rb-h.gif" />
+					<img width="145" height="91"
+					     alt="Diagram of glyph layout in auto aligned ruby when halfwidth ruby text is shorter than base"
+					     src="images/ra-c-h.gif" >
+					<img width="145" height="91"
+					     alt="Diagram of character layout in auto aligned ruby when ruby text is longer than narrow-width base"
+					     src="images/ra-c-rb-h.gif" >
 					<p class="caption">Narrow-width ruby text in ''ruby-align/space-around'' ruby distribution is centered
 				</div>
 			</div>
@@ -1200,7 +1214,7 @@ Overhanging Ruby</h3>
 
 	<div class="figure">
 		<img src="images/ro-n.gif"
-		        alt="Diagram showing the ruby boxes interacting with adjacent text">
+		     alt="Diagram showing the ruby boxes interacting with adjacent text">
 		<p class="caption">Simple ruby whose text is not allowed to overhang adjacent text
 	</div>
 
@@ -1211,7 +1225,7 @@ Overhanging Ruby</h3>
 
 	<div class="figure">
 		<img src="images/ro-a.gif"
-		      alt="Diagram showing the ruby boxes interacting with adjacent text">
+		     alt="Diagram showing the ruby boxes interacting with adjacent text">
 		<p class="caption">Simple ruby whose text is allowed to overhang adjacent text
 	</div>
 
@@ -1250,166 +1264,177 @@ Line-edge Alignment</h3>
 
 	<div class="figure">
 		<img src="images/ra-le-l.gif"
-			alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is shorter than base">
-			<img src="images/ra-le-r.gif"
-			alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is longer than base">
+		     alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is shorter than base" >
+		<img src="images/ra-le-r.gif"
+		     alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is longer than base" >
 		<p class="caption">Line-edge alignment
 	</div>
 
-	<!--
+<!--
 <h3 id="rubyover">
 Ruby overhanging: the 'ruby-overhang' property</h3>
 
-  <table class="propdef">
-    <tr>
-      <th>Name:
-      <td><dfn>ruby-overhang</dfn>
-    <tr>
-      <th>Value:
-      <td>auto | start | end | none
-    <tr>
-      <th>Initial:
-      <td>none
-    <tr>
-      <th>Applies to:
-      <td>the parent of elements with display: ruby-text
-    <tr>
-      <th>Inherited:
-      <td>yes
-    <tr>
-      <th>Percentages:
-      <td>N/A
-    <tr>
-      <th>Computed value:
-      <td>specified value (except for initial and inherit)
-  </table>
+	<table class="propdef">
+		<tr>
+			<th>Name:
+			<td><dfn>ruby-overhang</dfn>
+		<tr>
+			<th>Value:
+			<td>auto | start | end | none
+		<tr>
+			<th>Initial:
+			<td>none
+		<tr>
+			<th>Applies to:
+			<td>the parent of elements with display: ruby-text
+		<tr>
+			<th>Inherited:
+			<td>yes
+		<tr>
+			<th>Percentages:
+			<td>N/A
+		<tr>
+			<th>Computed value:
+			<td>specified value (except for initial and inherit)
+	</table>
 
-This property determines whether, and on which side, ruby text is allowed
-to partially overhang any adjacent text in addition to its own base, when the
-ruby text is wider than the ruby base. Note that ruby text is never allowed to
-overhang glyphs belonging to another ruby base. <span class="issue"><span class="issuehead">Issue:&nbsp;</span> This rule must be broken if we are to allow support for jukugo ruby.</span> Also the user agent is free to assume
-a maximum amount by which ruby text may overhang adjacent text. The user agent may use
-the [[JIS4051]] recommendation of using one ruby text character
-length as the maximum overhang length. Detailed rules for how ruby text can overhang adjacent characters for Japanese are described by [[JLREQ]].
+	This property determines whether, and on which side,
+	ruby text is allowed to partially overhang any adjacent text in addition to its own base,
+	when the ruby text is wider than the ruby base.
+	Note that ruby text is never allowed to overhang glyphs belonging to another ruby base.
+	<span class="issue"><span class="issuehead">Issue:&nbsp;</span> This rule must be broken
+	if we are to allow support for jukugo ruby.</span>
+	Also the user agent is free to assume
+	a maximum amount by which ruby text may overhang adjacent text.
+	The user agent may use the [[JIS4051]] recommendation
+	of using one ruby text character length as the maximum overhang length.
+	Detailed rules for how ruby text can overhang adjacent characters for Japanese are described by [[JLREQ]].
 
-Possible values:
-<dl>
-  <dt><strong>auto</strong></dt>
-    <dd>The ruby text can overhang text adjacent to the base on either side.   	  [[JLREQ]] and [[JIS4051]] specify the categories of characters that
-      ruby text can overhang. The user agent is free to follow those recommendations or specify its own classes of
-      characters to overhang. This is the initial value.
-		<div class="figure">
-      <img class="example" width="177" height="91"
-      alt="Diagram of glyph layout in overhanging ruby" src="images/ro-a.gif" />
-      <b>Figure 4.3.1</b>: Ruby overhanging adjacent text
-      </div>
-    </dd>
-  <dt><strong>start</strong></dt>
-    <dd>The ruby text can only overhang the text that precedes it. That means, for
-      example, that ruby cannot overhang text that is to the right of it in
-      horizontal LTR layout, and it cannot overhang text that is below it in
-      vertical-ideographic layout.
-		<div class="figure">
-      <img class="example" width="199" height="91"
-      alt="Diagram of glyph layout when ruby overhangs the preceding glyphs only"
-      src="images/ro-s.gif" />
-      <b>Figure 4.3.2</b>: Ruby overhanging preceding text only
-      </div>
-    </dd>
-  <dt><strong>end</strong></dt>
-    <dd>The ruby text can only overhang the text that follows it. That means, for
-      example, that ruby cannot overhang text that is to the left of it in
-      horizontal LTR layout, and it cannot overhang text that is above it in
-      vertical-ideographic layout.
-		<div class="figure">
-      <img class="example" width="198" height="91"
-      alt="Diagram of glyph layout when ruby overhangs the following characters only"
-      src="images/ro-e.gif" />
-      <b>Figure 4.3.3</b>: Ruby overhanging following text only
-      </div>
-    </dd>
-  <dt><strong>none</strong></dt>
-    <dd>The ruby text cannot overhang any text adjacent to its base, only its
-      own base.
+	Possible values:
+	<dl>
+		<dt><strong>auto</strong></dt>
+		<dd>
+			The ruby text can overhang text adjacent to the base on either side.
+			[[JLREQ]] and [[JIS4051]] specify the categories of characters
+			that ruby text can overhang.
+			The user agent is free to follow those recommendations
+			or specify its own classes of characters to overhang.
+			This is the initial value.
+			<div class="figure">
+				<img class="example" width="177" height="91"
+				     alt="Diagram of glyph layout in overhanging ruby" src="images/ro-a.gif" >
+				<b>Figure 4.3.1</b>: Ruby overhanging adjacent text
+			</div>
+		<dt><strong>start</strong></dt>
+		<dd>
+			The ruby text can only overhang the text that precedes it.
+			That means, for example, that ruby cannot overhang text
+			that is to the right of it in horizontal LTR layout,
+			and it cannot overhang text that is below it in vertical-ideographic layout.
+			<div class="figure">
+				<img class="example" width="199" height="91"
+				     alt="Diagram of glyph layout when ruby overhangs the preceding glyphs only"
+				     src="images/ro-s.gif" >
+				<b>Figure 4.3.2</b>: Ruby overhanging preceding text only
+			</div>
+		<dt><strong>end</strong></dt>
+		<dd>
+			The ruby text can only overhang the text that follows it.
+			That means, for example, that ruby cannot overhang text
+			that is to the left of it in horizontal LTR layout,
+			and it cannot overhang text that is above it in vertical-ideographic layout.
+			<div class="figure">
+				<img class="example" width="198" height="91"
+				     alt="Diagram of glyph layout when ruby overhangs the following characters only"
+				     src="images/ro-e.gif" >
+				<b>Figure 4.3.3</b>: Ruby overhanging following text only
+			</div>
+		<dt><strong>none</strong></dt>
+		<dd>
+			The ruby text cannot overhang any text adjacent to its base,
+			only its own base.
 
-      <div class="figure">
-      <img class="example" width="220" height="91"
-      alt="Diagram of glyph layout in non-overhanging ruby"
-      src="images/ro-n.gif" />
-      <b>Figure 4.3.4</b>: Ruby not allowed to overhang adjacent text
-      </div>
-    </dd>
-</dl>
+			<div class="figure">
+				<img class="example" width="220" height="91"
+				     alt="Diagram of glyph layout in non-overhanging ruby"
+				     src="images/ro-n.gif" >
+				<b>Figure 4.3.4</b>: Ruby not allowed to overhang adjacent text
+			</div>
+	</dl>
 
 <h3 id="rubyspan">
 Ruby annotation spanning: the 'ruby-span' property</h3>
 
-  <table class="propdef">
-    <tr>
-      <th>Name:
-      <td><dfn>ruby-span</dfn>
-    <tr>
-      <th>Value:
-      <td>attr(x) |  none
-    <tr>
-      <th>Initial:
-      <td>none
-    <tr>
-      <th>Applies to:
-      <td>elements with display: ruby-text
-    <tr>
-      <th>Inherited:
-      <td>no
-    <tr>
-      <th>Percentages:
-      <td>N/A
-    <tr>
-      <th>Computed value:
-      <td>&lt;number&gt;
-  </table>
+	<table class="propdef">
+		<tr>
+			<th>Name:
+			<td><dfn>ruby-span</dfn>
+		<tr>
+			<th>Value:
+			<td>attr(x) |  none
+		<tr>
+			<th>Initial:
+			<td>none
+		<tr>
+			<th>Applies to:
+			<td>elements with display: ruby-text
+		<tr>
+			<th>Inherited:
+			<td>no
+		<tr>
+			<th>Percentages:
+			<td>N/A
+		<tr>
+			<th>Computed value:
+			<td>&lt;number&gt;
+	</table>
 
-This property controls the spanning behavior of annotation elements.
+	This property controls the spanning behavior of annotation elements.
 
-Note: A XHTML user agent may also use the <samp>rbspan</samp>
-attribute to get the same effect.
+	Note: A XHTML user agent may also use the <samp>rbspan</samp> attribute
+	to get the same effect.
 
-Possible values:
+	Possible values:
 
-<dl>
-  <dt><strong>attr(x)</strong></dt>
-    <dd>The value of attribute 'x' as a string value. The string value is
-    evaluated as a &lt;number&gt; to determine the number of ruby base elements to be
-    spanned by the annotation element. If the &lt;number&gt; is &#39;0&#39;, it is replaced by
-    &#39;1&#39;.The &lt;number&gt; is the computed value. </dd>
-  <dt>none</dt>
-  <dd>No spanning. The computed value is &#39;1&#39;.</dd>
-</dl>
+	<dl>
+		<dt><strong>attr(x)</strong></dt>
+		<dd>
+			The value of attribute 'x' as a string value.
+			The string value is evaluated as a &lt;number&gt;
+			to determine the number of ruby base elements to be spanned by the annotation element.
+			If the &lt;number&gt; is &#39;0&#39;,
+			it is replaced by &#39;1&#39;.The &lt;number&gt; is the computed value.
 
-The following example shows an XML example using the 'display' property
-values associated with the 'ruby structure and the 'ruby-span' property
-<pre class="xml">myruby       { display: ruby; }
-myrbc        { display: ruby-base-container; }
-myrb         { display: ruby-base; }
-myrtc.before { display: ruby-text-container; ruby-position: before}
-myrtc.after  { display: ruby-text-container; ruby-position: after}
-myrt         { display: ruby-text; ruby-span: attr(rbspan); }
-...
-&lt;myruby&gt;
-  &lt;myrbc&gt;
-    &lt;myrb&gt;10&lt;/myrb&gt;
-    &lt;myrb&gt;31&lt;/myrb&gt;
-    &lt;myrb&gt;2002&lt;/myrb&gt;
-  &lt;/myrbc&gt;
-  &lt;myrtc class=&quot;before&quot;&gt;
-    &lt;myrt&gt;Month&lt;/myrt&gt;
-    &lt;myrt&gt;Day&lt;/myrt&gt;
-    &lt;myrt&gt;Year&lt;/myrt&gt;
-  &lt;/myrtc&gt;
-  &lt;myrtc class=&quot;after&quot;&gt;
-    &lt;myrt rbspan=&quot;3&quot;&gt;Expiration Date&lt;/myrt&gt;
-  &lt;/myrtc&gt;
-&lt;/myruby&gt;</pre>
-	-->
+		<dt>none</dt>
+		<dd>
+			No spanning. The computed value is &#39;1&#39;.
+	</dl>
+
+	The following example shows an XML example using the 'display' property values
+	associated with the ruby structure and the 'ruby-span' property
+	<pre class="xml">myruby       { display: ruby; }
+	myrbc        { display: ruby-base-container; }
+	myrb         { display: ruby-base; }
+	myrtc.before { display: ruby-text-container; ruby-position: before}
+	myrtc.after  { display: ruby-text-container; ruby-position: after}
+	myrt         { display: ruby-text; ruby-span: attr(rbspan); }
+	...
+	&lt;myruby&gt;
+		&lt;myrbc&gt;
+			&lt;myrb&gt;10&lt;/myrb&gt;
+			&lt;myrb&gt;31&lt;/myrb&gt;
+			&lt;myrb&gt;2002&lt;/myrb&gt;
+		&lt;/myrbc&gt;
+		&lt;myrtc class=&quot;before&quot;&gt;
+			&lt;myrt&gt;Month&lt;/myrt&gt;
+			&lt;myrt&gt;Day&lt;/myrt&gt;
+			&lt;myrt&gt;Year&lt;/myrt&gt;
+		&lt;/myrtc&gt;
+		&lt;myrtc class=&quot;after&quot;&gt;
+			&lt;myrt rbspan=&quot;3&quot;&gt;Expiration Date&lt;/myrt&gt;
+		&lt;/myrtc&gt;
+	&lt;/myruby&gt;</pre>
+-->
 
 <h2 id="default-stylesheet" class="no-num">
 Appendix A: Default Style Sheet</h2>
@@ -1485,47 +1510,65 @@ Appendix A: Default Style Sheet</h2>
 
 <h2 id="glossary">
 Glossary</h2>
-<dl>
-  <dt id="g-bopomofo" lang="zh">Bopomofo
-    <dd>37 characters and 4 tone markings used as phonetics in Chinese,
-      especially standard Mandarin.
+	<dl>
+		<dt id="g-bopomofo" lang="zh">Bopomofo
+		<dd>
+			37 characters and 4 tone markings used as phonetics in Chinese,
+			especially standard Mandarin.
 
-      Note: The user agent is responsible for ensuring the correct relative alignment and positioning of the glyphs,
-      including bopomofo tone marks, when displaying text,
-      whether it occurs in ruby annotations or as normal inline text.
-      Bopomofo Tone marks are spacing characters that occur (in memory) at the end of the ruby text for each base character.
-      They are usually displayed in a separate column to the right of or above the bopomofo characters,
-      and the position of the tone mark depends on the number of characters in the syllable.
-      One tone mark, however, is placed before the bopomofo, not over it.
-      <!-- See Taiwanese requirements doc for EPUB at http://epub-revision.googlecode.com/files/EGLS_TW_eng.ppt -->
-  <dt id="g-hanja" lang="ko">Hanja
-    <dd>Subset of the Korean writing system that utilizes ideographic
-      characters borrowed or adapted from the Chinese writing system. Also see
-      <a href="#g-kanji"><span lang="ja">Kanji</span></a>.</dd>
-  <dt id="g-hiragana" lang="ja">Hiragana
-    <dd>Japanese syllabic script, or character of that script. Rounded and
-    cursive in appearance. Subset of the Japanese writing system, used together
-    with kanji and katakana. In recent times, mostly used to write Japanese
-    words when kanji are not available or appropriate, and word endings and
-    particles. Also see <a
-      href="#g-katakana"><span lang="ja">Katakana</span></a>.</dd>
-  <dt id="g-ideogram">Ideograph
-    <dd>A character that is used to represent an idea, word, or word component,
-    in contrast to a character from an alphabetic or syllabic script. The most
-    well-known ideographic script is used (with some variation) in East Asia
-    (China, Japan, Korea,...).</dd>
-  <dt id="g-kana" lang="ja">Kana
-    <dd>Collective term for hiragana and katakana.</dd>
-  <dt id="g-kanji">Kanji
-    <dd>Japanese term for ideographs; ideographs used in Japanese. Subset of the
-    Japanese writing system, used together with hiragana and katakana. Also see <a
-      href="#g-hanja"><span lang="ko">Hanja</span></a>.</dd>
-  <dt id="g-katakana" lang="ja">Katakana
-    <dd>Japanese syllabic script, or character of that script. Angular in
-    appearance. Subset of the Japanese writing system,&nbsp; used together with
-    kanji and hiragana. In recent times, mainly used to write foreign words. Also see <a
-      href="#g-hiragana"><span lang="ja">Hiragana</span></a>.</dd>
-</dl>
+			Note: The user agent is responsible for ensuring the correct relative alignment and positioning of the glyphs,
+			including bopomofo tone marks, when displaying text,
+			whether it occurs in ruby annotations or as normal inline text.
+			Bopomofo Tone marks are spacing characters that occur (in memory) at the end of the ruby text for each base character.
+			They are usually displayed in a separate column to the right of or above the bopomofo characters,
+			and the position of the tone mark depends on the number of characters in the syllable.
+			One tone mark, however, is placed before the bopomofo, not over it.
+			<!-- See Taiwanese requirements doc for EPUB at http://epub-revision.googlecode.com/files/EGLS_TW_eng.ppt -->
+
+		<dt id="g-hanja" lang="ko">Hanja
+		<dd>
+			Subset of the Korean writing system that utilizes ideographic
+			characters borrowed or adapted from the Chinese writing system.
+			Also see <a href="#g-kanji"><span lang="ja">Kanji</span></a>.
+
+		<dt id="g-hiragana" lang="ja">Hiragana
+		<dd>
+			Japanese syllabic script, or character of that script.
+			Rounded and cursive in appearance.
+			Subset of the Japanese writing system,
+			used together with kanji and katakana.
+			In recent times,
+			mostly used to write Japanese words
+			when kanji are not available or appropriate,
+			and word endings and particles.
+			Also see <a href="#g-katakana"><span lang="ja">Katakana</span></a>.
+
+		<dt id="g-ideogram">Ideograph
+		<dd>
+			A character that is used to represent an idea, word, or word component,
+			in contrast to a character from an alphabetic or syllabic script.
+			The most well-known ideographic script is used (with some variation)
+			in East Asia (China, Japan, Korea,...).
+		<dt id="g-kana" lang="ja">Kana
+		<dd>
+			Collective term for hiragana and katakana.
+
+		<dt id="g-kanji">Kanji
+		<dd>
+			Japanese term for ideographs; ideographs used in Japanese.
+			Subset of the Japanese writing system,
+			used together with hiragana and katakana.
+			Also see <a href="#g-hanja"><span lang="ko">Hanja</span></a>.
+
+		<dt id="g-katakana" lang="ja">Katakana
+		<dd>
+			Japanese syllabic script, or character of that script.
+			Angular in appearance.
+			Subset of the Japanese writing system,
+			used together with kanji and hiragana.
+			In recent times, mainly used to write foreign words.
+			Also see <a href="#g-hiragana"><span lang="ja">Hiragana</span></a>.
+	</dl>
 
 <h2 class=no-num id="acknowledgments">
 Acknowledgments</h2>
@@ -1555,99 +1598,120 @@ Acknowledgments</h2>
 <h2 class="no-num" id="changes">
 Changes</h2>
 
-This section documents the changes since previous publications.
+	This section documents the changes since previous publications.
 
 <h3 id="changes-20140805">
 Changes since the 5 August 2014 WD</h3>
 
-<ul>
-	<li>Harmonize ininification with the <a href="https://www.w3.org/TR/css-display-3/">CSS Display Module</a>.
-	<li>Allow UA to shift ruby/emphasis marks if they conflict with underlines/overlines.
-	<li>Disable autohiding when the computed value of 'ruby-merge' is ''collapse''.
-	<li>Tweak the <a href="#default-stylesheet">default style sheet</a>.
-	<li>Add section on <a href="#ruby-text-decoration">text decoration</a>.
-	<li>Defer the <css>right</css> and <css>left</css> values of 'ruby-position' to the next level.
-	<li>Change ruby [=pairing=] rules to only operate on anonymous annotations (i.e. content directly contained by an <{rtc}>).
-	<li>Apply 'ruby-position' to ''::first-line''.
-		(<a href="https://github.com/w3c/csswg-drafts/issues/2998">Issue 2998</a>)
-</ul>
+	<ul>
+		<li>Harmonize ininification with the <a href="https://www.w3.org/TR/css-display-3/">CSS Display Module</a>.
+		<li>Allow UA to shift ruby/emphasis marks if they conflict with underlines/overlines.
+		<li>Disable autohiding when the computed value of 'ruby-merge' is ''collapse''.
+		<li>Tweak the <a href="#default-stylesheet">default style sheet</a>.
+		<li>Add section on <a href="#ruby-text-decoration">text decoration</a>.
+		<li>Defer the <css>right</css> and <css>left</css> values of 'ruby-position' to the next level.
+		<li>Change ruby [=pairing=] rules to only operate on anonymous annotations (i.e. content directly contained by an <{rtc}>).
+		<li>
+			Apply 'ruby-position' to ''::first-line''.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/2998">Issue 2998</a>)
+	</ul>
 
 <h3 id="changes-20130919">
 Changes since the 19 September 2013 WD</h3>
 
 	<ul>
-		<li>Rewrite anonymous box generation rules and white space handling rules,
-		defined specialized [=pairing=] of anonymous white space boxes.
-		<li>Take [=nested ruby=] handling out of [=pairing=].
-		(Will be handling it via sizing/layout.)
-		<li>Define bidi layout of ruby structures.
+		<li>
+			Rewrite anonymous box generation rules and white space handling rules,
+			defined specialized [=pairing=] of anonymous white space boxes.
+		<li>
+			Take [=nested ruby=] handling out of [=pairing=].
+			(Will be handling it via sizing/layout.)
+		<li>
+			Define bidi layout of ruby structures.
 	</ul>
 
 <h3 id="changes-20110630">
-		Changes since the 30 June 2011 WD</h3>
+Changes since the 30 June 2011 WD</h3>
 
-		<dl>
-				<dt>Remove <code>ruby-span</code> and mentions of
-				 <code>rbspan</code>.
+	<dl>
+		<dt>Remove <code>ruby-span</code> and mentions of <code>rbspan</code>.
 
-				<dd> Explicit spanning is not used in HTML ruby in favor of implicit
-				 spanning. This can't handle some pathological double-sided spanning
-				 cases, but there seems to be no requirement for these at the moment. (For
-				 implementations that support full complex XHTML Ruby, they can imply
-				 spanning from the markup the same magic way that we handle cell spanning
-				 from tables. It doesn't seem necessary to include controls this in Level
-				 1.)
+		<dd>
+			Explicit spanning is not used in HTML ruby in favor of implicit spanning.
+			This can't handle some pathological double-sided spanning cases,
+			but there seems to be no requirement for these at the moment.
+			(For implementations that support full complex XHTML Ruby,
+			they can imply spanning from the markup the same magic way
+			that we handle cell spanning from tables.
+			It doesn't seem necessary to include controls this in Level 1.)
 
-				<dt>Defer <code>ruby-overhang</code> and <code>ruby-align: line-end</code> to Level 2.
+		<dt>Defer <code>ruby-overhang</code> and <code>ruby-align: line-end</code> to Level 2.
 
-				<dd> It's somewhat complicated, advanced feature. Proposal is to make this
-				 behavior UA-defined and provide some examples of acceptable options.
+		<dd>
+			It's somewhat complicated, advanced feature.
+			Proposal is to make this behavior UA-defined and provide some examples of acceptable options.
 
-				<dt>Close issue requesting <code>display: rp</code>: use
-				 <code>display: none</code>.
+		<dt>Close issue requesting <code>display: rp</code>: use <code>display: none</code>.
 
-				<dd> The Internationalization WG added an issue requesting a display value
-				 for <{rp}> elements. They're supposed to be hidden when <{ruby}> is
-				 displayed as ruby. But this is easily accomplished already with <code>display: none</code>.
+		<dd>
+			The Internationalization WG added an issue
+			requesting a display value for <{rp}> elements.
+			They're supposed to be hidden when <{ruby}> is displayed as ruby.
+			But this is easily accomplished already with <code>display: none</code>.
 
-				<dt>Change 'ruby-position' values to match 'text-emphasis-position'.
+		<dt>Change 'ruby-position' values to match 'text-emphasis-position'.
 
-				<dd> Other than ''inter-character'', which we
-				 need to keep, it makes more sense to align ruby positions with 'text-emphasis-position', which can correctly
-				 handle various combinations of horizontal/vertical preferences.
+		<dd>
+			Other than ''inter-character'', which we need to keep,
+			it makes more sense to align ruby positions with 'text-emphasis-position',
+			which can correctly handle various combinations of horizontal/vertical preferences.
 
-				<dt>Remove unused values of 'ruby-align'.
+		<dt>Remove unused values of 'ruby-align'.
 
-				<dd> <css>left</css>, <css>right</css>, and <css>end</css> are not needed.
+		<dd>
+			<css>left</css>, <css>right</css>, and <css>end</css> are not needed.
 
-				<dt>Replace <css>auto</css>, <css>distribute-letter</css>, and <css>distribute-space</css> from 'ruby-align' with ''space-between'' and ''space-around''.
+		<dt>
+			Replace <css>auto</css>, <css>distribute-letter</css>, and <css>distribute-space</css>
+			from 'ruby-align' with ''space-between'' and ''space-around''.
 
-				<dd> The <css>auto</css> value relied on inspecting
-				 content to determine behavior; this can be avoided by just using ''space-around'' with standard justification rules (which allow spacing between CJK but not between Latin).
-				 Replaced <css>distribute-letter</css> and <css>distribute-space</css> with ''space-between'' and ''space-around'' for consistency with distribution keywords in [[CSS-FLEXBOX-1]] and [[CSS-ALIGN-3]] and to avoid any links to the definition of <code>text-justify: distribute</code>.
+		<dd>
+			The <css>auto</css> value relied on inspecting content to determine behavior;
+			this can be avoided by just using ''space-around'' with standard justification rules
+			(which allow spacing between CJK but not between Latin).
+			Replaced <css>distribute-letter</css> and <css>distribute-space</css>
+			with ''space-between'' and ''space-around''
+			for consistency with distribution keywords in [[CSS-FLEXBOX-1]] and [[CSS-ALIGN-3]]
+			and to avoid any links to the definition of <code>text-justify: distribute</code>.
 
-				<dt>Added 'ruby-merge' property to control jukugo rendering.
+		<dt>Added 'ruby-merge' property to control jukugo rendering.
 
-				<dd> This is a stylistic effect, not a structural one; the previous model
-				 assumed that it was structural and suggested handling it by changing
-				 markup. :(
+		<dd>
+			This is a stylistic effect, not a structural one;
+			the previous model assumed that it was structural
+			and suggested handling it by changing markup. :(
 
-				<dt>Remove <css>inline</css> from 'ruby-position'.
+		<dt>Remove <css>inline</css> from 'ruby-position'.
 
-				<dd> This is do-able via <code>display: inline</code> on
-				 all the ruby-related elements, see <a href="#default-inline">Appendix A</a>.
+		<dd>
+			This is do-able via <code>display: inline</code>
+			on all the ruby-related elements,
+			see <a href="#default-inline">Appendix A</a>.
 
-				<dt>Added <a href="#default-stylesheet">Default Style</a> rules
+		<dt>Added <a href="#default-stylesheet">Default Style</a> rules
 
-				<dd> As requested by Internationalization WG.
+		<dd>As requested by Internationalization WG.
 
-				<dt>Wrote anonymous box generation rules
+		<dt>Wrote anonymous box generation rules
 
-				<dd> And defined [=pairing=] of bases and annotations. Should now handle all
-				 the crazy proposed permutations of HTML ruby markup.
+		<dd>
+			And defined [=pairing=] of bases and annotations.
+			Should now handle all the crazy proposed permutations of HTML ruby markup.
 
-				<dt>Defined layout of ruby
+		<dt>Defined layout of ruby
 
-				<dd> Defined in detail space distribution, white space handling, line
-				 breaking, line stacking, etc. Open issue left for bidi.
-			 </dl>
+		<dd>
+			Defined in detail space distribution, white space handling,
+			line breaking, line stacking, etc.
+			Open issue left for bidi.
+	</dl>

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -16,6 +16,10 @@ Abstract: “Ruby”, a form of interlinear annotation, are short runs of text a
 Abstract: They are typically used in East Asian documents to indicate pronunciation or to provide a short annotation.
 Abstract: This module describes the rendering model and formatting controls related to displaying ruby annotations in CSS.
 </pre>
+<pre class=link-defaults>
+spec:css-text-3; type:dfn; text:character
+</pre>
+
 
 <!--
 
@@ -53,7 +57,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the [=CSS-wide keywords=] keywords as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="diagram-conventions">
@@ -124,7 +128,7 @@ What is ruby?</h3>
 		correctly paired with their respective base characters.
 	</div>
 
-	<p><i>Ruby</i> formatting as used in Japanese is described in JIS X-4051 [[JIS4051]] (in Japanese)
+	<p>[=Ruby=] formatting as used in Japanese is described in JIS X-4051 [[JIS4051]] (in Japanese)
 	and in Requirements for Japanese Text Layout [[JLREQ]] (in English and Japanese)].
 	In HTML, ruby structure and markup to represent it is described
 	in the Ruby Markup Extension specification.
@@ -138,14 +142,14 @@ Ruby Box Model</h2>
 	the <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-ruby-element">W3C HTML5 Ruby Markup</a> model
 	and the <a href="https://www.w3.org/TR/ruby/">XHTML Ruby Annotation Recommendation</a> [[RUBY]].
 	In this model, a ruby structure consists of
-	one or more <i>ruby base</i> elements representing the base (annotated) text,
-	associated with one or more levels of <i>ruby annotation</i> elements representing the annotations.
+	one or more [=ruby base=] elements representing the base (annotated) text,
+	associated with one or more levels of [=ruby annotation=] elements representing the annotations.
 	The structure of ruby is similar to that of a table:
 	there are “rows” (the [=base text level=], each [=annotation level=])
-	and “columns” (each <i>ruby base</i> and its corresponding <i>ruby annotations</i>).
+	and “columns” (each [=ruby base=] and its corresponding [=ruby annotations=]).
 
 	<p>Consecutive bases and annotations are grouped together into [=ruby segments=].
-	Within a [=ruby segment=], a <i>ruby annotation</i> may span multiple <i>ruby bases</i>.
+	Within a [=ruby segment=], a [=ruby annotation=] may span multiple [=ruby bases=].
 
 	<p class="note">In HTML, a single <code>&lt;ruby&gt;</code> element may contain multiple [=ruby segments=].
 	(In the XHTML Ruby model, a single <code>&lt;ruby&gt;</code> element can only contain one [=ruby segment=].)
@@ -193,26 +197,26 @@ Ruby-specific 'display' Values</h3>
 <h4 id="formatting-context">
 The Ruby Formatting Context</h4>
 
-	<p><i>Ruby containers</i> are non-atomic inline-level boxes.
+	<p>[=Ruby containers=] are non-atomic inline-level boxes.
 	Like inline boxes, they break across lines,
 	and their containing block is the nearest block container ancestor.
 	And just as the contents of an inline box
 	participate in the same inline formatting context that contains the inline box itself,
-	a <i>ruby container</i> and its base-level contents
-	participate in the same inline formatting context that contains the <i>ruby container</i> itself.
+	a [=ruby container=] and its base-level contents
+	participate in the same inline formatting context that contains the [=ruby container=] itself.
 
-	<p>However <i>ruby containers</i> also establish a <dfn export>ruby formatting context</dfn>
+	<p>However [=ruby containers=] also establish a <dfn export>ruby formatting context</dfn>
 	that builds further structure around their segment of the inline formatting context.
-	<i>Ruby bases</i>, <i>ruby annotations</i>, <i>ruby base containers</i>, and <i>ruby annotation containers</i>
+	[=Ruby bases=], [=ruby annotations=], [=ruby base containers=], and [=ruby annotation containers=]
 	are <dfn export lt="internal ruby boxes|internal ruby display types">internal ruby boxes</dfn>:
-	like <i>internal table elements</i>,
+	like [=internal table elements=],
 	they have specific roles in ruby layout,
-	and participate in their <i>ruby container</i>’s <i>ruby formatting context</i>.
+	and participate in their [=ruby container=]’s [=ruby formatting context=].
 
 	<p>As with the contents of inline boxes,
-	the containing block for the contents of a <i>ruby container</i> (and all its <i>internal ruby boxes</i>)
-	is the containing block of the <i>ruby container</i>.
-	So floats, for example, are trapped by the <i>ruby container</i>’s containing block,
+	the containing block for the contents of a [=ruby container=] (and all its [=internal ruby boxes=])
+	is the containing block of the [=ruby container=].
+	So floats, for example, are trapped by the [=ruby container=]’s containing block,
 	not any of the ruby box types.
 
 	<p class="issue">Are internal ruby boxes inline-level?
@@ -220,20 +224,20 @@ The Ruby Formatting Context</h4>
 <h4 id="block-ruby">
 Non-Inline Ruby</h4>
 
-	<p>If an element has an <i>inner display type</i> of ''ruby''
-	and an <i>outer display type</i> other than ''display/inline'',
+	<p>If an element has an [=inner display type=] of ''ruby''
+	and an [=outer display type=] other than ''display/inline'',
 	then it generates two boxes:
-	a principal box of the required <i>outer display type</i> type,
-	and an inline-level <i>ruby container</i>.
+	a principal box of the required [=outer display type=] type,
+	and an inline-level [=ruby container=].
 	All properties specified on the element apply to the principal box
-	(and if inheritable, inherit to the <i>ruby container box</i>).
+	(and if inheritable, inherit to the [=ruby container box=]).
 	This allows styling the element as a block,
 	while correctly maintaining the internal ruby structure.
 
 	<p class="note">
 	Note that absolute positioning or floating an element causes its 'display' value
 	to compute to a block-level equivalent. (See [[!CSS-DISPLAY-3]] or [[!CSS2]] section 9.7.)
-	For the <i>internal ruby display types</i>,
+	For the [=internal ruby display types=],
 	this causes their 'display' value to compute to ''display/block''.
 
 <h3 id="box-fixup">
@@ -246,14 +250,14 @@ Anonymous Ruby Box Generation</h3>
 
 	<ol>
 
-		<li id="anon-gen-inlinize"><strong><a>Inlinify</a> block-level boxes:</strong>
+		<li id="anon-gen-inlinize"><strong>[=Inlinify=] block-level boxes:</strong>
 			Any in-flow boxes directly contained by a
-			<i>ruby container</i>,
-			<i>ruby base container</i>,
-			<i>ruby annotation container</i>,
-			<i>ruby base box</i>,
-			or <i>ruby annotation box</i>
-			are “<a>inlinified</a>” per [[!CSS-DISPLAY-3]]),
+			[=ruby container=],
+			[=ruby base container=],
+			[=ruby annotation container=],
+			[=ruby base box=],
+			or [=ruby annotation box=]
+			are “[=inlinified=]” per [[!CSS-DISPLAY-3]]),
 			and their 'display' value computed accordingly,
 			so that they contain only inline-level content.
 			For example,
@@ -264,34 +268,34 @@ Anonymous Ruby Box Generation</h3>
 		<li id="anon-gen-anon-ruby"><strong>Generate anonymous ruby containers</strong>:
 			Any <a href="https://www.w3.org/TR/CSS2/tables.html#anonymous-boxes">consecutive</a> sequence of
 			improperly-contained
-			<i>ruby base containers</i>,
-			<i>ruby annotation containers</i>,
-			<i>ruby bases</i>,
+			[=ruby base containers=],
+			[=ruby annotation containers=],
+			[=ruby bases=],
 			and/or
-			<i>ruby annotations</i>
-			(and any intervening <i>white space</i>)
-			is wrapped in an anonymous <i>ruby container</i>.
+			[=ruby annotations=]
+			(and any intervening [=white space=])
+			is wrapped in an anonymous [=ruby container=].
 			For the purpose of this step:
 			<ul>
-				<li>an improperly-contained <i>ruby base</i> is one not parented by a <i>ruby base container</i> or <i>ruby container</i>
-				<li>an improperly-contained <i>ruby annotation</i> is one not parented by a <i>ruby annotation container</i> or <i>ruby container</i>
-				<li>an improperly-contained <i>ruby base container</i> or <i>ruby annotation container</i>
-				    is one not parented by a <i>ruby container</i>
+				<li>an improperly-contained [=ruby base=] is one not parented by a [=ruby base container=] or [=ruby container=]
+				<li>an improperly-contained [=ruby annotation=] is one not parented by a [=ruby annotation container=] or [=ruby container=]
+				<li>an improperly-contained [=ruby base container=] or [=ruby annotation container=]
+				    is one not parented by a [=ruby container=]
 			</ul>
 
 		<li id="anon-gen-bare-inlines"><strong>Wrap misparented inline-level content:</strong>
 			Any consecutive sequence of text and inline-level boxes
-			directly parented by a <i>ruby container</i> or <i>ruby base container</i>
-			is wrapped in an anonymous <i>ruby base</i>.
+			directly parented by a [=ruby container=] or [=ruby base container=]
+			is wrapped in an anonymous [=ruby base=].
 			Similarly, any consecutive sequence of text and inline-level boxes
-			directly parented by a <i>ruby annotation container</i>
-			is wrapped in an anonymous <i>ruby annotation</i>.
-			(For this purpose, misparented <i>internal table elements</i>
-			are treated as <a>inline-level content</a>
+			directly parented by a [=ruby annotation container=]
+			is wrapped in an anonymous [=ruby annotation=].
+			(For this purpose, misparented [=internal table elements=]
+			are treated as [=inline-level content=]
 			since, being parented by ruby boxes,
 			they will be ultimately wrapped by an [=inline-level=] [=table wrapper box=].)
 
-			However, if an anonymous box so constructed contains only <i>white space</i>,
+			However, if an anonymous box so constructed contains only [=white space=],
 			it is considered <dfn>intra-ruby white space</dfn>
 			and is either discarded
 			or preserved
@@ -301,7 +305,7 @@ Anonymous Ruby Box Generation</h3>
 			Any [=intra-ruby white space=]
 			that is not the sole child of its parent
 			and occurs at the beginning or end of
-			a <i>ruby container</i>, <i>ruby annotation container</i>, or <i>ruby base container</i>
+			a [=ruby container=], [=ruby annotation container=], or [=ruby base container=]
 			is removed, as if it had ''display: none''
 
 		<li id="anon-gen-discard-space"><strong>Remove inter-level white space:</strong>
@@ -314,19 +318,19 @@ Anonymous Ruby Box Generation</h3>
 				<tr><th>Previous box
 				    <th>Next box
 			<tbody>
-				<tr><td><i>any</i>
-				    <td><i>ruby annotation container</i>
-				<tr><td>not <i>ruby annotation</i>
-				    <td><i>ruby annotation</i>
+				<tr><td>any
+				    <td>[=ruby annotation container=]
+				<tr><td>not [=ruby annotation=]
+				    <td>[=ruby annotation=]
 <!--
-				<tr><td><i>ruby base</i> or <i>ruby base container</i>
-				    <td><i>ruby annotation</i> or <i>ruby annotation container</i>
-				<tr><td><i>ruby annotation container</i>
-				    <td><i>ruby annotation container</i>
-				<tr><td><i>ruby annotation</i>
-				    <td><i>ruby annotation container</i>
-				<tr><td><i>ruby annotation container</i>
-				    <td><i>ruby annotation</i>
+				<tr><td>[=ruby base=] or [=ruby base container=]
+				    <td>[=ruby annotation=] or [=ruby annotation container=]
+				<tr><td>[=ruby annotation container=]
+				    <td>[=ruby annotation container=]
+				<tr><td>[=ruby annotation=]
+				    <td>[=ruby annotation container=]
+				<tr><td>[=ruby annotation container=]
+				    <td>[=ruby annotation=]
 -->
 			</table>
 
@@ -343,40 +347,40 @@ Anonymous Ruby Box Generation</h3>
 				    <th>Box type
 				    <th>Subtype
 			<tbody>
-				<tr><td><i>ruby base</i>
-				    <td><i>ruby base</i>
-				    <td><i>ruby base</i>
+				<tr><td>[=ruby base=]
+				    <td>[=ruby base=]
+				    <td>[=ruby base=]
 				    <td><dfn>inter-base white space</dfn>
-				<tr><td><i>ruby annotation</i>
-				    <td><i>ruby annotation</i>
-				    <td><i>ruby annotation</i>
+				<tr><td>[=ruby annotation=]
+				    <td>[=ruby annotation=]
+				    <td>[=ruby annotation=]
 				    <td><dfn>inter-annotation white space</dfn>
-				<tr><td><i>ruby annotation</i> or <i>ruby annotation container</i>
-				    <td><i>ruby base</i> or <i>ruby base container</i>
-				    <td rowspan=3><i>ruby base</i>
+				<tr><td>[=ruby annotation=] or [=ruby annotation container=]
+				    <td>[=ruby base=] or [=ruby base container=]
+				    <td rowspan=3>[=ruby base=]
 				    <td rowspan=3><dfn>inter-segment white space</dfn>
-				<tr><td><i>ruby base</i> or <i>ruby base container</i>
-				    <td><i>ruby base container</i>
-				<tr><td><i>ruby base container</i>
-				    <td><i>ruby base</i> or <i>ruby base container</i>
+				<tr><td>[=ruby base=] or [=ruby base container=]
+				    <td>[=ruby base container=]
+				<tr><td>[=ruby base container=]
+				    <td>[=ruby base=] or [=ruby base container=]
 			</table>
 			The <dfn>intra-level white space</dfn> boxes defined above are
 			treated specially for [=pairing=] and layout. See below.
 
 		<li id="anon-gen-unbreak"><strong>Suppress line breaks:</strong>
-			Convert all forced line breaks inside <i>ruby annotations</i> (regardless of 'white-space' value)
-			as defined for <i>collapsible</i> segment breaks in <a href="https://www.w3.org/TR/css-text-3/#line-break-transform">CSS Text Level 3 &sect; 4.1.2</a>.
+			Convert all forced line breaks inside [=ruby annotations=] (regardless of 'white-space' value)
+			as defined for [=collapsible=] segment breaks in <a href="https://www.w3.org/TR/css-text-3/#line-break-transform">CSS Text Level 3 &sect; 4.1.2</a>.
 			<p class="issue">The goal of this is to simplify the layout model by suppressing any line breaks within ruby annotations.
 			Alternatively we could try to define some kind of acceptable behavior for them.
 
 		<li id="anon-gen-anon-containers"><strong>Generate anonymous level containers:</strong>
-			Any consecutive sequence of <i>ruby bases</i> and <i>inter-base white space</i>
+			Any consecutive sequence of [=ruby bases=] and [=inter-base white space=]
 			(and not [=inter-segment white space=])
-			not parented by a <i>ruby base container</i>
-			is wrapped in an anonymous <i>ruby base container</i>.
-			Similarly, any consecutive sequence of <i>ruby annotations</i> and [=inter-annotation white space=]
-			not parented by a <i>ruby annotation container</i>
-			is wrapped in an anonymous <i>ruby annotation container</i>.
+			not parented by a [=ruby base container=]
+			is wrapped in an anonymous [=ruby base container=].
+			Similarly, any consecutive sequence of [=ruby annotations=] and [=inter-annotation white space=]
+			not parented by a [=ruby annotation container=]
+			is wrapped in an anonymous [=ruby annotation container=].
 	</ol>
 
 	<p class="issue">Make <a href="http://lists.w3.org/Archives/Public/www-archive/2014Jun/att-0027/PastedGraphic-1.png">this diagram</a> into an example.
@@ -394,20 +398,20 @@ Anonymous Ruby Box Generation</h3>
 Annotation Pairing</h3>
 
 	<p>Annotation <dfn>pairing</dfn> is the process of associating
-	<i>ruby annotations</i> with <i>ruby bases</i>.
-	Each <i>ruby annotation</i> is associated with one or more <i>ruby bases</i>,
+	[=ruby annotations=] with [=ruby bases=].
+	Each [=ruby annotation=] is associated with one or more [=ruby bases=],
 	and is said to <dfn>span</dfn> those bases.
-	(A <i>ruby annotation</i> that [=spans=] multiple bases is called
+	(A [=ruby annotation=] that [=spans=] multiple bases is called
 	a <dfn>spanning annotation</dfn>.)
 
-	A <i>ruby base</i> is can be associated with
-	only one <i>ruby annotation</i> per [=annotation level=].
+	A [=ruby base=] is can be associated with
+	only one [=ruby annotation=] per [=annotation level=].
 	However, if there are multiple [=annotation levels=],
-	it can be associated with multiple <i>ruby annotations</i>.
+	it can be associated with multiple [=ruby annotations=].
 
 	Once [=pairing=] is complete, ruby “column” units are defined,
-	each represented by a single <i>ruby base</i>
-	and one <i>ruby annotation</i> (possibly an empty, anonymous one)
+	each represented by a single [=ruby base=]
+	and one [=ruby annotation=] (possibly an empty, anonymous one)
 	from each [=annotation level=] in its [=ruby segment=].
 
 
@@ -415,64 +419,64 @@ Annotation Pairing</h3>
 Segment Pairing and Annotation Levels</h4>
 
 	<p>A ruby structure is divided into <dfn>ruby segments</dfn>,
-	each consisting of a single <i>ruby base container</i>
-	followed by one or more <i>ruby annotation containers</i>.
-	Each <i>ruby annotation container</i> in a [=ruby segment=]
+	each consisting of a single [=ruby base container=]
+	followed by one or more [=ruby annotation containers=].
+	Each [=ruby annotation container=] in a [=ruby segment=]
 	represents one <dfn lt="annotation level | level">level</dfn> of annotation for the base text:
 	the first one represents the first level of annotation,
 	the second one represents the second level of annotation,
 	and so on.
-	The <i>ruby base container</i> represents the <dfn lt="base level | base text level">base level</dfn>.
-	The <i>ruby base container</i> in each segment is thus paired
-	with each of the <i>ruby annotation containers</i> in that segment.
+	The [=ruby base container=] represents the <dfn lt="base level | base text level">base level</dfn>.
+	The [=ruby base container=] in each segment is thus paired
+	with each of the [=ruby annotation containers=] in that segment.
 
 	<p>In order to handle degenerate cases, some empty anonymous containers are assumed:
 	<ul>
-		<li>If the first child of a <i>ruby container</i> is a <i>ruby annotation container</i>,
-		an anonymous, empty <i>ruby base container</i> is assumed to exist before it.
-		<li>Similarly, if the <i>ruby container</i> contains consecutive <i>ruby base containers</i>,
-		anonymous, empty <i>ruby annotation containers</i> are assumed to exist between them.
+		<li>If the first child of a [=ruby container=] is a [=ruby annotation container=],
+		an anonymous, empty [=ruby base container=] is assumed to exist before it.
+		<li>Similarly, if the [=ruby container=] contains consecutive [=ruby base containers=],
+		anonymous, empty [=ruby annotation containers=] are assumed to exist between them.
 	</ul>
 
-	<p><i>Inter-segment white space</i> is effectively a [=ruby segment=] of its own.
+	<p>[=Inter-segment white space=] is effectively a [=ruby segment=] of its own.
 
 <h4 id="base-annotation-pairing">
 Unit Pairing and Spanning Annotations</h4>
 
 	<p>Within a [=ruby segment=],
-	each <i>ruby base</i> in the <i>ruby base container</i>
-	is paired with one <i>ruby annotation</i>
-	from each <i>ruby annotation container</i> in its [=ruby segment=].
+	each [=ruby base=] in the [=ruby base container=]
+	is paired with one [=ruby annotation=]
+	from each [=ruby annotation container=] in its [=ruby segment=].
 
-	<p>If a <i>ruby annotation container</i> contains only
-	a single, anonymous <i>ruby annotation</i>,
-	then that <i>ruby annotation</i> is paired with (i.e. [=spans=] across)
-	all of the <i>ruby bases</i> in its [=ruby segment=].
+	<p>If a [=ruby annotation container=] contains only
+	a single, anonymous [=ruby annotation=],
+	then that [=ruby annotation=] is paired with (i.e. [=spans=] across)
+	all of the [=ruby bases=] in its [=ruby segment=].
 
-	<p>Otherwise, each <i>ruby annotation</i> is paired,
-	in order, with the corresponding <i>ruby base</i> in that segment</i>.
-	If there are not enough <i>ruby annotations</i> in a <i>ruby annotation container</i>,
-	the remaining <i>ruby bases</i> are paired with anonymous empty annotations
-	inserted at the end of the <i>ruby annotation container</i>.
-	If there are not enough <i>ruby bases</i>,
-	any remaining <i>ruby annotations</i> pair with empty, anonymous bases
-	inserted at the end of the <i>ruby base container</i>.
+	<p>Otherwise, each [=ruby annotation=] is paired,
+	in order, with the corresponding [=ruby base=] in that segment</i>.
+	If there are not enough [=ruby annotations=] in a [=ruby annotation container=],
+	the remaining [=ruby bases=] are paired with anonymous empty annotations
+	inserted at the end of the [=ruby annotation container=].
+	If there are not enough [=ruby bases=],
+	any remaining [=ruby annotations=] pair with empty, anonymous bases
+	inserted at the end of the [=ruby base container=].
 
 	<p>If an implementation supports ruby markup with explicit spanning
 	(e.g. XHTML Complex Ruby Annotations),
 	it must adjust the [=pairing=] rules to pair [=spanning annotations=]
 	to their bases appropriately.
 
-	<p><i>Intra-level white space</i> does not participate in standard annotation [=pairing=].
-	However, if the immediately-adjacent <i>ruby bases</i> or <i>ruby annotations</i>
+	<p>[=Intra-level white space=] does not participate in standard annotation [=pairing=].
+	However, if the immediately-adjacent [=ruby bases=] or [=ruby annotations=]
 	are paired
 	<ul>
-		<li>with two <i>ruby bases</i> or <i lt="ruby annotations">annotations</i>
+		<li>with two [=ruby bases=] or [=ruby annotations|annotations=]
 		that surround corresponding [=intra-level white space=] in another level,
 		then the so-corresponding [=intra-level white space=] boxes are also paired.
-		<li>with a single spanning <i>ruby annotation</i>,
-		then the [=intra-level white space=] is also paired to that <i>ruby annotation</i>
-		<li>with two <i>ruby bases</i> or <i lt="ruby annotations">annotations</i>
+		<li>with a single spanning [=ruby annotation=],
+		then the [=intra-level white space=] is also paired to that [=ruby annotation=]
+		<li>with two [=ruby bases=] or [=ruby annotations|annotations=]
 		with no intervening [=intra-level white space=],
 		then the [=intra-level white space=] box pairs with
 		an anonymous empty [=intra-level white space=] box assumed to exist between them.
@@ -483,21 +487,21 @@ Unit Pairing and Spanning Annotations</h4>
 <h4 id="nested-pairing">
 Complex Spanning with Nested Ruby</h4>
 
-	<p>When <i>ruby containers</i> are <dfn lt="nested ruby">nested</dfn>,
-	[=pairing=] begins with the deepest <i>ruby container</i>,
+	<p>When [=ruby containers=] are <dfn lt="nested ruby">nested</dfn>,
+	[=pairing=] begins with the deepest [=ruby container=],
 	then expands out.
-	From the [=pairing=] perspective of the outer <i>ruby container</i>,
-	each <i>ruby container</i> nested within another <i>ruby container</i>
-	counts as representing a single <i>ruby base</i>/<i>annotation</i> per level.
-	The outer <i>ruby container</i>’s <i>ruby annotations</i> paired to the [=nested ruby=]
-	are therefore paired with (and [=span=]) all of the nested <i>ruby container</i>’s <i>ruby bases</i>.
-	Each <i>ruby annotation container</i> in the nested <i>ruby container</i>
-	occupies the same [=annotation level=] in the outer <i>ruby container</i>
+	From the [=pairing=] perspective of the outer [=ruby container=],
+	each [=ruby container=] nested within another [=ruby container=]
+	counts as representing a single [=ruby base=]/[=annotation=] per level.
+	The outer [=ruby container=]’s [=ruby annotations=] paired to the [=nested ruby=]
+	are therefore paired with (and [=span=]) all of the nested [=ruby container=]’s [=ruby bases=].
+	Each [=ruby annotation container=] in the nested [=ruby container=]
+	occupies the same [=annotation level=] in the outer [=ruby container=]
 	as it does in the inner one
-	and participates in its layout as if it were directly contained in the outer <i>ruby container</i>.
+	and participates in its layout as if it were directly contained in the outer [=ruby container=].
 
 	<p>This process is recursive.
-	Thus, using nested <i>ruby containers</i> allows the representation
+	Thus, using nested [=ruby containers=] allows the representation
 	of complex spanning relationships.
 
 	<p class="issue">It's not clear whether this falls out of layout handling of ruby containers inside ruby bases
@@ -507,15 +511,15 @@ Complex Spanning with Nested Ruby</h4>
 <h3 id="autohide">
 Autohiding Base-identical Annotations</h3>
 
-	<p>If a <i>ruby annotation</i> has the exact same text content as its base,
+	<p>If a [=ruby annotation=] has the exact same text content as its base,
 	it is <dfn lt="hidden ruby annotation | hidden annotation">hidden</dfn>.
-	Hiding a <i>ruby annotation</i> does not affect annotation [=pairing=]
+	Hiding a [=ruby annotation=] does not affect annotation [=pairing=]
 	or the block-axis positioning of boxes in other [=levels=].
 	However the [=hidden annotation=] is not visible,
 	and it has no impact on layout
-	other than to separate adjacent sequences of <i>ruby annotation boxes</i> within its level,
+	other than to separate adjacent sequences of [=ruby annotation boxes=] within its level,
 	as if they belonged to separate segments
-	and the [=hidden annotation=]’s base were not a <i>ruby base</i> but an intervening inline.
+	and the [=hidden annotation=]’s base were not a [=ruby base=] but an intervening inline.
 
 	<div class="example">
 		<p>This is to allow correct inlined display of annotations
@@ -556,9 +560,9 @@ White Space Collapsing</h3>
 
 	<p>White space within a ruby structure is <a href="#anon-gen-discard-space">discarded</a>
 	<ul>
-		<li>at the beginning and end of a <i>ruby container</i>, <i>ruby annotation container</i>, or <i>ruby base container</i>,
-		<li>between a <i>ruby base container</i> and its following <i>ruby annotation container</i>,
-		<li>between <i>ruby annotation containers</i>.
+		<li>at the beginning and end of a [=ruby container=], [=ruby annotation=] container, or [=ruby base container=],
+		<li>between a [=ruby base container=] and its following [=ruby annotation container=],
+		<li>between [=ruby annotation containers=].
 	</ul>
 
 	<div class="example">
@@ -571,7 +575,7 @@ White Space Collapsing</h3>
 <!--		-->&lt;/ruby></pre>
 	</div>
 
-	<p>Between [=ruby segments=], between <i>ruby bases</i>, and between <i>ruby annotations</i>, however,
+	<p>Between [=ruby segments=], between [=ruby bases=], and between [=ruby annotations=], however,
 	white space is not discarded,
 	and is maintained for rendering
 	as [=inter-base white space|inter-base=],
@@ -595,15 +599,15 @@ White Space Collapsing</h3>
 <!--		-->&lt;/ruby></pre>
 	</div>
 
-	<p>Where undiscarded white space is <i>collapsible</i>, it will collapse
+	<p>Where undiscarded white space is [=collapsible=], it will collapse
 	following the standard <a href="https://www.w3.org/TR/css3-text/#white-space-rules">white space processing rules</a>. [[!CSS3TEXT]]
-	For <i>collapsible white space</i> between [=ruby segments=] ([=inter-segment white space=]), however,
-	the contextual text for determining collapsing behavior is given by the <i>ruby bases</i> on either side,
+	For [=collapsible white space=] between [=ruby segments=] ([=inter-segment white space=]), however,
+	the contextual text for determining collapsing behavior is given by the [=ruby bases=] on either side,
 	not the text on either side of the white space in source document order.
 
 	<div class="note">
 		<p>Note that the white space processing rules
-		cause a white space sequence containing a <i>segment break</i> (such as a line feed)
+		cause a white space sequence containing a [=segment break=] (such as a line feed)
 		to <a href="https://www.w3.org/TR/css3-text/#line-break-transform">collapse to nothing</a> between Han and Kana characters.
 		This means that Chinese and Japanese ruby can safely use white space for indentation of ruby markup.
 		For example, the following markup will display without any spaces:
@@ -612,7 +616,7 @@ White Space Collapsing</h3>
 <!--		-->  屋&lt;rt>おく&lt;/rt>内&lt;rt>ない&lt;/rt>
 <!--		-->  禁&lt;rt>きん&lt;/rt>煙&lt;rt>えん&lt;/rt>
 <!--		-->&lt;/ruby></pre>
-		<p>However, white space that does not contain a <i>segment break</i> does not collapse completely away,
+		<p>However, white space that does not contain a [=segment break=] does not collapse completely away,
 		so this markup will display with a space between the first and second ruby pairs:
 		<pre>
 <!--		-->&lt;ruby>
@@ -627,21 +631,21 @@ Ruby Layout</h2>
 	<p>When a ruby structure is laid out,
 	its [=base level=] is laid out on the line,
 	aligned according to its 'vertical-align' property
-	exactly as if its <i>ruby bases</i> were a regular sequence of inline boxes.
-	Each <i>ruby base container</i> is sized and positioned
-	to contain exactly all of its <i>ruby bases</i>’ margin boxes.
+	exactly as if its [=ruby bases=] were a regular sequence of inline boxes.
+	Each [=ruby base container=] is sized and positioned
+	to contain exactly all of its [=ruby bases=]’ margin boxes.
 
-	<p><i>Ruby annotations</i> associated with the [=base level=]
-	are then positioned with respect to their <i>ruby base boxes</i>
+	<p>[=Ruby annotations=] associated with the [=base level=]
+	are then positioned with respect to their [=ruby base boxes=]
 	according to the applicable 'ruby-position' values.
-	<i>Ruby annotations</i> within a level (within a single <i>ruby container</i>)
+	[=Ruby annotations=] within a level (within a single [=ruby container=])
 	are aligned to each other as if they were inline boxes
 	participating in the same inline formatting context.
-	Each <i>ruby annotation container</i> is sized and positioned
-	to contain exactly all of its <i>ruby annotations</i>’ margin boxes.
+	Each [=ruby annotation container=] is sized and positioned
+	to contain exactly all of its [=ruby annotations=]’ margin boxes.
 
-	<p><i>Ruby annotation containers</i> are stacked outward
-	over or under their corresponding <i>ruby base container</i>,
+	<p>[=Ruby annotation containers=] are stacked outward
+	over or under their corresponding [=ruby base container=],
 	without any intervening space.
 
 	<p class="issue">Should block-axis margins collapse?
@@ -650,12 +654,12 @@ Ruby Layout</h2>
 
 	<p>A ruby container (or fragment thereof)
 	measures as wide as the content of its widest level.
-	Similarly, <i>ruby base boxes</i> and <i>ruby annotation boxes</i>
+	Similarly, [=ruby base boxes=] and [=ruby annotation boxes=]
 	within a ruby “column” have the measure of the widest content in that “column”.
 	In the case of [=spanning annotations=]
 	(whether actually spanning or pretending to span per 'ruby-merge'),
-	the measures of the <i>ruby annotation box</i> and
-	the sum of its associated <i>ruby base boxes</i> must match.
+	the measures of the [=ruby annotation box=] and
+	the sum of its associated [=ruby base boxes=] must match.
 
 	<p>How the extra space is distributed
 	when ruby content is narrower than the measure of its box
@@ -669,12 +673,12 @@ Inter-character Ruby Layout</h3>
 
 	<p>Inter-character annotations have special layout.
 	When 'ruby-position' indicates ''inter-character'' annotations,
-	the affected <i>ruby annotation boxes</i>
+	the affected [=ruby annotation boxes=]
 	are spliced into and measured as part of the layout of the [=base level=].
-	The <i>ruby base container</i> must be sized to include both the <i>ruby base boxes</i>
-	as well as the ''inter-character'' <i>ruby annotation boxes</i>.
-	The affected <i>ruby annotation container</i> is similarly sized
-	so that its content box coincides with that of the <i>ruby base container</i>.
+	The [=ruby base container=] must be sized to include both the [=ruby base boxes=]
+	as well as the ''inter-character'' [=ruby annotation boxes=].
+	The affected [=ruby annotation container=] is similarly sized
+	so that its content box coincides with that of the [=ruby base container=].
 
 	<p>For the purpose of laying out other levels of annotations,
 	an ''inter-character'' annotation effectively becomes part of its base.
@@ -690,7 +694,7 @@ Styling Ruby Boxes</h3>
 	any of the box properties (borders, margins, padding),
 	any of the background properties or outline properties,
 	or any other property that illustrates the bounds of the box
-	on <i>ruby base container boxes</i>, <i>ruby annotation container boxes</i>,
+	on [=ruby base container boxes=], [=ruby annotation container boxes=],
 	or <a href="#nested-pairing">ruby-internal ruby container boxes</a>.
 	The UA may implement these boxes simply as abstractions for inheritance
 	and control over the layout of their contents.
@@ -698,16 +702,16 @@ Styling Ruby Boxes</h3>
 <h3 id="line-breaks">
 Breaking Across Lines</h3>
 
-	<p>When there is not enough space for an entire <i>ruby container</i> to fit on the line,
+	<p>When there is not enough space for an entire [=ruby container=] to fit on the line,
 	the ruby may be broken wherever all levels simultaneously allow a break.
 	Ruby most often breaks between base-annotation sets,
-	but if the line-breaking rules allow it, can also break within a <i>ruby base</i>
-	(and, in parallel, its associated <i>ruby annotation boxes</i>).
+	but if the line-breaking rules allow it, can also break within a [=ruby base=]
+	(and, in parallel, its associated [=ruby annotation boxes=]).
 
-	<p>Whenever ruby breaks across lines, <i>ruby annotations</i> must stay
-	with their respective <i>ruby bases</i>.
-	The line <em>must not</em> break between a <i>ruby base</i> and its <i>annotations</i>,
-	even in the case of ''inter-character'' <i>annotations</i>.
+	<p>Whenever ruby breaks across lines, [=ruby annotations=] must stay
+	with their respective [=ruby bases=].
+	The line <em>must not</em> break between a [=ruby base=] and its [=annotations=],
+	even in the case of ''inter-character'' [=annotations=].
 
 	<div class="figure">
 		<img src="images/r-break-b.gif"
@@ -718,11 +722,11 @@ Breaking Across Lines</h3>
 <h4 id="break-between">
 Breaking Between Bases</h4>
 
-	<p>In typical cases, <i>ruby base boxes</i> and <i>ruby annotation boxes</i>
+	<p>In typical cases, [=ruby base boxes=] and [=ruby annotation boxes=]
 	are styled to forbid internal line wrapping and do not contain forced breaks.
 	(See <a href="#default-stylesheet">Appendix A</a>.)
-	In such cases the <i>ruby container</i> can only break between adjacent <i>ruby bases</i>,
-	and only if no <i>ruby annotations</i> span those <i>ruby bases</i>.
+	In such cases the [=ruby container=] can only break between adjacent [=ruby bases=],
+	and only if no [=ruby annotations=] span those [=ruby bases=].
 
 	<div class="figure">
 		<p><img src="images/r-break-a.gif"
@@ -730,9 +734,9 @@ Breaking Between Bases</h4>
 		<p class="caption">Ruby line breaking opportunity
 	</div>
 
-	<p>Whether ruby can break between two adjacent <i>ruby bases</i>
+	<p>Whether ruby can break between two adjacent [=ruby bases=]
 	is controlled by normal line-breaking rules for the base text,
-	exactly as if the <i>ruby bases</i> were adjacent inline boxes.
+	exactly as if the [=ruby bases=] were adjacent inline boxes.
 	(The annotations are ignored when determining soft wrap opportunities for the [=base level=].)
 
 	<div class="example">
@@ -743,7 +747,7 @@ Breaking Between Bases</h4>
 		<pre>&lt;ruby>蝴&lt;rt>hú&lt;/rt>蝶&lt;rt>dié&lt;/rt></pre>
 	</div>
 
-	<p>Inter-base white space is significant for evaluating line break opportunities between <i>ruby bases</i>.
+	<p>Inter-base white space is significant for evaluating line break opportunities between [=ruby bases=].
 	As with white space between inlines, it collapses when the line breaks there.
 	Similarly, annotation white space is also trimmed at a line break.
 
@@ -765,17 +769,17 @@ Breaking Within Bases</h4>
 	<p class="issue">
 	Insert scanned example so people don't think this is just the ramblings of an insane spec-writer.
 
-	<p>Line-breaking within a <i>ruby base</i> is only allowed if the 'white-space' property
-	of the <i>ruby base</i> and all its parallel <i>annotations</i> allow it,
-	and there exists a <i>soft wrap opportunity</i> <em>within</em> (i.e. not at the start or end)
+	<p>Line-breaking within a [=ruby base=] is only allowed if the 'white-space' property
+	of the [=ruby base=] and all its parallel [=annotations=] allow it,
+	and there exists a [=soft wrap opportunity=] <em>within</em> (i.e. not at the start or end)
 	the content of each base/annotation box.
 	Since there is no structural correspondence between fragments of content
-	within <i>ruby bases</i> and <i>annotations</i>,
+	within [=ruby bases=] and [=annotations=],
 	the UA may break at any set of opportunities;
 	but it is recommended that the UA attempt to proportionally balance
 	the amount of content inside each fragment.
 
-	<p>There are no line breaking opportunities within ''inter-character'' <i>annotations</i>.
+	<p>There are no line breaking opportunities within ''inter-character'' [=annotations=].
 
 	<p>Ruby alignment takes place within each fragment, after line-breaking.
 
@@ -786,43 +790,43 @@ Bidi Reordering</h3>
 	when characters from scripts of opposing directionalities are mixed
 	within a single paragraph.
 
-	<p>To preserve the correspondance of <i>ruby annotations</i>
-	to their respective <i>ruby bases</i>,
+	<p>To preserve the correspondance of [=ruby annotations=]
+	to their respective [=ruby bases=],
 	a few restrictions must be imposed:
 	<ul>
-		<li>The contents of a <i>ruby base</i> or <i>ruby annotation</i> must remain contiguous.
-		<li><i>Ruby annotations</i> must be reordered together with their <i>ruby bases</i>.
-		<li>All <i>ruby bases</i> spanned by a single <i>ruby annotation</i> must remain contiguous.
+		<li>The contents of a [=ruby base=] or [=ruby annotation=] must remain contiguous.
+		<li>[=Ruby annotations=] must be reordered together with their [=ruby bases=].
+		<li>All [=ruby bases=] spanned by a single [=ruby annotation=] must remain contiguous.
 	</ul>
 
 	<p>To this end,
 	<ul>
 		<li>
-			Bidi isolation is forced on all <i>internal ruby boxes</i> and the <i>ruby container</i>:
+			Bidi isolation is forced on all [=internal ruby boxes=] and the [=ruby container=]:
 			the ''unicode-bidi/normal'' and ''embed'' values of 'unicode-bidi' compute to ''isolate'',
 			and ''bidi-override'' computes to ''isolate-override''.
 			<p class="note">
 				Note this means that implicit bidi reordering does not work across ruby bases,
-				so authors will need to ensure that the <i>ruby container</i>’s declared directionality
+				so authors will need to ensure that the [=ruby container=]’s declared directionality
 				does indeed match its contents.
 		<li>
-			During layout, [=ruby segments=] are ordered within the <i>ruby container</i>
-			by the 'direction' property of their <i>ruby container</i>.
+			During layout, [=ruby segments=] are ordered within the [=ruby container=]
+			by the 'direction' property of their [=ruby container=].
 		<li>
-			Within a segment, <i>ruby bases</i> and <i>ruby annotations</i>
+			Within a segment, [=ruby bases=] and [=ruby annotations=]
 			are ordered within their respective containers
-			by the 'direction' property of the segment’s <i>ruby base container</i>.
+			by the 'direction' property of the segment’s [=ruby base container=].
 			<span class="note">
-				Note this means the 'direction' property on <i>ruby annotation containers</i>
+				Note this means the 'direction' property on [=ruby annotation containers=]
 				is ignored for the purpose of layout.
 				However, it can still inherit into the container's children
-				and thereby affect the <i>inline base direction</i>
-				of any <i>ruby annotations</i> it contains.
+				and thereby affect the [=inline base direction=]
+				of any [=ruby annotations=] it contains.
 			</span>
 	</ul>
 
 	<p>As with other inline-level content,
-	the bidi reordering of <i>internal ruby boxes</i> happens after line-breaking
+	the bidi reordering of [=internal ruby boxes=] happens after line-breaking
 	so that content is divided across lines according to its logical order.
 
 	<p>See [[CSS3-WRITING-MODES]] for a more in-depth discussion of bidirectional text in CSS.
@@ -840,25 +844,25 @@ Line Spacing</h3>
 	<p>In order to ensure consistent spacing of lines,
 	documents with ruby typically ensure that the 'line-height' is large enough
 	to accommodate ruby between lines of text.
-	Therefore, ordinarily, <i>ruby annotation containers</i> and <i>ruby annotation boxes</i>
+	Therefore, ordinarily, [=ruby annotation containers=] and [=ruby annotation boxes=]
 	do not contribute to the measured height of a line's inline contents;
 	any alignment (see 'vertical-align') and line-height calculations
-	are performed using only the <i>ruby base container</i>,
+	are performed using only the [=ruby base container=],
 	exactly as if it were a normal inline.
 
-	<p>However, if the 'line-height' specified on the <i>ruby container</i>
+	<p>However, if the 'line-height' specified on the [=ruby container=]
 	is less than the distance between
-	the top of the top <i>ruby annotation container</i>
-	and the bottom of the bottom <i>ruby annotation container</i>,
+	the top of the top [=ruby annotation container=]
+	and the bottom of the bottom [=ruby annotation container=],
 	then additional leading is added
-	on the appropriate side of the <i>ruby base container</i>
+	on the appropriate side of the [=ruby base container=]
 	such that if a block consisted of three lines
 	each containing ruby identical to this,
-	none of the <i>ruby containers</i> would overlap.
+	none of the [=ruby containers=] would overlap.
 
-	<p class="note">Note that this does not ensure that the <i>ruby annotations</i> remain within the line box.
+	<p class="note">Note that this does not ensure that the [=ruby annotations=] remain within the line box.
 	It merely ensures that <em>if all lines had equal spacing</em>
-	and equivalent amounts and positioning of <i>ruby annotations</i>,
+	and equivalent amounts and positioning of [=ruby annotations=],
 	there would be enough room to avoid overlap.
 
 	<p>Authors should ensure appropriate 'line-height' and 'padding' to accommodate ruby,
@@ -910,7 +914,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 	<p class="issue"><span class="issuehead">Issue-107:&nbsp;</span> Roland Steiner has requested the addition of an auto value as default. See <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=ruby-position%3A+undesirable+default+value+%27before%27+for+complex+ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=www-style&amp;resultsperpage=20&amp;sortby=date">this thread</a> and <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=Styling+of+complex+Ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=public-i18n-core&amp;resultsperpage=20&amp;sortby=date">this one</a>. Current proposal is to add an optional ''alternate?'' keyword.</p>
 	<dl dfn-for=ruby-position dfn-type=value>
 		<dt><dfn>over</dfn>
-		<dd>The ruby text appears <a>line-over</a> the base.
+		<dd>The ruby text appears [=line-over=] the base.
 
 			<div class="figure">
 				<p><img src="images/shinkansen-top.gif"
@@ -925,7 +929,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 		</dd>
 
 		<dt><dfn>under</dfn>
-		<dd>The ruby text appears <a>line-under</a> the base.
+		<dd>The ruby text appears [=line-under=] the base.
 			This is a relatively rare setting used in ideographic East Asian writing systems,
 			most easily found in educational text.
 
@@ -944,7 +948,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 		<dt><dfn>inter-character</dfn></dt>
 		<dd>
 			<p>The ruby text appears on the right of the base in horizontal text.
-			This value forces the computed value of 'writing-mode' of the <i>ruby annotation container</i> to be ''vertical-rl''.
+			This value forces the computed value of 'writing-mode' of the [=ruby annotation container=] to be ''vertical-rl''.
 
 			<p>This value is provided for the special case of traditional Chinese
 			as used especially in Taiwan:
@@ -961,7 +965,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 		</dd>
 	</dl>
 
-	<p>If multiple <i>ruby annotation containers</i> have the same 'ruby-position',
+	<p>If multiple [=ruby annotation containers=] have the same 'ruby-position',
 	they stack along the block axis,
 	with lower levels of annotation closer to the base text.
 
@@ -1004,11 +1008,11 @@ Sharing Annotation Space: the 'ruby-merge' property</h3>
 		<dt><dfn>collapse</dfn>
 		<dd>
 			<p>
-				All <i>ruby annotation boxes</i> within the same [=ruby segment=] on the same line are concatenated,
-				and laid out as if their contents belonged to a single <i>ruby annotation box</i>
-				spanning all their associated <i>ruby base boxes</i>.
+				All [=ruby annotation boxes=] within the same [=ruby segment=] on the same line are concatenated,
+				and laid out as if their contents belonged to a single [=ruby annotation box=]
+				spanning all their associated [=ruby base boxes=].
 				This style renders similar to “group ruby” in [[JLREQ]],
-				except that <i>ruby annotations</i> are kept together with their respective <i>ruby bases</i> when breaking lines.
+				except that [=ruby annotations=] are kept together with their respective [=ruby bases=] when breaking lines.
 			</p>
 
 			<div class="example">
@@ -1093,7 +1097,7 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dd>
 			<p>The ruby content expands as defined for normal text justification
 				(as defined by 'text-justify'),
-				except that if there are no <i>justification opportunities</i>
+				except that if there are no [=justification opportunities=]
 				the content is centered.
 			<div class="figure">
 				<p><img width="145" height="91"
@@ -1108,12 +1112,12 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dt><dfn>space-around</dfn></dt>
 		<dd>
 			<p>As for ''ruby-align/space-between''
-			except that there exists an extra <i>justification opportunities</i>
+			except that there exists an extra [=justification opportunities=]
 			whose space is distributed half before and half after the ruby content.
 			<div class="example">
-				<p>Since a typical implementation will by default define <i>justification opportunities</i>
-					between every adjacent pair of CJK <i>characters</i>
-					and not between adjacent pairs of Latin <i>characters</i>,
+				<p>Since a typical implementation will by default define [=justification opportunities=]
+					between every adjacent pair of CJK [=characters=]
+					and not between adjacent pairs of Latin [=characters=],
 					this should result in the behavior recommended by [[JLREQ]]:
 					for wide-cell ruby content to be distributed...
 				<div class="figure">
@@ -1183,8 +1187,8 @@ Edge Effects</h2>
 Overhanging Ruby</h3>
 
 	<p>
-		When <i>ruby annotation box</i> is longer than its corresponding <i>ruby base box</i>,
-		the <i>ruby annotation box</i> may partially overhang adjacent boxes.
+		When [=ruby annotation box=] is longer than its corresponding [=ruby base box=],
+		the [=ruby annotation box=] may partially overhang adjacent boxes.
 	</p>
 	<p>
 		This level of the specification does not define
@@ -1202,10 +1206,10 @@ Overhanging Ruby</h3>
 		<p class="caption">Simple ruby whose text is not allowed to overhang adjacent text
 	</div>
 
-	<p>However, if <i>ruby annotation</i> content is allowed to overhang adjacent elements
+	<p>However, if [=ruby annotation=] content is allowed to overhang adjacent elements
 	and it happens to be wider than its base,
-	then the adjacent content is partially rendered within the area of the <i>ruby container box</i>,
-	while the <i>ruby annotation</i> may partially overlap the upper blank parts of the adjacent content:
+	then the adjacent content is partially rendered within the area of the [=ruby container box=],
+	while the [=ruby annotation=] may partially overlap the upper blank parts of the adjacent content:
 
 	<div class="figure">
 	<p><img src="images/ro-a.gif"
@@ -1213,8 +1217,8 @@ Overhanging Ruby</h3>
 	<p class="caption">Simple ruby whose text is allowed to overhang adjacent text
 	</div>
 
-	<p>The <i>ruby annotations</i> related to a <i>ruby base</i>
-	must never overhang another <i>ruby base</i>.
+	<p>The [=ruby annotations=] related to a [=ruby base=]
+	must never overhang another [=ruby base=].
 
 	<p>The alignment of the contents of the base or the ruby text
 	is not affected by overhanging behavior.
@@ -1242,9 +1246,9 @@ Overhanging Ruby</h3>
 Line-edge Alignment</h3>
 
 	<p>
-		When a <i>ruby annotation box</i> that is longer than its <i>ruby base</i>
+		When a [=ruby annotation box=] that is longer than its [=ruby base=]
 		is at the start or end edge of a line,
-		the user agent <em>may</em> force the side of the <i>ruby annotation</i> that touches the edge of the line
+		the user agent <em>may</em> force the side of the [=ruby annotation=] that touches the edge of the line
 		to align to the corresponding edge of the base.
 		This type of alignment is described by [[JLREQ]].
 	</p>
@@ -1467,7 +1471,7 @@ Appendix A: Default Style Sheet</h2>
 	<p>Unfortunately, because Selectors cannot match against text nodes,
 	it's not possible with CSS to express rules that will automatically and correctly
 	add parentheses to unparenthesized ruby annotations in HTML.
-	(This is because HTML ruby allows implying the <i>ruby base</i> from raw text, without a corresponding element.)
+	(This is because HTML ruby allows implying the [=ruby base=] from raw text, without a corresponding element.)
 	However, these rules will handle cases where either <code>&lt;rb&gt;</code>
 	or <code>&lt;rtc&gt;</code> is used rigorously.
 

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -15,7 +15,6 @@ Editor: Xidorn Quan, Mozilla https://www.mozilla.org/, https://www.upsuper.org/,
 Abstract: “Ruby”, a form of interlinear annotation, are short runs of text alongside the base text.
 Abstract: They are typically used in East Asian documents to indicate pronunciation or to provide a short annotation.
 Abstract: This module describes the rendering model and formatting controls related to displaying ruby annotations in CSS.
-Ignored terms: internal table elements
 Ignored vars: any
 </pre>
 

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -15,7 +15,6 @@ Editor: Xidorn Quan, Mozilla https://www.mozilla.org/, https://www.upsuper.org/,
 Abstract: “Ruby”, a form of interlinear annotation, are short runs of text alongside the base text.
 Abstract: They are typically used in East Asian documents to indicate pronunciation or to provide a short annotation.
 Abstract: This module describes the rendering model and formatting controls related to displaying ruby annotations in CSS.
-Ignored vars: any
 </pre>
 
 <!--
@@ -315,7 +314,7 @@ Anonymous Ruby Box Generation</h3>
 				<tr><th>Previous box
 				    <th>Next box
 			<tbody>
-				<tr><td><var>any</var>
+				<tr><td><i>any</i>
 				    <td><i>ruby annotation container</i>
 				<tr><td>not <i>ruby annotation</i>
 				    <td><i>ruby annotation</i>

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -34,15 +34,15 @@ Redo all examples with consistent font. (M+ 2p?)
 <h2 id="intro">
 Introduction</h2>
 
-	<p><em>This section is not normative.</em>
+	<em>This section is not normative.</em>
 
 <h3 id="placement">
 Module interactions</h3>
 
-	<p>This module extends the inline box model of CSS Level 2 [[!CSS2]]
+	This module extends the inline box model of CSS Level 2 [[!CSS2]]
 	to support ruby.
 
-	<p>None of the properties in this module apply to the ''::first-line'' or
+	None of the properties in this module apply to the ''::first-line'' or
 	''::first-letter'' pseudo-elements,
 	except for 'ruby-position' which applies to ''::first-line'',
 	inheriting to affect ruby annotations on the first line.
@@ -63,7 +63,7 @@ Value Definitions</h3>
 <h3 id="diagram-conventions">
 Diagram conventions</h3>
 
-	<p>Many typographical conventions in East Asian typography depend
+	Many typographical conventions in East Asian typography depend
 	on whether the character rendered is wide (CJK) or narrow (non-CJK).
 	There are a number of illustrations in this document
 	for which the following legend is used:
@@ -76,7 +76,7 @@ Diagram conventions</h3>
 		<dd>Narrow-cell glyph (e.g. Roman) which is the <var>n</var>th glyph in the text run.
 	</dl>
 
-	<p>The orientation which the above symbols assume in the diagrams
+	The orientation which the above symbols assume in the diagrams
 	corresponds to the orientation that the glyphs they represent
 	are intended to assume when rendered by the user agent.
 	Spacing between these characters in the diagrams is incidental,
@@ -85,38 +85,39 @@ Diagram conventions</h3>
 <h3 id="ruby-def">
 What is ruby?</h3>
 
-	<p><dfn export>Ruby</dfn> is the commonly-used name for a run of text
+	<dfn export>Ruby</dfn> is the commonly-used name for a run of text
 	that appears alongside another run of text (referred to as the “base”)
 	and serves as an annotation or a pronunciation guide associated with that run of text.
 
-	<p>The following figures show two examples of Ruby,
+	The following figures show two examples of Ruby,
 	a simple case and one with more complicated structure.
 
 	<div class="example">
-		<p>In this first example, a single annotation is used to annotate the base text.
+		In this first example, a single annotation is used to annotate the base text.
 		<div class="figure">
-			<p><img src="images/licence.png"
+			<img src="images/licence.png"
 			        alt="Example of ruby applied on top of a Japanese expression">
 			<p class="caption">Example of ruby used in Japanese (simple case)
 		</div>
-		<p>In Japanese typography, this case is sometimes called
+
+		In Japanese typography, this case is sometimes called
 		<span lang="ja">taigo</span> ruby or group-ruby (per-word ruby),
 		because the annotation as a whole is associated
 		with multi-character word (as a whole).
 	</div>
 
 	<div class="example">
-		<p>In this second example,
+		In this second example,
 		two levels of annotations are attached to a base sequence:
 		the hiragana characters on top refer to the pronunciation of each of the base kanji characters,
 		while the words “Keio” and “University” on the bottom are annotations describing the English translation.
 		<div class="figure">
-			<p><img src="images/ruby-univ.gif"
+			<img src="images/ruby-univ.gif"
 			        alt="Example showing complex ruby with annotation text over and under the base characters">
 			<p class="caption">Complex ruby with annotation text over and under the base characters
 		</div>
-		<p>
-		<p>Notice that to allow correct association between the hiragana characters and
+
+		Notice that to allow correct association between the hiragana characters and
 		their corresponding Kanji base characters,
 		the spacing between these Kanji characters is adjusted.
 		(This happens around the fourth Kanji character in the figure above.)
@@ -128,7 +129,7 @@ What is ruby?</h3>
 		correctly paired with their respective base characters.
 	</div>
 
-	<p>[=Ruby=] formatting as used in Japanese is described in JIS X-4051 [[JIS4051]] (in Japanese)
+	[=Ruby=] formatting as used in Japanese is described in JIS X-4051 [[JIS4051]] (in Japanese)
 	and in Requirements for Japanese Text Layout [[JLREQ]] (in English and Japanese)].
 	In HTML, ruby structure and markup to represent it is described
 	in the Ruby Markup Extension specification.
@@ -138,7 +139,7 @@ What is ruby?</h3>
 <h2 id="ruby-model">
 Ruby Box Model</h2>
 
-	<p>The CSS ruby model is based on
+	The CSS ruby model is based on
 	the <a href="https://www.w3.org/TR/html5/text-level-semantics.html#the-ruby-element">W3C HTML5 Ruby Markup</a> model
 	and the <a href="https://www.w3.org/TR/ruby/">XHTML Ruby Annotation Recommendation</a> [[RUBY]].
 	In this model, a ruby structure consists of
@@ -148,16 +149,16 @@ Ruby Box Model</h2>
 	there are “rows” (the [=base text level=], each [=annotation level=])
 	and “columns” (each [=ruby base=] and its corresponding [=ruby annotations=]).
 
-	<p>Consecutive bases and annotations are grouped together into [=ruby segments=].
+	Consecutive bases and annotations are grouped together into [=ruby segments=].
 	Within a [=ruby segment=], a [=ruby annotation=] may span multiple [=ruby bases=].
 
-	<p class="note">In HTML, a single <code>&lt;ruby&gt;</code> element may contain multiple [=ruby segments=].
+	Note: In HTML, a single <code>&lt;ruby&gt;</code> element may contain multiple [=ruby segments=].
 	(In the XHTML Ruby model, a single <code>&lt;ruby&gt;</code> element can only contain one [=ruby segment=].)
 
 <h3 id="ruby-display">
 Ruby-specific 'display' Values</h3>
 
-	<p>For document languages (such as XML applications) that do not have pre-defined ruby elements,
+	For document languages (such as XML applications) that do not have pre-defined ruby elements,
 	authors must map document language elements to ruby elements;
 	this is done with the 'display' property.
 
@@ -166,7 +167,7 @@ Ruby-specific 'display' Values</h3>
 	New values: ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container
 	</pre>
 
-	<p>The following new 'display' values assign ruby layout roles to an arbitrary element:
+	The following new 'display' values assign ruby layout roles to an arbitrary element:
 
 	<dl dfn-type=value export dfn-for=display>
 		<dt><dfn>ruby</dfn>
@@ -197,7 +198,7 @@ Ruby-specific 'display' Values</h3>
 <h4 id="formatting-context">
 The Ruby Formatting Context</h4>
 
-	<p>[=Ruby containers=] are non-atomic inline-level boxes.
+	[=Ruby containers=] are non-atomic inline-level boxes.
 	Like inline boxes, they break across lines,
 	and their containing block is the nearest block container ancestor.
 	And just as the contents of an inline box
@@ -205,7 +206,7 @@ The Ruby Formatting Context</h4>
 	a [=ruby container=] and its base-level contents
 	participate in the same inline formatting context that contains the [=ruby container=] itself.
 
-	<p>However [=ruby containers=] also establish a <dfn export>ruby formatting context</dfn>
+	However [=ruby containers=] also establish a <dfn export>ruby formatting context</dfn>
 	that builds further structure around their segment of the inline formatting context.
 	[=Ruby bases=], [=ruby annotations=], [=ruby base containers=], and [=ruby annotation containers=]
 	are <dfn export lt="internal ruby boxes|internal ruby display types">internal ruby boxes</dfn>:
@@ -213,18 +214,18 @@ The Ruby Formatting Context</h4>
 	they have specific roles in ruby layout,
 	and participate in their [=ruby container=]’s [=ruby formatting context=].
 
-	<p>As with the contents of inline boxes,
+	As with the contents of inline boxes,
 	the containing block for the contents of a [=ruby container=] (and all its [=internal ruby boxes=])
 	is the containing block of the [=ruby container=].
 	So floats, for example, are trapped by the [=ruby container=]’s containing block,
 	not any of the ruby box types.
 
-	<p class="issue">Are internal ruby boxes inline-level?
+	Issue: Are internal ruby boxes inline-level?
 
 <h4 id="block-ruby">
 Non-Inline Ruby</h4>
 
-	<p>If an element has an [=inner display type=] of ''ruby''
+	If an element has an [=inner display type=] of ''ruby''
 	and an [=outer display type=] other than ''display/inline'',
 	then it generates two boxes:
 	a principal box of the required [=outer display type=] type,
@@ -234,8 +235,7 @@ Non-Inline Ruby</h4>
 	This allows styling the element as a block,
 	while correctly maintaining the internal ruby structure.
 
-	<p class="note">
-	Note that absolute positioning or floating an element causes its 'display' value
+	Note: Absolute positioning or floating an element causes its 'display' value
 	to compute to a block-level equivalent. (See [[!CSS-DISPLAY-3]] or [[!CSS2]] section 9.7.)
 	For the [=internal ruby display types=],
 	this causes their 'display' value to compute to ''display/block''.
@@ -243,7 +243,7 @@ Non-Inline Ruby</h4>
 <h3 id="box-fixup">
 Anonymous Ruby Box Generation</h3>
 
-	<p>The CSS model does not require that the document language
+	The CSS model does not require that the document language
 	include elements that correspond to each of these components.
 	Missing parts of the structure are implied through the anonymous box generation rules
 	<a href="https://www.w3.org/TR/CSS2/tables.html#anonymous-boxes">similar to those used to normalize tables</a>. [[!CSS2]]
@@ -370,7 +370,8 @@ Anonymous Ruby Box Generation</h3>
 		<li id="anon-gen-unbreak"><strong>Suppress line breaks:</strong>
 			Convert all forced line breaks inside [=ruby annotations=] (regardless of 'white-space' value)
 			as defined for [=collapsible=] segment breaks in <a href="https://www.w3.org/TR/css-text-3/#line-break-transform">CSS Text Level 3 &sect; 4.1.2</a>.
-			<p class="issue">The goal of this is to simplify the layout model by suppressing any line breaks within ruby annotations.
+
+			Issue: The goal of this is to simplify the layout model by suppressing any line breaks within ruby annotations.
 			Alternatively we could try to define some kind of acceptable behavior for them.
 
 		<li id="anon-gen-anon-containers"><strong>Generate anonymous level containers:</strong>
@@ -383,13 +384,12 @@ Anonymous Ruby Box Generation</h3>
 			is wrapped in an anonymous [=ruby annotation container=].
 	</ol>
 
-	<p class="issue">Make <a href="http://lists.w3.org/Archives/Public/www-archive/2014Jun/att-0027/PastedGraphic-1.png">this diagram</a> into an example.
+	Issue: Make <a href="http://lists.w3.org/Archives/Public/www-archive/2014Jun/att-0027/PastedGraphic-1.png">this diagram</a> into an example.
 
-	<p>Once all ruby layout structures are properly parented,
+	Once all ruby layout structures are properly parented,
 	the UA can start to associate bases with their annotations.
 
-	<p class="note">
-	Note that the UA is not required to create any of these anonymous boxes
+	Note: The UA is not required to create any of these anonymous boxes
 	(or the anonymous empty [=intra-level white space=] boxes in [[#ruby-pairing]])
 	in its internal structures,
 	as long as [=pairing=] and layout behaves as if they existed.
@@ -397,7 +397,7 @@ Anonymous Ruby Box Generation</h3>
 <h3 id="ruby-pairing">
 Annotation Pairing</h3>
 
-	<p>Annotation <dfn>pairing</dfn> is the process of associating
+	Annotation <dfn>pairing</dfn> is the process of associating
 	[=ruby annotations=] with [=ruby bases=].
 	Each [=ruby annotation=] is associated with one or more [=ruby bases=],
 	and is said to <dfn>span</dfn> those bases.
@@ -418,7 +418,7 @@ Annotation Pairing</h3>
 <h4 id="segment-pairing">
 Segment Pairing and Annotation Levels</h4>
 
-	<p>A ruby structure is divided into <dfn>ruby segments</dfn>,
+	A ruby structure is divided into <dfn>ruby segments</dfn>,
 	each consisting of a single [=ruby base container=]
 	followed by one or more [=ruby annotation containers=].
 	Each [=ruby annotation container=] in a [=ruby segment=]
@@ -430,7 +430,7 @@ Segment Pairing and Annotation Levels</h4>
 	The [=ruby base container=] in each segment is thus paired
 	with each of the [=ruby annotation containers=] in that segment.
 
-	<p>In order to handle degenerate cases, some empty anonymous containers are assumed:
+	In order to handle degenerate cases, some empty anonymous containers are assumed:
 	<ul>
 		<li>If the first child of a [=ruby container=] is a [=ruby annotation container=],
 		an anonymous, empty [=ruby base container=] is assumed to exist before it.
@@ -438,22 +438,22 @@ Segment Pairing and Annotation Levels</h4>
 		anonymous, empty [=ruby annotation containers=] are assumed to exist between them.
 	</ul>
 
-	<p>[=Inter-segment white space=] is effectively a [=ruby segment=] of its own.
+	[=Inter-segment white space=] is effectively a [=ruby segment=] of its own.
 
 <h4 id="base-annotation-pairing">
 Unit Pairing and Spanning Annotations</h4>
 
-	<p>Within a [=ruby segment=],
+	Within a [=ruby segment=],
 	each [=ruby base=] in the [=ruby base container=]
 	is paired with one [=ruby annotation=]
 	from each [=ruby annotation container=] in its [=ruby segment=].
 
-	<p>If a [=ruby annotation container=] contains only
+	If a [=ruby annotation container=] contains only
 	a single, anonymous [=ruby annotation=],
 	then that [=ruby annotation=] is paired with (i.e. [=spans=] across)
 	all of the [=ruby bases=] in its [=ruby segment=].
 
-	<p>Otherwise, each [=ruby annotation=] is paired,
+	Otherwise, each [=ruby annotation=] is paired,
 	in order, with the corresponding [=ruby base=] in that segment</i>.
 	If there are not enough [=ruby annotations=] in a [=ruby annotation container=],
 	the remaining [=ruby bases=] are paired with anonymous empty annotations
@@ -462,12 +462,12 @@ Unit Pairing and Spanning Annotations</h4>
 	any remaining [=ruby annotations=] pair with empty, anonymous bases
 	inserted at the end of the [=ruby base container=].
 
-	<p>If an implementation supports ruby markup with explicit spanning
+	If an implementation supports ruby markup with explicit spanning
 	(e.g. XHTML Complex Ruby Annotations),
 	it must adjust the [=pairing=] rules to pair [=spanning annotations=]
 	to their bases appropriately.
 
-	<p>[=Intra-level white space=] does not participate in standard annotation [=pairing=].
+	[=Intra-level white space=] does not participate in standard annotation [=pairing=].
 	However, if the immediately-adjacent [=ruby bases=] or [=ruby annotations=]
 	are paired
 	<ul>
@@ -482,12 +482,12 @@ Unit Pairing and Spanning Annotations</h4>
 		an anonymous empty [=intra-level white space=] box assumed to exist between them.
 	</ul>
 
-	<p class="issue">Insert diagram</p>
+	Issue: Insert diagram
 
 <h4 id="nested-pairing">
 Complex Spanning with Nested Ruby</h4>
 
-	<p>When [=ruby containers=] are <dfn lt="nested ruby">nested</dfn>,
+	When [=ruby containers=] are <dfn lt="nested ruby">nested</dfn>,
 	[=pairing=] begins with the deepest [=ruby container=],
 	then expands out.
 	From the [=pairing=] perspective of the outer [=ruby container=],
@@ -500,18 +500,18 @@ Complex Spanning with Nested Ruby</h4>
 	as it does in the inner one
 	and participates in its layout as if it were directly contained in the outer [=ruby container=].
 
-	<p>This process is recursive.
+	This process is recursive.
 	Thus, using nested [=ruby containers=] allows the representation
 	of complex spanning relationships.
 
-	<p class="issue">It's not clear whether this falls out of layout handling of ruby containers inside ruby bases
+	Issue: It's not clear whether this falls out of layout handling of ruby containers inside ruby bases
 	or needs to be handled specially.
 	Waiting until layout is better-defined to find out...
 
 <h3 id="autohide">
 Autohiding Base-identical Annotations</h3>
 
-	<p>If a [=ruby annotation=] has the exact same text content as its base,
+	If a [=ruby annotation=] has the exact same text content as its base,
 	it is <dfn lt="hidden ruby annotation | hidden annotation">hidden</dfn>.
 	Hiding a [=ruby annotation=] does not affect annotation [=pairing=]
 	or the block-axis positioning of boxes in other [=levels=].
@@ -522,43 +522,45 @@ Autohiding Base-identical Annotations</h3>
 	and the [=hidden annotation=]’s base were not a [=ruby base=] but an intervening inline.
 
 	<div class="example">
-		<p>This is to allow correct inlined display of annotations
+		This is to allow correct inlined display of annotations
 		for Japanese words that are a mix of kanji and hiragana.
 		For example, the word <span lang=ja>振り仮名</span> should be inlined as
+
 		<p class="figure">振り仮名(ふりがな)
-		<p>and therefore marked up as
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  &lt;rb>振&lt;/rb>&lt;rb>り&lt;/rb>&lt;rb>仮&lt;/rb>&lt;rb>名&lt;/rb>
-<!--		-->  &lt;rp>(&lt;/rp>&lt;rt>ふ&lt;/rt>&lt;rt>り&lt;/rt>&lt;rt>が&lt;/rt>&lt;rt>な&lt;/rt>&lt;rp>)&lt;/rp>
-<!--		-->&lt;/ruby></pre>
-		<p>However, when displayed as ruby, the “り” should be hidden
+
+		and therefore marked up as
+		<pre highlight=html>
+			&lt;ruby>
+				&lt;rb>振&lt;/rb>&lt;rb>り&lt;/rb>&lt;rb>仮&lt;/rb>&lt;rb>名&lt;/rb>
+				&lt;rp>(&lt;/rp>&lt;rt>ふ&lt;/rt>&lt;rt>り&lt;/rt>&lt;rt>が&lt;/rt>&lt;rt>な&lt;/rt>&lt;rp>)&lt;/rp>
+			&lt;/ruby></pre>
+
+		However, when displayed as ruby, the “り” should be hidden
 		<div class="figure">
-			<p><img src="images/furigana-separate.png"
+			<img src="images/furigana-separate.png"
 			        alt="Hiragana annotations for 振り仮名 appear, each pronunciation above its kanji base character.">
 			<p class="caption">Hiragana ruby for 振り仮名. Notice there is no hiragana annotation above り,  since it is already in hiragana.
 		</div>
 	</div>
 
-	<p>When the computed value of 'ruby-merge' is ''collapse'',
+	When the computed value of 'ruby-merge' is ''collapse'',
 	the autohiding is disabled.
 	When the computed value of 'ruby-merge' is ''auto'',
 	the user agent may decide whether to autohide or not,
 	but it is recommended to autohide if the algorithm the user agent chose
 	produces the results similar to ''separate'' would produce.
 
-	<p>The content comparison for this auto-hiding behavior
+	The content comparison for this auto-hiding behavior
 	takes place prior to white space collapsing ('white-space') and text transformation ('text-transform')
 	and ignores elements (considers only the <code>textContent</code> of the boxes).
 
-	<p class="note">
-		Future levels of CSS Ruby may add controls for auto-hiding,
-		but in this level it is always forced.
+	Note: Future levels of CSS Ruby may add controls for auto-hiding,
+	but in this level it is always forced.
 
 <h3 id="white-space">
 White Space Collapsing</h3>
 
-	<p>White space within a ruby structure is <a href="#anon-gen-discard-space">discarded</a>
+	White space within a ruby structure is <a href="#anon-gen-discard-space">discarded</a>
 	<ul>
 		<li>at the beginning and end of a [=ruby container=], [=ruby annotation=] container, or [=ruby base container=],
 		<li>between a [=ruby base container=] and its following [=ruby annotation container=],
@@ -567,15 +569,15 @@ White Space Collapsing</h3>
 
 	<div class="example">
 		For example, the following markup will display without any spaces:
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  &lt;rb>東&lt;/rb>&lt;rb>京&lt;/rb>
-<!--		-->  &lt;rt>とう&lt;/rt>&lt;rt>きょう&lt;/rt>
-<!--		-->  &lt;rt>Tō&lt;/rt>&lt;rt>kyō&lt;/rt>
-<!--		-->&lt;/ruby></pre>
+		<pre highlight=html>
+			&lt;ruby>
+				&lt;rb>東&lt;/rb>&lt;rb>京&lt;/rb>
+				&lt;rt>とう&lt;/rt>&lt;rt>きょう&lt;/rt>
+				&lt;rt>Tō&lt;/rt>&lt;rt>kyō&lt;/rt>
+			&lt;/ruby></pre>
 	</div>
 
-	<p>Between [=ruby segments=], between [=ruby bases=], and between [=ruby annotations=], however,
+	Between [=ruby segments=], between [=ruby bases=], and between [=ruby annotations=], however,
 	white space is not discarded,
 	and is maintained for rendering
 	as [=inter-base white space|inter-base=],
@@ -584,58 +586,60 @@ White Space Collapsing</h3>
 	(See <a href="#box-fixup">Anonymous Ruby Box Generation</a>, above.)
 
 	<div class="example">
-		<p>The rules preserving white space allow ruby to be used with space-separated scripts such as Latin.
+		The rules preserving white space allow ruby to be used with space-separated scripts such as Latin.
 		For example,
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  &lt;rb>W&lt;/rb>&lt;rb>W&lt;/rb>&lt;rb>W&lt;/rb>
-<!--		-->  &lt;rt>World&lt;/rt> &lt;rt>Wide&lt;/rt> &lt;rt>Web&lt;/rt>
-<!--		-->&lt;/ruby></pre>
-		<p>They also ensure that annotated white space is preserved. For example,
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  &lt;rb>Aerith&lt;/rb>&lt;rb> &lt;/rb>&lt;rb>Gainsboro&lt;/rb>
-<!--		-->  &lt;rt>エアリス&lt;/rt>&lt;rt>・&lt;/rt>&lt;rt>ゲインズブール&lt;/rt>
-<!--		-->&lt;/ruby></pre>
+		<pre highlight=html>
+			&lt;ruby>
+				&lt;rb>W&lt;/rb>&lt;rb>W&lt;/rb>&lt;rb>W&lt;/rb>
+				&lt;rt>World&lt;/rt> &lt;rt>Wide&lt;/rt> &lt;rt>Web&lt;/rt>
+			&lt;/ruby></pre>
+
+		They also ensure that annotated white space is preserved. For example,
+		<pre highlight=html>
+			&lt;ruby>
+				&lt;rb>Aerith&lt;/rb>&lt;rb> &lt;/rb>&lt;rb>Gainsboro&lt;/rb>
+				&lt;rt>エアリス&lt;/rt>&lt;rt>・&lt;/rt>&lt;rt>ゲインズブール&lt;/rt>
+			&lt;/ruby></pre>
 	</div>
 
-	<p>Where undiscarded white space is [=collapsible=], it will collapse
+	Where undiscarded white space is [=collapsible=], it will collapse
 	following the standard <a href="https://www.w3.org/TR/css3-text/#white-space-rules">white space processing rules</a>. [[!CSS3TEXT]]
 	For [=collapsible white space=] between [=ruby segments=] ([=inter-segment white space=]), however,
 	the contextual text for determining collapsing behavior is given by the [=ruby bases=] on either side,
 	not the text on either side of the white space in source document order.
 
 	<div class="note">
-		<p>Note that the white space processing rules
+		Note: The white space processing rules
 		cause a white space sequence containing a [=segment break=] (such as a line feed)
 		to <a href="https://www.w3.org/TR/css3-text/#line-break-transform">collapse to nothing</a> between Han and Kana characters.
 		This means that Chinese and Japanese ruby can safely use white space for indentation of ruby markup.
 		For example, the following markup will display without any spaces:
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  屋&lt;rt>おく&lt;/rt>内&lt;rt>ない&lt;/rt>
-<!--		-->  禁&lt;rt>きん&lt;/rt>煙&lt;rt>えん&lt;/rt>
-<!--		-->&lt;/ruby></pre>
-		<p>However, white space that does not contain a [=segment break=] does not collapse completely away,
+		<pre highlight=html>
+			&lt;ruby>
+				屋&lt;rt>おく&lt;/rt>内&lt;rt>ない&lt;/rt>
+				禁&lt;rt>きん&lt;/rt>煙&lt;rt>えん&lt;/rt>
+			&lt;/ruby></pre>
+
+		However, white space that does not contain a [=segment break=] does not collapse completely away,
 		so this markup will display with a space between the first and second ruby pairs:
-		<pre>
-<!--		-->&lt;ruby>
-<!--		-->  屋&lt;rt>おく&lt;/rt>	内&lt;rt>ない&lt;/rt>
-<!--		-->  禁&lt;rt>きん&lt;/rt>	煙&lt;rt>えん&lt;/rt>
-<!--		-->&lt;/ruby></pre>
+		<pre highlight=html>
+			&lt;ruby>
+				屋&lt;rt>おく&lt;/rt>	内&lt;rt>ない&lt;/rt>
+				禁&lt;rt>きん&lt;/rt>	煙&lt;rt>えん&lt;/rt>
+			&lt;/ruby></pre>
 	</div>
 
 <h2 id="ruby-layout">
 Ruby Layout</h2>
 
-	<p>When a ruby structure is laid out,
+	When a ruby structure is laid out,
 	its [=base level=] is laid out on the line,
 	aligned according to its 'vertical-align' property
 	exactly as if its [=ruby bases=] were a regular sequence of inline boxes.
 	Each [=ruby base container=] is sized and positioned
 	to contain exactly all of its [=ruby bases=]’ margin boxes.
 
-	<p>[=Ruby annotations=] associated with the [=base level=]
+	[=Ruby annotations=] associated with the [=base level=]
 	are then positioned with respect to their [=ruby base boxes=]
 	according to the applicable 'ruby-position' values.
 	[=Ruby annotations=] within a level (within a single [=ruby container=])
@@ -644,15 +648,15 @@ Ruby Layout</h2>
 	Each [=ruby annotation container=] is sized and positioned
 	to contain exactly all of its [=ruby annotations=]’ margin boxes.
 
-	<p>[=Ruby annotation containers=] are stacked outward
+	[=Ruby annotation containers=] are stacked outward
 	over or under their corresponding [=ruby base container=],
 	without any intervening space.
 
-	<p class="issue">Should block-axis margins collapse?
+	Issue: Should block-axis margins collapse?
 	This makes layout more robust,
 	but is inconsistent with how inlines behave along the inline-axis.
 
-	<p>A ruby container (or fragment thereof)
+	A ruby container (or fragment thereof)
 	measures as wide as the content of its widest level.
 	Similarly, [=ruby base boxes=] and [=ruby annotation boxes=]
 	within a ruby “column” have the measure of the widest content in that “column”.
@@ -661,17 +665,17 @@ Ruby Layout</h2>
 	the measures of the [=ruby annotation box=] and
 	the sum of its associated [=ruby base boxes=] must match.
 
-	<p>How the extra space is distributed
+	How the extra space is distributed
 	when ruby content is narrower than the measure of its box
 	is specified by the 'ruby-align' property.
 
-	<p class="issue">Should the ruby bases and annotations size to the column,
+	Issue: Should the ruby bases and annotations size to the column,
 	or size to the content?
 
 <h3 id="inter-character-layout">
 Inter-character Ruby Layout</h3>
 
-	<p>Inter-character annotations have special layout.
+	Inter-character annotations have special layout.
 	When 'ruby-position' indicates ''inter-character'' annotations,
 	the affected [=ruby annotation boxes=]
 	are spliced into and measured as part of the layout of the [=base level=].
@@ -680,7 +684,7 @@ Inter-character Ruby Layout</h3>
 	The affected [=ruby annotation container=] is similarly sized
 	so that its content box coincides with that of the [=ruby base container=].
 
-	<p>For the purpose of laying out other levels of annotations,
+	For the purpose of laying out other levels of annotations,
 	an ''inter-character'' annotation effectively becomes part of its base.
 	<span class="issue">Or should it become a quasi-base between two bases?</span>
 	A spanning ''inter-character'' annotation is placed after
@@ -689,7 +693,7 @@ Inter-character Ruby Layout</h3>
 <h3 id="box-style">
 Styling Ruby Boxes</h3>
 
-	<p>In most respects, ruby boxes can be styled similar to inline boxes.
+	In most respects, ruby boxes can be styled similar to inline boxes.
 	However, the UA is not required to support
 	any of the box properties (borders, margins, padding),
 	any of the background properties or outline properties,
@@ -702,13 +706,13 @@ Styling Ruby Boxes</h3>
 <h3 id="line-breaks">
 Breaking Across Lines</h3>
 
-	<p>When there is not enough space for an entire [=ruby container=] to fit on the line,
+	When there is not enough space for an entire [=ruby container=] to fit on the line,
 	the ruby may be broken wherever all levels simultaneously allow a break.
 	Ruby most often breaks between base-annotation sets,
 	but if the line-breaking rules allow it, can also break within a [=ruby base=]
 	(and, in parallel, its associated [=ruby annotation boxes=]).
 
-	<p>Whenever ruby breaks across lines, [=ruby annotations=] must stay
+	Whenever ruby breaks across lines, [=ruby annotations=] must stay
 	with their respective [=ruby bases=].
 	The line <em>must not</em> break between a [=ruby base=] and its [=annotations=],
 	even in the case of ''inter-character'' [=annotations=].
@@ -722,39 +726,40 @@ Breaking Across Lines</h3>
 <h4 id="break-between">
 Breaking Between Bases</h4>
 
-	<p>In typical cases, [=ruby base boxes=] and [=ruby annotation boxes=]
+	In typical cases, [=ruby base boxes=] and [=ruby annotation boxes=]
 	are styled to forbid internal line wrapping and do not contain forced breaks.
 	(See <a href="#default-stylesheet">Appendix A</a>.)
 	In such cases the [=ruby container=] can only break between adjacent [=ruby bases=],
 	and only if no [=ruby annotations=] span those [=ruby bases=].
 
 	<div class="figure">
-		<p><img src="images/r-break-a.gif"
+		<img src="images/r-break-a.gif"
 		     alt="Diagram showing the line breaking opportunity in a complex ruby">
 		<p class="caption">Ruby line breaking opportunity
 	</div>
 
-	<p>Whether ruby can break between two adjacent [=ruby bases=]
+	Whether ruby can break between two adjacent [=ruby bases=]
 	is controlled by normal line-breaking rules for the base text,
 	exactly as if the [=ruby bases=] were adjacent inline boxes.
 	(The annotations are ignored when determining soft wrap opportunities for the [=base level=].)
 
 	<div class="example">
-		<p>For example, if two adjacent ruby bases are “蝴” and “蝶”,
+		For example, if two adjacent ruby bases are “蝴” and “蝶”,
 		the line may break between them,
 		because lines are normally allowed to break between two Han characters.
 		However, if 'word-break' is ''keep-all'', that line break is forbidden.
-		<pre>&lt;ruby>蝴&lt;rt>hú&lt;/rt>蝶&lt;rt>dié&lt;/rt></pre>
+		<pre highlight=html>&lt;ruby>蝴&lt;rt>hú&lt;/rt>蝶&lt;rt>dié&lt;/rt></pre>
 	</div>
 
-	<p>Inter-base white space is significant for evaluating line break opportunities between [=ruby bases=].
+	Inter-base white space is significant for evaluating line break opportunities between [=ruby bases=].
 	As with white space between inlines, it collapses when the line breaks there.
 	Similarly, annotation white space is also trimmed at a line break.
 
 	<div class="example">
-		<p>For example, given the following markup:
-		<pre>&lt;ruby>&lt;rb>one&lt;/rb> &lt;rb>two&lt;/rb> &lt;rt>1&lt;/rt> &lt;rt>2&lt;/rt>&lt;/ruby></pre>
-		<p>Due to the space, the line may break between “one” and “two“.
+		For example, given the following markup:
+		<pre highlight=html>&lt;ruby>&lt;rb>one&lt;/rb> &lt;rb>two&lt;/rb> &lt;rt>1&lt;/rt> &lt;rt>2&lt;/rt>&lt;/ruby></pre>
+
+		Due to the space, the line may break between “one” and “two“.
 		If the line breaks there, that space&mdash;and the space between “1” and “2”&mdash;disappears,
 		in accordance with standard CSS white space processing rules. [[CSS3TEXT]]
 	</div>
@@ -762,14 +767,13 @@ Breaking Between Bases</h4>
 <h4 id="break-within">
 Breaking Within Bases</h4>
 
-	<p>For longer base texts, it is sometimes appropriate to allow breaking within a base-annotation pair.
+	For longer base texts, it is sometimes appropriate to allow breaking within a base-annotation pair.
 	For example, if an English sentence is annotated with its Japanese translation,
 	allowing the text to wrap allows for reasonable line breaking behavior in the paragraph.
 
-	<p class="issue">
-	Insert scanned example so people don't think this is just the ramblings of an insane spec-writer.
+	Issue: Insert scanned example so people don't think this is just the ramblings of an insane spec-writer.
 
-	<p>Line-breaking within a [=ruby base=] is only allowed if the 'white-space' property
+	Line-breaking within a [=ruby base=] is only allowed if the 'white-space' property
 	of the [=ruby base=] and all its parallel [=annotations=] allow it,
 	and there exists a [=soft wrap opportunity=] <em>within</em> (i.e. not at the start or end)
 	the content of each base/annotation box.
@@ -779,18 +783,18 @@ Breaking Within Bases</h4>
 	but it is recommended that the UA attempt to proportionally balance
 	the amount of content inside each fragment.
 
-	<p>There are no line breaking opportunities within ''inter-character'' [=annotations=].
+	There are no line breaking opportunities within ''inter-character'' [=annotations=].
 
-	<p>Ruby alignment takes place within each fragment, after line-breaking.
+	Ruby alignment takes place within each fragment, after line-breaking.
 
 <h3 id="bidi">
 Bidi Reordering</h3>
 
-	<p>The Unicode bidirectional algorithm reorders logically-stored text for visual presentation
+	The Unicode bidirectional algorithm reorders logically-stored text for visual presentation
 	when characters from scripts of opposing directionalities are mixed
 	within a single paragraph.
 
-	<p>To preserve the correspondance of [=ruby annotations=]
+	To preserve the correspondance of [=ruby annotations=]
 	to their respective [=ruby bases=],
 	a few restrictions must be imposed:
 	<ul>
@@ -799,16 +803,16 @@ Bidi Reordering</h3>
 		<li>All [=ruby bases=] spanned by a single [=ruby annotation=] must remain contiguous.
 	</ul>
 
-	<p>To this end,
+	To this end,
 	<ul>
 		<li>
 			Bidi isolation is forced on all [=internal ruby boxes=] and the [=ruby container=]:
 			the ''unicode-bidi/normal'' and ''embed'' values of 'unicode-bidi' compute to ''isolate'',
 			and ''bidi-override'' computes to ''isolate-override''.
-			<p class="note">
-				Note this means that implicit bidi reordering does not work across ruby bases,
-				so authors will need to ensure that the [=ruby container=]’s declared directionality
-				does indeed match its contents.
+
+			Note: This means that implicit bidi reordering does not work across ruby bases,
+			so authors will need to ensure that the [=ruby container=]’s declared directionality
+			does indeed match its contents.
 		<li>
 			During layout, [=ruby segments=] are ordered within the [=ruby container=]
 			by the 'direction' property of their [=ruby container=].
@@ -816,32 +820,31 @@ Bidi Reordering</h3>
 			Within a segment, [=ruby bases=] and [=ruby annotations=]
 			are ordered within their respective containers
 			by the 'direction' property of the segment’s [=ruby base container=].
-			<span class="note">
-				Note this means the 'direction' property on [=ruby annotation containers=]
-				is ignored for the purpose of layout.
-				However, it can still inherit into the container's children
-				and thereby affect the [=inline base direction=]
-				of any [=ruby annotations=] it contains.
-			</span>
+
+			Note: This means the 'direction' property on [=ruby annotation containers=]
+			is ignored for the purpose of layout.
+			However, it can still inherit into the container's children
+			and thereby affect the [=inline base direction=]
+			of any [=ruby annotations=] it contains.
 	</ul>
 
-	<p>As with other inline-level content,
+	As with other inline-level content,
 	the bidi reordering of [=internal ruby boxes=] happens after line-breaking
 	so that content is divided across lines according to its logical order.
 
-	<p>See [[CSS3-WRITING-MODES]] for a more in-depth discussion of bidirectional text in CSS.
+	See [[CSS3-WRITING-MODES]] for a more in-depth discussion of bidirectional text in CSS.
 
 	<!-- Some alternate proposals exist in the 2013 draft's comments section. -->
 
 <h3 id="line-height">
 Line Spacing</h3>
 
-	<p>The 'line-height' property controls spacing between lines in CSS.
+	The 'line-height' property controls spacing between lines in CSS.
 	When inline content on line is shorter than the 'line-height',
 	half-leading is added on either side of the content,
 	as specified in <a href="https://www.w3.org/TR/CSS2/visudet.html#line-height">CSS2.1&sect;10.8</a>. [[!CSS2]]
 
-	<p>In order to ensure consistent spacing of lines,
+	In order to ensure consistent spacing of lines,
 	documents with ruby typically ensure that the 'line-height' is large enough
 	to accommodate ruby between lines of text.
 	Therefore, ordinarily, [=ruby annotation containers=] and [=ruby annotation boxes=]
@@ -850,7 +853,7 @@ Line Spacing</h3>
 	are performed using only the [=ruby base container=],
 	exactly as if it were a normal inline.
 
-	<p>However, if the 'line-height' specified on the [=ruby container=]
+	However, if the 'line-height' specified on the [=ruby container=]
 	is less than the distance between
 	the top of the top [=ruby annotation container=]
 	and the bottom of the bottom [=ruby annotation container=],
@@ -860,19 +863,19 @@ Line Spacing</h3>
 	each containing ruby identical to this,
 	none of the [=ruby containers=] would overlap.
 
-	<p class="note">Note that this does not ensure that the [=ruby annotations=] remain within the line box.
+	Note: This does not ensure that the [=ruby annotations=] remain within the line box.
 	It merely ensures that <em>if all lines had equal spacing</em>
 	and equivalent amounts and positioning of [=ruby annotations=],
 	there would be enough room to avoid overlap.
 
-	<p>Authors should ensure appropriate 'line-height' and 'padding' to accommodate ruby,
+	Authors should ensure appropriate 'line-height' and 'padding' to accommodate ruby,
 	and be particularly careful at the beginning or end of a block
 	and when a line contains inline-level content
 	(such as images, inline blocks, or elements shifted with 'vertical-align')
 	taller than the paragraph's default font size.
 
 	<div class="figure">
-		<p><img src="images/rlh-a.gif"
+		<img src="images/rlh-a.gif"
 		        alt="The content of each line sits in the middle of its line height;
 		             the additional space on each side is called half-leading.
 		             Ruby fits between lines if it is smaller than twice the half-leading,
@@ -882,7 +885,7 @@ Line Spacing</h3>
 		is adequately spaced to leave room for the ruby.
 	</div>
 
-	<p class="note">More control over how ruby affects alignment and line layout
+	Note: More control over how ruby affects alignment and line layout
 	will be part of the CSS Line Layout Module Level 3.
 	Note, it is currently in the process of being rewritten;
 	the current drafts should not be relied upon.
@@ -890,7 +893,7 @@ Line Spacing</h3>
 <h2 id="ruby-props">
 Ruby Formatting Properties</h2>
 
-	<p>The following properties are introduced to control ruby
+	The following properties are introduced to control ruby
 	<a href="#rubypos">positioning</a>,
 	<a href="#collapsed-ruby">text distribution</a>,
 	and <a href="#rubyalign">alignment</a>.
@@ -908,38 +911,40 @@ Ruby Positioning: the 'ruby-position' property</h3>
 	Animation type: discrete
 	</pre>
 
-	<p>This property controls position of the ruby text with respect to its base.
+	This property controls position of the ruby text with respect to its base.
 	Values have the following meanings:
 
-	<p class="issue"><span class="issuehead">Issue-107:&nbsp;</span> Roland Steiner has requested the addition of an auto value as default. See <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=ruby-position%3A+undesirable+default+value+%27before%27+for+complex+ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=www-style&amp;resultsperpage=20&amp;sortby=date">this thread</a> and <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=Styling+of+complex+Ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=public-i18n-core&amp;resultsperpage=20&amp;sortby=date">this one</a>. Current proposal is to add an optional ''alternate?'' keyword.</p>
+	Issue: <span class="issuehead">Issue-107:&nbsp;</span> Roland Steiner has requested the addition of an auto value as default. See <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=ruby-position%3A+undesirable+default+value+%27before%27+for+complex+ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=www-style&amp;resultsperpage=20&amp;sortby=date">this thread</a> and <a href="http://www.w3.org/Search/Mail/Public/advanced_search?keywords=&amp;hdr-1-name=subject&amp;hdr-1-query=Styling+of+complex+Ruby&amp;hdr-2-name=from&amp;hdr-2-query=&amp;hdr-3-name=message-id&amp;hdr-3-query=&amp;period_month=&amp;period_year=&amp;index-grp=Public__FULL&amp;index-type=t&amp;type-index=public-i18n-core&amp;resultsperpage=20&amp;sortby=date">this one</a>. Current proposal is to add an optional ''alternate?'' keyword.
+
 	<dl dfn-for=ruby-position dfn-type=value>
 		<dt><dfn>over</dfn>
 		<dd>The ruby text appears [=line-over=] the base.
 
 			<div class="figure">
-				<p><img src="images/shinkansen-top.gif"
+				<img src="images/shinkansen-top.gif"
 				        alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing above the base">
 				<p class="caption">Ruby over Japanese base text in horizontal layout
 			</div>
 			<div class="figure">
-				<p><img src="images/shinkansen-right.gif" width="33"
+				<img src="images/shinkansen-right.gif" width="33"
 				        alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the right of the base">
 				<p class="caption">Ruby to the right of Japanese base text in vertical layout
 			</div>
 		</dd>
 
 		<dt><dfn>under</dfn>
-		<dd>The ruby text appears [=line-under=] the base.
+		<dd>
+			The ruby text appears [=line-under=] the base.
 			This is a relatively rare setting used in ideographic East Asian writing systems,
 			most easily found in educational text.
 
 			<div class="figure">
-				<p><img src="images/shinkansen-bottom.gif"
+				<img src="images/shinkansen-bottom.gif"
 				        alt="Diagram of ruby glyph layout in horizontal mode with ruby text appearing below the base">
 				<p class="caption">Ruby under Japanese base text in horizontal layout
 			</div>
 			<div class="figure">
-				<p><img src="images/shinkansen-left.gif"
+				<img src="images/shinkansen-left.gif"
 				        alt="Diagram of ruby glyph layout in vertical mode with ruby text appearing vertically on the left of the base">
 				<p class="caption">Ruby to the left of Japanese base text in vertical layout
 			</div>
@@ -947,17 +952,17 @@ Ruby Positioning: the 'ruby-position' property</h3>
 
 		<dt><dfn>inter-character</dfn></dt>
 		<dd>
-			<p>The ruby text appears on the right of the base in horizontal text.
+			The ruby text appears on the right of the base in horizontal text.
 			This value forces the computed value of 'writing-mode' of the [=ruby annotation container=] to be ''vertical-rl''.
 
-			<p>This value is provided for the special case of traditional Chinese
+			This value is provided for the special case of traditional Chinese
 			as used especially in Taiwan:
 			ruby (made of <a href="#g-bopomofo">bopomofo</a> glyphs) in that context
 			appears vertically along the right side of the base glyph,
 			even when the layout of the base characters is horizontal:
 
 				<div class="figure">
-					<p><img src="images/bopomofo.gif"
+					<img src="images/bopomofo.gif"
 					        alt="Example of Taiwanese-style ruby">
 					<p class="caption">“Bopomofo” ruby in traditional Chinese
 					(ruby text shown in blue for clarity) in horizontal layout
@@ -965,7 +970,7 @@ Ruby Positioning: the 'ruby-position' property</h3>
 		</dd>
 	</dl>
 
-	<p>If multiple [=ruby annotation containers=] have the same 'ruby-position',
+	If multiple [=ruby annotation containers=] have the same 'ruby-position',
 	they stack along the block axis,
 	with lower levels of annotation closer to the base text.
 
@@ -982,52 +987,47 @@ Sharing Annotation Space: the 'ruby-merge' property</h3>
 	Animation type: by computed value type
 	</pre>
 
-	<p>
-		This property controls how ruby annotation boxes should be rendered
-		when there are more than one in a ruby container box:
-		whether each pair should be kept separate,
-		the annotations should be <dfn lt="collapsed annotation">collapsed</dfn> and rendered as a group,
-		or the separation should be determined based on the space available.
+	This property controls how ruby annotation boxes should be rendered
+	when there are more than one in a ruby container box:
+	whether each pair should be kept separate,
+	the annotations should be <dfn lt="collapsed annotation">collapsed</dfn> and rendered as a group,
+	or the separation should be determined based on the space available.
 
-	<p>Possible values:</p>
+	Possible values:
 	<dl dfn-for=ruby-merge dfn-type=value>
 		<dt><dfn>separate</dfn>
 		<dd>
-			<p>
-				Each ruby annotation box is rendered in the same column(s) as its corresponding base box(es).
-				This style is called “mono ruby” in [[JLREQ]].
+			Each ruby annotation box is rendered in the same column(s) as its corresponding base box(es).
+			This style is called “mono ruby” in [[JLREQ]].
 
 			<div class="example">
-				<p>For example, the following two markups render the same:
-				<pre>&lt;ruby&gt;無&lt;rt&gt;む&lt;/ruby&gt;&lt;ruby&gt;常&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
-				<p>and:
-				<pre>&lt;ruby style="ruby-merge:separate"&gt;&lt;rb&gt;無&lt;rb&gt;常&lt;rt&gt;む&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
+				For example, the following two markups render the same:
+				<pre highlight=html>&lt;ruby&gt;無&lt;rt&gt;む&lt;/ruby&gt;&lt;ruby&gt;常&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
+				and:
+				<pre highlight=html>&lt;ruby style="ruby-merge:separate"&gt;&lt;rb&gt;無&lt;rb&gt;常&lt;rt&gt;む&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
 			</div>
 		</dd>
 
 		<dt><dfn>collapse</dfn>
 		<dd>
-			<p>
-				All [=ruby annotation boxes=] within the same [=ruby segment=] on the same line are concatenated,
-				and laid out as if their contents belonged to a single [=ruby annotation box=]
-				spanning all their associated [=ruby base boxes=].
-				This style renders similar to “group ruby” in [[JLREQ]],
-				except that [=ruby annotations=] are kept together with their respective [=ruby bases=] when breaking lines.
-			</p>
+			All [=ruby annotation boxes=] within the same [=ruby segment=] on the same line are concatenated,
+			and laid out as if their contents belonged to a single [=ruby annotation box=]
+			spanning all their associated [=ruby base boxes=].
+			This style renders similar to “group ruby” in [[JLREQ]],
+			except that [=ruby annotations=] are kept together with their respective [=ruby bases=] when breaking lines.
 
 			<div class="example">
-				<p>The following two markups render the same both characters fit on one line:
-				<pre>&lt;ruby&gt;無常&lt;rt&gt;むじょう&lt;/ruby&gt;</pre>
-				<p>and:
-				<pre>&lt;ruby style="ruby-merge:collapse"&gt;&lt;rb&gt;無&lt;rb&gt;常&lt;rt&gt;む&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
-				<p>However, the second one renders the same as ''ruby-position: separate''
+				The following two markups render the same both characters fit on one line:
+				<pre highlight=html>&lt;ruby&gt;無常&lt;rt&gt;むじょう&lt;/ruby&gt;</pre>
+				and:
+				<pre highlight=html>&lt;ruby style="ruby-merge:collapse"&gt;&lt;rb&gt;無&lt;rb&gt;常&lt;rt&gt;む&lt;rt&gt;じょう&lt;/ruby&gt;</pre>
+				However, the second one renders the same as ''ruby-position: separate''
 				when the two bases are split across lines.
 			</div>
 		</dd>
 
 		<dt><dfn>auto</dfn></dt>
 		<dd>
-			<p>
 				The user agent may use any algorithm to determine how each ruby annotation box
 				is rendered to its corresponding base box,
 				with the intention that if all annotations fit over their respective bases,
@@ -1036,14 +1036,12 @@ Sharing Annotation Space: the 'ruby-merge' property</h3>
 				the space is shared in some way
 				to avoid imposing space between bases.
 			<div class="example">
-			<p>
 				One possible algorithm is described as “jukugo ruby” in [[JLREQ]].
-			<p>
+
 				Another, more simplified algorithm of “jukugo ruby” is
 				to render as ''separate'' if all ruby annotation boxes fit
 				within the advances of their corresponding base boxes,
 				and render as ''collapse'' otherwise.
-			</p>
 			</div>
 		</dd>
 	</dl>
@@ -1061,17 +1059,18 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 	Animation type: by computed value type
 	</pre>
 
-	<p>This property specifies how text is distributed within the various ruby boxes
+	This property specifies how text is distributed within the various ruby boxes
 	when their contents do not exactly fill their respective boxes.
 	Note that space distributed by 'ruby-align' is unrelated to, and independent of,
 	any space distributed due to justification.
 
-	<p>Values have the following meanings:
+	Values have the following meanings:
 	<dl dfn-for=ruby-align dfn-type=value>
 		<dt><dfn>start</dfn></dt>
-		<dd>The ruby content is aligned with the start edge of its box.
+		<dd>
+			The ruby content is aligned with the start edge of its box.
 			<div class="figure">
-				<p><img
+				<img
 					alt="Diagram of glyph layout in left aligned ruby when ruby text is shorter than base"
 					width="145" height="91" src="images/ra-l.gif" /><img
 					width="145" height="91"
@@ -1084,7 +1083,7 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		<dt><dfn>center</dfn></dt>
 		<dd>The ruby content is centered within its box.
 			<div class="figure">
-				<p><img width="145" height="91"
+				<img width="145" height="91"
 					alt="Diagram of glyph layout in center aligned ruby when ruby text is shorter than base"
 					src="images/ra-c.gif" /><img width="145" height="91"
 					alt="Diagram of glyph layout in center aligned ruby when ruby text is longer than base"
@@ -1095,12 +1094,12 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 
 		<dt><dfn>space-between</dfn></dt>
 		<dd>
-			<p>The ruby content expands as defined for normal text justification
+			The ruby content expands as defined for normal text justification
 				(as defined by 'text-justify'),
 				except that if there are no [=justification opportunities=]
 				the content is centered.
 			<div class="figure">
-				<p><img width="145" height="91"
+				<img width="145" height="91"
 				alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is shorter than base"
 				src="images/ra-dl.gif" /><img width="145" height="91"
 				alt="Diagram of glyph layout in distribute-letter aligned ruby when ruby text is longer than base"
@@ -1111,26 +1110,27 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 
 		<dt><dfn>space-around</dfn></dt>
 		<dd>
-			<p>As for ''ruby-align/space-between''
+			As for ''ruby-align/space-between''
 			except that there exists an extra [=justification opportunities=]
 			whose space is distributed half before and half after the ruby content.
 			<div class="example">
-				<p>Since a typical implementation will by default define [=justification opportunities=]
-					between every adjacent pair of CJK [=characters=]
-					and not between adjacent pairs of Latin [=characters=],
-					this should result in the behavior recommended by [[JLREQ]]:
-					for wide-cell ruby content to be distributed...
+				Since a typical implementation will by default define [=justification opportunities=]
+				between every adjacent pair of CJK [=characters=]
+				and not between adjacent pairs of Latin [=characters=],
+				this should result in the behavior recommended by [[JLREQ]]:
+				for wide-cell ruby content to be distributed...
 				<div class="figure">
-					<p><img width="145" height="91"
+					<img width="145" height="91"
 					alt="Diagram of glyph layout in auto aligned ruby when ruby text is shorter than base"
 					src="images/ra-ds.gif" /><img width="145" height="91"
 					alt="Diagram of glyph layout in auto aligned ruby when ruby text is longer than base"
 					src="images/ra-ds-rb.gif" />
 					<p class="caption">Wide-cell text in ''ruby-align/space-around'' ruby distribution is spaced apart
 				</div>
-				<p>... and narrow-cell glyph ruby to be centered.
+
+				... and narrow-cell glyph ruby to be centered.
 				<div class="figure">
-					<p><img
+					<img
 					alt="Diagram of glyph layout in auto aligned ruby when halfwidth ruby text is shorter than base"
 					width="145" height="91"
 					src="images/ra-c-h.gif" /><img
@@ -1143,40 +1143,41 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		</dd>
 	</dl>
 
-	<p class="issue">Add a paragraph explaining how to distribute space in situations with [=spanning annotations=].
+	Issue: Add a paragraph explaining how to distribute space in situations with [=spanning annotations=].
 <!--
-	<p>For a complex ruby with spanning elements, one additional consideration is
-		required. If the spanning element spans multiple 'rows' (other rbc or rtc
-		elements), and the ruby alignment requires space distribution among the
-		'spanned' elements, a ratio must be determined among the 'columns' of spanned
-		elements. This ratio is computed by taking into consideration the widest
-		element within each column.</p>
+	For a complex ruby with spanning elements, one additional consideration is
+	required. If the spanning element spans multiple 'rows' (other rbc or rtc
+	elements), and the ruby alignment requires space distribution among the
+	'spanned' elements, a ratio must be determined among the 'columns' of spanned
+	elements. This ratio is computed by taking into consideration the widest
+	element within each column.
 -->
 
 <h3 id="ruby-text-decoration">
 Ruby Text Decoration</h3>
 
-	<p>Text decoration does not propagate from the base text to the annotations.
-	<p>When text decoration is specified on an ancestor of the ruby,
+	Text decoration does not propagate from the base text to the annotations.
+
+	When text decoration is specified on an ancestor of the ruby,
 	it is drawn across the entire content area of the ruby base container,
 	including any extra space added on either side of the ruby base contents to accommodate long annotations.
 	When text decoration is specified on a ruby base itself,
 	this extra space is not decorated,
 	similar to how a box's own padding is not decorated when text decoration is specified directly on that box. [[!CSS3-TEXT-DECOR]]
 
-	<p>Text decoration may be specified directly on ruby base containers
+	Text decoration may be specified directly on ruby base containers
 	and ruby annotation containers:
 	in such cases it is propagated to all of the container's bases or annotations (respectively),
 	and is also drawn between them for continuity.
 
-	<p>The positions of ruby annotations may be adjusted
+	The positions of ruby annotations may be adjusted
 	to avoid potential conflicts
 	with overline and underline decorations applied to the base text.
 	In the basic case of consistent font size and baseline alignment,
 	an underline or overline is positioned
 	between the [=base level=] and any annotations on that side.
 
-	<p class="issue">This section needs some clarification about
+	Issue: This section needs some clarification about
 	drawing decorations between the content of adjacent bases/annotations.
 	Depends on if those boxes are as wide as their column or not.
 
@@ -1186,77 +1187,69 @@ Edge Effects</h2>
 <h3 id="ruby-overhang">
 Overhanging Ruby</h3>
 
-	<p>
-		When [=ruby annotation box=] is longer than its corresponding [=ruby base box=],
-		the [=ruby annotation box=] may partially overhang adjacent boxes.
-	</p>
-	<p>
-		This level of the specification does not define
-		how much the overhang may be allowed, and under what conditions.
-	</p>
+	When [=ruby annotation box=] is longer than its corresponding [=ruby base box=],
+	the [=ruby annotation box=] may partially overhang adjacent boxes.
 
-	<p>If the ruby text is not allowed to overhang,
+	This level of the specification does not define
+	how much the overhang may be allowed, and under what conditions.
+
+	If the ruby text is not allowed to overhang,
 	then the ruby behaves like a traditional inline box,
 	i.e. only its own contents are rendered within its boundaries
 	and adjacent elements do not cross the box boundary:
 
 	<div class="figure">
-		<p><img src="images/ro-n.gif"
+		<img src="images/ro-n.gif"
 		        alt="Diagram showing the ruby boxes interacting with adjacent text">
 		<p class="caption">Simple ruby whose text is not allowed to overhang adjacent text
 	</div>
 
-	<p>However, if [=ruby annotation=] content is allowed to overhang adjacent elements
+	However, if [=ruby annotation=] content is allowed to overhang adjacent elements
 	and it happens to be wider than its base,
 	then the adjacent content is partially rendered within the area of the [=ruby container box=],
 	while the [=ruby annotation=] may partially overlap the upper blank parts of the adjacent content:
 
 	<div class="figure">
-	<p><img src="images/ro-a.gif"
+		<img src="images/ro-a.gif"
 		      alt="Diagram showing the ruby boxes interacting with adjacent text">
-	<p class="caption">Simple ruby whose text is allowed to overhang adjacent text
+		<p class="caption">Simple ruby whose text is allowed to overhang adjacent text
 	</div>
 
-	<p>The [=ruby annotations=] related to a [=ruby base=]
+	The [=ruby annotations=] related to a [=ruby base=]
 	must never overhang another [=ruby base=].
 
-	<p>The alignment of the contents of the base or the ruby text
+	The alignment of the contents of the base or the ruby text
 	is not affected by overhanging behavior.
 	The alignment is achieved the same way regardless of the overhang behavior setting
 	and it is computed before the space available for overlap is determined.
 	It is controlled by the 'ruby-align' property.
 
-	<p class="issue">
-		I suspect overhanging interacts with alignment in some cases;
-		might need to look into this later.
+	Issue: I suspect overhanging interacts with alignment in some cases;
+	might need to look into this later.
 
-	<p>This entire logic applies the same way in vertical ideographic layout,
+	This entire logic applies the same way in vertical ideographic layout,
 	only the dimension in which it works in such a layout is vertical,
 	instead of horizontal.
 
 	<div class="example">
-	<p>
 		The user agent may use [[JIS4051]] recommendation of
 		using one ruby text character length as the maximum overhang length.
 		Detailed rules for how ruby text can overhang adjacent characters for Japanese are described by [[JLREQ]].
-	</p>
 	</div>
 
 <h3 id="line-edge">
 Line-edge Alignment</h3>
 
-	<p>
-		When a [=ruby annotation box=] that is longer than its [=ruby base=]
-		is at the start or end edge of a line,
-		the user agent <em>may</em> force the side of the [=ruby annotation=] that touches the edge of the line
-		to align to the corresponding edge of the base.
-		This type of alignment is described by [[JLREQ]].
-	</p>
-	<p>
-		This level of the specification does not provide a mechanism to control this behavior.
-	</p>
+	When a [=ruby annotation box=] that is longer than its [=ruby base=]
+	is at the start or end edge of a line,
+	the user agent <em>may</em> force the side of the [=ruby annotation=] that touches the edge of the line
+	to align to the corresponding edge of the base.
+	This type of alignment is described by [[JLREQ]].
+
+	This level of the specification does not provide a mechanism to control this behavior.
+
 	<div class="figure">
-		<p><img src="images/ra-le-l.gif"
+		<img src="images/ra-le-l.gif"
 			alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is shorter than base">
 			<img src="images/ra-le-r.gif"
 			alt="Diagram of glyph layout in line-edge aligned ruby when ruby text is longer than base">
@@ -1291,24 +1284,24 @@ Ruby overhanging: the 'ruby-overhang' property</h3>
       <td>specified value (except for initial and inherit)
   </table>
 
-<p>This property determines whether, and on which side, ruby text is allowed
+This property determines whether, and on which side, ruby text is allowed
 to partially overhang any adjacent text in addition to its own base, when the
 ruby text is wider than the ruby base. Note that ruby text is never allowed to
 overhang glyphs belonging to another ruby base. <span class="issue"><span class="issuehead">Issue:&nbsp;</span> This rule must be broken if we are to allow support for jukugo ruby.</span> Also the user agent is free to assume
 a maximum amount by which ruby text may overhang adjacent text. The user agent may use
 the [[JIS4051]] recommendation of using one ruby text character
-length as the maximum overhang length. Detailed rules for how ruby text can overhang adjacent characters for Japanese are described by [[JLREQ]].</p>
+length as the maximum overhang length. Detailed rules for how ruby text can overhang adjacent characters for Japanese are described by [[JLREQ]].
 
-<p>Possible values:</p>
+Possible values:
 <dl>
   <dt><strong>auto</strong></dt>
     <dd>The ruby text can overhang text adjacent to the base on either side.   	  [[JLREQ]] and [[JIS4051]] specify the categories of characters that
       ruby text can overhang. The user agent is free to follow those recommendations or specify its own classes of
       characters to overhang. This is the initial value.
 		<div class="figure">
-      <p><img class="example" width="177" height="91"
-      alt="Diagram of glyph layout in overhanging ruby" src="images/ro-a.gif" /></p>
-      <p><b>Figure 4.3.1</b>: Ruby overhanging adjacent text</p>
+      <img class="example" width="177" height="91"
+      alt="Diagram of glyph layout in overhanging ruby" src="images/ro-a.gif" />
+      <b>Figure 4.3.1</b>: Ruby overhanging adjacent text
       </div>
     </dd>
   <dt><strong>start</strong></dt>
@@ -1317,10 +1310,10 @@ length as the maximum overhang length. Detailed rules for how ruby text can over
       horizontal LTR layout, and it cannot overhang text that is below it in
       vertical-ideographic layout.
 		<div class="figure">
-      <p><img class="example" width="199" height="91"
+      <img class="example" width="199" height="91"
       alt="Diagram of glyph layout when ruby overhangs the preceding glyphs only"
-      src="images/ro-s.gif" /></p>
-      <p><b>Figure 4.3.2</b>: Ruby overhanging preceding text only</p>
+      src="images/ro-s.gif" />
+      <b>Figure 4.3.2</b>: Ruby overhanging preceding text only
       </div>
     </dd>
   <dt><strong>end</strong></dt>
@@ -1329,10 +1322,10 @@ length as the maximum overhang length. Detailed rules for how ruby text can over
       horizontal LTR layout, and it cannot overhang text that is above it in
       vertical-ideographic layout.
 		<div class="figure">
-      <p><img class="example" width="198" height="91"
+      <img class="example" width="198" height="91"
       alt="Diagram of glyph layout when ruby overhangs the following characters only"
-      src="images/ro-e.gif" /></p>
-      <p><b>Figure 4.3.3</b>: Ruby overhanging following text only</p>
+      src="images/ro-e.gif" />
+      <b>Figure 4.3.3</b>: Ruby overhanging following text only
       </div>
     </dd>
   <dt><strong>none</strong></dt>
@@ -1340,10 +1333,10 @@ length as the maximum overhang length. Detailed rules for how ruby text can over
       own base.
 
       <div class="figure">
-      <p><img class="example" width="220" height="91"
+      <img class="example" width="220" height="91"
       alt="Diagram of glyph layout in non-overhanging ruby"
-      src="images/ro-n.gif" /></p>
-      <p><b>Figure 4.3.4</b>: Ruby not allowed to overhang adjacent text</p>
+      src="images/ro-n.gif" />
+      <b>Figure 4.3.4</b>: Ruby not allowed to overhang adjacent text
       </div>
     </dd>
 </dl>
@@ -1375,12 +1368,12 @@ Ruby annotation spanning: the 'ruby-span' property</h3>
       <td>&lt;number&gt;
   </table>
 
-<p>This property controls the spanning behavior of annotation elements. </p>
+This property controls the spanning behavior of annotation elements.
 
-<p class="note"><span class="note-label">Note:</span> A XHTML user agent may also use the <samp>rbspan</samp>
-attribute to get the same effect.</p>
+Note: A XHTML user agent may also use the <samp>rbspan</samp>
+attribute to get the same effect.
 
-<p>Possible values:</p>
+Possible values:
 
 <dl>
   <dt><strong>attr(x)</strong></dt>
@@ -1392,8 +1385,8 @@ attribute to get the same effect.</p>
   <dd>No spanning. The computed value is &#39;1&#39;.</dd>
 </dl>
 
-<p>The following example shows an XML example using the 'display' property
-values associated with the 'ruby structure and the 'ruby-span' property</p>
+The following example shows an XML example using the 'display' property
+values associated with the 'ruby structure and the 'ruby-span' property
 <pre class="xml">myruby       { display: ruby; }
 myrbc        { display: ruby-base-container; }
 myrb         { display: ruby-base; }
@@ -1421,15 +1414,15 @@ myrt         { display: ruby-text; ruby-span: attr(rbspan); }
 <h2 id="default-stylesheet" class="no-num">
 Appendix A: Default Style Sheet</h2>
 
-	<p><em>This section is informative.</em>
+	<em>This section is informative.</em>
 
 <h3 id="default-ua-ruby" class="no-num">
 <span class="secno">A.1</span> Supporting Ruby Layout</h3>
 
-	<p>The following represents a default UA style sheet
+	The following represents a default UA style sheet
 	for rendering HTML and XHTML ruby markup as ruby layout:
 
-	<pre>
+	<pre highlight=css>
 		ruby { display: ruby; }
 		rp   { display: none; }
 		rbc  { display: ruby-base-container; }
@@ -1452,42 +1445,43 @@ Appendix A: Default Style Sheet</h2>
 			font-size: 30%; }               /* bopomofo */
 	</pre>
 
-	<p class="note">Authors should not use the above rules:
+	Note: Authors should not use the above rules:
 	a UA that supports ruby layout should provide these by default.
 
 <h3 id="default-inline" class="no-num">
 <span class="secno">A.2</span> Inlining Ruby Annotations</h3>
 
-	<p>The following represents a sample style sheet
+	The following represents a sample style sheet
 	for rendering HTML and XHTML ruby markup as inline annotations:
 
-	<pre>ruby, rb, rt, rbc, rtc, rp {
-<!--	-->  display: inline; white-space: inherit;
-<!--	-->  font: inherit; text-emphasis: inherit; }</pre>
+	<pre highlight=css>
+		ruby, rb, rt, rbc, rtc, rp {
+			display: inline; white-space: inherit;
+			font: inherit; text-emphasis: inherit; }</pre>
 
 <h3 id="default-parens" class="no-num">
 <span class="secno">A.3</span> Generating Parentheses</h3>
 
-	<p>Unfortunately, because Selectors cannot match against text nodes,
+	Unfortunately, because Selectors cannot match against text nodes,
 	it's not possible with CSS to express rules that will automatically and correctly
 	add parentheses to unparenthesized ruby annotations in HTML.
 	(This is because HTML ruby allows implying the [=ruby base=] from raw text, without a corresponding element.)
 	However, these rules will handle cases where either <code>&lt;rb&gt;</code>
 	or <code>&lt;rtc&gt;</code> is used rigorously.
 
-	<pre>
-<!--	-->/* Parens around &lt;rtc> */
-<!--	-->rtc::before { content: "("; }
-<!--	-->rtc::after  { content: ")"; }
+	<pre highlight=css>
+		/* Parens around &lt;rtc> */
+		rtc::before { content: "("; }
+		rtc::after  { content: ")"; }
 
-<!--	-->/* Parens before first &lt;rt> not inside &lt;rtc> */
-<!--	-->rb  + rt::before,
-<!--	-->rtc + rt::before { content: "("; }
+		/* Parens before first &lt;rt> not inside &lt;rtc> */
+		rb  + rt::before,
+		rtc + rt::before { content: "("; }
 
-<!--	-->/* Parens after &lt;rt> not inside &lt;rtc> */
-<!--	-->rb ~ rt:last-child::after,
-<!--	-->rt + rb::before  { content: ")"; }
-<!--	-->rt + rtc::before { content: ")("; }</pre>
+		/* Parens after &lt;rt> not inside &lt;rtc> */
+		rb ~ rt:last-child::after,
+		rt + rb::before  { content: ")"; }
+		rt + rtc::before { content: ")("; }</pre>
 
 <h2 id="glossary">
 Glossary</h2>
@@ -1495,14 +1489,14 @@ Glossary</h2>
   <dt id="g-bopomofo" lang="zh">Bopomofo
     <dd>37 characters and 4 tone markings used as phonetics in Chinese,
       especially standard Mandarin.
-      <p class="note">
-          Note that the user agent is responsible for ensuring the correct relative alignment and positioning of the glyphs,
-          including bopomofo tone marks, when displaying text,
-          whether it occurs in ruby annotations or as normal inline text.
-          Bopomofo Tone marks are spacing characters that occur (in memory) at the end of the ruby text for each base character.
-          They are usually displayed in a separate column to the right of or above the bopomofo characters,
-          and the position of the tone mark depends on the number of characters in the syllable.
-          One tone mark, however, is placed before the bopomofo, not over it.
+
+      Note: The user agent is responsible for ensuring the correct relative alignment and positioning of the glyphs,
+      including bopomofo tone marks, when displaying text,
+      whether it occurs in ruby annotations or as normal inline text.
+      Bopomofo Tone marks are spacing characters that occur (in memory) at the end of the ruby text for each base character.
+      They are usually displayed in a separate column to the right of or above the bopomofo characters,
+      and the position of the tone mark depends on the number of characters in the syllable.
+      One tone mark, however, is placed before the bopomofo, not over it.
       <!-- See Taiwanese requirements doc for EPUB at http://epub-revision.googlecode.com/files/EGLS_TW_eng.ppt -->
   <dt id="g-hanja" lang="ko">Hanja
     <dd>Subset of the Korean writing system that utilizes ideographic
@@ -1536,9 +1530,8 @@ Glossary</h2>
 <h2 class=no-num id="acknowledgments">
 Acknowledgments</h2>
 
-	<p>This specification would not have been possible without the help from:</p>
+	This specification would not have been possible without the help from:
 
-	<p>
 	David Baron,
 	Robin Berjon,
 	Stephen Deach,
@@ -1555,7 +1548,7 @@ Acknowledgments</h2>
 	Boris Zbarsky,
 	Steve Zilles.
 
-	<p>Special thanks goes to the previous editors:
+	Special thanks goes to the previous editors:
 	Michel Suignard and Marcin Sawicki of Microsoft,
 	and Richard Ishida of W3C.
 

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -117,9 +117,9 @@ What is ruby?</h3>
 		the spacing between these Kanji characters is adjusted.
 		(This happens around the fourth Kanji character in the figure above.)
 		To avoid variable spacing between the Kanji characters in the example above
-		the hiragana annotations can be styled as a <i>collapsed annotation</i>,
+		the hiragana annotations can be styled as a [=collapsed annotation=],
 		which will look more like the group-ruby example earlier.
-		However because the base-annotation pairings are recorded in the ruby structure,
+		However because the base-annotation [=pairings=] are recorded in the ruby structure,
 		if the text breaks across lines, the annotation characters will stay
 		correctly paired with their respective base characters.
 	</div>
@@ -141,14 +141,14 @@ Ruby Box Model</h2>
 	one or more <i>ruby base</i> elements representing the base (annotated) text,
 	associated with one or more levels of <i>ruby annotation</i> elements representing the annotations.
 	The structure of ruby is similar to that of a table:
-	there are “rows” (the <i lt="base level">base text level</i>, each <i>annotation level</i>)
+	there are “rows” (the [=base text level=], each [=annotation level=])
 	and “columns” (each <i>ruby base</i> and its corresponding <i>ruby annotations</i>).
 
-	<p>Consecutive bases and annotations are grouped together into <i>ruby segments</i>.
-	Within a <i>ruby segment</i>, a <i>ruby annotation</i> may span multiple <i>ruby bases</i>.
+	<p>Consecutive bases and annotations are grouped together into [=ruby segments=].
+	Within a [=ruby segment=], a <i>ruby annotation</i> may span multiple <i>ruby bases</i>.
 
-	<p class="note">In HTML, a single <code>&lt;ruby&gt;</code> element may contain multiple <i>ruby segments</i>.
-	(In the XHTML Ruby model, a single <code>&lt;ruby&gt;</code> element can only contain one <i>ruby segment</i>.)
+	<p class="note">In HTML, a single <code>&lt;ruby&gt;</code> element may contain multiple [=ruby segments=].
+	(In the XHTML Ruby model, a single <code>&lt;ruby&gt;</code> element can only contain one [=ruby segment=].)
 
 <h3 id="ruby-display">
 Ruby-specific 'display' Values</h3>
@@ -298,16 +298,16 @@ Anonymous Ruby Box Generation</h3>
 			as described below.
 
 		<li id="anony-gen-trim-space"><strong>Trim leading/trailing white space:</strong>
-			Any <i>intra-ruby white space</i>
+			Any [=intra-ruby white space=]
 			that is not the sole child of its parent
 			and occurs at the beginning or end of
 			a <i>ruby container</i>, <i>ruby annotation container</i>, or <i>ruby base container</i>
 			is removed, as if it had ''display: none''
 
 		<li id="anon-gen-discard-space"><strong>Remove inter-level white space:</strong>
-			Any <i>intra-ruby white space</i>
+			Any [=intra-ruby white space=]
 			whose immediately adjacent siblings match one of the patterns below
-			is <dfn>inter-level white space</dfn>
+			is <dfn noexport>inter-level white space</dfn>
 			and is removed, as if it had ''display: none''.
 			<table class="data">
 			<thead>
@@ -331,7 +331,7 @@ Anonymous Ruby Box Generation</h3>
 			</table>
 
 		<li id="anon-gen-interpret-space"><strong>Interpret intra-level white space:</strong>
-			Any <i>intra-ruby white space</i> box
+			Any [=intra-ruby white space=] box
 			whose immediately adjacent siblings match one of the patterns below
 			is assigned the box type and subtype defined in the table below:
 			<table class="data">
@@ -361,7 +361,7 @@ Anonymous Ruby Box Generation</h3>
 				    <td><i>ruby base</i> or <i>ruby base container</i>
 			</table>
 			The <dfn>intra-level white space</dfn> boxes defined above are
-			treated specially for pairing and layout. See below.
+			treated specially for [=pairing=] and layout. See below.
 
 		<li id="anon-gen-unbreak"><strong>Suppress line breaks:</strong>
 			Convert all forced line breaks inside <i>ruby annotations</i> (regardless of 'white-space' value)
@@ -371,10 +371,10 @@ Anonymous Ruby Box Generation</h3>
 
 		<li id="anon-gen-anon-containers"><strong>Generate anonymous level containers:</strong>
 			Any consecutive sequence of <i>ruby bases</i> and <i>inter-base white space</i>
-			(and not <i>inter-segment white space</i>)
+			(and not [=inter-segment white space=])
 			not parented by a <i>ruby base container</i>
 			is wrapped in an anonymous <i>ruby base container</i>.
-			Similarly, any consecutive sequence of <i>ruby annotations</i> and <i>inter-annotation white space</i>
+			Similarly, any consecutive sequence of <i>ruby annotations</i> and [=inter-annotation white space=]
 			not parented by a <i>ruby annotation container</i>
 			is wrapped in an anonymous <i>ruby annotation container</i>.
 	</ol>
@@ -386,9 +386,9 @@ Anonymous Ruby Box Generation</h3>
 
 	<p class="note">
 	Note that the UA is not required to create any of these anonymous boxes
-	(or the anonymous empty <i>intra-level white space</i> boxes in the pairing section)
+	(or the anonymous empty [=intra-level white space=] boxes in [[#ruby-pairing]])
 	in its internal structures,
-	as long as pairing and layout behaves as if they existed.
+	as long as [=pairing=] and layout behaves as if they existed.
 
 <h3 id="ruby-pairing">
 Annotation Pairing</h3>
@@ -397,18 +397,18 @@ Annotation Pairing</h3>
 	<i>ruby annotations</i> with <i>ruby bases</i>.
 	Each <i>ruby annotation</i> is associated with one or more <i>ruby bases</i>,
 	and is said to <dfn>span</dfn> those bases.
-	(A <i>ruby annotation</i> that <i>spans</i> multiple bases is called
+	(A <i>ruby annotation</i> that [=spans=] multiple bases is called
 	a <dfn>spanning annotation</dfn>.)
 
 	A <i>ruby base</i> is can be associated with
-	only one <i>ruby annotation</i> per <i>annotation level</i>.
-	However, if there are multiple <i>annotation levels</i>,
+	only one <i>ruby annotation</i> per [=annotation level=].
+	However, if there are multiple [=annotation levels=],
 	it can be associated with multiple <i>ruby annotations</i>.
 
-	Once pairing is complete, ruby “column” units are defined,
+	Once [=pairing=] is complete, ruby “column” units are defined,
 	each represented by a single <i>ruby base</i>
 	and one <i>ruby annotation</i> (possibly an empty, anonymous one)
-	from each <i>annotation level</i> in its <i>ruby segment</i>.
+	from each [=annotation level=] in its [=ruby segment=].
 
 
 <h4 id="segment-pairing">
@@ -417,12 +417,12 @@ Segment Pairing and Annotation Levels</h4>
 	<p>A ruby structure is divided into <dfn>ruby segments</dfn>,
 	each consisting of a single <i>ruby base container</i>
 	followed by one or more <i>ruby annotation containers</i>.
-	Each <i>ruby annotation container</i> in a <i>ruby segment</i>
+	Each <i>ruby annotation container</i> in a [=ruby segment=]
 	represents one <dfn lt="annotation level | level">level</dfn> of annotation for the base text:
 	the first one represents the first level of annotation,
 	the second one represents the second level of annotation,
 	and so on.
-	The <i>ruby base container</i> represents the <dfn>base level</dfn>.
+	The <i>ruby base container</i> represents the <dfn lt="base level | base text level">base level</dfn>.
 	The <i>ruby base container</i> in each segment is thus paired
 	with each of the <i>ruby annotation containers</i> in that segment.
 
@@ -434,20 +434,20 @@ Segment Pairing and Annotation Levels</h4>
 		anonymous, empty <i>ruby annotation containers</i> are assumed to exist between them.
 	</ul>
 
-	<p><i>Inter-segment white space</i> is effectively a <i>ruby segment</i> of its own.
+	<p><i>Inter-segment white space</i> is effectively a [=ruby segment=] of its own.
 
 <h4 id="base-annotation-pairing">
 Unit Pairing and Spanning Annotations</h4>
 
-	<p>Within a <i>ruby segment</i>,
+	<p>Within a [=ruby segment=],
 	each <i>ruby base</i> in the <i>ruby base container</i>
 	is paired with one <i>ruby annotation</i>
-	from each <i>ruby annotation container</i> in its <i>ruby segment</i>.
+	from each <i>ruby annotation container</i> in its [=ruby segment=].
 
 	<p>If a <i>ruby annotation container</i> contains only
 	a single, anonymous <i>ruby annotation</i>,
-	then that <i>ruby annotation</i> is paired with (i.e. <i>spans</i> across)
-	all of the <i>ruby bases</i> in its <i>ruby segment</i>.
+	then that <i>ruby annotation</i> is paired with (i.e. [=spans=] across)
+	all of the <i>ruby bases</i> in its [=ruby segment=].
 
 	<p>Otherwise, each <i>ruby annotation</i> is paired,
 	in order, with the corresponding <i>ruby base</i> in that segment</i>.
@@ -460,22 +460,22 @@ Unit Pairing and Spanning Annotations</h4>
 
 	<p>If an implementation supports ruby markup with explicit spanning
 	(e.g. XHTML Complex Ruby Annotations),
-	it must adjust the pairing rules to pair <i>spanning annotations</i>
+	it must adjust the [=pairing=] rules to pair [=spanning annotations=]
 	to their bases appropriately.
 
-	<p><i>Intra-level white space</i> does not participate in standard annotation <i>pairing</i>.
+	<p><i>Intra-level white space</i> does not participate in standard annotation [=pairing=].
 	However, if the immediately-adjacent <i>ruby bases</i> or <i>ruby annotations</i>
 	are paired
 	<ul>
 		<li>with two <i>ruby bases</i> or <i lt="ruby annotations">annotations</i>
-		that surround corresponding <i>intra-level white space</i> in another level,
-		then the so-corresponding <i>intra-level white space</i> boxes are also paired.
+		that surround corresponding [=intra-level white space=] in another level,
+		then the so-corresponding [=intra-level white space=] boxes are also paired.
 		<li>with a single spanning <i>ruby annotation</i>,
-		then the <i>intra-level white space</i> is also paired to that <i>ruby annotation</i>
+		then the [=intra-level white space=] is also paired to that <i>ruby annotation</i>
 		<li>with two <i>ruby bases</i> or <i lt="ruby annotations">annotations</i>
-		with no intervening <i>intra-level white space</i>,
-		then the <i>intra-level white space</i> box pairs with
-		an anonymous empty <i>intra-level white space</i> box assumed to exist between them.
+		with no intervening [=intra-level white space=],
+		then the [=intra-level white space=] box pairs with
+		an anonymous empty [=intra-level white space=] box assumed to exist between them.
 	</ul>
 
 	<p class="issue">Insert diagram</p>
@@ -484,15 +484,15 @@ Unit Pairing and Spanning Annotations</h4>
 Complex Spanning with Nested Ruby</h4>
 
 	<p>When <i>ruby containers</i> are <dfn lt="nested ruby">nested</dfn>,
-	pairing begins with the deepest <i>ruby container</i>,
+	[=pairing=] begins with the deepest <i>ruby container</i>,
 	then expands out.
-	From the pairing perspective of the outer <i>ruby container</i>,
+	From the [=pairing=] perspective of the outer <i>ruby container</i>,
 	each <i>ruby container</i> nested within another <i>ruby container</i>
 	counts as representing a single <i>ruby base</i>/<i>annotation</i> per level.
-	The outer <i>ruby container</i>’s <i>ruby annotations</i> paired to the <i>nested ruby</i>
-	are therefore paired with (and <i>span</i>) all of the nested <i>ruby container</i>’s <i>ruby bases</i>.
+	The outer <i>ruby container</i>’s <i>ruby annotations</i> paired to the [=nested ruby=]
+	are therefore paired with (and [=span=]) all of the nested <i>ruby container</i>’s <i>ruby bases</i>.
 	Each <i>ruby annotation container</i> in the nested <i>ruby container</i>
-	occupies the same <i>annotation level</i> in the outer <i>ruby container</i>
+	occupies the same [=annotation level=] in the outer <i>ruby container</i>
 	as it does in the inner one
 	and participates in its layout as if it were directly contained in the outer <i>ruby container</i>.
 
@@ -509,13 +509,13 @@ Autohiding Base-identical Annotations</h3>
 
 	<p>If a <i>ruby annotation</i> has the exact same text content as its base,
 	it is <dfn lt="hidden ruby annotation | hidden annotation">hidden</dfn>.
-	Hiding a <i>ruby annotation</i> does not affect annotation pairing
-	or the block-axis positioning of boxes in other <i>levels</i>.
-	However the <i>hidden annotation</i> is not visible,
+	Hiding a <i>ruby annotation</i> does not affect annotation [=pairing=]
+	or the block-axis positioning of boxes in other [=levels=].
+	However the [=hidden annotation=] is not visible,
 	and it has no impact on layout
 	other than to separate adjacent sequences of <i>ruby annotation boxes</i> within its level,
 	as if they belonged to separate segments
-	and the <i>hidden annotation</i>’s base were not a <i>ruby base</i> but an intervening inline.
+	and the [=hidden annotation=]’s base were not a <i>ruby base</i> but an intervening inline.
 
 	<div class="example">
 		<p>This is to allow correct inlined display of annotations
@@ -571,12 +571,12 @@ White Space Collapsing</h3>
 <!--		-->&lt;/ruby></pre>
 	</div>
 
-	<p>Between <i>ruby segments</i>, between <i>ruby bases</i>, and between <i>ruby annotations</i>, however,
+	<p>Between [=ruby segments=], between <i>ruby bases</i>, and between <i>ruby annotations</i>, however,
 	white space is not discarded,
 	and is maintained for rendering
-	as <i lt="inter-base white space">inter-base</i>,
-	<i lt="inter-annotation white space">inter-annotation</i>,
-	or <i>inter-segment white space</i>.
+	as [=inter-base white space|inter-base=],
+	[=inter-annotation white space|inter-annotation=],
+	or [=inter-segment white space=].
 	(See <a href="#box-fixup">Anonymous Ruby Box Generation</a>, above.)
 
 	<div class="example">
@@ -597,7 +597,7 @@ White Space Collapsing</h3>
 
 	<p>Where undiscarded white space is <i>collapsible</i>, it will collapse
 	following the standard <a href="https://www.w3.org/TR/css3-text/#white-space-rules">white space processing rules</a>. [[!CSS3TEXT]]
-	For <i>collapsible white space</i> between <i>ruby segments</i> (<i>inter-segment white space</i>), however,
+	For <i>collapsible white space</i> between [=ruby segments=] ([=inter-segment white space=]), however,
 	the contextual text for determining collapsing behavior is given by the <i>ruby bases</i> on either side,
 	not the text on either side of the white space in source document order.
 
@@ -625,13 +625,13 @@ White Space Collapsing</h3>
 Ruby Layout</h2>
 
 	<p>When a ruby structure is laid out,
-	its <i>base level</i> is laid out on the line,
+	its [=base level=] is laid out on the line,
 	aligned according to its 'vertical-align' property
 	exactly as if its <i>ruby bases</i> were a regular sequence of inline boxes.
 	Each <i>ruby base container</i> is sized and positioned
 	to contain exactly all of its <i>ruby bases</i>’ margin boxes.
 
-	<p><i>Ruby annotations</i> associated with the <i>base level</i>
+	<p><i>Ruby annotations</i> associated with the [=base level=]
 	are then positioned with respect to their <i>ruby base boxes</i>
 	according to the applicable 'ruby-position' values.
 	<i>Ruby annotations</i> within a level (within a single <i>ruby container</i>)
@@ -652,7 +652,7 @@ Ruby Layout</h2>
 	measures as wide as the content of its widest level.
 	Similarly, <i>ruby base boxes</i> and <i>ruby annotation boxes</i>
 	within a ruby “column” have the measure of the widest content in that “column”.
-	In the case of <i>spanning annotations</i>
+	In the case of [=spanning annotations=]
 	(whether actually spanning or pretending to span per 'ruby-merge'),
 	the measures of the <i>ruby annotation box</i> and
 	the sum of its associated <i>ruby base boxes</i> must match.
@@ -670,7 +670,7 @@ Inter-character Ruby Layout</h3>
 	<p>Inter-character annotations have special layout.
 	When 'ruby-position' indicates ''inter-character'' annotations,
 	the affected <i>ruby annotation boxes</i>
-	are spliced into and measured as part of the layout of the <i>base level</i>.
+	are spliced into and measured as part of the layout of the [=base level=].
 	The <i>ruby base container</i> must be sized to include both the <i>ruby base boxes</i>
 	as well as the ''inter-character'' <i>ruby annotation boxes</i>.
 	The affected <i>ruby annotation container</i> is similarly sized
@@ -733,7 +733,7 @@ Breaking Between Bases</h4>
 	<p>Whether ruby can break between two adjacent <i>ruby bases</i>
 	is controlled by normal line-breaking rules for the base text,
 	exactly as if the <i>ruby bases</i> were adjacent inline boxes.
-	(The annotations are ignored when determining soft wrap opportunities for the <i>base level</i>.)
+	(The annotations are ignored when determining soft wrap opportunities for the [=base level=].)
 
 	<div class="example">
 		<p>For example, if two adjacent ruby bases are “蝴” and “蝶”,
@@ -806,7 +806,7 @@ Bidi Reordering</h3>
 				so authors will need to ensure that the <i>ruby container</i>’s declared directionality
 				does indeed match its contents.
 		<li>
-			During layout, <i>ruby segments</i> are ordered within the <i>ruby container</i>
+			During layout, [=ruby segments=] are ordered within the <i>ruby container</i>
 			by the 'direction' property of their <i>ruby container</i>.
 		<li>
 			Within a segment, <i>ruby bases</i> and <i>ruby annotations</i>
@@ -1004,7 +1004,7 @@ Sharing Annotation Space: the 'ruby-merge' property</h3>
 		<dt><dfn>collapse</dfn>
 		<dd>
 			<p>
-				All <i>ruby annotation boxes</i> within the same <i>ruby segment</i> on the same line are concatenated,
+				All <i>ruby annotation boxes</i> within the same [=ruby segment=] on the same line are concatenated,
 				and laid out as if their contents belonged to a single <i>ruby annotation box</i>
 				spanning all their associated <i>ruby base boxes</i>.
 				This style renders similar to “group ruby” in [[JLREQ]],
@@ -1139,7 +1139,7 @@ Ruby Text Distribution: the 'ruby-align' property</h3>
 		</dd>
 	</dl>
 
-	<p class="issue">Add a paragraph explaining how to distribute space in situations with spanning annotations.
+	<p class="issue">Add a paragraph explaining how to distribute space in situations with [=spanning annotations=].
 <!--
 	<p>For a complex ruby with spanning elements, one additional consideration is
 		required. If the spanning element spans multiple 'rows' (other rbc or rtc
@@ -1170,7 +1170,7 @@ Ruby Text Decoration</h3>
 	with overline and underline decorations applied to the base text.
 	In the basic case of consistent font size and baseline alignment,
 	an underline or overline is positioned
-	between the base level and any annotations on that side.
+	between the [=base level=] and any annotations on that side.
 
 	<p class="issue">This section needs some clarification about
 	drawing decorations between the content of adjacent bases/annotations.
@@ -1570,7 +1570,7 @@ Changes since the 5 August 2014 WD</h3>
 	<li>Tweak the <a href="#default-stylesheet">default style sheet</a>.
 	<li>Add section on <a href="#ruby-text-decoration">text decoration</a>.
 	<li>Defer the <css>right</css> and <css>left</css> values of 'ruby-position' to the next level.
-	<li>Change ruby pairing rules to only operate on anonymous annotations (i.e. content directly contained by an <{rtc}>).
+	<li>Change ruby [=pairing=] rules to only operate on anonymous annotations (i.e. content directly contained by an <{rtc}>).
 	<li>Apply 'ruby-position' to ''::first-line''.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/2998">Issue 2998</a>)
 </ul>
@@ -1580,8 +1580,8 @@ Changes since the 19 September 2013 WD</h3>
 
 	<ul>
 		<li>Rewrite anonymous box generation rules and white space handling rules,
-		defined specialized pairing of anonymous white space boxes.
-		<li>Take nested ruby handling out of pairing.
+		defined specialized [=pairing=] of anonymous white space boxes.
+		<li>Take [=nested ruby=] handling out of [=pairing=].
 		(Will be handling it via sizing/layout.)
 		<li>Define bidi layout of ruby structures.
 	</ul>
@@ -1646,7 +1646,7 @@ Changes since the 19 September 2013 WD</h3>
 
 				<dt>Wrote anonymous box generation rules
 
-				<dd> And defined pairing of bases and annotations. Should now handle all
+				<dd> And defined [=pairing=] of bases and annotations. Should now handle all
 				 the crazy proposed permutations of HTML ruby markup.
 
 				<dt>Defined layout of ruby

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -291,7 +291,7 @@ Anonymous Ruby Box Generation</h3>
 			(For this purpose, misparented <i>internal table elements</i>
 			are treated as <a>inline-level content</a>
 			since, being parented by ruby boxes,
-			they will be ultimately wrapped by an <a>inline table</a>.)
+			they will be ultimately wrapped by an [=inline-level=] [=table wrapper box=].)
 
 			However, if an anonymous box so constructed contains only <i>white space</i>,
 			it is considered <dfn>intra-ruby white space</dfn>
@@ -1592,7 +1592,7 @@ Changes since the 19 September 2013 WD</h3>
 		Changes since the 30 June 2011 WD</h3>
 
 		<dl>
-				<dt>Remove 'ruby-span' and mentions of
+				<dt>Remove <code>ruby-span</code> and mentions of
 				 <code>rbspan</code>.
 
 				<dd> Explicit spanning is not used in HTML ruby in favor of implicit
@@ -1603,7 +1603,7 @@ Changes since the 19 September 2013 WD</h3>
 				 from tables. It doesn't seem necessary to include controls this in Level
 				 1.)
 
-				<dt>Defer 'ruby-overhang' and <code>ruby-align: line-end</code> to Level 2.
+				<dt>Defer <code>ruby-overhang</code> and <code>ruby-align: line-end</code> to Level 2.
 
 				<dd> It's somewhat complicated, advanced feature. Proposal is to make this
 				 behavior UA-defined and provide some examples of acceptable options.


### PR DESCRIPTION
A series of commits (best reviewed one by one) to clean up the spec, get rid of bikeshed errors, get consistent source code formatting, and other editorial tweaks to make it easy to work with.

Contains no normative change.