### PR TITLE
[scroll-animations-1][web-animations-1] Added phase calculation for ScrollTimeline #4325

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -709,22 +709,23 @@ The procedure to calculate <dfn>effective scroll range</dfn> of a
 
 ### The phase of a {{ScrollTimeline}} ### {#phase-algorithm}
 
-The [=phase=] of a {{ScrollTimeline}} is calculated from the first matching
-condition from below:
+The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
+
+1.  If <em>any</em> of the following are true:
+
+    * {{source}} is null, or
+    * {{source}} does not currently have a [=CSS layout box=], or
+    * {{source}}'s layout box is not a [=scroll container=], or
+    * [=effective scroll range=] is null.
+
+    :  return [=timeline inactive phase|inactive=] and abort remaining steps.
+
+1.  Let <var>current scroll offset</var> be the current scroll offset of
+    {{source}} in the direction specified by {{orientation}}.
+
+1.  Return the result corresponding to the first matching condition from below:
 
 <div class="switch">
-
-:   If <em>any</em> of the following are true:
-
-    1.  {{source}} is null, or
-    1.  {{source}} does not currently have a [=CSS layout box=], or
-    1.  {{source}}'s layout box is not a [=scroll container=], or
-    1.  [=effective scroll range=] is null
-
-::  return [=timeline inactive phase|inactive=]
-
-:   Otherwise, let <var>current scroll offset</var> be the current scroll offset
-    of {{source}} in the direction specified by {{orientation}}.
 
 :   If <var>current scroll offset</var> is less than [=effective start offset=]:
 ::  return [=before phase=]
@@ -741,22 +742,23 @@ condition from below:
 
 ### The current time of a {{ScrollTimeline}} ### {#current-time-algorithm}
 
-The [=current time=] of a {{ScrollTimeline}} is calculated from the first
-matching condition from below:
+The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
+
+1.  If <em>any</em> of the following are true:
+
+    * {{source}} is null, or
+    * {{source}} does not currently have a [=CSS layout box=], or
+    * {{source}}'s layout box is not a [=scroll container=], or
+    * [=effective scroll range=] is null.
+
+    : return an unresolved time value and abort remaining steps.
+
+1.  Let <var>current scroll offset</var> be the current scroll offset of
+    {{source}} in the direction specified by {{orientation}}.
+
+1.  Return the result corresponding to the first matching condition from below:
 
 <div class="switch">
-
-:   If <em>any</em> of the following are true:
-
-    1.  {{source}} is null, or
-    1.  {{source}} does not currently have a [=CSS layout box=], or
-    1.  {{source}}'s layout box is not a [=scroll container=], or
-    1.  [=effective scroll range=] is null
-
-::  return an unresolved time value.
-
-:   Otherwise, let <var>current scroll offset</var> be the current scroll offset
-    of {{source}} in the direction specified by {{orientation}}.
 
 :   If <var>current scroll offset</var> is less than [=effective start offset=]:
 ::  return 0.
@@ -765,7 +767,8 @@ matching condition from below:
     end offset=]:
 ::  return [=effective time range=].
 
-:  Otherwise, return the result of evaluating the following expression:
+:   Otherwise,
+::  return the result of evaluating the following expression:
 
     <blockquote>
       <code>(<var>current scroll offset</var> - [=effective start offset=]) / [=effective scroll range=] &times; [=effective time range=]</code>

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -709,50 +709,69 @@ The procedure to calculate <dfn>effective scroll range</dfn> of a
 
 ### The phase of a {{ScrollTimeline}} ### {#phase-algorithm}
 
-The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
+The [=phase=] of a {{ScrollTimeline}} is calculated from the first matching
+condition from below:
 
-1.  If {{source}} is null, does not currently have a [=CSS layout box=], or if
-    its layout box is not a [=scroll container=], return [=inactive phase=].
+<div class="switch">
 
-1.  Otherwise, let <var>current scroll offset</var> be the current scroll offset
+:   If <em>any</em> of the following are true:
+
+    1.  {{source}} is null, or
+    1.  {{source}} does not currently have a [=CSS layout box=], or
+    1.  {{source}}'s layout box is not a [=scroll container=], or
+    1.  [=effective scroll range=] is null
+
+::  return [=timeline inactive phase|inactive=]
+
+:   Otherwise, let <var>current scroll offset</var> be the current scroll offset
     of {{source}} in the direction specified by {{orientation}}.
 
-1.  If [=effective scroll range=] is null, return [=inactive phase=].
+:   If <var>current scroll offset</var> is less than [=effective start offset=]:
+::  return [=before phase=]
 
