### PR TITLE
https://wpt.fyi/results/mathml/relations?label=experimental&label=master&aligned

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2819,6 +2819,11 @@ If the user agent supports SVG, the following IDL applies: [[SVG11]]
 SVGElement includes ElementCSSInlineStyle;
 </pre>
 
+If the user agent supports MathML, the following IDL applies: [[MathML-Core]]
+
+<pre class=idl>
+MathMLElement includes ElementCSSInlineStyle;
+</pre>
 
 Extensions to the {{Window}} Interface {#extensions-to-the-window-interface}
 ----------------------------------------------------------------------------


### PR DESCRIPTION
closes #5513 as per resolution from the minutes there documenting reality of what is shipping.

Previously MathML elements didn't specify IDL, but now they do and are widely shipping - Lots of tests in https://wpt.fyi/results/mathml/relations?label=experimental&label=master&aligned make use of this.