### PR TITLE
[css-rhythm-1] Collapse img for Bikeshed

### DIFF
--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -407,8 +407,7 @@ by making heights of all lines an integer multiple of the <a>step unit</a>.
 	<div class="example">
 		<div class="figure" style="float:right">
 			<img src="images/line-grid-center.svg"
-			style="height: 300px"
-			>
+			style="height: 300px">
 		</div>
 
 		In the following example,

--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -406,8 +406,7 @@ by making heights of all lines an integer multiple of the <a>step unit</a>.
 
 	<div class="example">
 		<div class="figure" style="float:right">
-			<img src="images/line-grid-center.svg"
-			style="height: 300px">
+			<img src="images/line-grid-center.svg" style="height: 300px">
 		</div>
 
 		In the following example,


### PR DESCRIPTION
Maybe more of a Bikeshed issue, but was outputing as `<img U0003Cblockquote src="images/line-grid-center.svg" style="height: 300px">` before