### PR TITLE
[css-regions] Avoid the use of Region as a return type

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -1090,10 +1090,10 @@ The NamedFlow interface</h3>
 		interface NamedFlow : EventTarget {
 			readonly attribute CSSOMString name;
 			readonly attribute boolean overset;
-			sequence&lt;Region&gt; getRegions();
+			sequence&lt;Element&gt; getRegions();
 			readonly attribute short firstEmptyRegionIndex;
 			sequence&lt;Node&gt; getContent();
-			sequence&lt;Region&gt; getRegionsByContent(Node node);
+			sequence&lt;Element&gt; getRegionsByContent(Node node);
 		};
 	</pre>
 


### PR DESCRIPTION
As an interface mixin, Region can't be used as a type per Web IDL:
https://heycam.github.io/webidl/#idl-types

Fixes https://github.com/w3c/csswg-drafts/issues/5519.