### PR TITLE
[web-animations-1] Non-normative mention of "iterationCount" instead of "iterations"

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1691,7 +1691,7 @@ enters the finished state. If notification of the finished state occurred
 synchronously this code would cause the <a>finish event</a> to be queued
 and the <a>current finished promise</a> to be resolved. However, if we
 reverse the order of the two statements such that the
-<code>iterationCount</code> is updated first, this would not happen.
+<code>iterations</code> is updated first, this would not happen.
 To avoid this surprising behavior, notification about the finished state of
 an animation is typically performed asynchronously.
 
@@ -1699,7 +1699,7 @@ an animation is typically performed asynchronously.
 var animation = elem.animate({ left: '100px' }, 2000);
 animation.playbackRate = 2;
 animation.currentTime = 1000; // animation is now finished
-animation.effect.updateTiming({ iterationCount: 2 }); // animation is no longer finished
+animation.effect.updateTiming({ iterations: 2 }); // animation is no longer finished
 </pre></div>
 
 The one exception to this asynchronous behavior is when the <a>finish an


### PR DESCRIPTION
[web-animations-1] There is no `iterationCount` property but there is an `iterations` property. Fix some non-normative text to use the correct property name. This addresses issue #5096.