### PR TITLE
[css-syntax-3] Reference identifier-start instead of name-start

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -789,7 +789,7 @@ Definitions</h3>
 		<dd>
 			A <a>code point</a> with a value equal to or greater than U+0080 &lt;control>.
 
-		<dt><dfn export lt="identifier-start code point" oldids="name-start-code-point">identifier-start code point</dfn>
+		<dt><dfn export lt="identifier-start code point | name-start code point" oldids="name-start-code-point">identifier-start code point</dfn>
 		<dd>
 			A <a>letter</a>,
 			a <a>non-ASCII code point</a>,

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -789,7 +789,7 @@ Definitions</h3>
 		<dd>
 			A <a>code point</a> with a value equal to or greater than U+0080 &lt;control>.
 
-		<dt><dfn export lt="identifier-start code point | name-start code point" oldids="name-start-code-point">identifier-start code point</dfn>
+		<dt><dfn export lt="identifier-start code point" oldids="name-start-code-point">identifier-start code point</dfn>
 		<dd>
 			A <a>letter</a>,
 			a <a>non-ASCII code point</a>,
@@ -797,7 +797,7 @@ Definitions</h3>
 
 		<dt><dfn export lt="identifier code point | name code point" oldids="name-code-point">identifier code point</dfn>
 		<dd>
-			A <a>name-start code point</a>,
+			An <a>identifier-start code point</a>,
 			a <a>digit</a>,
 			or U+002D HYPHEN-MINUS (-).
 


### PR DESCRIPTION
This updates the label of a reference to the **identifier-start code point** definition in the CSS Syntax specification.

The **identifier code point** definition contains a potentially mislabeled [reference to a “_**name-start** code point_”](https://drafts.csswg.org/date/2020-07-22T16:50:27/css-syntax-3/#identifier-code-point):

> **identifier code point**
> A name-start code point, a digit, or U+002D HYPHEN-MINUS (-).

In that definition, “_name-start code point_” links to the **identifier code point** definition.

I believe it should be relabeled to “_identifier-start code point_”:

> **identifier code point**
> An identifier-start code point, a digit, or U+002D HYPHEN-MINUS (-).