### PR TITLE
[cssom-1] Improve accuracy of <color> serialization

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2603,19 +2603,19 @@ depends on the component, as follows:
  <li>The string "<code>rgb(</code>".
  <li>The shortest base-ten integer serialization of the color's red component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten serialization of the color's green component.
+ <li>The shortest base-ten integer serialization of the color's green component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten serialization of the color's blue component.
+ <li>The shortest base-ten integer serialization of the color's blue component.
  <li>The string "<code>)</code>".
  </ol>
  The serialization of the <code>rgba()</code> functional equivalent is the concatenation of the following:
  <ol>
  <li>The string "<code>rgba(</code>".
- <li>The shortest base-ten serialization of the color's red component.
+ <li>The shortest base-ten integer serialization of the color's red component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten serialization of the color's green component.
+ <li>The shortest base-ten integer serialization of the color's green component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten serialization of the color's blue component.
+ <li>The shortest base-ten integer serialization of the color's blue component.
  <li>The string "<code>, </code>".
  <li>The serialization of the color's alpha component as an &lt;alphavalue>.
  <li>The string "<code>)</code>".

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2601,21 +2601,21 @@ depends on the component, as follows:
  The serialization of the <code>rgb()</code> functional equivalent is the concatenation of the following:
  <ol>
  <li>The string "<code>rgb(</code>".
- <li>The shortest base-ten integer serialization of the color's red component.
+ <li>The shortest base-ten serialization of the color's red component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten integer serialization of the color's green component.
+ <li>The shortest base-ten serialization of the color's green component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten integer serialization of the color's blue component.
+ <li>The shortest base-ten serialization of the color's blue component.
  <li>The string "<code>)</code>".
  </ol>
  The serialization of the <code>rgba()</code> functional equivalent is the concatenation of the following:
  <ol>
  <li>The string "<code>rgba(</code>".
- <li>The shortest base-ten integer serialization of the color's red component.
+ <li>The shortest base-ten serialization of the color's red component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten integer serialization of the color's green component.
+ <li>The shortest base-ten serialization of the color's green component.
  <li>The string "<code>, </code>".
- <li>The shortest base-ten integer serialization of the color's blue component.
+ <li>The shortest base-ten serialization of the color's blue component.
  <li>The string "<code>, </code>".
  <li>The serialization of the color's alpha component as an &lt;alphavalue>.
  <li>The string "<code>)</code>".


### PR DESCRIPTION
Either the word "integer" was missing from most of these steps, or it was accidentally added in one step. ~~This patch assumes the former.~~