### PR TITLE
[CSS2] simplify reference to RFC2318

### DIFF
--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -1560,21 +1560,17 @@ support as experimental. A future level of CSS may specify this further.
 <p>In general, this document specifies error handling behavior
 throughout the specification. For example, see the <a href="#parsing-errors">rules for handling parsing errors</a>. 
 
-<h3><dfn data-lt="text/css" id="text-css">The text/css content type</dfn></h3>
+<h3 id="text-css">The text/css content type</h3>
 
-<p>CSS style sheets that exist in separate files are sent over the
-Internet as a sequence of bytes accompanied by encoding
-information. The structure of the
-transmission, termed a <dfn data-lt="message entity" id="message-entity">message
-entity,</dfn> is defined by RFC 2045 and RFC 2616 (see
-[[!RFC2045]] and [[!RFC2616]]). A message entity with a content type of
-"text/css" represents an independent CSS document. The "text/css"
-content type has been registered by RFC 2318 ([[!RFC2318]]).
+<span id="message-entity"></span>
+
+The <i>media type</i> (commonly <i>MIME type</i>)
+of <code>text/css</code>
+has been registered by [[!RFC2318]].
 
 
 
 
-</p>
 <h2 id="syndata"><span id="q4.0">Syntax and basic data types</span></h2>
 <h3 id="syntax">Syntax</h3>
 


### PR DESCRIPTION
This avoids referencing the obsolete RFC2616.

Should we be marking this section as informative? It doesn't seem to have any conformance criteria beyond what RFC2318 itself gives. I guess we could have something such as "When encoding a style sheet as a message entity [[!RFC2015]] or an HTTP message [[!RFC7231]], an author must use the text/css media type. When a UA receives a message entity or an HTTP message with a media type of text/css, it must process it as a CSS style sheet."?