### PR TITLE
[scroll-animations-1] Remove default vaule for ScrollTimelineOptions.source

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -361,7 +361,7 @@ typedef (CSSNumericValue or CSSKeywordish) ContainerBasedOffset;
 typedef (ContainerBasedOffset or ElementBasedOffset) ScrollTimelineOffset;
 
 dictionary ScrollTimelineOptions {
-  Element? source = null;
+  Element? source;
   ScrollDirection orientation = "block";
   ScrollTimelineOffset start = "auto";
   ScrollTimelineOffset end = "auto";


### PR DESCRIPTION
Follow-up to #5263, which specifies that a "missing" source shall
result in using the Document's scrollingElement, but if we give
source a default value of null, it can never be missing.
