### PR TITLE
[css-color-5] Fix definition of color-contrast

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -478,7 +478,7 @@ Selecting the most contrasting color: the ''color-contrast()'' function {#colorc
 	with the keyword 'to'.
 
 	<pre class='prod'>
-		<dfn>color-contrast()</dfn> = color-contrast( <<color>> vs <<color>>#{2,}  ( to [<<number>> | AA | AA-large])? )
+		<dfn>color-contrast()</dfn> = color-contrast( <<color>> vs <<color>>#{2,}  [ to [<<number>> | AA | AA-large]]? )
 	</pre>
 
 	The keyword 'AA' is equivalent to 4.5, and the keyword 'AA-large' is equivalent to 3.


### PR DESCRIPTION
According to the Value Definition Syntax, parentheses are to be interpreted as representing their corresponding tokens. For grouping, brackets must be used:
https://drafts.csswg.org/css-values/#value-defs
