### PR TITLE
[mediaqueries-5] Fix grammar typo in advisment for prefers-contrast:forced 

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -2669,7 +2669,7 @@ Detecting the desire for increased or decreased color contrast from elements on 
 			See [[css-color-adjust-1#forced]] for details.
 
 			<div class=advisement>
-				This does <em>not</em> necessarily indicates
+				This does <em>not</em> necessarily indicate
 				a preference for more contrast.
 				The colors have been forcibly adjusted
 				to match the preference of the user,


### PR DESCRIPTION
Non-substantive edit.

In an advisement section on `prefers-contrast`, concerning "forced"...

> This does not necessarily indicates a preference for more contrast.

"indicates" should be "indicate"
