### PR TITLE
[css-regions-1] Use maplike declaration for NamedFlowMap

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -1043,12 +1043,8 @@ The NamedFlow interface</h3>
 	and is read-only.
 
 	<pre class="idl">
-		[Exposed=Window,
-		 MapClass=(CSSOMString, NamedFlow)] interface NamedFlowMap {
-			NamedFlow? get(CSSOMString flowName);
-			boolean has(CSSOMString flowName);
-			NamedFlowMap set(CSSOMString flowName, NamedFlow flowValue);
-			boolean delete(CSSOMString flowName);
+		[Exposed=Window] interface NamedFlowMap {
+			maplike&lt;CSSOMString, NamedFlow&gt;;
 		};
 	</pre>
 


### PR DESCRIPTION
The previously defined members are implicit in the maplike declaration:
https://heycam.github.io/webidl/#es-maplike

Fixes https://github.com/w3c/csswg-drafts/issues/6014.