-1.  If <var>current scroll offset</var> is less than [=effective start offset=],
-    return [=before phase=].
+:   If <var>current scroll offset</var> is greater than or equal to [=effective
+    end offset=] <em>and</em> [=effective end offset=] is less than the maximum
+    scroll offset of {{source}} in {{orientation}}:
+::  return [=after phase=]
 
-1.  If <var>current scroll offset</var> is greater than or equal to [=effective
-    end offset=], return [=after phase=].
+:   Otherwise,
+::  return [=active phase=].
 
-1.  Otherwise, return [=active phase=].
+</div>
 
 ### The current time of a {{ScrollTimeline}} ### {#current-time-algorithm}
 
-The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
+The [=current time=] of a {{ScrollTimeline}} is calculated from the first
+matching condition from below:
 
-1.  If {{source}} is null, does not currently have a [=CSS layout box=], or if
-    its layout box is not a [=scroll container=], return an unresolved time
-    value.
+<div class="switch">
 
-1.  Otherwise, let <var>current scroll offset</var> be the current scroll offset
+:   If <em>any</em> of the following are true:
+
+    1.  {{source}} is null, or
+    1.  {{source}} does not currently have a [=CSS layout box=], or
+    1.  {{source}}'s layout box is not a [=scroll container=], or
+    1.  [=effective scroll range=] is null
+
+::  return an unresolved time value.
+
+:   Otherwise, let <var>current scroll offset</var> be the current scroll offset
     of {{source}} in the direction specified by {{orientation}}.
 
-1.  If [=effective scroll range=] is null, return an unresolved time value.
+:   If <var>current scroll offset</var> is less than [=effective start offset=]:
+::  return 0.
 
-1.  If <var>current scroll offset</var> is less than [=effective start offset=],
-    return 0.
+:   If <var>current scroll offset</var> is greater than or equal to [=effective
+    end offset=]:
+::  return [=effective time range=].
 
-1.  If <var>current scroll offset</var> is greater than or equal to [=effective
-    end offset=], return [=effective time range=].
-
-1.  Return the result of evaluating the following expression:
+:  Otherwise, return the result of evaluating the following expression:
 
     <blockquote>
       <code>(<var>current scroll offset</var> - [=effective start offset=]) / [=effective scroll range=] &times; [=effective time range=]</code>
     </blockquote>
 
-
+</div>
 
 Note: To be considered active a scroll timeline requires its [=effective start
 offset=] and its [=effective end offset=] to be non-null. This means that for

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -718,7 +718,7 @@ The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
     * {{source}}'s layout box is not a [=scroll container=], or
     * [=effective scroll range=] is null.
 
-    :  return [=timeline inactive phase|inactive=] and abort remaining steps.
+    return [=timeline inactive phase|inactive=] and abort remaining steps.
 
 1.  Let <var>current scroll offset</var> be the current scroll offset of
     {{source}} in the direction specified by {{orientation}}.
@@ -751,7 +751,7 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
     * {{source}}'s layout box is not a [=scroll container=], or
     * [=effective scroll range=] is null.
 
-    : return an unresolved time value and abort remaining steps.
+    return an unresolved time value and abort remaining steps.
 
 1.  Let <var>current scroll offset</var> be the current scroll offset of
     {{source}} in the direction specified by {{orientation}}.

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -778,8 +778,8 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
     end offset=]:
 ::  The [=current time=] is the [=effective time range=].
 
-:   Otherwise, the [=current time=] is the result of evaluating the following
-    expression:
+:   Otherwise,
+::  The [=current time=] is the result of evaluating the following expression:
 
     <blockquote>
       <code>(<var>current scroll offset</var> - [=effective start offset=]) / [=effective scroll range=] &times; [=effective time range=]</code>

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -718,7 +718,7 @@ The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
     * {{source}}'s layout box is not a [=scroll container=], or
     * [=effective scroll range=] is null.
 
-    The [=phase=] is the [=inactive phase=] and abort remaining steps.
+    The [=phase=] is [=inactive phase|inactive=] and abort remaining steps.
 
 1.  Let <var>current scroll offset</var> be the current scroll offset of
     {{source}} in the direction specified by {{orientation}}.
@@ -729,13 +729,13 @@ The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
 <div class="switch">
 
 :   If <var>current scroll offset</var> is less than [=effective start offset=]:
