### PR TITLE
[css-images-4] Fix typos (s/tho/though/, s/It/If/)

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -223,9 +223,9 @@ Resolution/Type Negotiation: the ''image-set()'' notation {#image-set-notation}
 		It does not have any effect on the image itself;
 		an <<image-set-option>> like <code highlight=css>url("picture.png") 1x format("image/jpeg")</code> is valid,
 		and if chosen will display the linked PNG image,
-		even tho it was declared to be a JPEG.
+		even though it was declared to be a JPEG.
 
-		It not specified,
+		If not specified,
 		it has no effect on the <<image-set-option>>.
 
 


### PR DESCRIPTION
Just two small typo fixes to prose in https://drafts.csswg.org/css-images-4/#image-set-notation