### PR TITLE
[css-highlight-api-1] Make HighlightRegistry maplike

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -229,6 +229,10 @@ Registering Custom Highlights</h3>
 		The <dfn>custom highlight name</dfn> assigned to a [=custom highlight=] when it is [=registered=]
 		is used to identify the highlight during styling (see [[#styling-highlights]]).
 
+	Note: When registering a [=custom highlight=], authors are recommended to use a
+	[=custom highlight name=] that is a valid CSS [=identifier=]. Using a name that is not a valid
+	identifier can make the highlight hard, and in some cases impossible, to style via CSS.
+
 <h2 id=styling-highlights>
 Styling Custom Highlights</h2>
 

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -103,7 +103,7 @@ Introduction</h2>
 			r.setStart(document.body, 0);
 			r.setEnd(document.body, 2);
 
-			CSS.highlights.add(new Highlight("example-highlight", r));
+			CSS.highlights.set("example-highlight", new Highlight(r));
 			</script>
 		</xmp>
 
@@ -139,7 +139,7 @@ Setting up Custom Highlights</h2>
 <h3 id=creation>
 Creating Custom Highlights</h3>
 
-	A <dfn>custom highlight</dfn> is a named collection of [=ranges=]
+	A <dfn>custom highlight</dfn> is a collection of [=ranges=]
 	representing portions of a document.
 	They do not necessarily fit into the element tree,
 	and can arbitrarily cross element boundaries without honoring its nesting structure.
@@ -160,35 +160,24 @@ Creating Custom Highlights</h3>
 	authors can chose between using {{Range}} objects and {{StaticRange}} objects.
 	See [[#range-invalidation]] for more details about this choice and its implications.
 
-	The <dfn for="custom highlight">name</dfn> of a [=custom highlight=]
-	is represented by its {{Highlight/name}} attribute,
-	which must be a valid <<ident-token>>.
-
 	<xmp class="idl">
 	[Exposed=Window]
 	interface Highlight {
-		constructor(CSSOMString name, AbstractRange... initialRanges);
+		constructor(AbstractRange... initialRanges);
 		setlike<AbstractRange>;
 		attribute long priority;
-		readonly attribute CSSOMString name;
 	};
 	</xmp>
 
 	See [[#priorities]] for more information on the {{Highlight/priority}} attribute.
 
 	<div algorithm="to create a custom highlight">
-		When the <dfn for=Highlight constructor>Highlight(CSSOMString name, AbstractRange... initialRanges)</dfn> constructor is invoked,
+		When the <dfn for=Highlight constructor>Highlight(AbstractRange... initialRanges)</dfn> constructor is invoked,
 		run the following steps:
 
 		<ol>
 			<li>
 				Let |highlight| be the new {{Highlight}} object.
-			<li>
-				If {{name!!argument}} does not [=CSS/parse=] as an <<ident-token>>, then [=throw=] a {{"SyntaxError"}}.
-			<li>
-				Let |nameArg| be the result of [=converted to an ECMAScript value|converting=] {{name!!argument}} to an ECMAScript value.
-			<li>
-				Set |highlight|'s {{Highlight/name}} to |nameArg|
 			<li>
 				Set |highlight|'s {{Highlight/priority}} to <code>0</code>.
 			<li>
@@ -206,13 +195,13 @@ Creating Custom Highlights</h3>
 Registering Custom Highlights</h3>
 
 	In order to have any effect,
-	[=custom highlights=] then needs to be
-	[=registered=] it into the [=highlight registry=].
+	[=custom highlights=] need to be
+	[=registered=] into the [=highlight registry=].
 
 	The <dfn>highlight registry</dfn> is accessed via the {{CSS/highlights}} attribute of the {{CSS}} namespace,
 	and represents all the [=custom highlights=] [=registered=] for the [=current global object=]’s [=associated Document=].
-	It is a [=setlike=], and can be updated using the usual methods.
-	It's [=set entries=] is initially empty.
+	It is a [=maplike=], and can be updated using the usual methods.
+	It's [=map entries=] is initially empty.
 
 	A [=custom highlight=] is said to be <dfn>registered</dfn>
 	if it is in the [=highlight registry=].
@@ -225,26 +214,20 @@ Registering Custom Highlights</h3>
 
 	[Exposed=Window]
 	interface HighlightRegistry {
-		setlike<Highlight>;
+		maplike<DOMString, Highlight>;
 	};
 	</xmp>
 
 	<div algorithm="to register a custom highlight">
 		To [=register=] a [=custom highlight=],
-		invoke the {{HighlightRegistry/add()}} method of the [=highlight registry=]
-		with the [=custom highlight=] as the argument.
+		invoke the <code>set</code> method of the [=highlight registry=]
+		which will run [[webidl#es-map-set|the steps for a built-in maplike set function]],
+		with the [=context object=] as the <code>this</code> value,
+		the passed-in [=custom highlight name=] as |keyArg|,
+		and the passed-in highlight as |valueArg|.
 
-		When invoked,
-		the <dfn method for=HighlightRegistry>add(Highlight value)</dfn> method must run these steps:
-
-		1. If there is already a [=set entry=] with the same {{Highlight/name}} as the {{Highlight/name}} of {{value}},
-			then [=throw=] an {{"OperationError"}}.
-		3. Let |valueArg| be the result of [=converted to an ECMAScript value|converting=] {{value}} to an ECMAScript value.
-		4. Let |result| be the result of running [[webidl#es-add-delete|the steps for a built-in setlike add function]],
-			with the [=context object=] as the <code>this</code> value
-			and with |valueArg| as the argument.
-		5. Return |result|.
-	</div>
+		The <dfn>custom highlight name</dfn> assigned to a [=custom highlight=] when it is [=registered=]
+		is used to identify the highlight during styling (see [[#styling-highlights]]).
 
 <h2 id=styling-highlights>
 Styling Custom Highlights</h2>
@@ -252,14 +235,14 @@ Styling Custom Highlights</h2>
 <h3 id=custom-highlight-pseudo>
 The Custom Highlight Pseudo-element: ''::highlight()''</h3>
 
-	The <dfn>::highlight(<<highlight-name>>)</dfn> pseudo-element
+	The <dfn>::highlight(<<custom-highlight-name>>)</dfn> pseudo-element
 	(also known as the <dfn>custom highlight pseudo-element</dfn>)
 	represents the portion of a document that
 	is being [=contained=] or [=partially contained=]
 	in all the [=ranges=] of the [=registered=] [=custom highlight=]
-	with the [=custom highlight/name=] <<highlight-name>>,
+	with the [=custom highlight name=] <<custom-highlight-name>>,
 	if any.
-	<dfn type><<highlight-name>></dfn> must be a valid CSS <<ident-token>>.
+	<dfn type><<custom-highlight-name>></dfn> must be a valid CSS <<ident-token>>.
 
 
 <h3 id=processing-model>
@@ -317,7 +300,7 @@ Painting</h4>
 						r2.setStart(textNode, 3);
 						r2.setEnd(textNode, 7);
 
-						CSS.highlights.add(new Highlight("sample", r1, r2));
+						CSS.highlights.set("sample", new Highlight(r1, r2));
 					</script>
 				</xmp>
 

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -233,6 +233,40 @@ Registering Custom Highlights</h3>
 	[=custom highlight name=] that is a valid CSS [=identifier=]. Using a name that is not a valid
 	identifier can make the highlight hard, and in some cases impossible, to style via CSS.
 
+	Note: It is possible to [=register=] a [=custom highlight=] with more than one [=custom highlight name=].
+	However, using more than one name to style a highlight will assign the highlight multiple different sets
+	of styles, without a way to control the stacking order of conflicting styles within these sets
+	during [[#painting|painting]]. This may be limiting for authors and may cause confusing painting behavior
+	(see the [[#styling-problems-with-multiple-names-per-highlight|example]] below for more context). Therefore,
+	<b>it is recommended that authors only use one name per highlight during styling</b>.
+	<div class=example id=styling-problems-with-multiple-names-per-highlight>
+		<xmp highlight=html>
+			<style>
+			div::highlight(bar) {
+				color: red;
+			}
+			div::highlight(foo) {
+				color: green;
+			}
+			</style>
+			<body><div>abc</div>
+			<script>
+			let r = new Range();
+			r.setStart(div, 0);
+			r.setEnd(div, 1);
+			let h = new Highlight(r);
+			CSS.highlights.set('foo', h);
+			CSS.highlights.set('bar', h);
+			</script>
+		</xmp>
+		In the example above, the same [=custom highlight=] object is [=registered=] under the names 'foo' and 'bar'.
+		Since each of the [=style rules=] target the same highlight and have the same [=specificity=], authors may
+		expect the last rule to win in cascading order and the highlighted content to be green. However, each highlight
+		name gets an independent set of highlight styles, and the highlight will be painted once per name. In
+		this case, because 'foo' was registered before 'bar', the highlight will be first painted with 'foo''s
+		color (green) and then with 'bar''s color (red). As a result, the highlighted content will appear red.
+	</div>
+
 <h2 id=styling-highlights>
 Styling Custom Highlights</h2>
 


### PR DESCRIPTION
[css-highlight-api-1] Make HighlightRegistry maplike and remove name property from Highlight.
[css-highlight-api-1] Add note recommending authors to use custom highlight names that are CSS identifiers for easier styling via CSS.
[css-highlight-api-1] Add note recommending authors to only use one name to style a highlight and add an example showcasing why using multiple names is problematic.

Resolves #5910 