### PR TITLE
Editorial rewrite of HDR text

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1706,26 +1706,47 @@ color depth, and contrast ratio that are supported by the UA and output device.
 <dl dfn-type=value dfn-for="@media/dynamic-range">
 	<dt><dfn>high</dfn>
 	<dd>
-		If the following are true for the UA and the output device:
-		* max brightness is considered high
-		* color depth is greater than 24 bit
-		* has a <a>high contrast ratio</a>
+		The combination of the User Agent and the output device
+		fulfill all of the following criteria:
+		* it has a [=high peak brightness=]
+		* it has a [=high contrast ratio=]
+		* its color depth is greater than 24 bit or 8 bit per color component of RGB
 	<dt><dfn>standard</dfn>
 	<dd>
-		If the following are true for the UA and the output device:
-		* max brightness is considered standard
-		* color depth is 24 bit or 8 bit per color component of RGB
-		* has a <a>low contrast ratio</a>
+		One or more of the criteria for a ''high'' 'dynamic-range'
+		is not fulfilled.
 </dl>
 
 <h3 id="contrast-brightness-of-display">
 	Determining contrast and brightness of display</h3>
 
-This text is non-normative. There currently is no agreed upon standardization of
-<dfn export>high contrast ratio</dfn>, <dfn export>low contrast ratio</dfn>,
-max brightness or low brightness as it relates to displays. As such, the
-determination for '@media/dynamic-range' and '@media/video-dynamic-range' will
-be defined by the user agent.
+	<dfn export>Peak brightness</dfn> refers to how bright the brightest point
+	a light-emitting device such as an LCD screen can produce,
+	or in the case of a light reflective device such as paper or e-ink,
+	the point at which it least absorbs light.
+	Some devices can only produce their [=peak brightness=]
+	for brief periods of time or on a small portion of their surface at any given time.
+
+	The <dfn export>contrast ratio</dfn> is the ratio of the luminance
+	of the brightest color to that of the darkest color
+	that the system is capable of producing.
+
+	This specification does not define precise ways
+	by which these qualities can be measured;
+	it also lets the User Agent determine
+	what counts as a <dfn for="contrast ratio" lt="high contrast ratio">high</dfn> [=contrast ratio=]
+	and as a <dfn for="peak brightness" lt="high peak brightness">high</dfn> [=peak brightness=].
+	User Agents must nonetheless attempt to conform to the following intent:
+	a device capable of [=high peak brightness=]
+	can display “brighter than white” highlights,
+	and a simultaneous ability to do so
+	while also presenting deep blacks
+	(rather than an overall bright but washed out image)
+	is indicative of a [=high contrast ratio=].
+
+	Note: The determination for '@media/dynamic-range' and '@media/video-dynamic-range'
+	will be vary depending on the User Agent,
+	but is expected to have broadly dependable semantics.
 
 <h2 id="video-prefixed-features">Video Prefixed Features</h2>
 

--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -1724,7 +1724,8 @@ color depth, and contrast ratio that are supported by the UA and output device.
 	a light-emitting device such as an LCD screen can produce,
 	or in the case of a light reflective device such as paper or e-ink,
 	the point at which it least absorbs light.
-	Some devices can only produce their [=peak brightness=]
+
+	Note: Some devices can only produce their [=peak brightness=]
 	for brief periods of time or on a small portion of their surface at any given time.
 
 	The <dfn export>contrast ratio</dfn> is the ratio of the luminance


### PR DESCRIPTION
This is an attempt to rewrite the section of media-queries that defines and uses brightness and contrast ratio.

I think this makes the intent clearer, removes ambiguities, while keeping the details of the implementation up to user agents as intended.

This corresponds to the "For section 6.6 …" bullet point of https://github.com/w3c/csswg-drafts/pull/4678#issuecomment-610725135.

Review from @svgeesus, @gregwhitworth, @vi-dot-cpp, or @gregwfreedman very much appreciated.