### PR TITLE
[css-highlight-api-1] Rename HighlightsRegister to HighlightRegistry

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -86,7 +86,7 @@ Introduction</h2>
 	<div id=intro-ex class=example>
 		The following code uses the ''::highlight()'' pseudo-element
 		to apply a yellow background and blue foreground color to the text <q>One two</q>.
-		It does so by adding a {{Highlight}} to the {{HighlightsRegister}}
+		It does so by adding a {{Highlight}} to the {{HighlightRegistry}}
 		(both of these are new concepts introduced by this specification).
 		The {{Highlight}} will contain a {{Range}} whose boundary points surround the text <q>One two</q>.
 
@@ -207,36 +207,36 @@ Registering Custom Highlights</h3>
 
 	In order to have any effect,
 	[=custom highlights=] then needs to be
-	[=registered=] it into the [=highlights register=].
+	[=registered=] it into the [=highlight registry=].
 
-	The <dfn>highlights register</dfn> is accessed via the {{CSS/highlights}} attribute of the {{CSS}} namespace,
+	The <dfn>highlight registry</dfn> is accessed via the {{CSS/highlights}} attribute of the {{CSS}} namespace,
 	and represents all the [=custom highlights=] [=registered=] for the [=current global object=]’s [=associated Document=].
 	It is a [=setlike=], and can be updated using the usual methods.
 	It's [=set entries=] is initially empty.
 
 	A [=custom highlight=] is said to be <dfn>registered</dfn>
-	if it is in the [=highlights register=].
+	if it is in the [=highlight registry=].
 	It stops being [=registered=] if it is later removed.
 
 	<xmp class="idl">
 	partial namespace CSS {
-		readonly attribute HighlightsRegister highlights;
+		readonly attribute HighlightRegistry highlights;
 	};
 
 	[Exposed=Window]
-	interface HighlightsRegister {
+	interface HighlightRegistry {
 		setlike<Highlight>;
-		HighlightsRegister add(Highlight value);
+		HighlightRegistry add(Highlight value);
 	};
 	</xmp>
 
 	<div algorithm="to register a custom highlight">
 		To [=register=] a [=custom highlight=],
-		invoke the {{HighlightsRegister/add()}} of the [=highlights register=]
+		invoke the {{HighlightRegistry/add()}} of the [=highlight registry=]
 		with the [=custom highlight=] as the argument.
 
 		When invoked,
-		the <dfn method for=HighlightsRegister>add(Highlight value)</dfn> method must run these steps:
+		the <dfn method for=HighlightRegistry>add(Highlight value)</dfn> method must run these steps:
 
 		1. If there is already a [=set entry=] with the same {{Highlight/name}} as the {{Highlight/name}} of {{value}},
 			then [=throw=] an {{"OperationError"}}.
@@ -405,7 +405,7 @@ Priority of Overlapping Highlights</h4>
 		As there are no priorities set
 		(i.e. there is a tie between <code>rg1</code> and <code>rg2</code>),
 		the custom highlights' styles are stacked
-		in order of insertion into the [=highlights register=].
+		in order of insertion into the [=highlight registry=].
 		The rendered results will have "Som" with blue text on yellow background,
 		"e t" with blue text on orange background,
 		and "ext" with the default color on orange background.
@@ -431,7 +431,7 @@ Responding to Changes</h2>
 Repaints</h3>
 
 	The addition or removal
-	of a [=custom highlight=] in the [=highlights register=],
+	of a [=custom highlight=] in the [=highlight registry=],
 	or of a [=range=] in a [registered=] [=custom highlight=],
 	must cause the User Agent to reevaluate the rendering,
 	and to repaint if appropriate.
@@ -482,7 +482,7 @@ Range Updating and Invalidation</h3>
 
 	When computing how to render the document,
 	if [=start node=] or [=end node=] of any [=range=]
-	in the [=highlights register=]
+	in the [=highlight regsitry=]
 	refer to a {{Node}} which is no longer [=in a document tree=],
 	the User Agent must ignored that [=range=].
 	If the [=start offset=] or [=end offset=] of any [=range=]
@@ -558,11 +558,11 @@ Appendix C. Changes</h2>
 	<!-- This text from the explainer seems useful, and should go somewhere. But where?
 	----
 	If there are DOM/CSS changes that result in a different cascaded highlight map for a given element,
-	and there exists one or more Range objects in the highlights register for the cascaded identifiers,
+	and there exists one or more Range objects in the highlight registry for the cascaded identifiers,
 	the layout representation of that element should be notified that the painting of the element might have changed.
 
 	Ranges that are positioned inside of documents that are not in the view are ignored.
 
-	The HighlightsRegister is per-document — therefore, Ranges that are positioned inside of a different document than the HighlightsRegister it is a part of are ignored for rendering.
+	The HighlightRegistry is per-document — therefore, Ranges that are positioned inside of a different document than the HighlightRegistry it is a part of are ignored for rendering.
 	-->
 


### PR DESCRIPTION
The name HighlightRegistry makes more sense for this concept - a place with Highlight objects are registered. It also follows prior art established by CustomElementRegistry.

Closes #5760 