### PR TITLE
[css-color-4] Add missing / to close span for ButtonBorder

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1524,7 +1524,7 @@ System Colors</h3>
 		<dt><dfn>ButtonText</dfn>
 		<dd><span class="swatch" style="--color: buttontext"></span>&nbsp;Text on push buttons.
 		<dt><dfn>ButtonBorder</dfn>
-		<dd><span class="swatch" style="--color: buttonborder"><span>&nbsp;The base border color for push buttons.
+		<dd><span class="swatch" style="--color: buttonborder"></span>&nbsp;The base border color for push buttons.
 
 		<dt><dfn>Field</dfn>
 		<dd><span class="swatch" style="--color: field"></span>&nbsp;Background of input fields.


### PR DESCRIPTION
[css-color-4] Add missing / to close span for ButtonBorder so that the swatch doesn't include the description text.
 
