### PR TITLE
[css-grid-1] Specify height in example 8 for #grid

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -704,6 +704,7 @@ Grid Areas</h3>
 			                       ". a";
 			  grid-template-columns: 150px 1fr;
 			  grid-template-rows: 50px 1fr 50px;
+			  height: 100vh;
 			}
 
 			#item1 { grid-area: a }


### PR DESCRIPTION
I would specify the height property in example 8 of the Grid Areas chapter for `#grid`. This makes it easy to see the differences between `align-self: start;` and `align-self: end;` for newcomers in that example. Otherwise, it's may not so clear how `align-self: start;` and `align-self: end;` styles work if you try to run this snippet.

[3.3. Grid Areas](https://www.w3.org/TR/css-grid-1/#grid-area-concept)

What do you think?