### PR TITLE
[css-conditional-3] Fix plurality

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -178,7 +178,7 @@ href="#processing">described above</a>.
 Any rules that are not allowed after a style rule (e.g., ''@charset'',
 ''@import'', or ''@namespace'' rules) are also not allowed after a
 conditional group rule.  Therefore, style sheets <strong>must
-not</strong> place such rules after a conditional group rules, and CSS
+not</strong> place such rules after a conditional group rule, and CSS
 processors <strong>must</strong> ignore such rules.
 
 <h2 id="at-media">


### PR DESCRIPTION
"after a conditional group rules" is internally inconsistent.