### PR TITLE
[web-animations-2] Fix WebIDL - no inherit for partial dictionary

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2085,7 +2085,7 @@ partial dictionary OptionalEffectTiming {
   <code>ComputedEffectTiming</code> dictionary</h3>
 
 <pre class='idl'>
-partial dictionary ComputedEffectTiming : EffectTiming {
+partial dictionary ComputedEffectTiming {
     double startTime;
 };
 </pre>


### PR DESCRIPTION
Per WebIDL, a partial dictionary declaration cannot inherit from a base dictionary. See Note in:
https://heycam.github.io/webidl/#idl-interfaces

"Note: A partial interface definition cannot specify that the interface inherits from another interface. Inheritance must be specified on the original interface definition."

`ComputedEffectTiming`, defined in Level 1, already inherits from `EffectTiming`, so no need to formulate that again in the partial definition.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.