### PR TITLE
Editorial: Removed duplicate "keywords" from Value Definitions section

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -126,7 +126,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="partial">

--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -92,7 +92,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="animations">

--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -81,7 +81,7 @@ Values Definitions</h2>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h3 id="placement">
@@ -111,7 +111,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h3 id=animations>Animated Values</h3>

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -82,7 +82,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="placement">

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -82,7 +82,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="placement">

--- a/css-break-3/Overview.bs
+++ b/css-break-3/Overview.bs
@@ -67,7 +67,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h2 id="fragmentation-model">

--- a/css-break-4/Overview.bs
+++ b/css-break-4/Overview.bs
@@ -74,7 +74,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="fragmentation-model">

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -99,7 +99,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="terminology">Color terminology</h2>

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -36,7 +36,7 @@ Value Definitions {#values}
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 Preferred Color Schemes {#preferred}

--- a/css-color-hdr/Overview.bs
+++ b/css-color-hdr/Overview.bs
@@ -94,7 +94,7 @@ Value Definitions {#values}
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 Predefined colorspaces for HDR: {#predefined-HDR}

--- a/css-contain-1/Overview.bs
+++ b/css-contain-1/Overview.bs
@@ -67,7 +67,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='contain-property'>

--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -84,7 +84,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='contain-property'>

--- a/css-content-3/Overview.bs
+++ b/css-content-3/Overview.bs
@@ -90,7 +90,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="content-property">

--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -192,7 +192,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='the-display-properties'>

--- a/css-egg-1/Overview.bs
+++ b/css-egg-1/Overview.bs
@@ -74,7 +74,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="units">

--- a/css-exclusions-1/Overview.bs
+++ b/css-exclusions-1/Overview.bs
@@ -55,7 +55,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h2 id="terms">

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -428,7 +428,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='box-model'>

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -50,7 +50,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <h2 id="basic-font-props">

--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -38,7 +38,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <!--page areas-->

--- a/css-gcpm-4/Overview.bs
+++ b/css-gcpm-4/Overview.bs
@@ -31,7 +31,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <h2 id="running-headers-and-footers">

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -391,7 +391,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='overview'>

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -376,7 +376,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='overview'>

--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -73,7 +73,7 @@ Value Definitions {#values}
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -49,7 +49,7 @@ Value Definitions {#values}
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -77,7 +77,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="model">

--- a/css-line-grid-1/Overview.bs
+++ b/css-line-grid-1/Overview.bs
@@ -181,7 +181,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='line-grid-property'>

--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -82,7 +82,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='declaring-a-list-item'>

--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -166,7 +166,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h2 id="directional-keywords">

--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -191,7 +191,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="the-multi-column-model">

--- a/css-nav-1/Overview.bs
+++ b/css-nav-1/Overview.bs
@@ -198,7 +198,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 </div>
 

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -109,7 +109,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -206,7 +206,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="overflow-concepts">Types of overflow</h2>

--- a/css-overscroll-1/Overview.bs
+++ b/css-overscroll-1/Overview.bs
@@ -75,7 +75,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 Motivating Examples {#motivating-examples}

--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -114,7 +114,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="page-terms">

--- a/css-page-floats-3/Overview.bs
+++ b/css-page-floats-3/Overview.bs
@@ -58,7 +58,7 @@ Ignored Terms: near, 3em, intrude, top-corner, bottom-corner, left, right, both,
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h2 id="terms">

--- a/css-position-3/Overview.bs
+++ b/css-position-3/Overview.bs
@@ -186,7 +186,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 

--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -258,7 +258,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="css-regions-concepts">

--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -118,7 +118,7 @@ Value Definitions {#values}
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 Adjusting Block-level Box Heights {#block-height}

--- a/css-round-display-1/Overview.bs
+++ b/css-round-display-1/Overview.bs
@@ -79,7 +79,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 Terminology {#terminology}

--- a/css-scroll-anchoring-1/Overview.bs
+++ b/css-scroll-anchoring-1/Overview.bs
@@ -69,7 +69,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <h2 id='description'>

--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -88,7 +88,7 @@ Value Definitions {#values}
 
     In addition to the property-specific values listed in their definitions,
     all properties defined in this specification
-    also accept the <a>CSS-wide keywords</a> keywords as their property value.
+    also accept the <a>CSS-wide keywords</a> as their property value.
     For readability they have not been repeated explicitly.
 
 <!--

--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -72,7 +72,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h2 id="scrollbar-color">Scrollbar Colors: the 'scrollbar-color' property</h2>

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -75,7 +75,7 @@ Module Interactions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id=animations>Animated Values</h3>

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -64,7 +64,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 

--- a/css-size-adjust-1/Overview.bs
+++ b/css-size-adjust-1/Overview.bs
@@ -73,7 +73,7 @@ Value Definitions {#values}
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 Default size adjustment {#default-adjustment}

--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -67,7 +67,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -56,7 +56,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -102,7 +102,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id="example">

--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -97,7 +97,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <!--

--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -162,7 +162,7 @@ Value Definitions</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
 <h3 id="languages">

--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -63,7 +63,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="terms">Terminology</h3>

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -63,7 +63,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id="terms">Terminology</h3>

--- a/css-transforms-1/Overview.bs
+++ b/css-transforms-1/Overview.bs
@@ -130,7 +130,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 Terminology {#terminology}
 ==========================

--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -85,7 +85,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 Terminology {#terminology}

--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -134,7 +134,7 @@ Value Definitions {#values}
 
       In addition to the property-specific values listed in their definitions,
       all properties defined in this specification
-      also accept the <a>CSS-wide keywords</a> keywords as their property value.
+      also accept the <a>CSS-wide keywords</a> as their property value.
       For readability they have not been repeated explicitly.
 
 <span id="transitions-">Transitions</span> {#transitions}

--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -147,7 +147,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <h2 id="box-model">Box Model addition</h2>

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -192,7 +192,7 @@ Combination with other CSS modules may expand the definitions of these value typ
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 <h2 id="outline-props" caniuse="outline">Outline properties</h2>

--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -59,7 +59,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h2 id='defining-variables'>

--- a/css-will-change-1/Overview.bs
+++ b/css-will-change-1/Overview.bs
@@ -48,7 +48,7 @@ Value Definitions</h3>
 
 	In addition to the property-specific values listed in their definitions,
 	all properties defined in this specification
-	also accept the <a>CSS-wide keywords</a> keywords as their property value.
+	also accept the <a>CSS-wide keywords</a> as their property value.
 	For readability they have not been repeated explicitly.
 
 <h3 id='using'>

--- a/css-writing-modes-3/Overview.bs
+++ b/css-writing-modes-3/Overview.bs
@@ -171,7 +171,7 @@ Value Definitions and Terminology</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
   <p>Other important terminology and concepts used in this specification

--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -169,7 +169,7 @@ Value Definitions and Terminology</h3>
 
   In addition to the property-specific values listed in their definitions,
   all properties defined in this specification
-  also accept the <a>CSS-wide keywords</a> keywords as their property value.
+  also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
   <p>Other important terminology and concepts used in this specification

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -94,7 +94,7 @@ CSS modules may expand the definitions of these value types.
 
 In addition to the property-specific values listed in their definitions,
 all properties defined in this specification
-also accept the <a>CSS-wide keywords</a> keywords as their property value.
+also accept the <a>CSS-wide keywords</a> as their property value.
 For readability they have not been repeated explicitly.
 
 # Use cases # {#use-cases}


### PR DESCRIPTION
This fixes #5516 by removing the repeated "keywords" words from the Value Definitions section of all specifications.

The reason why so many specs have this error is that the css-module-bikeshed spec. previously had that mistake, which got fixed already by @svgeesus in https://github.com/w3c/csswg-drafts/commit/794fb4708c6a7bf210f9ae399adab260bca0a464.

Sebastian