### PR TITLE
[css-animations-1] Updating typo in CSSKeyframesRule.findRule

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -1195,7 +1195,7 @@ The <code>findRule</code> method</h4>
 	<dl>
 		<dt><dfn argument for="CSSKeyframesRule/findRule(select)">select</dfn> of type {{CSSOMString}}
 		<dd>
-			The keyframe selector of the rule to be deleted: a comma-separated list of percentage values between 0% and 100% or the keywords ''from'' or ''to'' which resolve to 0% and 100%, respectively.
+			The keyframe selector of the rule to be found: a comma-separated list of percentage values between 0% and 100% or the keywords ''from'' or ''to'' which resolve to 0% and 100%, respectively.
 
             The number and order of the values in the specified keyframe selector must match those of the targeted keyframe rule(s). The match is not sensitive to white space around the values in the list.
     </dl>


### PR DESCRIPTION
I was documenting this over at MDN and spotted that the information for `select` in findRule mentioned the "rule to be deleted", I think this should be "found".


