### PR TITLE
[css-syntax] Add css-nesting support to parser algorithm

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2519,6 +2519,14 @@ Consume a list of declarations</h4>
 			If anything was returned,
 			append it to the list of declarations.
 
+		<dt><<delim-token>>
+		<dd>
+			If the current input code point is a U+0026 AMPERSAND (&),
+			<a>Reconsume the current input token</a>,
+			<a>consume a qualified rule</a>,
+			and if anything is returned,
+			append it to the list of declarations.
+
 		<dt>anything else</dd>
 		<dd>
 			This is a <a>parse error</a>.


### PR DESCRIPTION
[css-syntax] This changes the parser algorithm used to **consume a list of declarations** in order to support directly nested qualified rules.

Presently, the [CSS Nesting specification](https://drafts.csswg.org/css-syntax/) and the [CSS Syntax specification](https://drafts.csswg.org/css-nesting/) are incompatible. The CSS Nesting specification defines that directly nested qualified rules must begin with a U+0026 AMPERSAND (`&`), while the CSS Syntax specification defines nothing for this character, instead handling it as a parse error.

From the CSS Nesting specification:

> When using a nested style rule, one must be able to refer to the elements matched by the parent rule; that is, after all, the entire point of nesting. To accomplish that, this specification defines a new selector, the nesting selector, written as an ASCII ampersand `&`.
> — [CSS Nesting: Nesting Selector: the `&` selector](https://drafts.csswg.org/css-nesting/#selectordef-)

---

With this change, the declaration list algorithm would read:

> Repeatedly consume the next input token:
>
> **`<whitespace-token>`**
> **`<semicolon-token>`**
> - Do nothing.
>
> **`<EOF-token>`**
> - Return the list of declarations.
>
> **`<at-keyword-token>`**
> - Reconsume the current input token. Consume an at-rule. Append the returned rule to the list of declarations.
>
> **`<ident-token>`**
> - Initialize a temporary list initially filled with the current input token. As long as the next input token is anything other than a `<semicolon-token>` or `<EOF-token>`, consume a component value and append it to the temporary list. Consume a declaration from the temporary list. If anything was returned, append it to the list of declarations.
>
> **`<delim-token>`**
> - If the current input code point is a U+0026 AMPERSAND (`&`), reconsume the current input token, consume a qualified rule, and if anything is returned, append it to the list of declarations.
>
> **anything else**
> - This is a parse error. Reconsume the current input token. As long as the next input token is anything other than a <semicolon-token> or <EOF-token>, consume a component value and throw away the returned value.