### PR TITLE
[css-fonts-4] Add range specifying that font-weight-absolute must be >= 1 and <= 1000

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -517,12 +517,12 @@ Generic font families</h4>
 
     This property accepts values of the following:
 
-    <pre class="prod"><dfn id="font-weight-absolute-values">&lt;font-weight-absolute&gt;</dfn> = [normal | bold | <<number>>]</pre>
+    <pre class="prod"><dfn id="font-weight-absolute-values">&lt;font-weight-absolute&gt;</dfn> = [normal | bold | <<number [1,1000]>>]</pre>
 
     Values have the following meanings:
 
     <dl dfn-for=font-weight dfn-type=value>
-        <dt id="font-weight-numeric-values"><dfn><<number>></dfn>
+        <dt id="font-weight-numeric-values"><dfn><<number [1,1000]>></dfn>
         <dd>
             Each number indicates a weight that is at least as dark as its predecessor.
             Only values greater than or equal to 1, and less than or equal to 1000, are valid,


### PR DESCRIPTION
This echoes what's already described in prose in the notes: https://drafts.csswg.org/css-fonts-4/#font-weight-numeric-values

The reason why I'd like this change is that I'm working on a fuzz testing tool that uses these grammars to generate valid CSS, via https://github.com/mdn/data/ -- see https://github.com/mdn/data/pull/420