### PR TITLE
[resize-observer-1] device-pixel-content-box should be in integral device pixels for SVG #5014

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -529,10 +529,18 @@ elements do not use standard CSS box model.
 To <dfn>calculate box size</dfn>, given |target| and |observedBox|, run these steps:
 
     1. If |target| is an {{SVGGraphicsElement}}
+    
+        1. If |observedBox| is "border-box" or "content-box"
 
-        1. Set |computedSize|.inlineSize to |target|'s <a>bounding box</a> inline length.
+            1. Set |computedSize|.inlineSize to |target|'s <a>bounding box</a> inline length.
 
-        2. Set |computedSize|.blockSize to |target|'s <a>bounding box</a> block length.
+            2. Set |computedSize|.blockSize to |target|'s <a>bounding box</a> block length.
+        
+        2. 1. If |observedBox| is "device-pixel-content-box"
+        
+            1. Set |computedSize|.inlineSize to |target|'s <a>bounding box</a> inline length, in integral device pixels.
+
+            2. Set |computedSize|.blockSize to |target|'s <a>bounding box</a> block length, in integral device pixels.
 
     2. If |target| is not an {{SVGGraphicsElement}}
 


### PR DESCRIPTION
Change the box size calculation algorithm for svg elements when observed box is "device-pixel-content-box" to return the bounding box in integral device pixels.

See [#5014](https://github.com/w3c/csswg-drafts/issues/5014)