### PR TITLE
[css-flexbox-1] Typo: s/specified size/specified size suggestion/

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -973,7 +973,7 @@ Automatic Minimum Size of Flex Items</h3>
 
 	In general, the <a>content-based minimum size</a> of a <a>flex item</a>
 	is the smaller of its <a>content size suggestion</a> and its <a>specified size suggestion</a>.
-	However, if the box has an aspect ratio and no <a>specified size</a>,
+	However, if the box has an aspect ratio and no <a>specified size suggestion</a>,
 	its <a>content-based minimum size</a>
 	is the smaller of its <a>content size suggestion</a> and its <a>transferred size suggestion</a>.
 	If the box has neither a <a>specified size suggestion</a> nor an aspect ratio,


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/blob/e2399816bd8f945d62d914597737d3e251ffc9a9/css-flexbox-1/Overview.bs#L976
The spec refers to https://drafts.csswg.org/css-flexbox/#specified-size-suggestion
But currently it's linking to https://drafts.csswg.org/css-images-3/#specified-size