### PR TITLE
[css-color-4] Fix rec2020 white chromaticity.

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2369,7 +2369,7 @@ Predefined colorspaces: ''srgb'', ''display-p3'', ''a98-rgb'', ''prophoto-rgb'',
 				<tr><th>Red chromaticity</th><td>0.708</td><td>0.292</td></tr>
 				<tr><th>Green chromaticity</th><td>0.170</td><td>0.797</td></tr>
 				<tr><th>Blue chromaticity</th><td>0.131</td><td>0.046</td></tr>
-				<tr><th>White chromaticity</th><td>0.3120</td><td>0.3290</td></tr>
+				<tr><th>White chromaticity</th><td>0.3127</td><td>0.3290</td></tr>
 				<tr><th>Transfer function</th><td colspan="2">1/2.4 (see note)</td></tr>
 			</table>
 


### PR DESCRIPTION
A previous reformat introduced an error.