### PR TITLE
[css-scoping-1] Let :host/:host-context/::slotted take a single compound

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -259,7 +259,7 @@ Selecting Into the Light: the '':host'', '':host()'', and '':host-context()'' ps
 	The <dfn selector id="selectordef-host-function">:host()</dfn> function pseudo-class
 	has the syntax:
 
-	<pre>:host( <<compound-selector-list>> )</pre>
+	<pre>:host( <<compound-selector>> )</pre>
 
 	When evaluated <a>in the context of a shadow tree</a>,
 	it matches the <a>shadow tree's</a> <a>shadow host</a>
@@ -321,12 +321,12 @@ Selecting Into the Light: the '':host'', '':host()'', and '':host-context()'' ps
 	which matches a particular selector.
 	Its syntax is:
 
-	<pre class=prod>:host-context( <<compound-selector-list>> )</pre>
+	<pre class=prod>:host-context( <<compound-selector>> )</pre>
 
 	When evaluated <a>in the context of a shadow tree</a>,
 	the '':host-context()'' pseudo-class matches the <a>shadow host</a>,
 	if the <a>shadow host</a> or one of its <a>shadow-including ancestors</a>
-	matches the provided <<compound-selector-list>>.
+	matches the provided <<compound-selector>>.
 	In any other context,
 	it matches nothing.
 
@@ -360,12 +360,12 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 
 	The grammar of the ''::slotted()'' pseudo-element is:
 
-	<pre class=prod>::slotted( <<compound-selector-list>> )</pre>
+	<pre class=prod>::slotted( <<compound-selector>> )</pre>
 
 	The ''::slotted()'' pseudo-element represents the elements that are:
 
 	* <a lt="find flattened slottables">assigned, after flattening,</a> to the <a>slot</a> that is ''::slotted''’s originating element
-	* <a lt="match a selector against an element">matched</a> by its <<compound-selector-list>> argument
+	* <a lt="match a selector against an element">matched</a> by its <<compound-selector>> argument
 
 	The ''::slotted()'' pseudo-element can be followed by a <a>tree-abiding pseudo-element</a>,
 	like ''::slotted()::before'',


### PR DESCRIPTION
This takes the liberty of also applying the related resolution to `:host-context`, although that's not mentioned in the issue.

Resolves #2158
