### PR TITLE
[css-nesting-1] demo the result of BEM style nesting

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -243,15 +243,6 @@ Direct Nesting {#direct}
 
 		.foo {
 			color: blue;
-			&__bar { padding: 2ch; }
-		}
-		/* equivalent to
-			 .foo { color: blue; }
-			 __bar.foo { padding: 2ch; }
-		 */
-
-		.foo {
-			color: blue;
 			& { padding: 2ch; }
 		}
 		/* equivalent to
@@ -312,6 +303,30 @@ Direct Nesting {#direct}
 			 main > :is(section, article) > header { font-size: 1.25rem; }
 		 */
 		</pre>
+
+		Note: 
+		<a href="https://en.wikipedia.org/wiki/CSS#:~:text=bem%20(block%2C%20element%2C%20modifier)">BEM</a> authors often use preprocessors to 
+		stay <a href="https://en.wikipedia.org/wiki/Don%27t_repeat_yourself">dry</a> 
+		within a file and selector context,
+		and preprocessors would concatenate the selectors like strings.
+		This however is not how it works in browsers. Authors may still practice BEM, 
+		but the nested selector string building technique will need to stay a feature 
+		of preprocessors.
+
+		For example:
+
+		<pre class=lang-css>
+		.foo {
+			color: blue;
+			&__bar { padding: 2ch; }
+		}
+		/* equivalent to
+			 .foo { color: blue; }
+			 __bar.foo { padding: 2ch; }
+		 */
+		</pre>
+
+		''__bar'' is a valid potential <a href="https://html.spec.whatwg.org/multipage/custom-elements.html">custom element</a>.
 
 		But the following are invalid:
 

--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -243,6 +243,15 @@ Direct Nesting {#direct}
 
 		.foo {
 			color: blue;
+			&__bar { padding: 2ch; }
+		}
+		/* equivalent to
+			 .foo { color: blue; }
+			 __bar.foo { padding: 2ch; }
+		 */
+
+		.foo {
+			color: blue;
 			& { padding: 2ch; }
 		}
 		/* equivalent to


### PR DESCRIPTION
[css-nesting-1] fixes #3748

Felt sufficient to demonstrate the result of a BEM style nesting selector, as opposed to a note specifically calling out BEM. The answer is in the examples. 