### PR TITLE
[css-flexbox-1] Drop styles with no matching ID

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -64,11 +64,6 @@ spec: css-pseudo-4; type: selector;
 </pre>
 
 <style>
-  #axis-mapping-table [rowspan=8] { writing-mode: sideways-lr; }
-  #axis-mapping-table a { white-space: nowrap; }
-</style>
-
-<style>
 code.one-line { white-space: pre;  }
 .code-and-figure {
 	display: table;


### PR DESCRIPTION
The IDs now have language postfixes like `axis-mapping-table-en`, and there is no rowspan value of 8.
This choked up the HTML validator, but that might be a bug there