### PR TITLE
[web-animations-2] Make WebIDL valid

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -1938,10 +1938,10 @@ partial interface AnimationEffect {
     readonly attribute AnimationEffect? previousSibling;
     readonly attribute AnimationEffect? nextSibling;
 
-    void before (AnimationEffect... effects);
-    void after (AnimationEffect... effects);
-    void replace (AnimationEffect... effects);
-    void remove ();
+    undefined before (AnimationEffect... effects);
+    undefined after (AnimationEffect... effects);
+    undefined replace (AnimationEffect... effects);
+    undefined remove ();
 };
 </pre>
 
@@ -1971,7 +1971,7 @@ partial interface AnimationEffect {
 <div class='methods'>
 
 :   <dfn method for=AnimationEffect lt='before()'>
-    void before (AnimationEffect... effects)</dfn>
+    undefined before (AnimationEffect... effects)</dfn>
 ::  Inserts <var>effects</var> before this <a>animation effect</a>.
 
     1.  If there is no <a>parent group</a>, abort these steps.
@@ -1991,7 +1991,7 @@ effect.before(effect); // throws HierarchyRequestError</pre>
     </div>
 
 :   <dfn method for=AnimationEffect lt='after()'>
-    void after(AnimationEffect... effects)</dfn>
+    undefined after(AnimationEffect... effects)</dfn>
 ::  Inserts <var>effects</var> after this <a>animation effect</a>.
 
     1.  If there is no <a>parent group</a>, abort these steps.
@@ -2006,7 +2006,7 @@ effect.before(effect); // throws HierarchyRequestError</pre>
         <var>reference child</var>.
 
 :   <dfn method for=AnimationEffect lt='replace()'>
-    void replace(AnimationEffect... effects)</dfn>
+    undefined replace(AnimationEffect... effects)</dfn>
 ::  Replaces this {{AnimationEffect}} with the passed in
     <var>effects</var>.
 
@@ -2023,7 +2023,7 @@ effect.before(effect); // throws HierarchyRequestError</pre>
     5.  <a lt="insert children">Insert</a> <var>effects</var> before
         <var>reference child</var>.
 
-:   <dfn method for=AnimationEffect lt='remove()'>void remove()</dfn>
+:   <dfn method for=AnimationEffect lt='remove()'>undefined remove()</dfn>
 ::  <a lt="remove an animation effect">Removes</a> this <a>animation
     effect</a> from its <a>parent group</a> or <a>animation</a>.
 
@@ -2149,15 +2149,15 @@ interface.
 [Exposed=Window]
 interface GroupEffect {
   constructor(sequence&lt;AnimationEffect>? children,
-              optional (unrestricted double or EffectTiming) timing);
+              optional (unrestricted double or EffectTiming) timing = {});
 
   readonly attribute AnimationNodeList  children;
   readonly attribute AnimationEffect?   firstChild;
   readonly attribute AnimationEffect?   lastChild;
   GroupEffect clone ();
 
-  void prepend (AnimationEffect... effects);
-  void append (AnimationEffect... effects);
+  undefined prepend (AnimationEffect... effects);
+  undefined append (AnimationEffect... effects);
 };
 </pre>
 
@@ -2231,7 +2231,7 @@ interface GroupEffect {
 <div class="methods">
 
 :   <dfn method for=GroupEffect lt="prepend()">
-:   void prepend (AnimationEffect... effects)</dfn>
+:   undefined prepend (AnimationEffect... effects)</dfn>
 ::
 
     1.  If any of the <a>animation effects</a> in <var>effects</var> is an
@@ -2242,7 +2242,7 @@ interface GroupEffect {
         the <a>first child</a>.
 
 :   <dfn method for=GroupEffect lt="append()">
-    void append (AnimationEffect... effects)</dfn>
+    undefined append (AnimationEffect... effects)</dfn>
 ::
 
     1.  If any of the <a>animation effects</a> in <var>effects</var> is an
@@ -2399,7 +2399,7 @@ interface AnimationNodeList {
 [Exposed=Window]
 interface SequenceEffect : GroupEffect {
   constructor(sequence&lt;AnimationEffect>? children,
-              optional (unrestricted double or EffectTiming) timing);
+              optional (unrestricted double or EffectTiming) timing = {});
 
   SequenceEffect clone ();
 };
@@ -2543,7 +2543,7 @@ enum IterationCompositeOperation { "replace", "accumulate" };
 {{EffectCallback}} callback function.
 
 <pre class='idl'>
-callback EffectCallback = void (double? progress,
+callback EffectCallback = undefined (double? progress,
                                 (Element or CSSPseudoElement) currentTarget,
                                 Animation animation);
 </pre>


### PR DESCRIPTION
Previous fix made WebIDL parse-able: https://github.com/w3c/csswg-drafts/pull/6267

However, the WebIDL remains invalid because `void` has now been replaced by `undefined` in WebIDL and because optional dictionary parameters with no required members need to have a default value. This update fixes these validity issues.
