### PR TITLE
[cssom-1] Follow Web IDL extended attribute changes

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -507,7 +507,7 @@ An object that implements the <code>MediaList</code> interface has an associated
 <pre class=idl>
 [Exposed=Window]
 interface MediaList {
-  stringifier attribute [TreatNullAs=EmptyString] CSSOMString mediaText;
+  stringifier attribute [LegacyNullToEmptyString] CSSOMString mediaText;
   readonly attribute unsigned long length;
   getter CSSOMString? item(unsigned long index);
   void appendMedium(CSSOMString medium);
@@ -2153,10 +2153,10 @@ interface CSSStyleDeclaration {
   getter CSSOMString item(unsigned long index);
   CSSOMString getPropertyValue(CSSOMString property);
   CSSOMString getPropertyPriority(CSSOMString property);
-  [CEReactions] void setProperty(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value, optional [TreatNullAs=EmptyString] CSSOMString priority = "");
+  [CEReactions] void setProperty(CSSOMString property, [LegacyNullToEmptyString] CSSOMString value, optional [LegacyNullToEmptyString] CSSOMString priority = "");
   [CEReactions] CSSOMString removeProperty(CSSOMString property);
   readonly attribute CSSRule? parentRule;
-  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString cssFloat;
+  [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString cssFloat;
 };
 </pre>
 
@@ -2387,7 +2387,7 @@ is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 
 <pre class="idl extract">
 partial interface CSSStyleDeclaration {
-  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>camel_cased_attribute</var>;
+  [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString _<var>camel_cased_attribute</var>;
 };
 </pre>
 
@@ -2411,7 +2411,7 @@ algorithm for <var>property</var>, with the <i>lowercase first</i> flag set.
 
 <pre class="idl extract">
 partial interface CSSStyleDeclaration {
-  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>webkit_cased_attribute</var>;
+  [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString _<var>webkit_cased_attribute</var>;
 };
 </pre>
 
@@ -2436,7 +2436,7 @@ the following partial interface applies where <var>dashed attribute</var> is <va
 
 <pre class="idl extract">
 partial interface CSSStyleDeclaration {
-  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString _<var>dashed_attribute</var>;
+  [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString _<var>dashed_attribute</var>;
 };
 </pre>
 
@@ -3138,4 +3138,3 @@ initial version of the alternative style sheets API and canonicalization
 
  </body>
 </html>
-


### PR DESCRIPTION
[TreatNullAs=EmptyString] → [LegacyNullToEmptyString], per https://github.com/heycam/webidl/pull/870.

---

This should not be merged until that PR is merged, and then given a day to reach the link databases.