### PR TITLE
[resize-observer-1] attributes cannot be sequence<T> #4683

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -304,12 +304,12 @@ A future version of this spec will extend the returned {{FrozenArray}} to contai
 included here in order to help provide clarity during the processing model. It effectively holds observation information for a single {{Element}}. This
 interface is not visible to Javascript.</p>
 
-<pre class="idl exclude">
+<pre highlight=idl>
 interface ResizeObservation {
     constructor(Element target);
     readonly attribute Element target;
     readonly attribute ResizeObserverBoxOptions observedBox;
-    readonly attribute sequence&lt;ResizeObserverSize> lastReportedSizes;
+    readonly attribute FrozenArray&lt;ResizeObserverSize> lastReportedSizes;
 };
 </pre>
 <div dfn-type="attribute" dfn-for="ResizeObservation">
@@ -318,7 +318,7 @@ interface ResizeObservation {
     : <dfn>observedBox</dfn>
     :: Which box is being observed.
     : <dfn>lastReportedSizes</dfn>
-    :: Ordered sequence of last reported sizes.
+    :: Ordered frozen array of last reported sizes.
 </div>
 <div dfn-type="method" dfn-for="ResizeObservation">
     : <dfn constructor lt="ResizeObservation(target, options)">new ResizeObservation(target, observedBox)</dfn>


### PR DESCRIPTION
#4683  

Use highlight=idl rather than class=idl so that the non-normative ResizeObservation interface is displayed as an IDL but not included in the idl index. Also use frozen array instead of sequence for LastReportedSize.