### PR TITLE
[css-font-loading-3] Add override attributes to FontFace interface following resolution in #4792

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -88,6 +88,9 @@ The <code>FontFace</code> Interface</h2>
 			CSSOMString featureSettings = "normal";
 			CSSOMString variationSettings = "normal";
 			CSSOMString display = "auto";
+			CSSOMString ascentOverride = "normal";
+			CSSOMString descentOverride = "normal";
+			CSSOMString lineGapOverride = "normal";
 		};
 
 		enum FontFaceLoadStatus { "unloaded", "loading", "loaded", "error" };
@@ -105,6 +108,9 @@ The <code>FontFace</code> Interface</h2>
 			attribute CSSOMString featureSettings;
 			attribute CSSOMString variationSettings;
 			attribute CSSOMString display;
+			attribute CSSOMString ascentOverride;
+			attribute CSSOMString descentOverride;
+			attribute CSSOMString lineGapOverride;
 
 			readonly attribute FontFaceLoadStatus status;
 
@@ -144,6 +150,9 @@ The <code>FontFace</code> Interface</h2>
 		: <dfn>featureSettings</dfn>
 		: <dfn>variationSettings</dfn>
 		: <dfn>display</dfn>
+		: <dfn>ascentOverride</dfn>
+		: <dfn>descentOverride</dfn>
+		: <dfn>lineGapOverride</dfn>
 		::
 			These attributes have the same meaning,
 			and are parsed the same as,


### PR DESCRIPTION
[css-font-loading-3] Add override attributes to FontFace interface following resolution in https://github.com/w3c/csswg-drafts/issues/4792#issuecomment-693528301

