### PR TITLE
[css-scroll-anchoring-1] Add priority candidates for scroll anchor selection #5018

### DIFF
--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -76,7 +76,8 @@ Anchor Node Selection</h3>
 
 Each <a>scrolling box</a> aims to select an <a>anchor node</a>
 that is deep in the DOM
-and close to the block start edge of its <a>optimal viewing region</a>.
+and either should be prioritized as an important DOM node or is close to the
+block start edge of its <a>optimal viewing region</a>.
 
 Note: If the user agent does not support the 'scroll-padding' property,
 the optimal viewing region of the scrolling box is equivalent to its <a>content area</a>.
@@ -85,16 +86,41 @@ An anchor node can be any <a>box</a> except one for a non-<a>atomic inline</a>.
 The anchor node is always a <a>descendant</a> of the <a>scrolling box</a>.
 In some cases, a scrolling box may not select any anchor node.
 
+An element |C| is a <dfn id="anchor-viable-candidate">viable candidate</dfn>
+for becoming a scroll anchor for a scrolling box |S| if it meets all of the
+following criteria:
+  * |C| is a non-<a>atomic inline</a>.
+  * |C| is <a>partially visible</a> or <a>fully visible</a> in |S|
+  * |C| is a descendant of |S|
+  * |C| is not in an <a>excluded subtree</a>
+  * None of the ancestors of |C| up to |S| are in an <a>excluded subtree</a>
+
+Some elements are considered to be <dfn
+id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
+  1. An element that <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-focus">has focus</a>.
+  2. An element containing the <a href="https://drafts.csswg.org/css-ui-3/#insertion-caret">insertion caret</a>.
+  3. An element containing the current active selected match of the
+      find-in-page user-agent algorithm. If the match spans multiple elements, then
+      consider only the first such element.
+
+Note that if the <a>priority candidate</a> is an <a>atomic inline</a> element,
+then instead consider its nearest non-atomic inline ancestor element as the
+priority candidate.
+
 <div algorithm>
 	The <dfn id="anchoring-algorithm">anchor node selection algorithm</dfn>
 	for a scrolling box |S| is as follows:
 
-	1. If |S| is associated with an element
-		whose computed value of the 'overflow-anchor' property is ''overflow-anchor/none'',
-		then do not select an anchor node for |S|.
-	2. Otherwise, for each DOM child |N| of the element or document associated with |S|,
-		perform the <a>candidate examination algorithm</a> for |N| in |S|,
-		and terminate if it selects an anchor node.
+  1. If |S| is associated with an element whose computed value of the
+    'overflow-anchor' property is ''overflow-anchor/none'', then do not select an
+    anchor node for |S|.
+  2. Otherwise, for each <a>priority candidate</a> |PC| in order specified,
+    check if |PC| is a <a>viable candidate</a> in |S|. If so, select it as an
+    anchor node and terminate.
+  3. Otherwise, for each DOM child |N| of the element or document associated
+    with |S|, perform the <a>candidate examination algorithm</a> for |N| in |S|,
+    and terminate if it selects an anchor node.
+
 </div>
 
 <div algorithm>

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -97,7 +97,7 @@ following criteria:
 
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
-  1. An element that <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-focus">has focus</a>.
+  1. An element that <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement">has focus</a>.
   2. An element containing the <a href="https://drafts.csswg.org/css-ui-3/#insertion-caret">insertion caret</a>.
   3. An element containing the current active selected match of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then
@@ -111,15 +111,15 @@ non-atomic inline element as the priority candidate.
 	The <dfn id="anchoring-algorithm">anchor node selection algorithm</dfn>
 	for a scrolling box |S| is as follows:
 
-  1. If |S| is associated with an element whose computed value of the
-    'overflow-anchor' property is ''overflow-anchor/none'', then do not select an
-    anchor node for |S|.
-  2. Otherwise, for each <a>priority candidate</a> |PC| in order specified,
-    check if |PC| is a <a>viable candidate</a> in |S|. If so, select it as an
-    anchor node and terminate.
-  3. Otherwise, for each DOM child |N| of the element or document associated
-    with |S|, perform the <a>candidate examination algorithm</a> for |N| in |S|,
-    and terminate if it selects an anchor node.
+	1. If |S| is associated with an element
+		whose computed value of the 'overflow-anchor' property is ''overflow-anchor/none'',
+		then do not select an anchor node for |S|.
+	2. Otherwise, for each <a>priority candidate</a> |PC| in order specified,
+		check if |PC| is a <a>viable candidate</a> in |S|. If so, select it as an
+		anchor node and terminate.
+	3. Otherwise, for each DOM child |N| of the element or document associated with |S|,
+		perform the <a>candidate examination algorithm</a> for |N| in |S|,
+		and terminate if it selects an anchor node.
 
 </div>
 

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -97,7 +97,9 @@ following criteria:
 
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
-  1. An element that <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement">has focus</a>.
+  1. The <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">DOM anchor</a>
+      of the <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document">focused area</a>
+      of the document.
   2. An element containing the <a href="https://drafts.csswg.org/css-ui-3/#insertion-caret">insertion caret</a>.
   3. An element containing the current active selected match of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -105,8 +105,7 @@ following criteria:
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
   1. The [=DOM anchor=] of the [=focused area of the document=].
-  2. An element containing the <a href="https://drafts.csswg.org/css-ui-3/#insertion-caret">insertion caret</a>.
-  3. An element containing the current active selected match of the
+  2. An element containing the current active selected match of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then
       consider only the first such element.
 

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -29,6 +29,13 @@ spec:css22;
 		text:width
 	type:dfn; text:line box
 </pre>
+<pre class="anchors">
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
+    urlPrefix: interaction.html
+        type: dfn;
+            text:DOM anchor
+            text:focused area of the document
+</pre>
 
 <h2 id=intro>
 Introduction</h2>
@@ -97,9 +104,7 @@ following criteria:
 
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
-  1. The <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">DOM anchor</a>
-      of the <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document">focused area</a>
-      of the document.
+  1. The [=DOM anchor=] of the [=focused area of the document=].
   2. An element containing the <a href="https://drafts.csswg.org/css-ui-3/#insertion-caret">insertion caret</a>.
   3. An element containing the current active selected match of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -89,7 +89,7 @@ In some cases, a scrolling box may not select any anchor node.
 An element |C| is a <dfn id="anchor-viable-candidate">viable candidate</dfn>
 for becoming a scroll anchor for a scrolling box |S| if it meets all of the
 following criteria:
-  * |C| is a non-<a>atomic inline</a>.
+  * |C| is an element that is not a non-<a>atomic inline</a>.
   * |C| is <a>partially visible</a> or <a>fully visible</a> in |S|
   * |C| is a descendant of |S|
   * |C| is not in an <a>excluded subtree</a>
@@ -103,9 +103,9 @@ id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
       find-in-page user-agent algorithm. If the match spans multiple elements, then
       consider only the first such element.
 
-Note that if the <a>priority candidate</a> is an <a>atomic inline</a> element,
-then instead consider its nearest non-atomic inline ancestor element as the
-priority candidate.
+Note that if the <a>priority candidate</a> is a non-<a>atomic inline</a>
+element, then instead consider its nearest ancestor element that is not a
+non-atomic inline element as the priority candidate.
 
 <div algorithm>
 	The <dfn id="anchoring-algorithm">anchor node selection algorithm</dfn>


### PR DESCRIPTION
The PR adds scroll anchoring priority candidates which would be used before the DOM order children are considered as scroll anchors.

#5018 