### PR TITLE
[css-fonts-4] Escpape string placeholder

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2625,7 +2625,7 @@ If the 'font-named-instance!!descriptor' descriptor is set
 to a value other than 'font-named-instance/auto',
 then the appropriate stage in the [[#font-feature-variation-resolution]]
 will inspect the font file to find the first named instance in
-the font which has a localized name equal to the given <string>
+the font which has a localized name equal to the given <<string>>
 according to the rules given in [[#localized-name-matching]].
 If no such named instance exists,
 this descriptor is treated as if it has a value of 'font-named-instance/auto'.


### PR DESCRIPTION
Caused it to be output as an HTML element in Bikeshed