### PR TITLE
[css-backgrounds-4] Added box-shadow-* longhand properties

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -690,6 +690,184 @@ The 'border-clip' properties</h3>
 		<p>The fragments are shown in red for illustrative purposes; they should be black in compliant UAs.
 	</div>
 
+<h2 id="misc">Drop Shadows</h2>
+
+<h3 id="box-shadow-color">Coloring shadows: the 'box-shadow-color' property</h3>
+
+<pre class="propdef">
+Name: box-shadow-color
+Value: <<color>>#
+Initial: currentcolor
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: list, each item a computed color
+Animatable: by computed value
+</pre>
+
+<p>The 'box-shadow-color' property defines one or more drop shadow colors.
+The property accepts a comma-separated list of shadow colors.
+
+<p>See the section [[css-backgrounds-3#shadow-layers|“Layering, Layout, and
+Other Details”]] for how 'box-shadow-color' interacts with other
+comma-separated drop shadow properties to form each drop shadow
+layer.
+
+<h3 id="box-shadow-offset">Offsetting shadows: the 'box-shadow-offset' property</h3>
+
+<pre class="propdef">
+Name: box-shadow-offset
+Value: none | <<length>>{2}#
+Initial: none
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: either 'none' or a list,
+	each item a pair of offsets (horizontal and vertical) from the element‘s box
+Animatable: by computed value
+</pre>
+
+<p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
+The property accepts a comma-separated list of horizontal and vertical offset pairs,
+where both values are described as <<length>> values.
+
+<dl>
+  <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
+  <dd>
+    Specifies the <dfn>horizontal offset</dfn> of the shadow.
+    A positive value draws a shadow that is offset to the right of the box,
+    a negative length to the left.
+
+  <dt><dfn id="shadow-offset-y">2nd <<length>></dfn>
+  <dd>
+    Specifies the <dfn>vertical offset</dfn> of the shadow.
+    A positive value offsets the shadow down, a negative one up.
+</dl>
+
+<p>See the section [[css-backgrounds-3#shadow-layers|“Layering, Layout, and
+Other Details”]] for how 'box-shadow-offset' interacts with other
+comma-separated drop shadow properties to form each drop shadow
+layer.
+
+<h3 id="box-shadow-blur">Blurring shadows: the 'box-shadow-blur' property</h3>
+
+<pre class="propdef">
+Name: box-shadow-blur
+Value: <<length [0,&infin;]>>#
+Initial: 0
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: list, each item a <<length>>
+Animatable: by computed value
+</pre>
+
+<p>The 'box-shadow-blur' property defines one or more blur radii for drop shadows.
+The property accepts a comma-separated list of <<length>> values.
+
+<p>Negative values are invalid.
+If the blur value is zero, the shadow’s edge is sharp.
+Otherwise, the larger the value, the more the shadow’s edge is blurred.
+See [[css-backgrounds-3#shadow-blur|Shadow Blurring]], below.
+
+<p>See the section [[css-backgrounds-3#shadow-layers|“Layering, Layout, and
+Other Details”]] for how 'box-shadow-blur' interacts with other
+comma-separated drop shadow properties to form each drop shadow
+layer.
+
+<h3 id="box-shadow-spread">Spreading shadows: the 'box-shadow-spread' property</h3>
+
+<pre class="propdef">
+Name: box-shadow-spread
+Value: <<length>>#
+Initial: 0
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: list, each item a <<length>>
+Animatable: by computed value
+</pre>
+
+<p>The 'box-shadow-spread' property defines one or more spread distances for drop shadows.
+The property accepts a comma-separated list of <<length>> values.
+
+<p>Positive values cause the shadow to expand in all directions by the specified radius.
+Negative values cause the shadow to contract.
+See [[css-backgrounds-3#shadow-shape|Shadow Shape]], below.
+<p class="note">Note that for inner shadows,
+expanding the shadow (creating more shadow area)
+means contracting the shadow’s perimeter shape.
+
+<p>See the section [[css-backgrounds-3#shadow-layers|“Layering, Layout, and
+Other Details”]] for how 'box-shadow-spread' interacts with other
+comma-separated drop shadow properties to form each drop shadow
+layer.
+
+<h3 id="box-shadow-position">Spreading shadows: the 'box-shadow-position' property</h3>
+
+<pre class="propdef">
+Name: box-shadow-position
+Value: [ outset | inset ]#
+Initial: outset
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: list, each item one of the keywords
+Animatable: by computed value
+</pre>
+
+<p>The 'box-shadow-position' property defines one or more drop shadow positions.
+The property accepts a comma-separated list of 'outset' and 'inset' keywords.
+
+<dl dfn-type=value dfn-for=box-shadow-position>
+  <dt><dfn>outset</dfn>
+  <dd>
+  Causes the drop shadow to be an <dfn local-lt="outer shadow">outer box-shadow</dfn>.
+  That means, one that shadows the box onto the canvas, as if it were lifted above the canvas.
+
+  <dt><dfn>inset</dfn>
+  <dd>
+  Causes the drop shadow to be an <dfn local-lt="inner shadow">inner box-shadow</dfn>.
+  That means, one that shadows the canvas onto the box, as if the box were cut out
+  of the canvas and shifted behind it.
+</dl>
+
+<p>See the section [[css-backgrounds-3#shadow-layers|“Layering, Layout, and
+Other Details”]] for how 'box-shadow-position' interacts with other
+comma-separated drop shadow properties to form each drop shadow
+layer.
+
+<h3 id="box-shadow" oldids="the-box-shadow">Drop Shadows Shorthand: the 'box-shadow' property</h3>
+
+<pre class="propdef">
+Name: box-shadow
+Value: <<spread-shadow>>#
+Initial: none
+Applies to: all elements
+Inherited: no
+Percentages: N/A
+Computed value: either the keyword ''box-shadow-offset/none'' or
+    a list, each item consisting of four absolute lengths
+    plus a computed color and optionally also a ''box-shadow-position/inset'' keyword
+Animatable: by computed value,
+    treating ''box-shadow-offset/none'' as a zero-item list
+    and appending blank shadows (''transparent 0 0 0 0'')
+    with a corresponding ''box-shadow-position/inset'' keyword as needed
+    to match the longer list
+    if the shorter list is otherwise compatible with the longer one
+</pre>
+
+  <p>The 'box-shadow' property attaches one or more drop-shadows to the box.
+  The property accepts either the ''box-shadow-offset/none'' value, which indicates no shadows,
+  or a comma-separated list of shadows, ordered front to back.
+
+  <p>Each shadow is given as a <<spread-shadow>>,
+  outlining the 'box-shadow-offset', and optional values for the 'box-shadow-blur',
+  'box-shadow-spread', 'box-shadow-color', and 'box-shadow-position'.
+  Omitted lengths are 0; omitted colors default to the ''currentcolor'' value.
+  <pre class=prod>
+  <dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ <<'box-shadow-offset'>> [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
+
 <h2 id="changes">
 Changes</h2>
 


### PR DESCRIPTION
This change adds the different longhand properties for the `box-shadow` property to the CSS Backgrounds and Borders Module Level 4. This is one part of #4431.

The definition of the `box-shadow` property was taken from [level 3 of the specification](https://drafts.csswg.org/css-backgrounds-3/#box-shadow). Then the different longhand properties were created by splitting the syntax and value descriptions of the `box-shadow` property. Some additional descriptions were added and all the properties placed in a new section "Drop Shadows".