### PR TITLE
[css-color-adjust-1] Revert non-URL background images in Forced Colors Mode

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -383,8 +383,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		<li>'text-shadow'
 	</pre>
 
-	Additionally, on <em>on user input controls (except button-like controls) only</em>,
-	'background-image'.
+	Additionally, 'background-image', unless the value is a 'url()' function.
 
 	'color-scheme' on the element must compute to ''light dark'',
 	to allow the user preference (see [[#forced|above]])


### PR DESCRIPTION
This addresses issues #4916 and #4917.

This change removes the `background-image` special-casing for input controls and adds logic to revert non-URL background images in Forced Colors Mode.
