### PR TITLE
[selectors-4] Remove example related to :focus:not(:focus-visible) (#4278)

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2326,23 +2326,6 @@ The Focus-Indicated Pseudo-class: '':focus-visible''</h3>
 	so that authors using '':focus-visible'' will not also need to disable
 	the default '':focus'' style.
 
-	<div class=example>
-	In this example,
-	authors use a '':not()'' pseudo-class to remove default user agent focus styling
-	if '':focus-visible'' is supported,
-	and provide enhanced focus styling via '':focus-visible''.
-
-	<pre highlight=css>
-	:focus:not(:focus-visible) {
-		outline: 0;
-	}
-
-	:focus-visible {
-		outline: 3px solid var(--focus-gold);
-	}
-	</pre>
-	</div>
-
 <h3 id="the-focus-within-pseudo">
 The Focus Container Pseudo-class: '':focus-within''</h3>
 


### PR DESCRIPTION
[selectors-4] Remove example related to :focus:not(:focus-visible) (#4278)

:focus:not(:focus-visible) is a workaround due to some implementations
not following the spec (not using :focus-visible in the default UA style sheet).
Apart that this is no longer needed as implementations have been updated,
this kind of workarounds shouldn't be in the spec as they're confusing.

Fixes #4278
