### PR TITLE
[web-animations-1] Update the procedure for determining if the animation play state is idle.

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2000,7 +2000,7 @@ condition from the following:
     *   The <a>current time</a> of <var>animation</var> is <a>unresolved</a>,
         <em>and</em>
     *   the <a>start time</a> of <var>animation</var> is <a>unresolved</a>
-        or the <a>timeline</a> of <var>animation</var> is <a>unresolved</a>,
+        or the <a>timeline</a> of <var>animation</var> is <a>null</a>,
         <em>and</em>
     *   <var>animation</var> does <em>not</em> have <em>either</em>
         a <a>pending play task</a> <em>or</em> a <a>pending pause task</a>,

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -703,7 +703,7 @@ frame</a>.
 
 ### Timeline Phase ### {#timeline-phases}
 
-A [=timeline=] may be in one of four possible 
+A [=timeline=] may be in one of four possible
 <dfn export lt="timeline phase">phases</dfn>:
 
 1.  <dfn export lt="timeline inactive phase">inactive</dfn>
@@ -755,7 +755,7 @@ time=]. If |timeline| is inactive, return an [=unresolved=] [=time value=].
 
 ### The default document timeline ### {#the-documents-default-timeline}
 
-Each {{Document}} has a <a>document timeline</a> called the 
+Each {{Document}} has a <a>document timeline</a> called the
 <dfn export>default document timeline</dfn>.
 The <a>default document timeline</a> is unique to each document and persists for
 the lifetime of the document including calls to <a>document.open()</a> [[!HTML]].
@@ -1184,7 +1184,7 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
     </div>
 
 1.  If |seek time| is <a lt=unresolved>resolved</a>,
-     
+
         <div class="switch">
 
         :   If |has finite timeline| is true,
@@ -1684,7 +1684,7 @@ animation.finish(); // finish event is queued immediately and finished promise
 animation.currentTime = 0;
 </pre></div>
 
-Note that like the procedure to <a>finish an animation</a>, 
+Note that like the procedure to <a>finish an animation</a>,
 the procedure to <a>cancel an animation</a> similarly queues the
 <a>cancel event</a> and rejects the <a>current finished promise</a> and
 <a>current ready promise</a> in a <em>synchronous</em> manner.
@@ -1966,7 +1966,7 @@ The procedure to <dfn>reverse an animation</dfn> of <a>animation</a>
 ### Play states ### {#play-states}
 
 An <a>animation</a> may be described as being in one of the following
-<dfn lt="play state">play states</dfn> for each of which, a 
+<dfn lt="play state">play states</dfn> for each of which, a
 non-normative description is also provided:
 
 <div class=informative-bg>
@@ -1999,7 +1999,8 @@ condition from the following:
 :   <em>All</em> of the following conditions are true:
     *   The <a>current time</a> of <var>animation</var> is <a>unresolved</a>,
         <em>and</em>
-    *   the <a>start time</a> of <var>animation</var> is <a>unresolved</a>,
+    *   the <a>start time</a> of <var>animation</var> is <a>unresolved</a>
+        or the <a>timeline</a> of <var>animation</var> is <a>unresolved</a>,
         <em>and</em>
     *   <var>animation</var> does <em>not</em> have <em>either</em>
         a <a>pending play task</a> <em>or</em> a <a>pending pause task</a>,


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/issues/5400

Explicitly setting the start time on an animation with a null timeline causes it to be flagged as being in the running state. The constraint that the start time be unresolved was added recently to accommodate scroll-timelines, which may have an unresolved current time even though the start time has been set. Relaxing the constraint to required that the start time be unresolved or the timeline be null restores the previous behavior for null timelines without breaking scroll timelines.
