### PR TITLE
[css-flexbox-1] Bikeshed errors

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -3603,8 +3603,6 @@ Appendix A: Axis Mappings</h2>
 				<th><a lt=cross-end><abbr title="cross-end">end</abbr></a>
 		<tbody>
 			<tr>
-		<tbody>
-			<tr>
 				<th>''row'' + ''nowrap''/''wrap''
 				<td rowspan=4>vertical
 				<td>top
@@ -3697,7 +3695,6 @@ Boris Zbarsky.
 	This section documents the changes since previous publications.
 
 <h3 id="changes-20181119">
-
 Changes since the <a href="https://www.w3.org/TR/2018/CR-css-flexbox-1-20181119/">19 November 2018 CR</a></h3>
 
 	<ul>


### PR DESCRIPTION
- Double TBODY
- Spacing causing extra P tag