### PR TITLE
[css-color-5] Adjustments to edge cases and set notation for hue interpolation types

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -752,20 +752,20 @@ Unless the type of hue interpolation is ''specified'', both angles need to be co
 One way to do this is <code><i>θ</i> = ((<i>θ</i> % 360) + 360) % 360</code>.
 
 : ''shorter''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ [0, 180). In pseudo-Javascript:
+:: Angles are adjusted so that θ₂ - θ₁ ∈ [-180, 180). In pseudo-Javascript:
 	<pre>
 	if (θ₂ - θ₁ >= 180) {
 		θ₁ += 360;
 	}
-	else if (θ₂ - θ₁ <= -180) {
+	else if (θ₂ - θ₁ < -180) {
 		θ₂ += 360;
 	}
 	</pre>
 
 : ''longer''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ [180, 360). In pseudo-Javascript:
+:: Angles are adjusted so that θ₂ - θ₁ ∈ {(-360, -180], 0, (180, 360)}. In pseudo-Javascript:
 	<pre>
-	if (0 < θ₂ - θ₁ < 180) {
+	if (0 < θ₂ - θ₁ <= 180) {
 	  θ₁ += 360;
 	}
 	else if (-180 < θ₂ - θ₁ < 0) {
@@ -774,7 +774,7 @@ One way to do this is <code><i>θ</i> = ((<i>θ</i> % 360) + 360) % 360</code>.
 	</pre>
 
 : ''increasing''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ [0, 360) and θ₁ ≤ θ₂. In pseudo-Javascript:
+:: Angles are adjusted so that θ₂ - θ₁ ∈ [0, 360). In pseudo-Javascript:
 	<pre>
 	if (θ₂ < θ₁) {
 		θ₂ += 360;
@@ -782,7 +782,7 @@ One way to do this is <code><i>θ</i> = ((<i>θ</i> % 360) + 360) % 360</code>.
 	</pre>
 
 : ''decreasing''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ [0, 360) and θ₁ ≥ θ₂. In pseudo-Javascript:
+:: Angles are adjusted so that θ₂ - θ₁ ∈ (-360, 0]. In pseudo-Javascript:
 	<pre>
 	if (θ₁ < θ₂) {
 		θ₁ += 360;

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -752,9 +752,9 @@ Unless the type of hue interpolation is ''specified'', both angles need to be co
 One way to do this is <code><i>θ</i> = ((<i>θ</i> % 360) + 360) % 360</code>.
 
 : ''shorter''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ [-180, 180). In pseudo-Javascript:
+:: Angles are adjusted so that θ₂ - θ₁ ∈ [-180, 180]. In pseudo-Javascript:
 	<pre>
-	if (θ₂ - θ₁ >= 180) {
+	if (θ₂ - θ₁ > 180) {
 		θ₁ += 360;
 	}
 	else if (θ₂ - θ₁ < -180) {
@@ -763,13 +763,13 @@ One way to do this is <code><i>θ</i> = ((<i>θ</i> % 360) + 360) % 360</code>.
 	</pre>
 
 : ''longer''
-:: Angles are adjusted so that θ₂ - θ₁ ∈ {(-360, -180], 0, (180, 360)}. In pseudo-Javascript:
+:: Angles are adjusted so that |θ₂ - θ₁| ∈ {0, [180, 360)}. In pseudo-Javascript:
 	<pre>
-	if (0 < θ₂ - θ₁ <= 180) {
-	  θ₁ += 360;
+	if (0 < θ₂ - θ₁ < 180) {
+		θ₁ += 360;
 	}
 	else if (-180 < θ₂ - θ₁ < 0) {
-	  θ₂ += 360;
+		θ₂ += 360;
 	}
 	</pre>
 


### PR DESCRIPTION
This makes a few adjustments to the definitions of hue interpolation
types to follow up on the discussions in #4735.

First, it adjusts the pseudo-code so that for 'shorter' and 'longer',
angles that differ by 180 degrees will always go in the decreasing
direction, as described in
https://github.com/w3c/csswg-drafts/issues/4735#issuecomment-650254063

Second, it adjusts the set notation to match the pseudo-code.  (They
were not matching even prior to this change.)  The set notation
previously seemed to assume that there were absolute-value functions
present that were not actually there.  However, given the asymmetry of
always going in the decreasing direction, it's more correct to write it
without absolute values.