### PR TITLE
[selectors-4] Define a number of new pseudo-classes for matching the state of media elements.

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -35,14 +35,11 @@ spec:css-pseudo-4; type:selector;
 	text: ::after
 	text: ::first-line
 	text: ::first-letter
-</pre>
-<pre class="anchors">
-urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
-    text: effective media volume; url: media.html#effective-media-volume; type: dfn
-    text: media data; url: media.html#media-data; type: dfn
-    text: seeking; url: media.html#seeking; type: dfn
-    text: stall timeout; url: media.html#stall-timeout; type: dfn
-    text: stalled; url: media.html#stall-timeout; type: dfn
+spec:HTML; type:dfn;
+	text: effective media volume
+	text: seeking
+	text: media data
+	text: stall timeout
 </pre>
 
 <style>

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -36,6 +36,14 @@ spec:css-pseudo-4; type:selector;
 	text: ::first-line
 	text: ::first-letter
 </pre>
+<pre class="anchors">
+urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
+    text: effective media volume; url: media.html#effective-media-volume; type: dfn
+    text: media data; url: media.html#media-data; type: dfn
+    text: seeking; url: media.html#seeking; type: dfn
+    text: stall timeout; url: media.html#stall-timeout; type: dfn
+    text: stalled; url: media.html#stall-timeout; type: dfn
+</pre>
 
 <style>
 #selector-examples td:first-child {
@@ -2403,23 +2411,63 @@ Resource State Pseudos</h2>
 	particularly images/videos,
 	and allow authors to select them based on some quality of their state.
 
-<h3 id="video-state">
-Video/Audio Play State: the '':playing'' and '':paused'' pseudo-classes</h3>
+<h3 id="video-state"> <!-- keeping this ID because Cool URIs Don't Change -->
+Media Playback State: the '':playing'', '':paused'', and '':seeking'' pseudo-classes</h3>
 
 	The <dfn>:playing</dfn> pseudo-class represents an element
-	representing an audio, video, or similar resource
 	that is capable of being “played” or “paused”,
 	when that element is “playing”.
 	(This includes both when the element is explicitly playing,
 	and when it's temporarily stopped for some reason not connected to user intent,
 	but will automatically resume when that reason is resolved,
-	such as a “buffering” state.)
+	such as a “buffering” or “stalled” state.)
 
