### PR TITLE
[css-overflow] Update link to outline properties

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -170,7 +170,7 @@ Types of Overflow</h2>
 	<a href="https://www.w3.org/TR/css-text-decor-3/">text decoration</a>,
 	overhanging glyphs (with negative side bearings,
 	or with ascenders/descenders extending outside the em box),
-	<a href="https://www.w3.org/TR/CSS2/ui.html#dynamic-outlines">outlines</a>,
+	<a href="https://www.w3.org/TR/css-ui-3/#outline-props">outlines</a>,
 	etc.
 
 	Since some effects in CSS (for example, the blurs in


### PR DESCRIPTION
Point it to css-ui-3 spec instead of CSS2.