### PR TITLE
[css-egg-1] Add the `adafish` unit and the `performance` media query

### DIFF
--- a/css-egg-1/Overview.bs
+++ b/css-egg-1/Overview.bs
@@ -68,8 +68,8 @@ Module Interactions</h3>
 Value Definitions</h3>
 
 	This specification follows the <a href="https://www.w3.org/TR/CSS2/about.html#property-defs">CSS property definition conventions</a> from [[!CSS2]]
-	using the <a href="https://www.w3.org/TR/css-values-3/#value-defs">value definition syntax</a> from [[!CSS-VALUES-3]].
-	Value types not defined in this specification are defined in CSS Values &amp; Units [[!CSS-VALUES-3]].
+	using the <a href="https://www.w3.org/TR/css-values-3/#value-defs">value definition syntax</a> from [[!CSS3-VALUES]].
+	Value types not defined in this specification are defined in CSS Values &amp; Units [[!CSS3-VALUES]].
 	Combination with other CSS modules may expand the definitions of these value types.
 
 	In addition to the property-specific values listed in their definitions,

--- a/css-egg-1/Overview.bs
+++ b/css-egg-1/Overview.bs
@@ -19,6 +19,7 @@ spec:css-images-3; type:value;
 	text: closest-corner
 	text: farthest-corner
 spec:css-values-3; type:type; text:<time>
+spec:css-conditional-3; type:at-rule; text:@media
 </pre>
 
 <style type="text/css">
@@ -62,6 +63,7 @@ Module Interactions</h3>
 		<li>the data type definitions in [[!CSS3-VALUES]]
 		<li>the <<gradient>> definition in [[!CSS4-IMAGES]]
 		<li>the 'voice-rate' property in [[!CSS3SPEECH]]
+		<li>the '@media' rule in [[!MEDIAQUERIES-5]]
 	</ul>
 
 <h3 id="values">
@@ -365,6 +367,68 @@ This specification extends the 'voice-rate' property, so that the ''tmbl'' unit 
 </pre>
 
 Issue: Should negative values be allowed for <<speech-rate>> for reversed speech?
+
+
+<h3 id=fps>
+Device performance</h3>
+
+<div class="informative">
+Device performance is known to be a perfectly linear quantity with a total ordering consistent across different kinds of workloads. It is desirable to be able to design adaptive content that works across a range of user agent and device performance.</div>
+
+This specification introduces an new <a spec="css-values">dimension</a>, together with a new unit to be used with this dimension.
+
+The <dfn id="device-performance-value"><<device-performance>></dfn> describes the performance of the current device and user agent combination. It can be expressed using the ''adafish'' unit, as defined below.
+
+
+<table class="data" export>
+	<thead>
+		<tr><th>unit
+		    <th>name
+		    <th>definition
+	<tbody>
+		<tr><th><dfn>adafish</dfn>
+		    <td>Adafish
+		    <td>This is the maximum number of fish that can be displayed on the current device and user agent combination in <a href="https://ada.is/xrgarden/">Ada Rose Cannon's Fish Garden</a> without the user agent dropping any frames.
+</table>
+
+Note: <a href="https://ada.is/xrgarden/">Ada Rose Cannon's Fish Garden</a> supports changing the number of fish through the `?fish=` query parameter, e.g. <a href="https://ada.is/xrgarden/?fish=50">this link will show 50 fish</a>
+
+<h4 id="media-query-ext">
+Extension to the ''@media'' rule: The 'performance' feature</h4>
+
+	<pre class='descdef mq'>
+	Name: performance
+	Value: <<device-performance>>
+	For: @media
+	Type: range
+	</pre>
+
+The 'performance' media feature describes the performance characteristics of the current device and user agent combination at the current time. It SHOULD incorporate transient and permanent environmental factors affecting performance such as the current room temperature, the accumulation of dust in the device's cooling system, and the existence of spilled lemonade or coffee on the device's motherboard.
+
+When querying the 'performance' feature the user agent SHOULD ensure that it is querying a recent value. The user agent MAY in the background run <a href="https://ada.is/xrgarden/">Ada's Fish Garden</a> with various parameters to estimate this value. If device performance characteristics change while content is being viewed, the user agent MUST recompute its value for 'performance', potentially restyling the document.
+
+<div class=example>
+This feature is useful for designing robust content that adapts to different device characteristics.
+
+<pre><code class="lang-css">
+@media (min-performance: 1000adafish) {
+	#very-cool-demo-with-blinky-lights {
+		display: block;
+	}
+}
+
+@media (max-performance: 1000adafish) {
+	#really-bad-demo-with-no-blinky-lights-whatsoever {
+		display: block;
+	}
+}
+</code></pre>
+</div>
+
+<h4 id="adafish-fingerprinting">Fingerprinting concerns</h4>
+
+This API may be used for gleaning information about the user's environment, which may be used to fingerprint them. This is recognized to be an acceptable loss for the momentous benefits this API is expected to provide the web platform.
+
 
 <h2 id="rainbow">
 Double Rainbow</h2>


### PR DESCRIPTION
[css-egg-1] Add the `adafish` unit and the `performance` media query

This was first proposed by @toji in https://twitter.com/Tojiro/status/1317298532630499329 , and has rapidly gained the support of the community (me).

cc @AdaRoseCannon

r? @tabatkins  @frivoal 