-::  The [=phase=] is the [=before phase=]
+::  The [=phase=] is [=before phase|before=]
 
 :   If <var>current scroll offset</var> is greater than or equal to [=effective
     end offset=] <em>and</em> [=effective end offset=] is less than the maximum
     scroll offset of {{source}} in {{orientation}}:
 
-::  The [=phase=] is the [=after phase=]
+::  The [=phase=] is [=after phase|after=]
 
 Note: In web animations, in general ranges are normally exclusive of their end
 point. But there is an exception here for the scroll timeline active range as it
@@ -746,7 +746,7 @@ in the active range would leave to animations that would not be active at the
 very last scroll position.
 
 :   Otherwise,
-::  The [=phase=] is the [=active phase=].
+::  The [=phase=] is [=active phase|active=].
 
 </div>
 

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -718,25 +718,35 @@ The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
     * {{source}}'s layout box is not a [=scroll container=], or
     * [=effective scroll range=] is null.
 
-    return [=timeline inactive phase|inactive=] and abort remaining steps.
+    The [=phase=] is the [=inactive phase=] and abort remaining steps.
 
 1.  Let <var>current scroll offset</var> be the current scroll offset of
     {{source}} in the direction specified by {{orientation}}.
 
-1.  Return the result corresponding to the first matching condition from below:
+1.  The [=phase=] is the result corresponding to the first matching condition
+    from below:
 
 <div class="switch">
 
 :   If <var>current scroll offset</var> is less than [=effective start offset=]:
-::  return [=before phase=]
+::  The [=phase=] is the [=before phase=]
 
 :   If <var>current scroll offset</var> is greater than or equal to [=effective
     end offset=] <em>and</em> [=effective end offset=] is less than the maximum
     scroll offset of {{source}} in {{orientation}}:
-::  return [=after phase=]
+
+::  The [=phase=] is the [=after phase=]
+
+Note: In web animations, in general ranges are normally exclusive of their end
+point. But there is an exception here for the scroll timeline active range as it
+may in some cases be inclusive of its end. In particular if the timeline end
+offset is the maximum scroll offset we include it in active range because it is
+not possible for user to scroll passed this point and not including this value
+in the active range would leave to animations that would not be active at the
+very last scroll position.
 
 :   Otherwise,
-::  return [=active phase=].
+::  The [=phase=] is the [=active phase=].
 
 </div>
 
@@ -751,24 +761,25 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
     * {{source}}'s layout box is not a [=scroll container=], or
     * [=effective scroll range=] is null.
 
-    return an unresolved time value and abort remaining steps.
+    The [=current time=] is an unresolved time value and abort remaining steps.
 
 1.  Let <var>current scroll offset</var> be the current scroll offset of
     {{source}} in the direction specified by {{orientation}}.
 
-1.  Return the result corresponding to the first matching condition from below:
+1.  The [=current time=] is the result corresponding to the first matching
+    condition from below:
 
 <div class="switch">
 
 :   If <var>current scroll offset</var> is less than [=effective start offset=]:
-::  return 0.
+::  The [=current time=] is 0.
 
 :   If <var>current scroll offset</var> is greater than or equal to [=effective
     end offset=]:
-::  return [=effective time range=].
+::  The [=current time=] is the [=effective time range=].
 
-:   Otherwise,
-::  return the result of evaluating the following expression:
+:   Otherwise, the [=current time=] is the result of evaluating the following
+    expression:
 
     <blockquote>
       <code>(<var>current scroll offset</var> - [=effective start offset=]) / [=effective scroll range=] &times; [=effective time range=]</code>

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -30,6 +30,11 @@ urlPrefix: https://w3c.github.io/web-animations/; type: dfn; spec: web-animation
     text: start delay
     text: target effect end
     text: timeline
+    text: phase; url: timeline-phase
+    text: inactive phase; url: timeline-inactive-phase
+    text: before phase; url: timeline-before-phase
+    text: active phase; url: timeline-active-phase
+    text: after phase; url: timeline-after-phase
 urlPrefix: https://drafts.csswg.org/cssom-view/; type: dfn; spec: cssom-view-1
     text: CSS layout box
     text: overflow direction; url: overflow-directions
@@ -701,6 +706,27 @@ The procedure to calculate <dfn>effective scroll range</dfn> of a
 
     </div>
 
