### PR TITLE
[css-images-3] `image-orientation: none` applies to non-decorative images too. #5245

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -25,6 +25,10 @@ Ignored Vars: start image, end image
 Link Defaults: css2 (property) display
 Include Can I Use Panels: yes
 </pre>
+<pre class=link-defaults>
+spec:html; type:element; text:link
+spec:filter-effects-1; type:element; text:feimage
+</pre>
 
 Introduction {#intro}
 =====================
@@ -1529,17 +1533,30 @@ Image Processing {#image-processing}
 	If that is confirmed, then it is likely that this property will be removed from CSS
 	unless use cases other than “correct for incorrect orientation” are raised for its other values.
 
-	This property specifies an orthogonal rotation to be applied to an image before it is laid out.
-	It applies only to content images
-	(e.g. replaced elements and generated content),
-	not decorative images
-	(such as 'background-image').
-	CSS layout processing applies to the image <em>after</em> rotation.
+	This property specifies an orthogonal rotation to be applied to an image before it is used.
+	It applies to images in replaced elements if part of the same document,
+	images referenced by SVG elements,
+	and those specified in any non-custom CSS property on an element.
+	This includes, for example:
+
+	* images referenced by the HTML <{img}>, <{picture}>, and SVG <{image}> elements
+	* a <{video}> element's poster
+	* filter image sources defined by the SVG <{feImage}> element
+	* any CSS property that takes an <<image>> value (such as 'background-image', 'content', and 'cursor')
+
+	But it excludes:
+
+	* images in separate documents referenced by embedded content (such as in an <{iframe}> element's document)
+	* images referenced by document metadata elements (such as favicons in <{link}> elements)
+
+	Any processing of the image (including CSS layout) is done <em>after</em> rotation.
 	This implies, for example:
 
-	* The intrinsic height and width are derived from the rotated rather than the original image dimensions.
+	* The intrinsic height and width of a content image are derived from the rotated rather than the original image dimensions.
 	* The height (width) property applies to the vertical (horizontal) dimension of the image,
 		<em>after</em> rotation.
+	* The hotspot coordinates of an image 'cursor' are relative to the image after rotation.
+	* Border image slicing is done after rotation.
 
 	Values have the following meanings:
 
@@ -1584,6 +1601,11 @@ Image Processing {#image-processing}
 	Values other than ''image-orientation/none'' and ''from-image'' are
 	<em>optional</em> to implement and <em>deprecated</em> in CSS.
 -->
+
+	For compatibility with existing non-browser implementations,
+	any value of 'image-orientation' other than ''image-orientation/none''
+	applied to an image referenced by any CSS property other than ''content''
+	must be treated as if ''from-image'' were used.
 
 	The 'image-orientation' property must be applied before any other transformations,
 	such as using CSS Transforms.


### PR DESCRIPTION
Fixes #5245.