### PR TITLE
[css-ui-4] Define the ''input-security'' property. Fixes #2495.

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -101,6 +101,15 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec:HTML
 <style>
 .awesome-table td {padding:5px}
 .awesome-table {color:#000;background:#fff;margin: auto;}
+
+.fake-input-type-password {
+	display: inline-block;
+	border: 1px solid black;
+	background: white;
+	text: black;
+	width: 20ch;
+	padding: 0 2px;
+}
 </style>
 
 <h2 id="intro">Introduction</h2>
@@ -2210,7 +2219,7 @@ Obscuring sensitive input: the 'input-security' property</h3>
 Name: input-security
 Value: auto | none
 Initial: ''input-security/auto''
-Applies to: elements that accept sensitive text input, such as <{input/type/password|&lt;input type=password&gt;}>
+Applies to: [=sensitive text inputs=]
 Inherited: no
 Percentages: N/A
 Computed Value: as specified
@@ -2218,12 +2227,16 @@ Canonical order: per grammar
 Animation type: by computed value type
 </pre>
 
-When the purpose of a text input control is to accept sensitive input,
-such as <{input/type/password|&lt;input type=password&gt;}> in HTML,
-user agents obscure the display of the control's content by default
+For the purpose of this specification,
+a <dfn>sensitive text input</dfn> is
+a <a spec=html>mutable</a> form control with textual content whose
+purpose is to accept sensitive input,
+such as <{input/type/password|&lt;input type=password&gt;}>.
+
+By default, user agents obscure the contents of [=sensitive text inputs=]
 in order to prevent onlookers from seeing it.
 Users may wish to temporarily disable this obscuring
-in order to confirm that they've typed their password correctly.
+in order to confirm that they've typed their sensitive information correctly.
 The ''input-security'' property may be used by authors
 to enable or disable this obscuring.
 
@@ -2238,7 +2251,21 @@ to enable or disable this obscuring.
 		so that it cannot be read by the user.
 </dl>
 
-The exact mechanism by which user agents obscure the text in the control is undefined.
+While the exact mechanism by which user agents obscure the text in the control is undefined, user agents typically obscure [=sensitive text inputs=] by replacing each character with some suitable replacement such as U+002A ASTERISK (*) or U+25CF BLACK CIRCLE (●).
+
+<div class="example">
+	For instance, given this style sheet
+	<pre><code class="lang-css">
+	input[type=password] {
+		input-security: auto;
+	}</code></pre>
+	and this HTML
+	<pre><code class="lang-html">
+	&lt;input type=password value=MySecret794>
+	</code></pre>
+	a user agent might render the <{input/type/password|&lt;input type=password&gt;}> like so:
+	<span class=fake-input-type-password>●●●●●●●●●●●</span>
+</div>
 
 <h3 id=control-specific-rules>
 Control Specific Rules</h3>

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -93,6 +93,10 @@ spec:css-color-4; type:property; text:color
 spec:selectors-4; type:selector; text::focus
 spec:selectors-4; type:selector; text::focus-visible
 </pre>
+<pre class=anchors>
+urlPrefix: https://html.spec.whatwg.org/multipage/; spec:HTML
+	text:password; type:attr-value; for:input/type; url: input.html#attr-input-type-password-keyword
+</pre>
 
 <style>
 .awesome-table td {padding:5px}
@@ -1787,7 +1791,7 @@ so this specification allows flexibility.
 <pre class=propdef>
 Name: accent-color
 Value: auto | <<color>>
-Initial: ''auto''
+Initial: ''accent-color/auto''
 Applies to: all elements
 Inherited: yes
 Percentages: N/A
@@ -2198,6 +2202,42 @@ that are typical of the element whose appearance it acquires.
 	The ability for an element to be focused
 	is also not changed by the 'appearance' property.
 </div>
+
+<h3 id="input-security">Obscuring sensitive input: the 'input-security' property</h3>
+
+<pre class=propdef>
+Name: input-security
+Value: auto | none
+Initial: ''input-security/auto''
+Applies to: elements that accept sensitive text input, such as <{input/type/password|&lt;input type=password&gt;}>
+Inherited: no
+Percentages: N/A
+Computed Value: the keword ''input-security/auto'' or the keyword ''input-security/none''
+Canonical order: per grammar
+Animation type: by computed value type
+</pre>
+
+When the purpose of a text input control is to accept sensitive input,
+such as <{input/type/password|&lt;input type=password&gt;}> in HTML,
+user agents obscure the display of the control's content by default
+in order to prevent onlookers from seeing it.
+Users may wish to temporarily disable this obscuring
+in order to confirm that they've typed their password correctly.
+The ''input-security'' property may be used by authors
+to enable or disable this obscuring.
+
+<dl dfn-type=value dfn-for=input-security>
+	<dt><dfn>none</dfn>
+	<dd>
+		The UA must not obscure the text in the control,
+		so that it can be read by the user.
+	<dt><dfn>auto</dfn>
+	<dd>
+		The UA should obscure the text in the control,
+		so that it cannot be read by the user.
+</dl>
+
+The exact mechanism by which user agents obscure the text in the control is undefined.
 
 <h3 id=control-specific-rules>
 Control Specific Rules</h3>

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -2203,7 +2203,8 @@ that are typical of the element whose appearance it acquires.
 	is also not changed by the 'appearance' property.
 </div>
 
-<h3 id="input-security">Obscuring sensitive input: the 'input-security' property</h3>
+<h3 id="input-security">
+Obscuring sensitive input: the 'input-security' property</h3>
 
 <pre class=propdef>
 Name: input-security
@@ -2212,7 +2213,7 @@ Initial: ''input-security/auto''
 Applies to: elements that accept sensitive text input, such as <{input/type/password|&lt;input type=password&gt;}>
 Inherited: no
 Percentages: N/A
-Computed Value: the keword ''input-security/auto'' or the keyword ''input-security/none''
+Computed Value: as specified
 Canonical order: per grammar
 Animation type: by computed value type
 </pre>

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -2228,10 +2228,10 @@ Animation type: by computed value type
 </pre>
 
 For the purpose of this specification,
-a <dfn>sensitive text input</dfn> is
-a <a spec=html>mutable</a> form control with textual content whose
-purpose is to accept sensitive input,
-such as <{input/type/password|&lt;input type=password&gt;}>.
+a <dfn export>sensitive text input</dfn> is
+a text input whose purpose is to accept sensitive input,
+as defined by the host language.
+For example, in HTML <{input/type/password|&lt;input type=password&gt;}> is a [=sensitive text input=].
 
 By default, user agents obscure the contents of [=sensitive text inputs=]
 in order to prevent onlookers from seeing it.


### PR DESCRIPTION
A [long time ago](https://github.com/w3c/csswg-drafts/issues/2495#issuecomment-380397331) we resolved to add an `input-security : auto | none` property that only applies to `<input type=password>`. Here's a PR that does this, though not very well.

I'll write a corresponding PR for HTML's Rendering section too.