-	The <dfn>:paused</dfn> pseudo-class represents the same elements,
-	but instead match when the element is <em>not</em> “playing”.
+	The <dfn>:paused</dfn> pseudo-class represents an element
+	that is capable of being “played” or “paused”,
+	when that element is “paused” (i.e. <em>not</em> ”playing”).
 	(This includes both an explicit “paused” state,
 	and other non-playing states like “loaded, hasn't been activated yet”, etc.)
 
+    The <dfn>:seeking</dfn> pseudo-class represents an element
+    that is capable of ”seeking”
+    when that element is ”seeking”.
+    (For the <{audio}> and <{video}> elements of HTML, see [=seeking=]. [[HTML]])
+
+<h3 id="media-loading-state">
+Media Loading State: the '':buffering'' and '':stalled'' pseudo-classes</h3>
+
+    The <dfn>:buffering</dfn> pseudo-class represents an element
+	that is capable of being “played” or “paused”,
+	when that element cannot continue playing
+    because it is actively attempting to obtain [=media data=]
+    but has not yet obtained enough data to resume playback.
+    (Note that the element is still considered to be “playing” when it is “buffering”.
+    Whenever '':buffering'' matches an element,
+    '':playing'' also matches the element.)
+
+    The <dfn>:stalled</dfn> pseudo-class represents an element
+	when that element cannot continue playing
+    because it is actively attempting to obtain [=media data=]
+    but it has failed to receive any data for some amount of time.
+    For the <{audio}> and <{video}> elements of HTML,
+    this amount of time is the [=stall timeout=]. [[HTML]]
+    (Note that, like with the '':buffering'' pseudo-class,
+    the element is still considered to be “playing” when it is “stalled”.
+    Whenever '':stalled'' matches an element,
+    '':playing'' also matches the element.)
+
+<h3 id="sound-state">
+Sound State: the '':muted'' and '':volume-locked'' pseudo-classes</h3>
+
+    The <dfn>:muted</dfn> pseudo-class represents
+    an element capable of making sound
+    when that element is “muted“.
+    (For the <{audio}> and <{video}> elements of HTML, see [=muted=]. [[HTML]])
+
+    The <dfn>:volume-locked</dfn> pseudo-class represents
+    an element capable of making sound
+    when programmatically changing the element’s volume
+    does not change the element's [=effective media volume=].
 
 <h2 id='input-pseudos'>
 The Input Pseudo-classes</h2>

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2408,7 +2408,7 @@ Resource State Pseudos</h2>
 	particularly images/videos,
 	and allow authors to select them based on some quality of their state.
 
-<h3 id="video-state"> <!-- keeping this ID because Cool URIs Don't Change -->
+<h3 id="video-state">
 Media Playback State: the '':playing'', '':paused'', and '':seeking'' pseudo-classes</h3>
 
 	The <dfn>:playing</dfn> pseudo-class represents an element
@@ -2425,46 +2425,46 @@ Media Playback State: the '':playing'', '':paused'', and '':seeking'' pseudo-cla
 	(This includes both an explicit “paused” state,
 	and other non-playing states like “loaded, hasn't been activated yet”, etc.)
 
-    The <dfn>:seeking</dfn> pseudo-class represents an element
-    that is capable of ”seeking”
-    when that element is ”seeking”.
-    (For the <{audio}> and <{video}> elements of HTML, see [=seeking=]. [[HTML]])
+	The <dfn>:seeking</dfn> pseudo-class represents an element
+	that is capable of ”seeking”
+	when that element is ”seeking”.
+	(For the <{audio}> and <{video}> elements of HTML, see [[HTML#seeking]].)
 
 <h3 id="media-loading-state">
 Media Loading State: the '':buffering'' and '':stalled'' pseudo-classes</h3>
 
-    The <dfn>:buffering</dfn> pseudo-class represents an element
+	The <dfn>:buffering</dfn> pseudo-class represents an element
 	that is capable of being “played” or “paused”,
 	when that element cannot continue playing
-    because it is actively attempting to obtain [=media data=]
-    but has not yet obtained enough data to resume playback.
-    (Note that the element is still considered to be “playing” when it is “buffering”.
-    Whenever '':buffering'' matches an element,
-    '':playing'' also matches the element.)
+	because it is actively attempting to obtain [=media data=]
+	but has not yet obtained enough data to resume playback.
+	(Note that the element is still considered to be “playing” when it is “buffering”.
+	Whenever '':buffering'' matches an element,
+	'':playing'' also matches the element.)
 
-    The <dfn>:stalled</dfn> pseudo-class represents an element
+	The <dfn>:stalled</dfn> pseudo-class represents an element
 	when that element cannot continue playing
-    because it is actively attempting to obtain [=media data=]
-    but it has failed to receive any data for some amount of time.
-    For the <{audio}> and <{video}> elements of HTML,
-    this amount of time is the [=stall timeout=]. [[HTML]]
-    (Note that, like with the '':buffering'' pseudo-class,
-    the element is still considered to be “playing” when it is “stalled”.
-    Whenever '':stalled'' matches an element,
-    '':playing'' also matches the element.)
+	because it is actively attempting to obtain [=media data=]
+	but it has failed to receive any data for some amount of time.
+	For the <{audio}> and <{video}> elements of HTML,
+	this amount of time is the [=stall timeout=]. [[HTML]]
+	(Note that, like with the '':buffering'' pseudo-class,
+	the element is still considered to be “playing” when it is “stalled”.
+	Whenever '':stalled'' matches an element,
+	'':playing'' also matches the element.)
 
 <h3 id="sound-state">
 Sound State: the '':muted'' and '':volume-locked'' pseudo-classes</h3>
 
-    The <dfn>:muted</dfn> pseudo-class represents
-    an element capable of making sound
-    when that element is “muted“.
-    (For the <{audio}> and <{video}> elements of HTML, see [=muted=]. [[HTML]])
+	The <dfn>:muted</dfn> pseudo-class represents
+	an element capable of making sound
+	when that element is “muted“.
+	(For the <{audio}> and <{video}> elements of HTML, see [=muted=]. [[HTML]])
 
-    The <dfn>:volume-locked</dfn> pseudo-class represents
-    an element capable of making sound
-    when programmatically changing the element’s volume
-    does not change the element's [=effective media volume=].
+	The <dfn>:volume-locked</dfn> pseudo-class represents
+	an element capable of making sound
+	when programmatically changing the element’s volume
+	does not change the element's [=effective media volume=].
 
 <h2 id='input-pseudos'>
 The Input Pseudo-classes</h2>


### PR DESCRIPTION
We resolved to add these [in Toronto in June 2019](https://lists.w3.org/Archives/Public/www-style/2019Jul/0002.html).

This is a first draft; I'm sure the text could use some work before merging.

Fixes #3821.
Fixes #3933.