### PR TITLE
[css-box][css-backgrounds][css-logical] Applicability of M/B/P on ruby

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -17,6 +17,7 @@ Editor: Brad Kemper, Invited Expert, brad.kemper@gmail.com, w3cid 43245
 Abstract: This draft contains the features of CSS relating to borders and backgrounds. The main extensions compared to <a href="https://www.w3.org/TR/CSS2/">level&nbsp;2</a> are borders consisting of images, boxes with multiple backgrounds, boxes with rounded corners and boxes with shadows.
 Test Suite: http://test.csswg.org/suites/css3-background/nightly-unstable/
 At risk: animatability of 'box-shadow'
+At risk: applicability of 'border' and its longhands to [=ruby base containers=] and [=ruby annotation containers=]
 Use <i> Autolinks: yes
 </pre>
 <pre class="link-defaults">
@@ -1368,7 +1369,7 @@ color ('border-color'), and thickness ('border-width') of the border.
     <td><a href="https://www.w3.org/TR/css3-color/#currentcolor">currentColor</a>
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no
@@ -1395,7 +1396,7 @@ color ('border-color'), and thickness ('border-width') of the border.
     <td>(see individual properties)
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no
@@ -1438,7 +1439,7 @@ also the same as top.
     <td>none
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no
@@ -1465,7 +1466,7 @@ also the same as top.
     <td>(see individual properties)
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no
@@ -1588,7 +1589,7 @@ the padding is less than the radius of the corner.
       <td>medium
     <tr>
       <th>Applies to:
-      <td>all elements
+      <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
     <tr>
       <th>Inherited:
       <td>no
@@ -1615,7 +1616,7 @@ the padding is less than the radius of the corner.
       <td>(see individual properties)
     <tr>
       <th>Applies to:
-      <td>all elements
+      <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
     <tr>
       <th>Inherited:
       <td>no
@@ -1671,7 +1672,7 @@ style is ''border-style/none'' and therefore the used width is 0.
     <td>See individual properties
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no
@@ -1704,7 +1705,7 @@ values are set to their initial values.
     <td>See individual properties
   <tr>
     <th>Applies to:
-    <td>all elements
+    <td>all elements except [=ruby base containers=] and [=ruby annotation containers=]
   <tr>
     <th>Inherited:
     <td>no

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -11,6 +11,7 @@ Previous Version: https://www.w3.org/TR/2018/WD-css-box-3-20180802/
 Abstract: This specification describes the margin and padding properties, which create spacing in and around a CSS box.
 Editor: Elika J. Etemad / fantasai, Invited Expert, http://fantasai.inkedblade.net/contact, w3cid 35400
 Ignored Terms: internal table elements, block layout
+At risk: applicability of 'margin', 'padding' and their longhands to [=ruby base containers=] and [=ruby annotation containers=]
 </pre>
 <pre class='link-defaults'>
 spec:css-sizing-3; type:dfn; text:size
@@ -286,7 +287,7 @@ Page-relative (Physical) Margin Properties: the 'margin-top', 'margin-right', 'm
 		Name: margin-top, margin-right, margin-bottom, margin-left
 		Value: <<length-percentage>> | auto
 		Initial: 0
