### PR TITLE
[css-highlight-api] Remove redundant add method from HighlightRegistry interface

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -226,13 +226,12 @@ Registering Custom Highlights</h3>
 	[Exposed=Window]
 	interface HighlightRegistry {
 		setlike<Highlight>;
-		HighlightRegistry add(Highlight value);
 	};
 	</xmp>
 
 	<div algorithm="to register a custom highlight">
 		To [=register=] a [=custom highlight=],
-		invoke the {{HighlightRegistry/add()}} of the [=highlight registry=]
+		invoke the {{HighlightRegistry/add()}} method of the [=highlight registry=]
 		with the [=custom highlight=] as the argument.
 
 		When invoked,


### PR DESCRIPTION
[css-highlight-api] Remove redundant add method from HighlightRegistry interface

Since HighlightRegistry is setlike, it gets its add method from the setlike interface. This method just needs to be implemented with some special rules, as defined in the highlight-api spec. We need not define an explicit add method on HighlightRegistry - this is redundant and confusing to read.
