### PR TITLE
[css-inline-3] Fix the code point for maqaf

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -2724,7 +2724,7 @@ Appendix A: Synthesizing Alignment Metrics</h2>
 					the ideographic character face edges.
 
 				<li>
-					The top edge of the center of the Hebrew maqaf (U+05B3 “־”)
+					The top edge of the center of the Hebrew maqaf (U+05BE “־”)
 					can be taken as the Hebrew hanging baseline.
 
 				<li>


### PR DESCRIPTION
https://drafts.csswg.org/css-inline-3/#baseline-synthesis-fonts

`U+05B3` is a Hebrew niqqud (vowel) sign, instead of a maqaf (a punctuation). The correct code point should be `U+05BE` instead.