### PR TITLE
[css-fonts-4] Use “create a potential-CORS request”

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -24,6 +24,8 @@ spec:css-color-4; type:property; text:color
 spec:css-values; type:value; text:ex
 spec:css22; type:value; for:/; text:block
 spec:html; type:element; text:font
+spec:fetch; type:dfn; for:/; text:request
+spec:fetch; type:dfn; for:/; text:fetch
 </pre>
 
 
@@ -2698,12 +2700,9 @@ downloadable fonts to avoid large page reflows where possible.
 <h4 id="font-fetching-requirements" oldids="same-origin-restriction,allowing-cross-origin-font-loading">
 Font fetching requirements</h4>
 
-For font loads, user agents must use the
-<a href="https://fetch.spec.whatwg.org/#fetching">potentially CORS-enabled fetch</a>
-method defined by the [[!HTML]] specification for URL's defined
-within @font-face rules. When fetching, user agents must use
-"Anonymous" mode, set the referrer source to the stylesheet's URL and
-set the origin to the URL of the containing document.
+For font loads from @font-face rules, user agents must create a <a>request</a>
+whose <var>url</var> is the URL given by the @font-face rule, whose <var>referrer</var>
+is the stylesheet's URL, and whose <var>origin</var> is the URL of the containing document.
 
 Note: The implications of this for authors are that fonts
 will typically not be loaded cross-origin unless authors specifically
@@ -2711,8 +2710,8 @@ takes steps to permit cross-origin loads. Sites can explicitly allow
 cross-site loading of font data using the <code>Access-Control-Allow-Origin</code>
 HTTP header.  For other schemes, no explicit mechanism to allow
 cross-origin loading, beyond what is permitted by the
-<a href="https://fetch.spec.whatwg.org/#fetching">potentially CORS-enabled fetch</a>
-method, is defined or required.
+<a>fetch</a>
+algorithm, is defined or required.
 
 <div class="example">
 	For the examples given below, assume that a document is located at


### PR DESCRIPTION
This change makes the CSS Fonts spec reference the “create a potential-CORS request” algorithm from the HTML spec.

Otherwise, without this change, the CSS Fonts spec references “potentially CORS-enabled fetch”, which is an obsolete algorithm that no longer exists either in the Fetch spec nor in HTML.

---

Related: https://github.com/whatwg/html/pull/6265