### PR TITLE
[css-display-3] Link to definition of inline block

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -997,7 +997,7 @@ Appendix A: Glossary</h2>
 			A <a>block-level box</a> that is also a <a>block container</a>.
 
 			Note: Not all <a>block container</a> boxes are <a>block-level</a> boxes:
-			non-replaced inline blocks and non-replaced table cells,
+			non-replaced <a>inline blocks</a> and non-replaced table cells,
 			for example, are block containers
 			but not block-level boxes.
 			Similarly, not all block-level boxes are block containers:


### PR DESCRIPTION
I think this link to the definition of inline block would be helpful because inline blocks are not defined [in the glossary](https://drafts.csswg.org/css-display/#glossary) with the other box types.  Inline blocks are instead only defined as an alias to inline boxes [here in the generated box table](https://drafts.csswg.org/css-display/#inline-block), which one might miss when reading the paragraph in this diff.