### PR TITLE
[resize-observer-1] Invoke callback with observer as 2nd argument and `this` value

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -495,7 +495,7 @@ run these steps:
 
         5. Set |shallowestTargetDepth| to |targetDepth| if |targetDepth| < |shallowestTargetDepth|
 
-    4. Invoke |observer|.{{ResizeObserver/[[callback]]}} with |entries|.
+    4. Invoke |observer|.{{ResizeObserver/[[callback]]}} with |entries| as the first argument and |observer| as the second argument and <a>callback this value</a>. If this throws an exception, <a>report the exception</a>.
 
     5. Clear |observer|.{{ResizeObserver/[[activeTargets]]}}.
 


### PR DESCRIPTION
This PR aligns [`ResizeObserver` spec](https://drafts.csswg.org/resize-observer/#broadcast-active-observations) (step 2.4) with implementations (WPT: [test](https://github.com/web-platform-tests/wpt/blob/e35de4d284f3272e3f914eb9deea6cf7d1924605/resize-observer/observe.html#L207), [results](https://wpt.fyi/results/resize-observer/observe.html?label=experimental&label=master&aligned)) and other observers:
* [`MutationObserver`](https://dom.spec.whatwg.org/#notify-mutation-observers) (step 5.4);
* [`IntersectionObserver`](https://w3c.github.io/IntersectionObserver/#notify-intersection-observers-algo) (step 3.4);
* [`PerformanceObserver`](https://w3c.github.io/performance-timeline/#queue-the-performanceobserver-task) (step 3.3.5).

Passing `observer` to `callback` enables users to reuse a single `callback` function, which invokes [`unobserve`](https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve) with [entry's `target`](https://drafts.csswg.org/resize-observer/#dom-resizeobserverentry-target), for multiple `ResizeObserver` instances.