### PR TITLE
[css-grid-1][css-grid-2] Remove `grid-row: auto`

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -2503,13 +2503,11 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 				/* Place all labels in the "labels" column and
 				   automatically find the next available row. */
 				grid-column: labels;
-				grid-row: auto;
 			}
 			form > input, form > select {
 				/* Place all controls in the "controls" column and
 				   automatically find the next available row. */
 				grid-column: controls;
-				grid-row: auto;
 			}
 
 			#department-block {
@@ -2524,8 +2522,6 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 			/* Place all the buttons of the form
 			   in the explicitly defined grid area. */
 			#buttons {
-				grid-row: auto;
-
 				/* Ensure the button area spans the entire grid element
 				   in the inline axis. */
 				grid-column: 1 / -1;

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -2649,13 +2649,11 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 				/* Place all labels in the "labels" column and
 				   automatically find the next available row. */
 				grid-column: labels;
-				grid-row: auto;
 			}
 			form > input, form > select {
 				/* Place all controls in the "controls" column and
 				   automatically find the next available row. */
 				grid-column: controls;
-				grid-row: auto;
 			}
 
 			#department-block {
@@ -2670,8 +2668,6 @@ Implicit Track Sizing: the 'grid-auto-rows' and 'grid-auto-columns' properties</
 			/* Place all the buttons of the form
 			   in the explicitly defined grid area. */
 			#buttons {
-				grid-row: auto;
-
 				/* Ensure the button area spans the entire grid element
 				   in the inline axis. */
 				grid-column: 1 / -1;


### PR DESCRIPTION
Although we use `grid-row: auto` in example 24 of the "Automatic
Placement" chapter, I believe it's redundant and we free to remove that.

I'm not sure about the situation regarding this property in the past,
but according to my investigation nowadays we already have implicit
`grid-row: auto` for all grid children for all major browsers: the
Chromium-family, FF, Safari, Edge (legacy)

_Chrome_
<img width="1760" alt="chrome" src="https://user-images.githubusercontent.com/33809585/113836308-709a1700-9795-11eb-8d0c-15d2a57f67a9.png">

_Firefox_
<img width="1760" alt="firefox" src="https://user-images.githubusercontent.com/33809585/113836360-7db70600-9795-11eb-9f5e-193b224447dc.png">

_Safari_
<img width="1760" alt="safari-1" src="https://user-images.githubusercontent.com/33809585/113836401-87406e00-9795-11eb-87fb-ede3cc7e2a4f.png">
<img width="1760" alt="safari-2" src="https://user-images.githubusercontent.com/33809585/113836438-8f001280-9795-11eb-93df-f078df1c8eef.png">

_Edge (legacy)_
![edge-1](https://user-images.githubusercontent.com/33809585/113836487-98897a80-9795-11eb-9ce1-72e4244950c3.png)
![edge-2](https://user-images.githubusercontent.com/33809585/113836533-a17a4c00-9795-11eb-8a2c-840c382a4225.png)
