### PR TITLE
[css-images-4] image() fragments example missing semi-colon

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -403,7 +403,7 @@ Image Fallbacks and Annotations: the ''image()'' notation {#image-notation}
 			<img src="images/sprites.svg" height="20" width="180" alt="[9 circles, with 0 to 8 eighths filled in]">
 		</a>
 
-		<pre class="lang-css">background-image: image('sprites.svg#xywh=40,0,20,20')</pre>
+		<pre class="lang-css">background-image: image('sprites.svg#xywh=40,0,20,20');</pre>
 
 		...the background of the element will be the portion of the image that starts at (40px,0px) and is 20px wide and tall,
 		which is just the circle with a quarter filled in.


### PR DESCRIPTION
https://drafts.csswg.org/css-images-4/#image-notation

Example 5 missing closing semi-colon