### PR TITLE
[mediaqueries-5] Add viewport segment media features

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -1252,6 +1252,46 @@ Inline-Axis Overflow: the '@media/overflow-inline' feature</h3>
 	and the very concept doesn't seem to make much sense,
 	so there is intentionally no ''paged'' value for '@media/overflow-inline'.
 
+<h3 id='mf-horizontal-viewport-segments'>
+Horizontal Viewport Segments: the '@media/horizontal-viewport-segments' feature</h3>
+
+	<pre class="descdef mq">
+	Name: horizontal-viewport-segments
+	Value: <<integer>>
+	For: @media
+	Type: range
+	</pre>
+
+	The '@media/horizontal-viewport-segments' media feature describes the number of logical segments of
+    the viewport in the horizontal direction. 
+
+    The '@media/horizontal-viewport-segments' media feature is <a>false in the negative range</a>.
+
+    When the viewport is split by one or more hardware features (such as a fold or a hinge between
+    separate displays) that act as a logical divider, segments are the regions of the viewport that
+    can be treated as logically distinct by the page.
+
+<h3 id='mf-vertical-viewport-segments'>
+Vertical Viewport Segments: the '@media/vertical-viewport-segments' feature</h3>
+
+	<pre class="descdef mq">
+	Name: vertical-viewport-segments
+	Value: <<integer>>
+	For: @media
+	Type: range
+	</pre>
+
+	The '@media/vertical-viewport-segments' media feature describes the number of logical segments of
+    the viewport in the vertical direction.
+
+    The '@media/vertical-viewport-segments' media feature is <a>false in the negative range</a>.
+
+	<div class='example'>
+		This media query detects a viewport that has exactly two segments that are side-by-side.
+
+		<pre>@media (horizontal-viewport-segments: 2) and (vertical-viewport-segments: 1) { … }</pre>
+	</div>
+
 <!--
 ████████  ████  ██████  ████████         ███████  ██     ██    ███    ██       ████ ████████ ██    ██
 ██     ██  ██  ██    ██ ██     ██       ██     ██ ██     ██   ██ ██   ██        ██     ██     ██  ██


### PR DESCRIPTION
Add two new media feature that allow for authors to detect situations where the viewport is logically separated based on the window's configuration with respect to display features. This is designed to allow authors to target foldable devices where the viewport spans multiple displays (logical or physical). 

There are features for both the horizontal and vertical directions and are integers so that future form factors (think a tri-fold device) that do not yet exist can be explicitly detected and supported by authors.

 Fixes #5621 
