### PR TITLE
[css-transforms-2] Add note that computed value of translate has percentages

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -611,6 +611,11 @@ If three values are given,
 this specifies a 3d translation,
 equivalent to the ''translate3d()'' function.
 
+Note: The <a>resolved value</a> of the 'translate' property
+is the <a>computed value</a>,
+and thus {{Window/getComputedStyle()}}
+includes percentage values in its results.
+
 <pre class="propdef">
 Name: rotate
 Value: none | <<angle>> | [ x | y | z | <<number>>{3} ] && <<angle>>


### PR DESCRIPTION
While the premise of #2124 was that this was not already defined, I
believe this is already the straightforward result of the definition in
cssom-1.  Thus this adds a note rather than additional normative text.

Fixes #2124.