### PR TITLE
typo: Double word elements

### DIFF
--- a/css-gcpm-3/2009-06-10.html
+++ b/css-gcpm-3/2009-06-10.html
@@ -1266,7 +1266,7 @@ div.figure { float: bottom page }
   <p>Potentially, every page has a footnote area. If there are no footnotes
    on the page, the footnote area will not take up any space. If there are
    footnotes on a page, the layout of the footnote area will be determined by
-   the properties/values set on it, and by the footnote elements elements
+   the properties/values set on it, and by the footnote elements
    inside it.
 
   <p>These properties apply to the footnote area: &lsquo;<code

--- a/css-gcpm-3/2009-06-10.src.html
+++ b/css-gcpm-3/2009-06-10.src.html
@@ -900,7 +900,7 @@ div.figure { float: bottom page }
 are no footnotes on the page, the footnote area will not take up any
 space. If there are footnotes on a page, the layout of the footnote
 area will be determined by the properties/values set on it, and by the
-footnote elements elements inside it.
+footnote elements inside it.
 
 <p>These properties apply to the footnote area: 'content', 'border',
 'padding', 'margin', 'height', 'width', 'max-height', 'max-width',

--- a/css-writing-modes-3/Overview.bs
+++ b/css-writing-modes-3/Overview.bs
@@ -2212,7 +2212,7 @@ Purely Physical Mappings</h3>
     and
     <code>&lt;video&gt;</code>
 
-  <p>Form elements elements contain text, therefore their contents should be
+  <p>Form elements contain text, therefore their contents should be
     affected by writing mode, in which case these attributes refer to the
     <em>logical</em> width and height. The UA may, however, choose not
     to rotate nor flip these elements in vertical writing modes if it is not

--- a/css-writing-modes-4/Overview.bs
+++ b/css-writing-modes-4/Overview.bs
@@ -2415,7 +2415,7 @@ Purely Physical Mappings</h3>
     and
     <code>&lt;video&gt;</code>
 
-  <p>Form elements elements contain text, therefore their contents should be
+  <p>Form elements contain text, therefore their contents should be
     affected by writing mode, in which case these attributes refer to the
     <em>logical</em> width and height. The UA may, however, choose not
     to rotate nor flip these elements in vertical writing modes if it is not


### PR DESCRIPTION
Could go a few ways as possessive or singular then plural, but I think these are duplicates