### PR TITLE
[css-ui-4] Add full <image> support for 'cursor' property

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -601,7 +601,7 @@ user resizing of that element.
 
 <pre class="propdef">
 Name: cursor
-Value: [ [ <<url>> | <<url-set>> ] [&lt;x&gt; &lt;y&gt;]? ]#? <br>
+Value: [ <<image>> [&lt;x&gt; &lt;y&gt;]? ]#? <br>
  [ auto | default | none |<br>
  context-menu | help | pointer | progress | wait | <br>
  cell | crosshair | text | vertical-text | <br>
@@ -665,15 +665,9 @@ Values have the following meanings:
 		Each author-defined image-based cursor is defined by the following values:
 
 		<dl>
-			<dt><<url>> | <<url-set>>
+			<dt><<image>>
 			<dd>
-				The user agent retrieves the cursor from the resource designated by the <<url>> or <<url-set>>.
-				Conforming user agents may, instead of <<url>> and <<url-set>>,
-				support <<image>> which is a superset.
-
-				<dfn type>&lt;url-set></dfn> is a limited version of ''image-set()'',
-				where only <<url>> and <<url-set>> can be used
-				in the part of the <<image-set-option>> sub-production which would normally allow <<image>>.
+				The user agent retrieves the cursor from the resource designated by the <<image>>.
 
 				The UA must support the following image file formats:
 


### PR DESCRIPTION
This change replaces the currently defined `<url>` value supported by the `cursor` property by its superset `<image>`.

Closes #5831

Sebastian