### PR TITLE
[css-fonts-4] font-stretch should serialize to a number/percentage, not a keyword

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -710,11 +710,7 @@ Font width: the 'font-stretch!!property' property</h3>
 
     User Agents must not synthesize stretched faces for font families which lack actual stretched faces.
 
-    For compatibility with [[CSS-FONTS-3]],
-    {{getComputedStyle()}} serializes values
-    that correspond to one of the 'font-stretch!!property' keywords
-    as that keyword
-    (instead of as a <<percentage>>).
+    {{getComputedStyle()}} always serializes its value as a <<percentage>>, regardless of how the value was specified by the author, or whether or not a keyword happens to map to the value.
 
 <h3 id="font-style-prop">
 Font style: the 'font-style!!property' property</h3>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6171