### PR TITLE
[cssom] CSSStyleDeclaration.cssText should return the empty string for computed style.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1808,7 +1808,7 @@ On setting the {{CSSStyleRule/selectorText}} attribute these steps must be run:
 The <dfn attribute for=CSSStyleRule>style</dfn> attribute must return a <code>CSSStyleDeclaration</code> object for the style rule, with the
 following properties:
 <dl>
- <dt><a for="CSSStyleDeclaration">readonly flag</a>
+ <dt><a for="CSSStyleDeclaration">computed flag</a>
  <dd>Unset.
  <dt><a for="CSSStyleDeclaration">declarations</a>
  <dd>The declared declarations in the rule, in <a>specified order</a>.
@@ -1908,7 +1908,7 @@ On setting the {{CSSPageRule/selectorText}} attribute  these steps must be run:
 The <dfn attribute for=CSSGroupingRule>style</dfn> attribute must return a <code>CSSStyleDeclaration</code> object for the
 <code>@page</code> at-rule, with the following properties:
 <dl>
- <dt><a for="CSSStyleDeclaration">readonly flag</a>
+ <dt><a for="CSSStyleDeclaration">computed flag</a>
  <dd>Unset.
  <dt><a for="CSSStyleDeclaration">declarations</a>
  <dd>The declared declarations in the rule, in <a>specified order</a>.
@@ -1938,7 +1938,7 @@ included in the name. [[!CSS3SYN]]
 The <dfn attribute for=CSSMarginRule>style</dfn> attribute must return a <code>CSSStyleDeclaration</code> object for the
 margin at-rule, with the following properties:
 <dl>
- <dt><a for="CSSStyleDeclaration">readonly flag</a>
+ <dt><a for="CSSStyleDeclaration">computed flag</a>
  <dd>Unset.
  <dt><a for="CSSStyleDeclaration">declarations</a>
  <dd>The declared declarations in the rule, in <a>specified order</a>.
@@ -1996,9 +1996,9 @@ the DOM a <a>CSS declaration block</a> is a
 <a>CSS declaration block</a> has the following associated properties:
 
 <dl dfn-for="CSSStyleDeclaration" export>
- <dt><dfn>readonly flag</dfn>
- <dd>Unset if the object can be manipulated. Set if it can not be
- manipulated. Unless otherwise stated it is unset.
+ <dt><dfn>computed flag</dfn>
+ <dd>Set if the object is a computed style declaration, rather than a specified
+     style. Unless otherwise stated it is unset.
 
  <dt><dfn>declarations</dfn>
  <dd>The <a>CSS declarations</a> associated with the object.
@@ -2099,7 +2099,7 @@ A <a>CSS declaration block</a> has these <a>attribute change steps</a> for its <
 with <var>localName</var>, <var>value</var>, and <var>namespace</var>:
 
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set, then return.
+ <li>If the <a for="CSSStyleDeclaration">computed flag</a> is set, then return.
  <li>If the <a for="CSSStyleDeclaration">updating flag</a> is set, then return.
  <li>If <var>localName</var> is not "<code>style</code>", or <var>namespace</var> is not null, then return.
  <li>If <var>value</var> is null, empty the <a for="CSSStyleDeclaration">declarations</a>.
@@ -2111,7 +2111,7 @@ When a <a>CSS declaration block</a> object is created, then:
 
 <ol>
  <li>Let <var>owner node</var> be the <a for="CSSStyleDeclaration">owner node</a>.
- <li>If <var>owner node</var> is null, or the <a for="CSSStyleDeclaration">readonly flag</a> is set, then return.
+ <li>If <var>owner node</var> is null, or the <a for="CSSStyleDeclaration">computed flag</a> is set, then return.
  <li>Let <var>value</var> be the result of <a lt="get an attribute by namespace and local name">getting an attribute</a>
  given null, "<code>style</code>", and <var>owner node</var>.
  <li>If <var>value</var> is not null, let the <a for="CSSStyleDeclaration">declarations</a> be the result of
@@ -2121,7 +2121,7 @@ When a <a>CSS declaration block</a> object is created, then:
 To <dfn export>update style attribute for</dfn> <var>declaration block</var> means to run the steps below:
 
 <ol>
