### PR TITLE
[web-animations-1] Fixed play animation procedure for scroll animations  (#2075)

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1201,6 +1201,11 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
 
     </div>
 
+1.  If |performed seek| is true and |has finite timeline| is true,
+
+    1.  Let |animation|'s [=hold time=] be <a>unresolved</a>.
+    1.  [=Apply any pending playback rate=] on |animation|.
+
 1.  If <var>animation</var> has a <a>pending play task</a> or a
     <a>pending pause task</a>,
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1123,7 +1123,7 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
     <var>animation</var> has a <a>pending pause task</a>, and false otherwise.
 1.  Let <var>has pending ready promise</var> be a boolean flag that is
     initially false.
-1.  Let <var>performed seek</var> be a boolean flag that is initially false.
+1.  Let <var>seek time</var> be a <a>time value</a> that is initially <a>unresolved</a>.
 1.  Let <var>has finite timeline</var> be true if |animation| has an associated
     <a>timeline</a> that is not [=monotonically increasing=].
 1.  Perform the steps corresponding to the <em>first</em> matching
@@ -1139,18 +1139,7 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
         *   <a>current time</a> &lt; zero, or
         *   <a>current time</a> &ge; <a>associated effect end</a>,
 
-    ::  1.  Set <var>performed seek</var> to true.
-        1.  Update either <var>animation</var>’s <a>start time</a> or
-            <a>hold time</a> as follows:
-
-            <div class="switch">
-
-            :   If |has finite timeline| is true,
-            ::  Set <var>animation</var>'s <a>start time</a> to zero.
-            :   Otherwise,
-            ::  Set <var>animation</var>'s <a>hold time</a> to zero.
-
-            </div>
+    ::  Set <var>seek time</var> to zero.
 
     :   If |animation|'s [=effective playback rate=] &lt; 0,
         the <var>auto-rewind</var> flag is true and <em>either</em>
@@ -1166,45 +1155,32 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
         ::  <a>throw</a> an "{{InvalidStateError}}" {{DOMException}} and
             abort these steps.
         :   Otherwise,
-        ::  1.  Set <var>performed seek</var> to true.
-            1.  Update either <var>animation</var>’s <a>start time</a> or
-                <a>hold time</a> as follows:
-
-                <div class="switch">
-
-                :   If |has finite timeline| is true,
-                ::  Set <var>animation</var>'s <a>start time</a> to <a>associated
-                    effect end</a>.
-                :   Otherwise,
-                ::  Set <var>animation</var>'s <a>hold time</a> to <a>associated
-                    effect end</a>.
-
-                </div>
+        ::  Set <var>seek time</var> to |animation|'s <a>associated effect end</a>.
 
         </div>
 
     :   If |animation|'s [=effective playback rate=] = 0 and |animation|'s
         [=current time=] is [=unresolved=],
 
-        ::  1.  Set <var>performed seek</var> to true.
-            1.  Update either <var>animation</var>’s <a>start time</a> or
-                <a>hold time</a> as follows:
-
-                <div class="switch">
-
-                :   If |has finite timeline| is true,
-                ::  Set <var>animation</var>'s <a>start time</a> to zero.
-                :   Otherwise,
-                ::  Set <var>animation</var>'s <a>hold time</a> to zero.
-
-                </div>
+        ::  Set <var>seek time</var> to zero.
 
     </div>
 
-1.  If |performed seek| is true and |has finite timeline| is true,
+1.  If |seek time| is <a lt=unresolved>resolved</a>,
+     
+        <div class="switch">
 
-    1.  Let |animation|'s [=hold time=] be <a>unresolved</a>.
-    1.  [=Apply any pending playback rate=] on |animation|.
+        :   If |has finite timeline| is true,
+        ::  1.  Set <var>animation</var>'s <a>start time</a> to <var>seek time</var>.
+            1.  Let |animation|'s [=hold time=] be <a>unresolved</a>.
+            1.  [=Apply any pending playback rate=] on |animation|.
+        :   Otherwise,
+        ::  Set <var>animation</var>'s <a>hold time</a> to <var>seek time</var>.
+
+        </div>
+
+1.  If <var>animation</var>'s <a>hold time</a> is <a lt=unresolved>resolved</a>,
+    let its [=start time=] be <a>unresolved</a>.
 
 1.  If <var>animation</var> has a <a>pending play task</a> or a
     <a>pending pause task</a>,
@@ -1215,14 +1191,11 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
 1.  If the following four conditions are <em>all</em> satisfied:
 
     * |animation|'s [=hold time=] is [=unresolved=], and
-    * |performed seek| is false, and
+    * |seek time| is [=unresolved=], and
     * |aborted pause| is false, and
     * |animation| does <em>not</em> have a [=pending playback rate=],
 
     abort this procedure.
-
-1.  If <var>animation</var>'s <a>hold time</a> is <a lt=unresolved>resolved</a>,
-    let its [=start time=] be <a>unresolved</a>.
 
 1.  If <var>has pending ready promise</var> is false,
     let <var>animation</var>'s <a>current ready promise</a> be
@@ -1348,6 +1321,7 @@ follows:
 1.  If <var>animation</var> has a <a>pending pause task</a>, abort these steps.
 1.  If the <a>play state</a> of <var>animation</var> is <a
     lt="paused play state">paused</a>, abort these steps.
+1.  Let <var>seek time</var> be a <a>time value</a> that is initially <a>unresolved</a>.
 1.  Let <var>has finite timeline</var> be true if |animation| has an associated
     <a>timeline</a> that is not [=monotonically increasing=].
 1.  If the <var>animation</var>'s <a>current time</a> is <a>unresolved</a>,
@@ -1356,18 +1330,7 @@ follows:
     <div class="switch">
 
     :   If <var>animation</var>'s [=playback rate=] is &ge; 0,
-    ::  Update either <var>animation</var>’s <a>start time</a> or
-        <a>hold time</a> as follows:
-
-        <div class="switch">
-
-        :   If |has finite timeline| is true,
-        ::  Set <var>animation</var>'s <a>start time</a> to zero.
-        :   Otherwise,
-        ::  Set <var>animation</var>'s <a>hold time</a> to zero.
-
-        </div>
-
+    ::  Set <var>seek time</var> to zero.
     :   Otherwise,
     ::
         <div class="switch">
@@ -1377,23 +1340,23 @@ follows:
         ::  <a>throw</a> an "{{InvalidStateError}}" {{DOMException}}
             and abort these steps.
         :   Otherwise,
-        ::  Update either <var>animation</var>’s <a>start time</a> or
-            <a>hold time</a> as follows:
-
-            <div class="switch">
-
-            :   If |has finite timeline| is true,
-            ::  let <var>animation</var>'s <a>start time</a> be
-                <a>associated effect end</a>.
-            :   Otherwise,
-            ::  let <var>animation</var>'s <a>hold time</a> be
-                <a>associated effect end</a>.
-
-            </div>
+        ::  Set <var>seek time</var> to <var>animation</var>'s <a>associated effect
+            end</a>.
 
         </div>
 
     </div>
+
+1.  If |seek time| is <a lt=unresolved>resolved</a>,
+
+        <div class="switch">
+
+        :   If |has finite timeline| is true,
+        ::  Set <var>animation</var>'s <a>start time</a> to <var>seek time</var>.
+        :   Otherwise,
+        ::  Set <var>animation</var>'s <a>hold time</a> to <var>seek time</var>.
+
+        </div>
 
 1.  Let <var>has pending ready promise</var> be a boolean flag that is
     initially false.


### PR DESCRIPTION
#4842 is missing updates required to handle reverse() API and re-playing finished animations:
- If scroll animation is reversed and start time is set as part of play animation procedure, pending playback rate needs to be applied to ensure correct current time calculation while the animation is in pending state.
- When re-playing finished scroll animation hold_time needs to be set to unresolved to ensure start_time stays resolved.
