### PR TITLE
Fix the figure description

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -806,9 +806,9 @@ Overflow Alignment: the ''safe'' and ''unsafe'' keywords and scroll safety limit
 				</div>
 			</div>
 			<figcaption>
-				The items in the figure on the right all strictly centered,
+				The items in the figure on the left all strictly centered,
 				even if the one that is too long to fit overflows on both sides,
-				while those in the figure on the left are centered unless they overflow,
+				while those in the figure on the right are centered unless they overflow,
 				in which case all the overflow goes off the end edge.
 				If the container was placed
 				against the left edge of the page,


### PR DESCRIPTION
Apparently the references to the "left" and "right" images were swapped, this commit fixes it

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
