### PR TITLE
[mediaqueries-5] Draft text for in-gamut MQ, see #5045

### DIFF
--- a/css-color-4/workings/Macbeth-Fogra39.txt
+++ b/css-color-4/workings/Macbeth-Fogra39.txt
@@ -1,0 +1,17 @@
+$ IccApplyNamedCmm MacBeth-Lab.txt 3:6 0 Coated_Fogra39L_VIGC_300.icc 41
+'CMYK'  ; Data Format
+icEncodeFloat   ; Encoding
+
+;Source Data Format: 'Lab '
+;Source Data Encoding: icEncodeValue
+;Source data is after semicolon
+
+;Profiles applied
+; Coated_Fogra39L_VIGC_300.icc
+
+   0.214380    0.515461    0.538744    0.566424         ;   38.358002   13.802000   14.646000
+   0.124987    0.414934    0.419734    0.153140         ;   66.056000   17.737000   17.848000
+   0.619272    0.353912    0.108622    0.254668         ;   50.090000   -4.407000  -22.510000
+   0.491342    0.162242    0.705859    0.529225         ;   43.203999  -13.464000   21.730000
+   0.512904    0.460825    0.035273    0.117966         ;   55.355999    8.891000  -24.820000
+   0.622900    0.000000    0.402187    0.000000         ;   70.699997  -32.891998   -0.240000

--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -1730,6 +1730,115 @@ Color Display Quality: the 'color-gamut' feature</h3>
 	you can use this feature in a negated boolean-context fashion:
 	''not (color-gamut)''.
 
+<h3 id="in-gamut">
+	Displayable Color: the 'in-gamut' feature</h3>
+
+	<pre class='descdef mq'>
+		Name: in-gamut
+		Value: <<color>>
+		For: @media
+		Type:  discrete
+	</pre>
+
+	The '@media/in-gamut' media feature
+	is used to query whether a given <<color>>
+	lies within the <a>gamut</a> of the output device,
+	and thus,
+	it can be accurately displayed.
+
+	<div class="example">
+		The following media query tests whether primary green,
+		in the <a>display-p3</a> colorspace,
+		is in gamut for the output device.
+
+		<pre class="lang-css">@media (in-gamut:color(display-p3 0 1 0)) { … }</pre>
+	</div>
+
+	To determine whether the color is in gamut,
+	it is first converted to CIE XYZ or CIE Lab,
+	and then converted to the colorspace of the output device.
+
+	If the value for each color component,
+	in the output colorspace,
+	lies in the range [0.0-1.0],
+	the color is in-gamut.
+	Otherwise, (if there are negative components, or components greater than one),
+	it is out of gamut.
+
+	<!--
+		This example was calculated with
+		https://colorjs.io/apps/convert/?color=color(display-p3%200%201%200)&precision=4
+	-->
+
+	<div class="example">
+		For example, if the display is an sRGB screen,
+		the display-p3 color from the previous example
+		has the following components: red -2.9058, green 1.0183, blue -1.0162.
+		It is therefore out of gamut for this screen.
+	</div>
+
+	If the colorspace of the output device is unknown,
+	then for Web compatibility,
+	it should be assumed to be <a>sRGB</a>.
+
+	<!--
+		This example was calculated with
+		https://colorjs.io/apps/convert/?color=color(a98-rgb%200.48%200.86%200.95)&precision=3
+	-->
+	<div class="example">
+		The following media query tests whether a sky blue,
+		in the <a>a98-rgb</a> colorspace,
+		is out of gamut for the output device,
+		and if so, displays an out of gamut warning.
+
+		<pre class="lang-css">@media not (in-gamut:color(a98-rgb 0.48 0.86 0.95)) {
+				p.swatch {border: thin dashed red; }
+			}</pre>
+	</div>
+
+	The media query is not restricted to RGB output devices.
+
+	<!--
+		This example was calculated using the ICCMax reference implementation
+		and two color profiles, one for FOGRA39 and one for FOGRA55.
+		The data files are in the csswg css-color-4/workings directory
+		The input data is a file of Lab values for the first row on a MacBeth color checker chart.
+		The command line is
+		$ IccApplyNamedCmm MacBeth-Lab.txt 3:6 0 Coated_Fogra39L_VIGC_300.icc 41
+		$ IccApplyNamedCmm MacBeth-Lab.txt 3:6 0 2020_13.003_FOGRA55beta_CL_Profile.icc 41
+		run $ IccApplyNamedCmm with no arguments for usage
+		Macbeth-Fogra39.txt
+		Macbeth-7color.txt
+		MacBeth-Lab.txt
+	-->
+
+	<div class="example">
+		This example tests whether a given color,
+		which represents the cyan on a ColorChecker chart
+		and is specified in FOGRA39 CMYK colorspace,
+		is in gamut for the output device.
+
+		<pre class="lang-css">@color-profile --fogra39 {
+			src: url('https://example.org/Coated_Fogra39L_VIGC_300.icc');
+		  }
+		@media (in-gamut:color(--fogra39 0.622900 0.000000 0.402187 0.000000))  { … }
+		</pre>
+
+		The color profile reports that this color
+		corresponds to lab(70.699997% -32.891998 -0.240000).
+
+		Suppose that the output device is a high-end 7 color printer
+		with cyan, magenta, yellow, black, orange, green and violet inks,
+		using the FOGRA55 characterisation data.
+
+		The color profile reports that this Lab color
+		has the following components:
+		cyan 0.397575, magenta 0.010047, yellow 0.223682, black 0.031140, orange 0.000000, green 0.317066, violet 0.000000.
+		These are all in the range [0.0-1.0] so the color is in-gamut and the query returns true.
+
+	</div>
+
+
 <h3 id="dynamic-range">
 Dynamic Range: the 'dynamic-range' feature</h3>
 
@@ -2159,13 +2268,13 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	</div>
 
 <!--
-██     ██ ████ ████████  ████████  ███████ 
+██     ██ ████ ████████  ████████  ███████
 ██     ██  ██  ██     ██ ██       ██     ██
 ██     ██  ██  ██     ██ ██       ██     ██
 ██     ██  ██  ██     ██ ██████   ██     ██
  ██   ██   ██  ██     ██ ██       ██     ██
   ██ ██    ██  ██     ██ ██       ██     ██
-   ███    ████ ████████  ████████  ███████ 
+   ███    ████ ████████  ████████  ███████
 -->
 
 <h2 id="video-prefixed-features">Video Prefixed Features</h2>


### PR DESCRIPTION
Has some worked examples.

Specifies a default sRGB if the output device is not known, which is fine for screens but not for printers, hence should.
