### PR TITLE
[css-contain-2] Specify that the first content-visibility: auto visibility check happens immediately

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1292,7 +1292,20 @@ Restrictions and Clarifications {#cv-notes}
 		and not cause any forced layouts.
 	</div>
 
-4. For the purposes of scrolling operations,
+4. The initial determination of visibility for ''content-visibility: auto'' must
+    happen in the same frame that determined an existence of a new
+    ''content-visibility: auto'' element.
+
+  <div class=note>
+    When an element first gains ''content-visibility: auto'', it may or may not
+    be positioned on screen. The determination of this state and thus
+    determination of whether this element is [=skipped=] must happen in the
+    same frame. If it does not, then there is a possibility of producing blank
+    content in the element's place since visibility check and [=skipped=] state
+    update would be deferred to the next frame.
+  </div>
+
+5. For the purposes of scrolling operations,
 	such as {{Element/scrollIntoView()}},
 	an element with ''content-visibility: auto''
 	that is [=skipping its contents=]
@@ -1305,7 +1318,7 @@ Restrictions and Clarifications {#cv-notes}
 	if this changes the element's size,
 	it might not align in the viewport exactly as requested.
 
-5. If an element with ''content-visibility: auto''
+6. If an element with ''content-visibility: auto''
 	that is [=skipping its contents=]
 	is focused
 	(or its contents are),
@@ -1317,7 +1330,7 @@ Restrictions and Clarifications {#cv-notes}
 	the element <em>will</em> be correctly sized and aligned in the viewport.
 	This is consistent with the order of the steps for the {{HTMLOrSVGElement/focus()}} method.
 
-6. If an <{iframe}> [=skips its contents=]
+7. If an <{iframe}> [=skips its contents=]
 	or is part of an element's [=skipped contents=],
 	the user agent should entirely skip the [=Update The Rendering=]
 	step in the iframe's event loop,
@@ -1327,7 +1340,7 @@ Restrictions and Clarifications {#cv-notes}
 	it needs to run that step at least once
 	to remove the painted output.
 
-7. [=Skipped contents=] do not contribute to the result of {{HTMLElement/innerText}}.
+8. [=Skipped contents=] do not contribute to the result of {{HTMLElement/innerText}}.
 
 Accessibility Implications {#cv-a11y}
 -------------------------------------


### PR DESCRIPTION
When a new content-visibility: auto element is added, the check to determine
its visibility needs to occur in the same frame to avoid a flash of blank content.

This PR adds a clarification to this effect.