+
+### The phase of a {{ScrollTimeline}} ### {#phase-algorithm}
+
+The [=phase=] of a {{ScrollTimeline}} is calculated as follows:
+
+1.  If {{source}} is null, does not currently have a [=CSS layout box=], or if
+    its layout box is not a [=scroll container=], return [=inactive phase=].
+
+1.  Otherwise, let <var>current scroll offset</var> be the current scroll offset
+    of {{source}} in the direction specified by {{orientation}}.
+
+1.  If [=effective scroll range=] is null, return [=inactive phase=].
+
+1.  If <var>current scroll offset</var> is less than [=effective start offset=],
+    return [=before phase=].
+
+1.  If <var>current scroll offset</var> is greater than or equal to [=effective
+    end offset=], return [=after phase=].
+
+1.  Otherwise, return [=active phase=].
+
 ### The current time of a {{ScrollTimeline}} ### {#current-time-algorithm}
 
 The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
@@ -716,9 +742,6 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
 
 1.  If <var>current scroll offset</var> is less than [=effective start offset=],
     return 0.
-
-    Issue(4325): Define what the correct timeline state is based on scroll
-    offset.
 
 1.  If <var>current scroll offset</var> is greater than or equal to [=effective
     end offset=], return [=effective time range=].

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2344,19 +2344,27 @@ definitions:
 
 An <a>animation effect</a> is in the <dfn>before phase</dfn> if the
 animation effect's <a>local time</a> is not <a>unresolved</a> and
-<em>either</em> of the following conditions are met:
+<em>any</em> of the following conditions are met:
 
 1.  the <a>local time</a> is less than the <a>before-active boundary time</a>,
     <em>or</em>
+1.  the effect is <a>associated with a timeline</a> <em>and</em> the associated
+    <a>timeline</a>'s [=timeline phase|phase=] is
+    [=timeline before phase|before=] <em>and</em> the <a>local time</a> is equal
+    to the <a>before-active boundary time</a>, <em>or</em>
 1.  the <a>animation direction</a> is &lsquo;backwards&rsquo; and the <a>local
     time</a> is equal to the <a>before-active boundary time</a>.
 
 An <a>animation effect</a> is in the <dfn>after phase</dfn> if the
 animation effect's <a>local time</a> is not <a>unresolved</a> and
-<em>either</em> of the following conditions are met:
+<em>any</em> of the following conditions are met:
 
 1.  the <a>local time</a> is greater than the <a>active-after boundary
     time</a>, <em>or</em>
+1.  the effect is <a>associated with a timeline</a> <em>and</em> the associated
+    <a>timeline</a>'s [=timeline phase|phase=] is
+    [=timeline after phase|after=] <em>and</em> the <a>local time</a> is equal
+    to the <a>active-after boundary time</a>, <em>or</em>
 1.  the <a>animation direction</a> is &lsquo;forwards&rsquo; and the <a>local
     time</a> is equal to the <a>active-after boundary time</a>.
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2344,27 +2344,19 @@ definitions:
 
 An <a>animation effect</a> is in the <dfn>before phase</dfn> if the
 animation effect's <a>local time</a> is not <a>unresolved</a> and
-<em>any</em> of the following conditions are met:
+<em>either</em> of the following conditions are met:
 
 1.  the <a>local time</a> is less than the <a>before-active boundary time</a>,
     <em>or</em>
-1.  the effect is <a>associated with a timeline</a> <em>and</em> the associated
-    <a>timeline</a>'s [=timeline phase|phase=] is
-    [=timeline before phase|before=] <em>and</em> the <a>local time</a> is equal
-    to the <a>before-active boundary time</a>, <em>or</em>
 1.  the <a>animation direction</a> is &lsquo;backwards&rsquo; and the <a>local
     time</a> is equal to the <a>before-active boundary time</a>.
 
 An <a>animation effect</a> is in the <dfn>after phase</dfn> if the
 animation effect's <a>local time</a> is not <a>unresolved</a> and
-<em>any</em> of the following conditions are met:
+<em>either</em> of the following conditions are met:
 
 1.  the <a>local time</a> is greater than the <a>active-after boundary
     time</a>, <em>or</em>
-1.  the effect is <a>associated with a timeline</a> <em>and</em> the associated
-    <a>timeline</a>'s [=timeline phase|phase=] is
-    [=timeline after phase|after=] <em>and</em> the <a>local time</a> is equal
-    to the <a>active-after boundary time</a>, <em>or</em>
 1.  the <a>animation direction</a> is &lsquo;forwards&rsquo; and the <a>local
     time</a> is equal to the <a>active-after boundary time</a>.
 


### PR DESCRIPTION
I added section describing how scroll timeline phase is calculated. Inclusive end exception that was removed in a previous PR has been added back in through the phase calculation (an explanatory note for the exception has been included). 

I also reformatted the section for calculating current time to match the new phase calculation formatting. 