### PR TITLE
[css-speech-1] Rephrase background information about media types

### DIFF
--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -63,22 +63,18 @@ Background information, CSS 2.1</h2>
 	The CSS Speech module is a re-work of the informative
 	<a href="https://www.w3.org/TR/CSS2/aural.html">CSS2.1 Aural appendix</a>,
 	within which the ''aural'' media type was described,
-	but also deprecated (in favor of the ''speech'' media type).
-	Although the [[!CSS2]] specification reserves the ''speech'' media type,
-	it doesn't actually define the corresponding properties.
-	The Speech module describes the CSS properties
-	that apply to the ''speech'' media type,
+	but also deprecated (in favor of the ''speech'' media type, which has now
+	also been deprecated).
+	Although the [[!CSS2]] specification reserved the ''speech'' media type,
+	it didn't actually define the corresponding properties.
+	The Speech module describes the CSS properties that apply to speech output,
 	and defines a new “box” model specifically for the aural dimension.
 
-	Content creators can conditionally include
-	CSS properties dedicated to user agents
-	with text to speech synthesis capabilities,
-	by specifying the ''speech'' media type
-	via the <code>media</code> attribute of the <{link}> element,
-	or with the ''@media'' at-rule,
-	or within an ''@import'' statement.
-	When styles are authored within the scope of such conditional statements,
-	they are ignored by user agents that do not support the Speech module.
+	Content creators can include CSS properties for user agents with
+	text to speech synthesis capabilities for any media type - though
+	generally, they will only make sense for ''all'' and ''screen''.
+	These styles are simply ignored by user agents that do not support
+	the Speech module.
 
 <h2 id="ssml-rel">
 Relationship with SSML</h2>


### PR DESCRIPTION
Since the `speech` media type has now also been deprecated (see https://github.com/w3c/csswg-drafts/issues/1751#event-3381393863), this clarifies that the CSS properties defined for CSS Speech Module apply to all media types, and that they cannot be scoped in the way that was described