### PR TITLE
[css-highlight-api] Misc highlight priority fixes based on recent resolutions

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -352,8 +352,10 @@ Priority of Overlapping Highlights</h4>
 	This is used to determine the stacking order of the corresponding [=highlight overlay=]
 	during painting operations (see [[#painting]]).
 	A higher [=priority=] results in being above in the stacking order.
+	A custom highlight will have a default numerical priority of 0
+	if its {{Highlight/priority}} attribute has not been explicitly set.
 
-	When two ore more [=custom highlights=] have the same numerical priority,
+	When two or more [=custom highlights=] have the same numerical priority,
 	the one most recently [=registered=] has the higher effective [=priority=].
 
 	<div class=example id=overlap-highlight-ex>

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -169,7 +169,7 @@ Creating Custom Highlights</h3>
 	interface Highlight {
 		constructor(CSSOMString name, AbstractRange... initialRanges);
 		setlike<AbstractRange>;
-		attribute double priority;
+		attribute long priority;
 		readonly attribute CSSOMString name;
 	};
 	</xmp>

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -356,27 +356,6 @@ Priority of Overlapping Highlights</h4>
 	When two ore more [=custom highlights=] have the same numerical priority,
 	the one most recently [=registered=] has the higher effective [=priority=].
 
-	Issue(4593): should negative numbers mean stacking
-	below the built-in [=highlight pseudo-elements=]?
-
-	Issue(4592): Should priority be an (unsigned) integer instead?
-	That would make comparisons more reliable,
-	but would likely lead to numbering reminiscent of BASIC line numbers.
-
-	Issue(4591): Should we drop priority by numbers entirely,
-	and replace it with some other ordering mechanism?
-	Experience with BASIC line number or z-index
-	does not give much confidence that ordering by number is a good idea.
-	Is placing in an ordered data-structure better?
-	Should authors be able to express a desired to be placed above/below
-	other named highlights,
-	and let the UA figure it out?
-
-	Issue(4594): Should the built-in [=highlight pseudo-elements=]
-	be exposed as well,
-	so that they too can be reordered,
-	and so that they can be interleaved with custom ones freely?
-
 	<div class=example id=overlap-highlight-ex>
 		<xmp highlight=html>
 			<style>


### PR DESCRIPTION
[css-highlight-api] Add comment about the default numerical priority for custom highlights.
[css-highlight-api] Highlight priority attribute should be long instead of double.
[css-highlight-api] Remove text for resolved highlight priority issues.

Resolves #4591 #4592 #4593 
