### PR TITLE
[css-grid-1][css-grid-2] Use `body` in example 9

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -801,7 +801,7 @@ Reordering and Accessibility</h2>
 		<pre class="lang-css">
 			@media all and (max-width: 60em) {
 				/* Too narrow to support three columns */
-				main { display: block; }
+				body { display: block; }
 			}
 		</pre>
 	</div>

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -843,7 +843,7 @@ Reordering and Accessibility</h2>
 		<pre class="lang-css">
 			@media all and (max-width: 60em) {
 				/* Too narrow to support three columns */
-				main { display: block; }
+				body { display: block; }
 			}
 		</pre>
 	</div>


### PR DESCRIPTION
Use the body element because it has used as a grid container in the
example above:

```
body { display: grid;
        grid: "h h h"
              "a b c"
              "f f f";
        grid-template-columns: auto 1fr 20%; }
article { grid-area: b; min-width: 12em;     }
nav     { grid-area: a; /* auto min-width */ }
aside   { grid-area: c; min-width: 12em;     }
```

This change makes these examples much more clear.