### PR TITLE
[css-2020] Remove css-transforms-1 from pre-CR exclusions

### DIFF
--- a/css-2020/Overview.bs
+++ b/css-2020/Overview.bs
@@ -761,10 +761,9 @@ Safe to Release pre-CR Exceptions</h2>
 	prior to the spec reaching Candidate Recommendation:
 	<ul>
 		<li>Everything in
-		<a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>,
-		<a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>,
+		<a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
 		and
-		<a href="https://www.w3.org/TR/css-transforms-1/">CSS Transforms Level 1</a>.
+		<a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>.
 		<li>The '':dir()'', '':lang()'', and '':focus-within'' pseudo-classes from [[SELECTORS-4]].
 	</ul>
 


### PR DESCRIPTION
Since [css-transforms-1] has been a CR since 2019 and is already listed in the Official Definition, it seems unreasonable to keep it among the pre-CR excections in the 2020 snapshot. I assume this is an editorial fix.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
