### PR TITLE
[css-tables-3] Remove file "debug.log"

### DIFF
--- a/css-tables-3/debug.log
+++ b/css-tables-3/debug.log
@@ -1,2 +1,0 @@
-[0224/101633:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
-[0224/101633:ERROR:node_debugger.cc(86)] Cannot start debugger server


### PR DESCRIPTION
It was presumably a mistake to add this file to the repository.

The following may be useful to a reviewer:

    $ git log -p master -- css-tables-3/debug.log
    commit 3ebc8f4adc79064ec074aa1bbb90978eb0d863ae
    Author: François REMY <email>
    Date:   Tue Jun 20 16:02:35 2017 -0700
    
        Fix #1025 (colgroup's widths only apply on its columns if their width is auto)
    
    diff --git a/css-tables-3/debug.log b/css-tables-3/debug.log
    new file mode 100644
    index 000000000..5ae48beca
    --- /dev/null
    +++ b/css-tables-3/debug.log
    @@ -0,0 +1,2 @@
    +[0224/101633:ERROR:tcp_listen_socket.cc(76)] Could not bind socket to 127.0.0.1:6004
    +[0224/101633:ERROR:node_debugger.cc(86)] Cannot start debugger server
