### PR TITLE
[css-variables] Use discrete animation type

### DIFF
--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -75,7 +75,7 @@ Defining Custom Properties: the '--*' family of properties</h2>
 	Applies to: all elements
 	Inherited: yes
 	Computed value: specified value with variables substituted, or the [=guaranteed-invalid value=]
-	Animatable: no
+	Animation type: discrete
 	</pre>
 
 	<p class=all-media>User Agents are expected to support this property on all media, including non-visual ones.</p>


### PR DESCRIPTION
Animatable:no would suggest that custom properties are not processed
at all if they appear in keyframes. Use 'discrete' animation type
instead.
