### PR TITLE
[css-ui-4] Added image-set() function to 'cursor' property

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -586,8 +586,9 @@ user resizing of that element.
 
 <pre class="propdef">
 Name: cursor
-Value: [ [ [ <<url>> | <<image-set()>> ] [&lt;x&gt; &lt;y&gt;]?,]* <br>
- [ auto | default | none |<br>
+Value: [ [ <<url>> | <<image-set()>> ] [ &lt;x&gt; &lt;y&gt; ]? , ]* <br>
+ [ <br>
+ auto | default | none | <br>
  context-menu | help | pointer | progress | wait | <br>
  cell | crosshair | text | vertical-text | <br>
  alias | copy | move | no-drop | not-allowed | grab | grabbing | <br>
@@ -596,7 +597,7 @@ Value: [ [ [ <<url>> | <<image-set()>> ] [&lt;x&gt; &lt;y&gt;]?,]* <br>
  col-resize | row-resize |
  all-scroll |<br>
  zoom-in | zoom-out <br>
- ] ]
+ ]
 Initial: auto
 Applies to: all elements
 Inherited: yes

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -586,7 +586,7 @@ user resizing of that element.
 
 <pre class="propdef">
 Name: cursor
-Value: [ [<<url>> [&lt;x&gt; &lt;y&gt;]?,]* <br>
+Value: [ [ [ <<url>> | <<image-set()>> ] [&lt;x&gt; &lt;y&gt;]?,]* <br>
  [ auto | default | none |<br>
  context-menu | help | pointer | progress | wait | <br>
  cell | crosshair | text | vertical-text | <br>
@@ -641,14 +641,16 @@ Values have the following meanings:
 	<dt>image cursors
 	<dd>
 	<dl>
-		<dt><<url>>
+		<dt><<url>>, <<image-set()>>
 		<dd>
-			The user agent retrieves the cursor from the resource designated by the URI.
+			The user agent retrieves the cursor from the resource designated by the
+			image function.
 			If the user agent cannot handle the first cursor of a list of cursors,
 			it must attempt to handle the second, etc.
 			If the user agent cannot handle any user-defined cursor,
 			it must use the cursor keyword at the end of the list.
-			Conforming User Agents may, instead of <<url>>, support <<image>> which is a superset.
+			Conforming User Agents may, instead of <<url>> and <<image-set()>>,
+			support <<image>> which is a superset.
 
 			The UA must support the following image file formats:
 

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -312,11 +312,11 @@ Note: This specification does not define the exact position or shape of the outl
 
 The 'outline-width' property accepts
 the same values as 'border-width'
-([[css-backgrounds-3#the-border-width]]).
+([[css-backgrounds-3#border-width]]).
 
 <dfn><<outline-line-style>></dfn> accepts
 the same values as <<line-style>>
-([[css-backgrounds-3#the-border-style]])
+([[css-backgrounds-3#border-style]])
 with the same meaning,
 except that
 <span class=css>hidden</span> is not a legal outline style.
@@ -609,7 +609,7 @@ Animation type: discrete
 This property specifies the type of cursor to be displayed for the pointing device
 when the cursor's hotspot is within the element's <a>border edge</a>.
 
-Note: As per [[css-backgrounds-3#the-border-radius]], the <a>border edge</a> is affected by 'border-radius'.
+Note: As per [[css-backgrounds-3#border-radius]], the <a>border edge</a> is affected by 'border-radius'.
 
 In the case of overlapping elements,
 which element determines the type of cursor


### PR DESCRIPTION
This change adds the `image-set()` function to the `cursor` property.

It got [implemented in Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1695402) lately and WebKit has support for a prefixed version of it.

Together with the addition of the function I've also adjusted the syntax a little bit for better readability and fixed some links to CSS Backgrounds 3 because otherwise Bikeshed marks them as fatal errors and doesn't compile the spec.

Closes #5831

Sebastian