- <li>Assert: <var>declaration block</var>'s <a for="CSSStyleDeclaration">readonly flag</a> is unset.
+ <li>Assert: <var>declaration block</var>'s <a for="CSSStyleDeclaration">computed flag</a> is unset.
  <li>Let <var>owner node</var> be <var>declaration block</var>'s <a for="CSSStyleDeclaration">owner node</a>.
  <li>If <var>owner node</var> is null, then return.
  <li>Set <var>declaration block</var>'s <a for="CSSStyleDeclaration">updating flag</a>.
@@ -2164,11 +2164,14 @@ The object's <a>supported property indices</a> are the numbers in the range zero
 <a>CSS declarations</a> in the <a for="CSSStyleDeclaration">declarations</a>. If there are no such
 <a>CSS declarations</a>, then there are no <a>supported property indices</a>.
 
-The <dfn attribute for=CSSStyleDeclaration>cssText</dfn> attribute must return the result of
-<a lt="serialize a CSS declaration block">serializing</a> the <a for="CSSStyleDeclaration">declarations</a>.
+Getting the <dfn attribute for="CSSStyleDeclaration">cssText</dfn> attribute must run these steps:
+
+1. If the <a for="CSSStyleDeclaration">computed flag</a> is set, then return the empty string.
+2. Return the result of <a lt="serialize a CSS declaration block">serializing</a> the <a for="CSSStyleDeclaration">declarations</a>.
+
 Setting the {{CSSStyleDeclaration/cssText}} attribute must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ <li>If the <a for="CSSStyleDeclaration">computed flag</a> is set,
  then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>Empty the <a for="CSSStyleDeclaration">declarations</a>.
  <li><a lt="Parse a CSS declaration block">Parse</a> the given value and, if the return value is not the empty list, insert the items in the list
@@ -2234,7 +2237,7 @@ value would be "<code>important</code>".</div>
 
 The <dfn method for=CSSStyleDeclaration>setProperty(<var>property</var>, <var>value</var>, <var>priority</var>)</dfn> method must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ <li>If the <a for="CSSStyleDeclaration">computed flag</a> is set,
  then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>, follow these substeps:
   <ol>
@@ -2349,7 +2352,7 @@ use different algorithms as long as the constraints above hold.
 
 The <dfn method for=CSSStyleDeclaration>removeProperty(<var>property</var>)</dfn> method must run these steps:
 <ol>
- <li>If the <a for="CSSStyleDeclaration">readonly flag</a> is set,
+ <li>If the <a for="CSSStyleDeclaration">computed flag</a> is set,
  then <a>throw</a> a {{NoModificationAllowedError}} exception.
  <li>If <var>property</var> is not a <a>custom property</a>,
  let <var>property</var> be <var>property</var> <a lt="ASCII lowercase">converted to ASCII lowercase</a>.
@@ -2801,7 +2804,7 @@ interface mixin ElementCSSInlineStyle {
 </pre>
 
 The <dfn attribute for=ElementCSSInlineStyle>style</dfn> attribute must return a <a>CSS declaration block</a> object whose
-<a for="CSSStyleDeclaration">readonly flag</a> is unset, whose <a for="CSSStyleDeclaration">parent CSS rule</a> is null, and
+<a for="CSSStyleDeclaration">computed flag</a> is unset, whose <a for="CSSStyleDeclaration">parent CSS rule</a> is null, and
 whose <a for="CSSStyleDeclaration">owner node</a> is the <a>context object</a>.
 
 If the user agent supports HTML, the following IDL applies: [[HTML]]
@@ -2859,7 +2862,7 @@ steps:
  <li>
   Return a live <a>CSS declaration block</a> with the following properties:
   <dl>
-   <dt><a for="CSSStyleDeclaration">readonly flag</a>
+   <dt><a for="CSSStyleDeclaration">computed flag</a>
    <dd>Set.
    <dt><a for="CSSStyleDeclaration">declarations</a>
    <dd><var>decls</var>.


### PR DESCRIPTION
Closes #1033