### PR TITLE
[scroll-animations] Ignore @scroll-timeline rules in shadow trees

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -759,6 +759,11 @@ Once specified, a scroll timeline may be associated with a CSS Animation
 The <<declaration-list>> inside of ''@scroll-timeline'' rule can only contain the
 descriptors defined in this section.
 
+An ''@scroll-timeline'' rule is invalid if it occurs in a stylesheet inside of a
+[=shadow tree=], and must be ignored.
+
+Issue(5167): This will likely change in the future.
+
 ### Scroll Timeline descriptors ### {#scroll-timeline-descriptors}
 
 


### PR DESCRIPTION
For now, that is.

Fixes #5167.
