### PR TITLE
[css-color-4] Rephrase interpolation to be more generic wrt to interpolation spac

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4403,7 +4403,7 @@ Interpolation</h2>
 
 	In general, interpolation between <<color>> values
 	occurs by linearly interpolating each component of the computed value of the color
-	separately, in Lab.
+	separately, in a given color space which will be referred to as the 'interpolation space' below.
 
 <!--
 
@@ -4441,25 +4441,25 @@ Interpolation</h2>
 
 <h3 id="interpolation-space">
 Color space for interpolation</h3>
+	Different color spaces may be more appropriate for each interpolation use case.
+	For example, Lab works well for gradients, and LCH works well for color mixing.
+	The host syntax may define what the default interpolation space should be for each case,
+	and optionally provide syntax for authors to override this default.
 
-	Issue(5928):
-
-	Colors are first converted to Lab
-	and then interpolated as Lab colors.
-	Host syntax can override the interpolation color space and specify which color space is used for interpolation.
-	<!-- For example, 'color-mix' and 'color-adjust' override the default to LCH. -->
-
-	The exception is that if all the <<color>>s to be interpolated
-	are sRGB values, and they are all expressed in a legacy syntax
-	such as hex colors, named colors,
+	If the host syntax does not define what colorspace interpolation should take place in,
+	it defaults to Lab. In that case, user agents may handle interpolation
+	between legacy sRGB color formats
+	(hex colors, named colors,
 	''rgb()'', ''hsl()'' or ''hwb()''
-	(and the equivalent alpha-including forms)
-	then they are interpolated in gamma-encoded sRGB space.
-
+	and the equivalent alpha-including forms)
+	in gamma-encoded sRGB space.
 	This provides Web compatibility; legacy sRGB content interpolates in the sRGB space by default.
 
 	This also means that authors can choose to opt-in to Lab interpolation
 	by using the non-legacy ''color(srgb r g b)'' form.
+
+	Issue(5928):
+
 
 <h3 id="interpolation-alpha">
 Interpolating with alpha</h3>


### PR DESCRIPTION
Currently, it is phrased as if interpolating in any other color space is an exception to Lab. If we're going to be referencing this for `color-mix()` and the like, it needs to be more generic wrt to interpolation space. 
