### PR TITLE
[css-device-adapt-1] Visual: Remove inline background-color style breaking dark theme

### DIFF
--- a/css-device-adapt-1/Overview.bs
+++ b/css-device-adapt-1/Overview.bs
@@ -1024,7 +1024,6 @@ comma as the preferred separator and semicolon as optional:
         white-space: pre;
         margin: 1em;
         padding: 1em;
-        background-color: #f4f4f4;
     }
 
     #algorithm .method {


### PR DESCRIPTION
Previously the background-color set inline for the pseudocode block resulted in nearly zero contrast between the text and the background. I feel it is preferable to remove the broken inline style and potentially later add a global style to readd a subtle background to all `pre` code blocks if desired.

## Before:

![Screenshot_20210308_011832](https://user-images.githubusercontent.com/6652840/110300932-60cbbf00-7fac-11eb-8318-53e20d65de6f.png)

![Screenshot_20210308_011816](https://user-images.githubusercontent.com/6652840/110300949-64f7dc80-7fac-11eb-8319-d999cc9ed052.png)

## After:

![Screenshot_20210308_011729](https://user-images.githubusercontent.com/6652840/110301039-793bd980-7fac-11eb-9f30-a129c3e50dbb.png)

![Screenshot_20210308_011750](https://user-images.githubusercontent.com/6652840/110300988-704b0800-7fac-11eb-9feb-2de09eacb2d4.png)
