### PR TITLE
[css-ui] Use :focus-visible instead of :focus

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -90,6 +90,7 @@ spec:selectors-4; type:selector; text::enabled
 spec:selectors-4; type:selector; text::disabled
 spec:css-color-4; type:property; text:color
 spec:selectors-4; type:selector; text::focus
+spec:selectors-4; type:selector; text::focus-visible
 </pre>
 
 <style>
@@ -207,7 +208,7 @@ ways:
 
 	<li>Outlines may be non-rectangular.
 
-	<li>UAs often render outlines on elements in the '':focus'' state.
+	<li>UAs often render outlines on elements in the '':focus-visible'' state.
 </ol>
 
 The outline properties control the style of these dynamic outlines.
@@ -221,7 +222,7 @@ This supersedes the stacking of outlines as defined in <a href="https://www.w3.o
 	 in particular people with disabilities
 	 who may not be able to interact with the page in any other fashion,
 	 depend on the outline being visible
-	 on elements in the '':focus'' state,
+	 on elements in the '':focus-visible'' state,
 	 thus authors must not make the outline invisible on such elements
 	 without making sure an alternative highlighting mechanism is provided.
 </strong>


### PR DESCRIPTION
Use :focus-visible instead of :focus in the explanation about when UAs paint outlines.
