### PR TITLE
Editorial: Replaced 'subgid' by 'subgrid'

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -1833,7 +1833,7 @@ Syntax of ''repeat()''</h5>
 		It can only appear once in the <a>track list</a>,
 		but the same <a>track list</a> can also contain <<fixed-repeat>>s.
 	* The <<name-repeat>> variant is for adding [=line names=] to [=subgrids=].
-		It can only be used with the ''grid-template-rows/subgid'' keyword
+		It can only be used with the ''grid-template-rows/subgrid'' keyword
 		and cannot specify track sizes, only [=line names=].
 
 	If a ''repeat()'' function that is not a <<name-repeat>>


### PR DESCRIPTION
[css-grid-2] Editorial: Corrected `subgid` to `subgrid` keyword.

This fixes #5579