### PR TITLE
[css-scroll-anchoring-1] Reduce the scope of focused element

### DIFF
--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -35,6 +35,20 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
         type: dfn;
             text:DOM anchor
             text:focused area of the document
+            text:active match; url: fip-active-match
+    urlPrefix: form-elements.html
+        type: dfn;
+            text:textarea; url: the-textarea-element
+    urlPrefix: input.html
+        type: dfn;
+            text:input; url: the-input-element
+    urlPrefix: form-control-infrastructure.html
+        type: dfn;
+            text:mutable; url: concept-fe-mutable
+spec: html; urlPrefix: https://w3c.github.io/editing/docs/execCommand/;
+    urlPrefix: index.html
+        type: dfn;
+            text:editable
 </pre>
 
 <h2 id=intro>
@@ -104,8 +118,10 @@ following criteria:
 
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
-  1. The [=DOM anchor=] of the [=focused area of the document=].
-  2. An element containing the current active selected match of the
+  1. The [=DOM anchor=] of the [=focused area of the document=], if such an anchor
+      is text editable ([=editable=], [=editing host=], [=mutable=] [=textarea=], or
+      [=mutable=] [=input=] with a type that allows text entry).
+  2. An element containing the current [=active match=] of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then
       consider only the first such element.
 

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -36,12 +36,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
             text:DOM anchor
             text:focused area of the document
             text:active match; url: fip-active-match
-    urlPrefix: form-elements.html
-        type: dfn;
-            text:textarea; url: the-textarea-element
-    urlPrefix: input.html
-        type: dfn;
-            text:input; url: the-input-element
     urlPrefix: form-control-infrastructure.html
         type: dfn;
             text:mutable; url: concept-fe-mutable
@@ -119,8 +113,8 @@ following criteria:
 Some elements are considered to be <dfn
 id="anchor-priority-candidates">priority candidates</dfn> for anchor selection:
   1. The [=DOM anchor=] of the [=focused area of the document=], if such an anchor
-      is text editable ([=editable=], [=editing host=], [=mutable=] [=textarea=], or
-      [=mutable=] [=input=] with a type that allows text entry).
+      is text editable ([=editable=], [=editing host=], [=mutable=] <{textarea}>, or
+      [=mutable=] <{input}> with a type that allows text entry).
   2. An element containing the current [=active match=] of the
       find-in-page user-agent algorithm. If the match spans multiple elements, then
       consider only the first such element.


### PR DESCRIPTION
This reduces the scope of the focused area priority candidate to only the elements that permit text entry. Notably, this excludes typical buttons and anchor tags

Also small fix-up to active match to reference the spec.
