### PR TITLE
[css-fonts-5] Don't allow more than 2 values for the font-size @font-face descriptor

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2244,21 +2244,21 @@ Font property descriptors: the 'font-style!!descriptor', 'font-weight!!descripto
 
 	<pre class='descdef'>
 	Name: font-style
-	Value: auto | normal | italic | oblique [ <<angle>> | <<angle>> <<angle>> ]?
+	Value: auto | normal | italic | oblique [ <<angle>> | <<angle>>{1,2} ]?
 	For: @font-face
 	Initial: auto
 	</pre>
 
 	<pre class='descdef'>
 	Name: font-weight
-	Value: auto | <<font-weight-absolute>> <<font-weight-absolute>>?
+	Value: auto | <<font-weight-absolute>>{1,2}
 	For: @font-face
 	Initial: auto
 	</pre>
 
 	<pre class='descdef'>
 	Name: font-stretch
-	Value: auto | <<'font-stretch'>> <<'font-stretch'>>?
+	Value: auto | <<'font-stretch'>>{1,2}
 	For: @font-face
 	Initial: auto
 	</pre>

--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -119,7 +119,7 @@ Issue(5892):
 
 <pre class='descdef'>
     Name: font-size
-    Value: auto | <<number>> <<number>>?
+    Value: auto | <<number>>{1,2}
     Initial: normal
     For: @font-face
     </pre>

--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -119,7 +119,7 @@ Issue(5892):
 
 <pre class='descdef'>
     Name: font-size
-    Value: auto | [<<number>>]#
+    Value: auto | <<number>> <<number>>?
     Initial: normal
     For: @font-face
     </pre>


### PR DESCRIPTION
The prose says what to do if there are exactly 1 or exactly 2 values, but not what to do if there are more. `#` indicates that there can be more.