### PR TITLE
[css-grid-1][css-grid-2] Set min-height for ex 39

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -3631,6 +3631,7 @@ Aligning the Grid: the 'justify-content' and 'align-content' properties</h3>
 				grid: 12rem 12rem 12rem 12rem / 10rem 10rem 10rem 10rem;
 				justify-content: end;
 				align-content: center;
+				min-height: 60rem;
 			}
 		</pre>
 

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -4169,6 +4169,7 @@ Aligning the Grid: the 'justify-content' and 'align-content' properties</h3>
 				grid: 12rem 12rem 12rem 12rem / 10rem 10rem 10rem 10rem;
 				justify-content: end;
 				align-content: center;
+				min-height: 60rem;
 			}
 		</pre>
 


### PR DESCRIPTION
Set the `min-height` property for the `.grid` class to make
`align-content: center;` work much more clear. `align-content: center;`
has no sense if we run example 39 as it is.

Without `min-height`
![Screen Shot 2021-04-15 at 1 04 45 pm](https://user-images.githubusercontent.com/33809585/114852614-99508b00-9deb-11eb-8cd4-c270e35ef686.png)

With `min-height`
![Screen Shot 2021-04-15 at 1 04 27 pm](https://user-images.githubusercontent.com/33809585/114852660-a40b2000-9deb-11eb-8ba9-a148e8e511b0.png)