### PR TITLE
[css-color-4] Fix typos in examples of lab(), lch() and color(lab ...)

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2812,7 +2812,7 @@ Device-independent Colors: Lab and LCH</h2>
 	For example, in HSL, the sRGB colors blue (#00F) and yellow (#FF0)
 	have the same value of L (50%) even though visually, blue is much darker.
 	This is much clearer in Lab:
-	sRGB blue is lab(29.567% 68.298,-112.0294)
+	sRGB blue is lab(29.567% 68.298 -112.0294)
 	while
 	sRGB yellow is lab(97.607% -15.753 93.388).
 	In Lab and LCH, if two colors have the same measured L value,
@@ -2880,7 +2880,7 @@ Specifying Lab and LCH: the ''lab()'' and ''lch()'' functional notations</h3>
 		<pre class="lang-css">
 			<span class="swatch" style="--color: rgb(49.06% 13.87% 15.9%)"></span> lab(29.2345% 39.3825 20.0664);
 			<span class="swatch" style="--color: rgb(77.61% 36.34% 2.45%)"></span> lab(52.2345% 40.1645 59.9971);
-			<span class="swatch" style="--color: rgb(61.65% 57.51% 9.28%)"></span> lab(60.2345, -5.3654 58.956);
+			<span class="swatch" style="--color: rgb(61.65% 57.51% 9.28%)"></span> lab(60.2345% -5.3654 58.956);
 			<span class="swatch" style="--color: rgb(40.73% 65.12% 22.35%)"></span> lab(62.2345% -34.9638 47.7721);
 			<span class="swatch" style="--color: rgb(38.29% 67.27% 93.85%)"></span> lab(67.5345% -8.6911 -41.6019);
 		</pre>
@@ -3217,7 +3217,7 @@ Profiled, Device-dependent Colors</h2>
 		This very intense lime color is in-gamut for rec.2020:
 		<pre class="lang-css">color(rec2020 0.42053 0.979780 0.00579);</pre>
 		in LCH, that color is
-		<pre class="lang-css">lch(86.6146 160.0000, 136.0088);</pre>
+		<pre class="lang-css">lch(86.6146% 160.0000 136.0088);</pre>
 		in display-p3, that color is
 		<pre class="lang-css">color(display-p3 -0.6112 1.0079 -0.2192);</pre>
 		and is out of gamut for display-p3
@@ -3557,7 +3557,7 @@ Predefined colorspaces: ''srgb'', ''display-p3'', ''a98-rgb'', ''prophoto-rgb'',
 					<pre class="lang-css">
 						<span class="swatch" style="--color: #7654CD"></span> #7654CD;
 						<span class="swatch" style="--color: #7654CD"></span> rgb(46.27% 32.94% 80.39%)
-						<span class="swatch" style="--color: #7654CD"></span> color(lab 44.36 36.05 -58.99)
+						<span class="swatch" style="--color: #7654CD"></span> color(lab 44.36% 36.05 -58.99)
 						<span class="swatch" style="--color: #7654CD"></span> color(xyz 0.2005, 0.14089, 0.4472)
 				</div>
 
@@ -3795,7 +3795,7 @@ you will use.
 	of cyan, magenta, yellow, and black.
 
 	In this profile, this resolves to the color
-	<span class="swatch" style="--color: rgb(93.124% 44.098% 57.491%)"></span>&nbsp;Lab(63.673303% 51.576902 5.811058)
+	<span class="swatch" style="--color: rgb(93.124% 44.098% 57.491%)"></span>&nbsp;lab(63.673303% 51.576902 5.811058)
 	which is
 	<span class="swatch" style="--color: rgb(93.124% 44.098% 57.491%)"></span>&nbsp;rgb(93.124, 44.098% 57.491%).
 </div>
@@ -3886,7 +3886,7 @@ can proceed as normal.
 	In this profile, this  amount of CMYK
 	(the same percentages as the previous example)
 	resolves to the color
-	<span class="swatch" style="--color: rgb(94.903% 45.248%  59.104%)"></span>&nbsp;Lab(64.965217% 52.119710 5.406966)
+	<span class="swatch" style="--color: rgb(94.903% 45.248%  59.104%)"></span>&nbsp;lab(64.965217% 52.119710 5.406966)
 	which is
 	<span class="swatch" style="--color: rgb(94.903% 45.248%  59.104%)"></span>&nbsp;rgb(94.903% 45.248% 59.104%).
 </div>
@@ -3925,14 +3925,14 @@ to be outside the sRGB gamut.
 
 	This example does not use illustrative swatches, because most of the colors are outside of sRGB.
 
-	This CMYK color corresponds to Lab(56.596645% -58.995875 28.072154)
-	or LCH(56.596645% 65.33421077211648, 154.5533771086801).
+	This CMYK color corresponds to lab(56.596645% -58.995875 28.072154)
+	or lch(56.596645% 65.33421077211648 154.5533771086801).
 	In sRGB this would be rgb(-60.568% 62.558% 32.390%) which,
 	as the large negative red component shows,
 	is out of gamut.
 
 	Reducing the chroma until the result is in gamut
-	gives LCH(56.596645% 51 154.5533771086801)
+	gives lch(56.596645% 51 154.5533771086801)
 	which is rgb(8.154% 60.9704% 37.184%)
 	and this is used as the fallback color.
 


### PR DESCRIPTION
I noticed a few typos in the example uses of lab(), lch() and color(lab ...) as I was reading through spec.