### PR TITLE
[css-tables-3] Drop zero-width spaces in border-spacing dfn

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -827,7 +827,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 			<pre class='propdef'>
 				Name: border-spacing
-				Value: <​length​>{1,2}
+				Value: <<length>>{1,2}
 				Initial: 0px 0px
 				Inherited: yes
 				Applies To: <a>table grid boxes</a> when 'border-collapse' is ''border-collapse/separate''


### PR DESCRIPTION
This addresses the syntax issue raised in #4275 (which got merged then reverted because `<>` have to be doubled in practice). The goal of the update is to make the definition compliant with the [Value Definition Syntax](https://www.w3.org/TR/css-values-4/#value-defs).
