### PR TITLE
[css-variables-1] Custom props that are IACVT become guaranteed-invalid

### DIFF
--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -598,11 +598,25 @@ Invalid Variables</h3>
 	after substituting its ''var()'' functions,
 	is invalid.
 	When this happens,
-	the computed value of the property is either
-	the property's inherited value
-	or its initial value
-	depending on whether the property is inherited or not, respectively,
-	as if the property's value had been specified as the ''unset'' keyword.
+	the computed value is one of the following
+	depending on the property's type:
+
+	<dl class="switch">
+
+		:   The property is a non-registered <a>custom property</a>
+		::  The computed value is the <a>guaranteed-invalid value</a>.
+
+		:   The property is a <a>registered custom property</a>
+		::  The computed value is defined by
+		    [[css-properties-values-api-1#calculation-of-computed-values]].
+
+		:   Otherwise
+		::  Either the property's inherited value
+		    or its initial value
+		    depending on whether the property is inherited or not, respectively,
+		    as if the property's value had been specified as the ''unset'' keyword.
+
+		</dl>
 
 	<div class='example'>
 		For example, in the following code:

--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -308,8 +308,7 @@ Resolving Dependency Cycles</h3>
 
 	If there is a cycle in the dependency graph,
 	all the <a>custom properties</a> in the cycle
-	are <dfn export>cyclic at computed-value time</dfn>,
-	and must compute to the [=guaranteed-invalid value=].
+	are [=invalid at computed-value time=].
 
 	Note: Defined properties that participate in a dependency cycle
 	either end up with invalid variables in their value
@@ -345,7 +344,7 @@ Resolving Dependency Cycles</h3>
 		}
 		</pre>
 
-		Both '--one' and '--two' are now [=cyclic at computed-value time=],
+		Both '--one' and '--two' are now [=invalid at computed-value time=],
 		and compute to the [=guaranteed-invalid value=]
 		rather than than lengths.
 	</div>
@@ -603,12 +602,10 @@ Invalid Variables</h3>
 
 	<dl class="switch">
 
-		:   The property is a non-registered <a>custom property</a>
+		:   The property is a non-registered [=custom property=]
+		:   The property is a [=registered custom property=]
+		    with [=univerisal syntax definition|universal syntax=]
 		::  The computed value is the <a>guaranteed-invalid value</a>.
-
-		:   The property is a <a>registered custom property</a>
-		::  The computed value is defined by
-		    [[css-properties-values-api-1#calculation-of-computed-values]].
 
 		:   Otherwise
 		::  Either the property's inherited value


### PR DESCRIPTION
Resolves #5370.
