### PR TITLE
[css-syntax] Simplify ident-like URL consumption

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -1136,11 +1136,9 @@ Consume an ident-like token</h4>
 	If |string|’s value is an <a>ASCII case-insensitive</a> match for "url",
 	and the <a>next input code point</a> is U+0028 LEFT PARENTHESIS ((),
 	consume it.
-	While the <a lt="next input code point">next two input code points</a> are <a>whitespace</a>,
-	consume the <a>next input code point</a>.
-	If the <a lt="next input code point">next one or two input code points</a> are U+0022 QUOTATION MARK ("),
-	U+0027 APOSTROPHE (&apos;),
-	or <a>whitespace</a> followed by U+0022 QUOTATION MARK (") or U+0027 APOSTROPHE (&apos;),
+	While the <a lt="next input code point">next input code point</a> is <a>whitespace</a>,
+	consume it.
+	If the <a lt="next input code point">next input code points</a> is U+0022 QUOTATION MARK (") or U+0027 APOSTROPHE (&apos;),
 	then create a <<function-token>>
 	with its value set to |string|
 	and return it.


### PR DESCRIPTION
The specification reads:

> While the next two input code points are whitespace, consume the next input code point.

If I understand correctly, this will repeatedly consume whitespace until 0 or 1 whitespace input code points remain.

Then it reads:

> If the next one or two input code points U+0022 QUOTATION MARK (`"`), U+0027 APOSTROPHE (`'`), or whitespace followed by U+0022 QUOTATION MARK (`"`) or U+0027 APOSTROPHE (`'`), then create a `<function-token>`...

Could this be simplified?

> While the next input code point is whitespace, consume it. If the next input code point is a U+0022 QUOTATION MARK (`"`) or U+0027 APOSTROPHE (`'`), then create a `<function-token>`...