### PR TITLE
[css-font-loading] Remove step 3 from FontFaceSet.check()

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -843,14 +843,10 @@ The <code>check()</code> method</h3>
 			the method returns <code>true</code>,
 			as the text will be rendered in the UA's fallback font instead,
 			and won't trigger any font loads.
-		* If none of the specified fonts exist,
-			even though this is technically similar to the previous case
-			(in that text rendered with that font list would just use the UA fallback font),
-			the method instead throws an error.
-			This is because such a situation is almost certainly either a typo,
-			or the result of changing the name of a downloadable font
-			and forgetting to update all places the old name was used,
-			and an error is more useful than a vacuous <code>true</code>.
+		* Likewise, if none of the specified fonts exist (for example, names are mis-spelled),
+			the method also returns <code>true</code>,
+			because using this font list will not trigger any loads;
+			instead, fallback will occur.
 	</div>
 
 	When the <dfn method for="FontFaceSet" lt="check(font, text)|check(font)">check</dfn>(
@@ -871,11 +867,6 @@ The <code>check()</code> method</h3>
 			If a syntax error was returned,
 			throw a SyntaxError exception
 			and terminate these steps.
-
-		<li>
-			If <var>found faces</var> is false,
-			throw an XXX error
-			and abort this algorithm.
 
 		<li>
 			If <var>font face list</var> is empty,


### PR DESCRIPTION
This fixes #5744 by removing the exception-throwing step in the algorithm (that nobody has implemented), and adjusting the related note to reflect this.