### PR TITLE
[cssom] Include custom properties in getComputedStyle().

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2853,11 +2853,16 @@ steps:
   set <var>decls</var> to a list of all longhand properties that are
   <a lt="supported CSS property">supported CSS properties</a>, in lexicographical order,
   with the value being the <a>resolved value</a> computed for <var>obj</var>
-  using the style rules associated with <var>doc</var>.
+  using the style rules associated with <var>doc</var>. Additionally, append to
+  <var>decls</var> all the <a>custom properties</a> whose <a>computed value</a>
+  for <var>obj</var> is not the <a>guaranteed-invalid value</a>.
 
   Issue: There are UAs that handle shorthands, and all UAs handle shorthands
   that used to be longhands like 'overflow', see
   <a href="https://github.com/w3c/csswg-drafts/issues/2529">#2529</a>.
+
+  Issue: Order of custom properties is currently undefined, see
+  <a href="https://github.com/w3c/csswg-drafts/issues/4947">#4947</a>.
 
  <li>
   Return a live <a>CSS declaration block</a> with the following properties:


### PR DESCRIPTION
Closes #1316. #4947 for the ordering issue.