### PR TITLE
[CSS2] inherit should use computed, not specified, value

### DIFF
--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -15,6 +15,7 @@ Former Editor: Editor: Bert Bos, W3C, mailto:bert@w3.org, w3cid 3343
 Former Editor: Elika J. Etemad / fantasai, Invited Expert, http://fantasai.inkedblade.net/contact, w3cid 35400
 Former Editor: Ian Hickson, ian@hixie.ch
 Former Editor: H&aring;kon Wium Lie, Opera Software, howcome@opera.com
+WPT Display: inline
 Abstract:
   This specification defines Cascading Style Sheets level&nbsp;2 (CSS&nbsp;2)
   revision&nbsp;2 (CSS&nbsp;2.2). CSS is a style sheet language
@@ -15682,9 +15683,15 @@ Colors</a></h3>
 
 The informative appendix on the [[CSS20]] ''aural'' media type and related properties has been removed.
 
+Note: there are no tests for this change as all the removed text is informative.
+
 <h4 id="inherit-computed-value">Specified value of inherit</h4>
 
 The [=specified value=] of ''inherit'' now comes from the [=computed value=] instead of the [=specified value=].
+
+<wpt>
+  css/CSS2/borders/border-width-011.xht
+</wpt>
 
 <h3 id="known-errors">Errors</h3>
 <!--

--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -4432,6 +4432,8 @@ on the following mechanisms (in order of precedence):</p>
 
 <ol>
 <li>If the <a href="#cascade">cascade</a> results in a value, use it.
+Except that, if the value is ''inherit'', the specified value is defined
+in [[#value-def-inherit]] below.
 <li>Otherwise, if the property is <a href="#inheritance">inherited</a> and the element is not the root of the <a>document tree</a>, use the computed value of the parent element.
 <li>Otherwise use the property's <dfn>initial value</dfn>. The initial value of each property is indicated in the property's definition. 
 </ol>
@@ -4541,8 +4543,8 @@ not intercepted by <a data-lt="" href="#box-gen">anonymous boxes.</a>
 value</h4>
 
 <p>Each property may also have a cascaded value of ''inherit'', which
-means that, for a given element, the property takes the same specified
-value as the property for the element's parent. The ''inherit'' value
+means that, for a given element, the property takes as specified
+value the computed value of the element's parent. The ''inherit'' value
 can be used to enforce inheritance of values, and it can also be used on
 properties that are not normally inherited.
 

--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -15682,6 +15682,10 @@ Colors</a></h3>
 
 The informative appendix on the [[CSS20]] ''aural'' media type and related properties has been removed.
 
+<h4 id="inherit-computed-value">Specified value of inherit</h4>
+
+The [=specified value=] of ''inherit'' now comes from the [=computed value=] instead of the [=specified value=].
+
 <h3 id="known-errors">Errors</h3>
 <!--
 


### PR DESCRIPTION
Fixes #2768.

From https://lists.w3.org/Archives/Public/www-style/2011Oct/0482.html:

   - RESOLVED: Fix wording in CSS2.1 sections 6.2.1 and 6.1.1 to say
               that 'inherit' causes the property's specified value
               to be its parent's computed value.
               http://www.w3.org/Bugs/Public/show_bug.cgi?id=14420

Originally fixed in 2aa48e8ef and ab60bee0d.

Co-authored-by: Sam Sneddon <me@gsnedders.com>