### PR TITLE
[css-font-loading-3] Remove unused ForEachCallback

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -77,8 +77,6 @@ The <code>FontFace</code> Interface</h2>
 	or they can be constructed manually from a url or binary data.
 
 	<xmp class="idl">
-		typedef (ArrayBuffer or ArrayBufferView) BinaryData;
-
 		dictionary FontFaceDescriptors {
 			CSSOMString style = "normal";
 			CSSOMString weight = "normal";
@@ -97,7 +95,7 @@ The <code>FontFace</code> Interface</h2>
 
 		[Exposed=(Window,Worker)]
 		interface FontFace {
-			constructor(CSSOMString family, (CSSOMString or BinaryData) source,
+			constructor(CSSOMString family, (CSSOMString or BufferSource) source,
 		                optional FontFaceDescriptors descriptors = {});
 			attribute CSSOMString family;
 			attribute CSSOMString style;
@@ -255,7 +253,7 @@ The Constructor</h3>
 	2. If the {{source!!argument}} argument was a {{CSSOMString}},
 		set <var>font face's</var> internal {{[[Urls]]}} slot to the string.
 
-		If the {{source}} argument was a {{BinaryData}},
+		If the {{source}} argument was a {{BufferSource}},
 		set <var>font face's</var> internal {{[[Data]]}} slot to the passed argument.
 
 	3. If <var>font face's</var> {{[[Data]]}} slot is not <code>null</code>,

--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -452,8 +452,6 @@ The <code>FontFaceSet</code> Interface</h2>
 
 		enum FontFaceSetLoadStatus { "loading", "loaded" };
 
-		callback ForEachCallback = undefined (FontFace font, long index, FontFaceSet self);
-
 		[Exposed=(Window,Worker)]
 		interface FontFaceSet : EventTarget {
 			constructor(sequence<FontFace> initialFaces);


### PR DESCRIPTION
It's not used anywhere since a4fdf3e4853af40542a6bb3a9cebc8b76dc760a8.