### PR TITLE
[css-fonts-5] The font-size-adjust property is applied after the size-adjust descriptor

### DIFF
--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -93,6 +93,11 @@ Issue(4044):
 <h3 id="font-size-adjust-prop">
 Relative sizing: the 'font-size-adjust' property</h3>
 
+The 'font-size-adjust' property is applied after the 'size-adjust' descriptor.
+
+Note: The consequence of applying 'font-size-adjust' after 'size-adjust' is that
+'size-adjust' appears to have no effect.
+
 Issue(5539):
 
 
@@ -218,6 +223,11 @@ the 'ascent-override', 'descent-override', and 'line-gap-override' descriptors</
 			The corresponding metric is replaced by
 			the given percentage multiplied by the used font size.
 	</dl>
+
+	The 'font-size-adjust' property is applied after the 'size-adjust' descriptor.
+
+	Note: The consequence of applying 'font-size-adjust' after 'size-adjust' is that
+	'size-adjust' appears to have no effect.
 
 	Note: None of these descriptors affect the [=computed value|computation=] of
 	'font-size', 'line-height', or [=font-relative lengths=].


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6128.