### PR TITLE
[css-syntax-3] Improvements to grammar, possessives, perspectives, and links

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2529,7 +2529,7 @@ Consume a declaration</h4>
 	<a>Consume the next input token</a>.
 	Create a new declaration
 	with its name set to the value of the <a>current input token</a>
-	and its value initially set to the empty [=list=].
+	and its value initially set to an empty [=list=].
 
 	<ol>
 		<li>

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2405,7 +2405,7 @@ Consume an at-rule</h4>
 	<a>Consume the next input token</a>.
 	Create a new at-rule
 	with its name set to the value of the <a>current input token</a>,
-	its prelude initially set to an empty list,
+	its prelude initially set to an empty [=list=],
 	and its value initially set to nothing.
 
 	Repeatedly consume the <a>next input token</a>:
@@ -2445,7 +2445,7 @@ Consume a qualified rule</h4>
 	To <dfn>consume a qualified rule</dfn>:
 
 	Create a new qualified rule
-	with its prelude initially set to an empty list,
+	with its prelude initially set to an empty [=list=],
 	and its value initially set to nothing.
 
 	Repeatedly consume the <a>next input token</a>:
@@ -2599,7 +2599,7 @@ Consume a simple block</h4>
 	(E.g. if it was called with <a href="#tokendef-open-square">&lt;[-token></a>, the <a>ending token</a> is <a href="#tokendef-close-square">&lt;]-token></a>.)
 
 	Create a <a>simple block</a> with its associated token set to the <a>current input token</a>
-	and with its value initially set to an empty list.
+	and with its value initially set to an empty [=list=].
 
 	Repeatedly consume the <a>next input token</a> and process it as follows:
 
@@ -2641,7 +2641,7 @@ Consume a function</h4>
 	To <dfn>consume a function</dfn>:
 
 	Create a function with its name equal to the value of the <a>current input token</a>
-	and with its value initially set to an empty list.
+	and with its value initially set to an empty [=list=].
 
 	Repeatedly consume the <a>next input token</a> and process it as follows:
 

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2640,8 +2640,8 @@ Consume a function</h4>
 
 	To <dfn>consume a function</dfn>:
 
-	Create a function with a name equal to the value of the <a>current input token</a>,
-	and with a value which is initially an empty list.
+	Create a function with its name equal to the value of the <a>current input token</a>
+	and with its value initially set to an empty list.
 
 	Repeatedly consume the <a>next input token</a> and process it as follows:
 

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2599,7 +2599,7 @@ Consume a simple block</h4>
 	(E.g. if it was called with <a href="#tokendef-open-square">&lt;[-token></a>, the <a>ending token</a> is <a href="#tokendef-close-square">&lt;]-token></a>.)
 
 	Create a <a>simple block</a> with its associated token set to the <a>current input token</a>
-	and with a value with is initially an empty list.
+	and with its value initially set to an empty list.
 
 	Repeatedly consume the <a>next input token</a> and process it as follows:
 


### PR DESCRIPTION
This changes various sentences in the css-syntax in order to improve the readability of the specification.

- This fixes a grammatical error in 1 description. (f32266a1a)
- This improves consistency in 2 descriptions by changing non-possessives to possessives. (f32266a1a, 6ca6cc82d)
- This improves consistency in 1 description by changing a specific article to a non-specific article. (3adc0363a)
- This improves terminology by linking a cross-referenced term in 4 descriptions. (306eaf0c2)

---

### A grammatical error in 1 description

The “**_Consume a simple block_**” section reads (with emphasis added):

> Create a simple block with its associated token set to the current input token and **with a value with is** initially an empty list.

The second half of this sentence has a typo where it reads “_with a value with is_”, while the author likely intended it to read “_with a value **which** is_”. This would have aligned with a similar description from the “**_Consume a function_**” section. Should other elements of this request be rejected, I would be happy to provide this exact fix. However, my fix is superseded in by next change.

### Consistently use possessives in 2 descriptions

The “**_Consume a simple block_**” section reads (with emphasis added):

> Create a simple block **with its associated token** set to the current input token and **with a value with is initially an empty list**.

The second half of this sentence loses its third-person perspective. This changes the second half of this sentence to preserve the third-person perspective, like this:

> Create a simple block **with its associated token** set to the current input token and **with its value initially set to an empty list**.

This change aligns this description with 5 other descriptions in the specification, and some 80+ other uses of the “_its_” third-person perspective.

A remaining outlier is the “**_Consume a function_**” section. This changes that sentence to use the “_its_” third-person perspective (_and a drop a comma not found in the other descriptions_), like this:

> Create a function **with its name** equal to the value of the current input token, and **with its value initially set to an empty list**.

### Consistently use a non-specific article in 1 description

The “_Consume a declaration_” description read differently than the other descriptions (emphasis added):

> Create a new declaration with its name set to the value of the current input token and its value initially set to **the empty list**.

In 4 similar descriptions, this portion reads as ”_an empty list_”. This changes the description to match the others, like this:

> Create a new declaration with its name set to the value of the current input token and its value initially set to **an empty list**.

### Improve terminology by linking a cross-referenced term in 4 descriptions

In the “**_Consume a declaration_**” description, the term “**_list_**” links to the **Infra Standard**. This PR links the word "**_list_**” in 4 similar descriptions (which all end as "_initially set to an empty list_”) to the **Infra Standard**.