### PR TITLE
[css-highlight-api] Custom highlight overlays should stack below native highlight overlays

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -334,7 +334,7 @@ Painting</h4>
 
 		<li>
 			The [=highlight overlays=] of the [=custom highlights=]
-			are above those of the built-in [=highlight pseudo-elements=]
+			are below those of the built-in [=highlight pseudo-elements=]
 			in the stacking order described in [[css-pseudo-4#highlight-painting]].
 
 		<li>


### PR DESCRIPTION
Resolves #4595 