### PR TITLE
[css-values-4] Fix <<number>> to <<integer>> in Combination of <integer> section

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -920,7 +920,7 @@ Combination of <<integer>></h4>
 	by rounding to the nearest integer,
 	with values halfway between adjacent integers rounded towards positive infinity.
 
-	<a>Addition</a> of <<number>> is defined as
+	<a>Addition</a> of <<integer>> is defined as
 	<var>V<sub>result</sub></var> =
 		<var>V<sub>a</sub></var> + <var>V<sub>b</sub></var>
 


### PR DESCRIPTION
 I found a small mistake in [the Combination of `<integer>`](https://www.w3.org/TR/css-values-4/#combine-integers) section, where Addition of `<number>` is mistakenly defined instead of` <integer>`.

This PR fixes it.