### PR TITLE
[css-cascade] Clarify how @import behaves with invalid rules  #5313

### DIFF
--- a/css-cascade-3/Overview.bs
+++ b/css-cascade-3/Overview.bs
@@ -82,16 +82,16 @@ Importing Style Sheets: the ''@import'' rule</h2>
 		then it doesn't apply to the imported stylesheet.
 
 	* If a feature relies on the relative ordering of two or more constructs in a stylesheet
-		(such as the requirement that ''@charset'' must not have any other content preceding it),
+		(such as the requirement that ''@namespace'' rules must not have any other rules other than
+		''@import'' preceding it),
 		it only applies between constructs in the same stylesheet.
 
 	<p class='example'>
 		For example, declarations in style rules from imported stylesheets interact with the cascade
 		as if they were written literally into the stylesheet at the point of the ''@import''.
 
-	Any ''@import'' rules must precede all other at-rules and style rules in a style sheet
-	(besides ''@charset'', which must be the first thing in the style sheet if it exists),
-	or else the ''@import'' rule is invalid.
+	Any ''@import'' rules must precede all other valid at-rules and style rules in a style sheet
+	(with ''@charset'' counting as an invalid rule), or else the ''@import'' rule is invalid.
 	The syntax of ''@import'' is:
 
 	<pre class='prod'>@import [ <<url>> | <<string>> ] <<media-query-list>>? ;</pre>

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -80,7 +80,8 @@ Importing Style Sheets: the ''@import'' rule</h2>
 		then it doesn't apply to the imported stylesheet.
 
 	* If a feature relies on the relative ordering of two or more constructs in a stylesheet
-		(such as the requirement that ''@charset'' must not have any other content preceding it),
+		(such as the requirement that ''@namespace'' rules must not have any other rules other than
+		''@import'' preceding it),
 		it only applies between constructs in the same stylesheet.
 
 	<p class='example'>
@@ -89,9 +90,8 @@ Importing Style Sheets: the ''@import'' rule</h2>
 		Similarly, style rules in a stylesheet imported into a scoped stylesheet
 		are scoped in the same way.
 
-	Any ''@import'' rules must precede all other at-rules and style rules in a style sheet
-	(besides ''@charset'', which must be the first thing in the style sheet if it exists),
-	or else the ''@import'' rule is invalid.
+	Any ''@import'' rules must precede all other valid at-rules and style rules in a style sheet
+	(with ''@charset'' counting as an invalid rule), or else the ''@import'' rule is invalid.
 	The syntax of ''@import'' is:
 
 	<pre class='prod'>


### PR DESCRIPTION
This change also modifies the mention of @charset as an example of an at-rule with restrictions on its relative ordering to replace it with@namespace, since @charset is no longer considered an at-rule.
