### PR TITLE
[css-cascade-5] Begin to define nested layers as lexical issue #6098

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1231,20 +1231,80 @@ Declaring Cascade Layers: the ''@layer'' rule</h4>
 	The optional <dfn for='@layer'><<layer-ident>></dfn>
 	is a list of one or more [=CSS identifiers=] (<<ident>>),
 	joined directly by a full stop (. U+002E) character
-	without any intervening whitespace.
-	The combined <<layer-ident>> represents its <dfn>layer name</dfn>.
-	The syntax for a <<layer-ident>> is:
+	without any intervening whitespace:
 
 	<pre class='prod'>
 		<<ident>>[.<<ident>>]*
 	</pre>
 
+	The combined <<layer-ident>> represents its <dfn>layer name</dfn>.
+
 	If the [=layer name=] matches that of a [=cascade layer=]
-	already defined within this [=origin=] and [=context=]
-	(and the same [=layer=] scope, see [[#nested-layers]]),
+	already defined within this [=origin=] and [=context=],
 	then its style rules are assigned to that same [=cascade layer=].
 	Otherwise, or if no <<layer-ident>> is provided,
 	a new [=cascade layer=] is created.
+
+	If the <<layer-ident>> is composed of multiple <<ident>> parts,
+	each part represents a unique layer, scoped to the preceeding layers.
+	If any of the scoping layers have not yet been defined,
+	new [=cascade layers=] are created for each implied scope.
+
+	<div class="example">
+		A single complex identifier:
+
+		<pre class='lang-css'>
+			@layer framework.components.default {
+				.title { font-weight: bold; }
+			}
+		</pre>
+
+		Establishes both the mentioned layer,
+		and any parent layers required for scoping:
+
+		1. framework.components.default
+		2. framework.components
+		3. framework
+	</div>
+
+	Layer ordering is determined within each scope,
+	so it is not possible to intermix sub-layers across different scopes.
+
+	<div class="example">
+		Given the following layer rules:
+
+		<pre class='lang-css'>
+			@layer framework.default {
+				strong { font-weight: bold; }
+			}
+
+			@layer utilities {
+				[hidden] { display: none; }
+			}
+
+			@layer framework {
+				.title { font-weight: 100; }
+			}
+
+			@layer framework.theme {
+				h1, h2 { color: maroon; }
+			}
+		</pre>
+
+		The resulting layers are sorted by scope first:
+
+		1. framework (and sub-layers)
+		2. utilities
+
+		Within each scope, declarations without further nesting
+		are added to an implicit sub-layer which
+		takes priority over (comes after) explicitly nested layers:
+
+		1. framework.default
+		2. framework.theme
+		3. framework (implicit sub-layer)
+		4. utilities
+	</div>
 
 	Note: Layer name matching does not cross the shadow DOM boundary,
 	so the ordering of layers in the light DOM has no impact
@@ -1259,8 +1319,6 @@ Declaring Cascade Layers: the ''@layer'' rule</h4>
 
 	Such empty ''@layer'' are allowed
 	anywhere either ''@import'' or other ''@layer'' rules are allowed.
-
-	Issue(w3c/csswg-drafts#5853): Provide an attribute for assigning link or style elements to cascade layers
 
 	<div class="example">
 		Layer identifiers are optional,
@@ -1328,7 +1386,7 @@ Nested Layers</h5>
 	[=layer names=] are scoped to their parent layer.
 	The resulting [=layer-ident=] is a combination
 	of the parent and child [=layer names=],
-	joined by a a full stop (. U+002E) character.
+	joined by a full stop (. U+002E) character.
 
 	It is not possible for nested layers
 	to reference a [=layer name=] in an outer layer’s scope,
@@ -1366,8 +1424,8 @@ Nested Layers</h5>
 		which can be represented as a flat list of joined layer identifiers:
 
 		1. default
-		3. framework
 		2. framework.default
+		3. framework (implicit sub-layer)
 	</div>
 
 	Issue(w3c/csswg-drafts#5791): What is the appropriate syntax for appending to nested layers?

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1229,8 +1229,16 @@ Declaring Cascade Layers: the ''@layer'' rule</h4>
 	with a true condition.
 
 	The optional <dfn for='@layer'><<layer-ident>></dfn>
-	is a [=CSS identifier=] (<<ident>>)
-	that represents its <dfn>layer name</dfn>.
+	is a list of one or more [=CSS identifiers=] (<<ident>>),
+	joined directly by a full stop (. U+002E) character
+	without any intervening whitespace.
+	The combined <<layer-ident>> represents its <dfn>layer name</dfn>.
+	The syntax for a <<layer-ident>> is:
+
+	<pre class='prod'>
+		<<ident>>[.<<ident>>]*
+	</pre>
+
 	If the [=layer name=] matches that of a [=cascade layer=]
 	already defined within this [=origin=] and [=context=]
 	(and the same [=layer=] scope, see [[#nested-layers]]),
@@ -1318,10 +1326,20 @@ Nested Layers</h5>
 
 	When ''@layer'' rules are nested,
 	[=layer names=] are scoped to their parent layer.
+	The resulting [=layer-ident=] is a combination
+	of the parent and child [=layer names=],
+	joined by a a full stop (. U+002E) character.
+
+	It is not possible for nested layers
+	to reference a [=layer name=] in an outer layer’s scope,
+	but it is possible to reference nested layers
+	from an outer scope,
+	by using the same combined identifier.
 
 	<div class="example">
 		In this example,
-		the nested ''framework default'' layer is distinct
+		the nested and un-nested variations of the
+		''framework.default'' layer are distinct
 		from the top-level ''default'' layer:
 
 		<pre class='lang-css'>
@@ -1329,92 +1347,27 @@ Nested Layers</h5>
 			  p { max-width: 70ch; }
 			}
 
+			/* The farmework.default layer can be created or accessed directly */
+			@layer framework.default {
+			  bockquote { margin-block: 0.75em; }
+			}
+
 			@layer framework {
+				p { color: #222; }
+
+				/* These styles are added to the farmework.default layer */
 			  @layer default {
 			    p { margin-block: 0.75em; }
 			  }
-
-			  @layer theme {
-			    p { color: #222; }
-			  }
 			}
 		</pre>
 
-		The resulting layers can be represented as a tree:
+		This results in three layers,
+		which can be represented as a flat list of joined layer identifiers:
 
 		1. default
-		2. framework
-			1. default
-			2. theme
-
-		or as a flat list with nested identifiers:
-
-		1. default
-		2. framework default
-		3. framework theme
-
-	</div>
-
-	It is not possible for nested layers
-	to reference a [=layer name=] in an outer layer’s scope,
-	but it is possible to reference nested layers
-	from an outer scope,
-	by combining identifiers with a full stop (. U+002E) character.
-
-	<div class="example">
-		<pre class='lang-css'>
-			@layer framework {
-			  @layer default {
-			     p { margin-block: 0.75em; }
-			  }
-
-			  @layer theme {
-			    p { color: #222; }
-			  }
-			}
-
-			@layer framework.theme {
-			  /* These styles will be added to the theme layer inside the framework layer */
-			  blockquote { color: rebeccapurple; }
-			}
-		</pre>
-	</div>
-
-	This syntax is provided as a shorthand for defining nested layers,
-	and has the same effect as declaring each [=layer name=]
-	inside nested ''@layer'' rules.
-
-	<div class="example">
-		That means the shorthand syntax can also be used in defining new layers,
-		and establishing layer order.
-
-		The following example defines <css>framework.theme</css> before <css>framework.default</css>:
-
-		<pre class='lang-css'>
-			@layer framework.theme {
-			  blockquote { color: rebeccapurple; }
-			}
-
-			@layer framework {
-			  @layer default {
-			     p { margin-block: 0.75em; }
-			  }
-
-			  @layer theme {
-			    p { color: #222; }
-			  }
-			}
-		</pre>
-
-		The <css>framework.theme</css> shorthand is purely syntax sugar for the following longhand:
-
-		<pre class='lang-css'>
-			@layer framework {
-			  @layer theme {
-			    blockquote { color: rebeccapurple; }
-			  }
-			}
-		</pre>
+		3. framework
+		2. framework.default
 	</div>
 
 	Issue(w3c/csswg-drafts#5791): What is the appropriate syntax for appending to nested layers?

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1255,7 +1255,7 @@ Declaring Cascade Layers: the ''@layer'' rule</h4>
 
 		<pre class='lang-css'>
 			@layer framework.components.default {
-				.title { font-weight: bold; }
+			  .title { font-weight: bold; }
 			}
 		</pre>
 
@@ -1275,19 +1275,19 @@ Declaring Cascade Layers: the ''@layer'' rule</h4>
 
 		<pre class='lang-css'>
 			@layer framework.default {
-				strong { font-weight: bold; }
+			  strong { font-weight: bold; }
 			}
 
 			@layer utilities {
-				[hidden] { display: none; }
+			  [hidden] { display: none; }
 			}
 
 			@layer framework {
-				.title { font-weight: 100; }
+			  .title { font-weight: 100; }
 			}
 
 			@layer framework.theme {
-				h1, h2 { color: maroon; }
+			  h1, h2 { color: maroon; }
 			}
 		</pre>
 
@@ -1411,9 +1411,9 @@ Nested Layers</h5>
 			}
 
 			@layer framework {
-				p { color: #222; }
+			  p { color: #222; }
 
-				/* These styles are added to the farmework.default layer */
+			  /* These styles are added to the farmework.default layer */
 			  @layer default {
 			    p { margin-block: 0.75em; }
 			  }


### PR DESCRIPTION
Resolves #6098 

- [x] Move the dot-combined identifier option into the original layer-identifier syntax definition
- [x] Need to clarify that layer sorting is grouped by scope, so that `one.one, two, one.two` results in a layer order of `one.one, one.two, two`