### PR TITLE
[selectors-4][editorial] Remove mention of <link> being a :link match

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1997,8 +1997,9 @@ The Hyperlink Pseudo-class: '':any-link''</h3>
 
 	The <dfn id='any-link-pseudo'>:any-link</dfn> pseudo-class represents an element
 	that acts as the source anchor of a hyperlink.
-	For example, in [[HTML5]], any <a element>a</a>, <a element>area</a>, or <a element>link</a> elements with an <code>href</code> attribute
-	are hyperlinks, and thus match <code>:any-link</code>.
+	For example, in [[HTML5]],
+	any <{a}> or <{area}> elements are hyperlinks,
+	and thus match <code>:any-link</code>.
 	It matches an element if the element would match either '':link'' or '':visited'',
 	and is equivalent to '':is(:link, :visited)''.
 


### PR DESCRIPTION
Mergeable when <https://github.com/whatwg/html/pull/6269> merges, and not before.