### PR TITLE
[css-grid-3] Remove hash from ID

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -219,7 +219,7 @@ Containing Block</h2>
 
 The <a>containing block</a> for a <a>grid item</a> is formed by its <a>grid area</a> in the [=grid axis=] and the grid container's content-box in the [=masonry axis=].
 
-<h2 id="#implicit-grid">
+<h2 id="implicit-grid">
 The Implicit Grid
 </h2>
 The [=implicit grid=] is formed in the same way as for a regular grid container.  However, it's only used in the [=grid axis=].  The flow axis specified by ''grid-auto-flow'' is ignored &mdash; items are always placed by filling the [=grid axis=] (though note that the ''grid-auto-flow'' property's ''grid-auto-flow/dense'' keyword does have an effect in determining which items end up at line 1 in the [=masonry axis=], in [[#grid-item-placement]] step 1).  ''direction:rtl'' reverses the grid if the inline-axis is the [=grid axis=] (as usual for a regular grid container) and it makes items flow from right to left if the inline-axis is the [=masonry axis=].


### PR DESCRIPTION
Generates out to an invalid anchor value with a double `##`