-		Applies to: all elements except <a>internal table elements</a>
+		Applies to: all elements except <a>internal table elements</a>, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: the keyword ''margin/auto'' or a computed <<length-percentage>> value
@@ -306,7 +307,7 @@ Margin Shorthand: the 'margin' property {#margin-shorthand}
 		Name: margin
 		Value: <<'margin-top'>>{1,4}
 		Initial: 0
-		Applies to: all elements except <a>internal table elements</a>
+		Applies to: all elements except <a>internal table elements</a>, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: see individual properties
@@ -380,7 +381,7 @@ Page-relative (Physical) Padding Properties: the 'padding-top', 'padding-right',
 		Name: padding-top, padding-right, padding-bottom, padding-left
 		Value: <<length-percentage>>
 		Initial: 0
-		Applies to: all elements except: <a>internal table elements</a> other than table cells
+		Applies to: all elements except: <a>internal table elements</a> other than table cells, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: a computed <<length-percentage>> value
@@ -399,7 +400,7 @@ Padding Shorthand: the 'padding' property {#padding-shorthand}
 		Name: padding
 		Value: <<'padding-top'>>{1,4}
 		Initial: 0
-		Applies to: all elements except: <a>internal table elements</a> other than table cells
+		Applies to: all elements except: <a>internal table elements</a> other than table cells, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: see individual properties
@@ -462,6 +463,7 @@ Changes Since CSS Level 2 {#changes}
 	since <a href="https://www.w3.org/TR/CSS2/box.html">CSS Level 2</a>:
 	<ul>
 		<li>Adapting the prose slightly to account for vertical <a>writing modes</a>.
+		<li>Defining the applicability of 'margin', 'padding' and their longhands to [=ruby base containers=] and [=ruby annotation containers=] (at risk)
 	</ul>
 
 Privacy and Security Considerations {#priv-sec}

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -285,7 +285,7 @@ Page-relative (Physical) Margin Properties: the 'margin-top', 'margin-right', 'm
 		Name: margin-top, margin-right, margin-bottom, margin-left
 		Value: <<length-percentage>> | auto
 		Initial: 0
-		Applies to: all elements except <a>internal table elements</a>
+		Applies to: all elements except <a>internal table elements</a>, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: the keyword ''margin/auto'' or a computed <<length-percentage>> value
@@ -305,7 +305,7 @@ Margin Shorthand: the 'margin' property {#margin-shorthand}
 		Name: margin
 		Value: <<'margin-top'>>{1,4}
 		Initial: 0
-		Applies to: all elements except <a>internal table elements</a>
+		Applies to: all elements except <a>internal table elements</a>, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: see individual properties
@@ -469,7 +469,7 @@ Page-relative (Physical) Padding Properties: the 'padding-top', 'padding-right',
 		Name: padding-top, padding-right, padding-bottom, padding-left
 		Value: <<length-percentage>>
 		Initial: 0
-		Applies to: all elements except: <a>internal table elements</a> other than table cells
+		Applies to: all elements except: <a>internal table elements</a> other than table cells, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: a computed <<length-percentage>> value
@@ -488,7 +488,7 @@ Padding Shorthand: the 'padding' property {#padding-shorthand}
 		Name: padding
 		Value: <<'padding-top'>>{1,4}
 		Initial: 0
-		Applies to: all elements except: <a>internal table elements</a> other than table cells
+		Applies to: all elements except: <a>internal table elements</a> other than table cells, [=ruby base containers=], and [=ruby annotation containers=]
 		Inherited: no
 		Percentages: refer to <a>logical width</a> of containing block
 		Computed value: see individual properties
@@ -560,6 +560,7 @@ Changes Since CSS Level 2 {#changes}
 	since <a href="https://www.w3.org/TR/CSS2/box.html">Level 2</a>:
 	<ul>
 		<li>Adapting the prose slightly to account for vertical <a>writing modes</a>.
+		<li>Defining the applicability of 'margin', 'padding' and their longhands to [=ruby base containers=] and [=ruby annotation containers=]
 	</ul>
 
 Privacy and Security Considerations {#priv-sec}

--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -509,7 +509,7 @@ the 'padding-block-start', 'padding-block-end', 'padding-inline-start', 'padding
   Name: padding-block-start, padding-block-end, padding-inline-start, padding-inline-end
   Value: <<'padding-top'>>
   Initial: 0
-  Applies to: all elements
+  Applies to: Same as 'padding-top'
   Inherited: no
   Percentages: As for the corresponding physical property
   Computed value: Same as corresponding 'padding-*' properties
@@ -545,7 +545,7 @@ the 'border-block-start-width', 'border-block-end-width', 'border-inline-start-w
   Name: border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width
   Value: <<'border-top-width'>>
   Initial: medium
-  Applies to: all elements
+  Applies to: Same as 'border-top-width'
   Inherited: no
   Percentages: n/a
   Computed value: Same as corresponding 'border-*-width' properties
@@ -579,7 +579,7 @@ the 'border-block-start-style', 'border-block-end-style', 'border-inline-start-s
   Name: border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style
   Value: <<'border-top-style'>>
   Initial: none
-  Applies to: all elements
+  Applies to: Same as 'border-top-style'
   Inherited: no
   Percentages: n/a
   Computed value: Same as corresponding 'border-*-style' properties
@@ -612,7 +612,7 @@ the 'border-block-start-color', 'border-block-end-color', 'border-inline-start-c
   Name: border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color
   Value: <<'border-top-color'>>
   Initial: currentcolor
-  Applies to: all elements
+  Applies to: Same as 'border-top-color'
   Inherited: no
   Percentages: n/a
   Computed value: Same as corresponding 'border-*-color' properties
@@ -669,7 +669,7 @@ the 'border-start-start-radius', 'border-start-end-radius', 'border-end-start-ra
   Name: border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius
   Value: <<'border-top-left-radius'>>
   Initial: Same as 'border-top-left-radius'
-  Applies to: all elements
+  Applies to: Same as 'border-top-left-radius'
   Inherited: no
   Percentages: Same as 'border-top-left-radius'
   Computed value: Same as corresponding physical 'border-*-radius' properties


### PR DESCRIPTION
This updates the definitions of the various margin/border/padding properties to clarify that they do not apply to ruby base containers nor to ruby annotation containers, as resolved in https://github.com/w3c/csswg-drafts/issues/4937#issuecomment-614153466

For css-box-3 and css-backgrounds-3, this is marked at risk, since they are more mature than css-ruby and may need to move along the REC track before it does.

For css-logical, there's no need to be explicit, and thus no need to mark at-risk: tying the applicability of the logical longhands to that of the physical ones deals with it without introducing tight coupling.
