### PR TITLE
Fix typo in color() syntax example

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -129,7 +129,7 @@ Value Definitions</h3>
 
 		<pre>
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(sRGB 0.41587, 0.503670, 0.36664);
-<span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(display-p3 0.43313, 0.50108, 0.37950);
+<span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(display-p3 0.43313 0.50108 0.37950);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(a98-rgb 0.44091 0.49971 0.37408);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(prophoto-rgb 0.36589 0.41717 0.31333);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(rec2020 0.42210 0.47580 0.35605);

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -128,7 +128,7 @@ Value Definitions</h3>
 		<p>This same color could be expressed in various colorspaces:</p>
 
 		<pre>
-<span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(sRGB 0.41587, 0.503670, 0.36664);
+<span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(sRGB 0.41587 0.503670 0.36664);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(display-p3 0.43313 0.50108 0.37950);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(a98-rgb 0.44091 0.49971 0.37408);
 <span class="swatch" style="--color: rgb(41.587%, 50.3670%, 36.664%)"></span> color(prophoto-rgb 0.36589 0.41717 0.31333);


### PR DESCRIPTION
It said:

    color(display-p3 0.43313, 0.50108, 0.37950);

That should have been:

    color(display-p3 0.43313 0.50108 0.37950);