### PR TITLE
Update Overview.bs

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -1061,7 +1061,7 @@ Skipping Glyphs: the 'text-decoration-skip-ink' property</h4>
 	<pre class="propdef">
 	Name: text-decoration-skip-ink
 	Value: auto | none | all
-	Initial: ''auto''
+	Initial: ''none''
 	Applies to: all elements
 	Inherited: yes
 	Percentages: N/A


### PR DESCRIPTION
Changed initial from auto to none for text-decoration-skip-ink-property. Reason: the auto setting leaves the default behaviour at the discretion of implementer which is never a good thing - a standard should be well defined and unambiguous, and may change the look of sites without knowledge of their creators and owners which is not a good idea either.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
