### PR TITLE
[web-animations-1][web-animations-2] Move mutable timeline back to web-animations-1

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -703,7 +703,7 @@ frame</a>.
 
 ### Timeline Phase ### {#timeline-phases}
 
-A [=timeline=] may be in one of four possible 
+A [=timeline=] may be in one of four possible
 <dfn export lt="timeline phase">phases</dfn>:
 
 1.  <dfn export lt="timeline inactive phase">inactive</dfn>
@@ -755,7 +755,7 @@ time=]. If |timeline| is inactive, return an [=unresolved=] [=time value=].
 
 ### The default document timeline ### {#the-documents-default-timeline}
 
-Each {{Document}} has a <a>document timeline</a> called the 
+Each {{Document}} has a <a>document timeline</a> called the
 <dfn export>default document timeline</dfn>.
 The <a>default document timeline</a> is unique to each document and persists for
 the lifetime of the document including calls to <a>document.open()</a> [[!HTML]].
@@ -1184,7 +1184,7 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
     </div>
 
 1.  If |seek time| is <a lt=unresolved>resolved</a>,
-     
+
         <div class="switch">
 
         :   If |has finite timeline| is true,
@@ -1684,7 +1684,7 @@ animation.finish(); // finish event is queued immediately and finished promise
 animation.currentTime = 0;
 </pre></div>
 
-Note that like the procedure to <a>finish an animation</a>, 
+Note that like the procedure to <a>finish an animation</a>,
 the procedure to <a>cancel an animation</a> similarly queues the
 <a>cancel event</a> and rejects the <a>current finished promise</a> and
 <a>current ready promise</a> in a <em>synchronous</em> manner.
@@ -1966,7 +1966,7 @@ The procedure to <dfn>reverse an animation</dfn> of <a>animation</a>
 ### Play states ### {#play-states}
 
 An <a>animation</a> may be described as being in one of the following
-<dfn lt="play state">play states</dfn> for each of which, a 
+<dfn lt="play state">play states</dfn> for each of which, a
 non-normative description is also provided:
 
 <div class=informative-bg>
@@ -4103,7 +4103,7 @@ interface Animation : EventTarget {
                 optional AnimationTimeline? timeline);
              attribute DOMString                id;
              attribute AnimationEffect?         effect;
-    readonly attribute AnimationTimeline?       timeline;
+             attribute AnimationTimeline?       timeline;
              attribute double?                  startTime;
              attribute double?                  currentTime;
              attribute double                   playbackRate;
@@ -4173,6 +4173,8 @@ interface Animation : EventTarget {
     the procedure to <a>set the associated effect of an animation</a>.
 :   <dfn attribute for=Animation>timeline</dfn>
 ::  The <a>timeline</a> associated with this animation.
+    Setting this attribute updates the object's <a>timeline</a> using
+    the procedure to <a>set the timeline of an animation</a>.
 :   <dfn attribute for=Animation>startTime</dfn>
 ::  Returns the [=start time=] of this animation.
     Setting this attribute updates the [=start time=] using

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -175,7 +175,7 @@ After the step to assign <var>new effect</var> as <var>animation</var>'s
 >       This is not quite right. If <var>old effect</var> is attached to another
 >       animation in the same task then we should probably not do an extra
 >       callback with <a>unresolved</a>.
-> 
+>
 >       The definition of when <a>custom effects</a> gets called needs to be
 >       audited and probably rewritten.
 >     </div>
@@ -1514,23 +1514,6 @@ partial interface AnimationTimeline {
     </div>
 
 </div>
-
-<h3 id="the-animation-interface">The <code>Animation</code> interface</h3>
-
-The <a>Animation</a> interface is amended to make the <var>timeline</var> member mutable:
-
-<pre class='idl'>
-partial interface Animation {
-               attribute AnimationTimeline?       timeline;
-};
-</pre>
-
-<div class='attributes'>
-
-:   <dfn attribute for=Animation>timeline</dfn>
-::  The <a>timeline</a> associated with this animation.
-    Setting this attribute updates the object's <a>timeline</a> using
-    the procedure to <a>set the timeline of an animation</a>.
 
 <h3 id="the-animationeffect-interface">The <code>AnimationEffect</code> interface</h3>
 


### PR DESCRIPTION
Related issue: https://github.com/w3c/csswg-drafts/issues/5401

This change moves mutable timelines back to web-animations-1. The procedure for setting the timeline was already in web-animations-1; however, the mutability of the timeline was moved to v2 of the spec. We are now close to supporting mutable timelines across browsers (albeit behind feature flags).
