### PR TITLE
[css + web-animations] Handle getKeyframes for CSSAnimations

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -299,8 +299,6 @@ and the position of the animation in |element|'s 'animation-name' list,
      1.   Iterate over all declarations in the keyframe block and
           add them to |keyframe| such that:
 
-          *     All variable references are resolved to their current values.
-
           *     Each shorthand property is expanded to its longhand
                 subproperties.
 
@@ -318,9 +316,7 @@ and the position of the animation in |element|'s 'animation-name' list,
                 have already added at this same |keyframe offset|,
                 they should be skipped.
 
-           *    All property values are replaced with their computed values.
-
-     1.   Add each physical longhand property name that was added to |keyframe|
+     1.   Add each property name that was added to |keyframe|
           to |animated properties|.
 
 1.   If there is no keyframe in |keyframes| with offset 0,
@@ -362,20 +358,6 @@ It could be rewritten so this is not required but that will likely change
 the behavior for some edge cases.
 We should verify what current implementations do and possible remove the
 requirement to iterate in reverse.
-
-Issue: In practice, implementations will likely maintain specified values and
-variable references internally and only resolve them to computed values when
-{{KeyframeEffect/getKeyframes()}} is called on a {{KeyframeEffect}}
-associated with a {{CSSAnimation}}
-(and, more specifically, a {{CSSAnimation}} whose effect has not been replaced
-and whose keyframes have not been overridden
-using {{KeyframeEffect/setKeyframes()}}).
-It is not clear that soing so would produce an observable difference in
-behavior, however.
-If it does, the above procedure might need to be adjusted so that the
-requirement to expand variables and convert to property values to computed
-values is limited to the result of {{KeyframeEffect/getKeyframes()}} and
-not the internal representation of keyframes.
 
 ## The 'animation-duration' property ## {#animation-duration}
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -5049,9 +5049,21 @@ interface KeyframeEffect : AnimationEffect {
     used to prepare the result of this method is defined in prose below:
 
     1.  Let <var>result</var> be an empty sequence of objects.
-    1.  Let <var>keyframes</var> be the result of applying the procedure to
-        <a>compute missing keyframe offsets</a> to the <a>keyframes</a>
-        for this <a>keyframe effect</a>.
+    1.  Let <var>keyframes</var> be one of the following:
+
+        1.  If this <a>keyframe effect</a> is associated with a
+            {{CSSAnimation}}, and its <a>keyframes</a> have not been replaced
+            by a successful call to {{KeyframeEffect/setKeyframes()}};
+            the <a>computed keyframes</a> for this <a>keyframe effect</a>.
+
+        1.  Otherwise, the result of applying the procedure
+            <a>compute missing keyframe offsets</a> to the <a>keyframes</a>
+            for this <a>keyframe effect</a>.
+
+        Note: We return <a>computed keyframes</a> for CSS Animations
+              because not all keyframes specified in CSS can be
+              represented by a dictionary.
+
     1.  For each <var>keyframe</var> in <var>keyframes</var>
         perform the following steps:
 
@@ -5077,9 +5089,8 @@ interface KeyframeEffect : AnimationEffect {
             keyframe-specific <a>timing function</a>, and
             <a>keyframe-specific composite operation</a>
             values of <var>keyframe</var>.
-        1.  For each animation property-value pair specified on
-            <var>keyframe</var>, <var>declaration</var>, perform the following
-            steps:
+        1.  For each animation property-value pair in <var>keyframe</var>,
+            <var>declaration</var>, perform the following steps:
 
             1.  Let <var>property name</var> be the result of applying the
                 <a>animation property name to IDL attribute name</a> algorithm


### PR DESCRIPTION
In css-animations-2, instead of generating keyframes resembling
computed keyframes, generate specified keyframes. Computing the
keyframes at keyframe-creation-time creates too many questions
regarding when/how property values inside the keyframes are computed.
We can instead rely on the existing process for calculating computed
keyframes, and apply that process at the time getKeyframes is called.

This means that var() references (and dependencies in general, such
as 'em' units) remain until computed-keyframe-time.

This isn't a problem for shorthand expansion at keyframe-creation-time:
if there's a var() in a shorthand, it expands using the "pending
substitution value" [1] for its longhands.

We can continue to resolve logical properties to physical at keyframe-
creation-time as well, assuming 'direction' and 'writing-mode' are not
allowed in keyframes. (FWIW, it's not allowed in Blink, but I'm not
sure if this is spec'd).

In web-animations-1, in the algorithm for getKeyframes, we either
use the specified keyframes (+ compute missing offset) as the source,
or the computed keyframes, depending on circumstance. This
"circumstance" could definitely be tightened up a bit (instead of
referring to whether or not calls to setKeyframes have taken place),
but it probably makes sense to do this as a whole for all the
"tainting" behavior described by css-animations-2 (Animations chapter),
so I haven't tried to address that here.

I'm not sure if we need to explicitly add somewhere that the computed
keyframes contains the necessary offset/easing/composite values, or
if it's already "understood" that these exist also for computed
keyframes. (I didn't make a change here).

Finally, the fact that getKeyframes returns objects listed as
"dictionary ComputedKeyframe" is a bit awkward, since it's not
consistent with the spec's "main" definition of computed keyframes.
We should probably rename it.

[1] https://drafts.csswg.org/css-variables/#pending-substitution-value