### PR TITLE
[css-text-decor-3] [css-text-decor-4] Fix incorrect CSS in text-decoration example

### DIFF
--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -328,7 +328,7 @@ Text Decoration Shorthand: the 'text-decoration' property</h3>
 		underline in CSS1 and CSS2 UAs and a navy dotted underline in CSS3 UAs.
 
 		<pre>
-			link {
+			:link {
 			  color: blue;
 			  text-decoration: underline;
 			  text-decoration: navy dotted underline; /* <a href="https://www.w3.org/TR/CSS21/syndata.html#ignore">Ignored</a> in CSS1/CSS2 UAs */

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -483,7 +483,7 @@ Text Decoration Shorthand: the 'text-decoration' property</h3>
 		underline in CSS1 and CSS2 UAs and a navy dotted underline in CSS3 UAs.
 
 		<pre>
-			link {
+			:link {
 			  color: blue;
 			  text-decoration: underline;
 			  text-decoration: navy dotted underline; /* <a href="https://www.w3.org/TR/CSS21/syndata.html#ignore">Ignored</a> in CSS1/CSS2 UAs */


### PR DESCRIPTION
The paragraph preceding the example for the text-decoration property in both CSS Text Decoration Module Level 3 and Level 4 says:

> The following example underlines unvisited links with a solid blue underline in CSS1 and CSS2 UAs and a navy dotted underline in CSS3 UAs.

However, the example uses a type selector of `link`. The `link` element is not used for hyperlinks, but instead to link their document to other resources, more typically used in the `<head>` of the document. The `a` element is used for hyperlinks. As a result, the example CSS does not do what is described.

Looking at the history, it looks like the selector was originally `:link` but the colon was mistakenly removed in b32b070, a commit which was intended to only change whitespace.

```diff
@@ -322,12 +326,13 @@ Text Decoration Shorthand: the 'text-decoration' property</h3>
                The following example underlines unvisited links with a solid blue
                underline in CSS1 and CSS2 UAs and a navy dotted underline in CSS3 UAs.

-    <pre><code class="css">
-<!-- -->:link {
-<!-- -->    color: blue;
-<!-- -->    text-decoration: underline;
-<!-- -->    text-decoration: navy dotted underline; /* <a href="https://www.w3.org/TR/CSS21/syndata.html#ignore">Ignored</a> in CSS1/CSS2 UAs */
-<!-- -->}</code></pre>
+               <pre>
+                       link {
+                         color: blue;
+                         text-decoration: underline;
+                         text-decoration: navy dotted underline; /* <a href="https://www.w3.org/TR/CSS21/syndata.html#ignore">Ignored</a> in CSS1/CSS2 UAs */
+                       }
+               </pre>
        </div>

        Note: The shorthand purposefully omits the 'text-underline-position' property,
```

The incorrect example was then copied into the Level 4 spec.

Restore the original `:link` selector, which correctly targets unvisited links.