### PR TITLE
[css-fonts-3] Consistent article "an" for `@font-face`

### DIFF
--- a/css-fonts-3/Fonts.src.html
+++ b/css-fonts-3/Fonts.src.html
@@ -1703,7 +1703,7 @@ name must not be used.</p>
 }
 </pre>
 
-<p>Just as a <code>@font-face</code> rule specifies the characteristics of a single font
+<p>Just as an <code>@font-face</code> rule specifies the characteristics of a single font
 within a family, the unique name used with <code>local()</code> specifies a single
 font, not an entire font family. Defined in terms of
 OpenType font data, the Postscript name is found in the font's
@@ -3840,7 +3840,7 @@ the following extension to the CSS Object Model.</p>
 
 <h3 id="om-fontface">The <code>CSSFontFaceRule</code> interface</h3>
 
-<p>The <dfn>CSSFontFaceRule</dfn> interface represents a <code>@font-face</code> rule.</p>
+<p>The <dfn>CSSFontFaceRule</dfn> interface represents an <code>@font-face</code> rule.</p>
 
 <pre class="idl">
 interface CSSFontFaceRule : CSSRule {

--- a/css-fonts-3/Overview-wip.bs
+++ b/css-fonts-3/Overview-wip.bs
@@ -1414,7 +1414,7 @@ name must not be used.
 }
 </pre>
 
-Just as a ''@font-face'' rule specifies the characteristics of a single font
+Just as an ''@font-face'' rule specifies the characteristics of a single font
 within a family, the unique name used with ''local()'' specifies a single
 font, not an entire font family. Defined in terms of
 OpenType font data, the Postscript name is found in the font's
@@ -3677,7 +3677,7 @@ the following extensions to the CSS Object Model.
 
 <h3 id="om-fontface">The {{CSSFontFaceRule}} interface</h3>
 
-The <dfn interface>CSSFontFaceRule</dfn> interface represents a ''@font-face'' rule.
+The <dfn interface>CSSFontFaceRule</dfn> interface represents an ''@font-face'' rule.
 
 <pre class="idl">
 interface CSSFontFaceRule : CSSRule {


### PR DESCRIPTION
I was arguing with our tech writer whether it should be "a @​font-face" (silent '@') or "a**n** @​font-face" (pronounced '@'). The spec was inconsistent, but generally favored "a**n** @​font-face". I have changed the remaining occurrences to "an".