### PR TITLE
[css-inline-3] Extend “applies to” for SVG text

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -32,6 +32,8 @@ At Risk: the 'initial-letter-wrap' property
 spec:css-align-3; type:dfn; text:alignment baseline
 spec:css-box; type:dfn; text:content area
 spec:css-break-3; type:dfn; text:fragment
+spec:css-shapes-1; type:property; text:shape-margin
+spec:svg2; type:dfn; text: current text position
 </pre>
 
 <h2 id="intro">
@@ -446,7 +448,7 @@ Dominant Baselines: the 'dominant-baseline' property</h3>
 	Name: dominant-baseline
 	Value: auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top
 	Initial: auto
-	Applies to: block containers, inline boxes, table rows, table columns, grid containers, and flex containers
+	Applies to: block containers, inline boxes, table rows, table columns, grid containers, flex containers, and SVG <a>text content elements</a>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: specified keyword
@@ -526,7 +528,7 @@ Transverse Box Alignment: the 'vertical-align' property</h3>
 	Name: vertical-align
 	Value: <<'baseline-source'>> || <<'baseline-shift'>> || <<'alignment-baseline'>>
 	Initial: baseline
-	Applies to: inline-level boxes
+	Applies to: see individual properties
 	Inherited: no
 	Percentages: N/A
 	</pre>
@@ -567,7 +569,7 @@ Alignment Baseline Source: the 'baseline-source' longhand</h4>
 	indicating the box’s <dfn export>baseline alignment preference</dfn>.
 	Values have the following meanings:
 
-	<dl dfn-for=alignment-baseline dfn-type=value>
+	<dl dfn-for=baseline-source dfn-type=value>
 		<dt><dfn>auto</dfn>
 		<dd>Specifies <a>last-baseline alignment</a> for ''inline-block'',
 		<a>first-baseline alignment</a> for everything else.
@@ -586,7 +588,7 @@ Alignment Baseline Type: the 'alignment-baseline' longhand</h4>
 	Name: alignment-baseline
 	Value: baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top | bottom | center | top
 	Initial: baseline
-	Applies to: inline-level boxes, flex items, grid items, table cells
+	Applies to: inline-level boxes, flex items, grid items, table cells, and SVG <a>text content elements</a>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified keyword
@@ -598,9 +600,12 @@ Alignment Baseline Type: the 'alignment-baseline' longhand</h4>
 	prior to applying its [=post-alignment shift=].
 
 	The <dfn>alignment baseline values</dfn>,
-	which specify which [=baseline=] of the box is aligned
+	specify which [=baseline=] of the box is aligned
 	to the corresponding [=baseline=] of its [=alignment context=]
-	when performing [=baseline alignment=], are defined below:
+	when performing [=baseline alignment=].
+	For SVG text layout, specifies the baseline that is aligned
+	to the SVG <a>current text position</a>.
+	They are defined as follows:
 
 	<dl dfn-for=alignment-baseline dfn-type=value>
 		<dt><dfn>baseline</dfn>
@@ -692,7 +697,7 @@ Post-Alignment Shift: the 'baseline-shift' longhand</h4>
 	Name: baseline-shift
 	Value: <<length-percentage>> | sub | super
 	Initial: 0
-	Applies to: inline-level boxes, flex items, grid items
+	Applies to: inline-level boxes, flex items, grid items, and SVG <a>text content elements</a>
 	<!-- table cells left out b/c CSS2.1 vertical-align values must have no effect... -->
 	Inherited: no
 	Percentages: refer to the used value of 'line-height'
@@ -744,7 +749,7 @@ Line Spacing: the 'line-height' property</h3>
 	Name: line-height
 	Value: normal | <<number>> | <<length-percentage>>
 	Initial: normal
-	Applies to: non-replaced inline boxes
+	Applies to: non-replaced inline boxes and SVG <a>text content elements</a>
 	Inherited: yes
 	Percentages: computed relative to ''1em''
 	Computed value: the specified keyword, a number, or a computed <<length>> value


### PR DESCRIPTION
Closes #3411
See issue for discussion/reasoning & differences from SVG 1.

Bikeshed error that needs fixing:
the “current text position” definition from SVG text
is not being exported in a way that Bikeshed is picking up,
even with hints about which spec to look for it in.
(@TabAtkins, can I fix this here, or do I need to add some attributes to the SVG spec?)

Changes should be copied over to css-inline-4 after review.
