### PR TITLE
[cssom-view] Remove "familiar with" check for move/resize methods

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -20,7 +20,6 @@ Former Editor: Glenn Adams, Cox Communications&#44; Inc. http://www.cox.com, gle
 Former Editor: Anne van Kesteren, Opera Software ASA http://www.opera.com, annevk@annevk.nl, https://annevankesteren.nl/
 !Legacy issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=CSS&amp;component=CSSOM%20View&amp;resolution=---">Bugzilla</a>
 Abstract: The APIs introduced by this specification provide authors with a way to inspect and manipulate the visual view of a document. This includes getting the position of element layout boxes, obtaining the width of the viewport through script, and also scrolling an element.
-Ignored Terms: open(), EventTarget, EventListener, Event, EventInit, Element, Range, Node, Text
 Ignored Vars: rect, point, quad
 Include Can I Use Panels: true
 Can I Use URL: https://drafts.csswg.org/cssom-view/
@@ -30,62 +29,17 @@ Can I Use URL: https://www.w3.org/TR/cssom-view-1/
 <pre class='anchors'>
 urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: infrastructure.html
-        type: dfn; text: html elements
-    urlPrefix: browsers.html
-        type: interface; text: WindowProxy
         type: dfn
-            text: browsing context
-            text: auxiliary browsing context
-            text: familiar with
-            text: associated Document; url: concept-document-window
-            text: same origin
-            text: active document
-    urlPrefix: webappapis.html
-        type: dfn
-            text: responsible browsing context
-            text: incumbent settings object
-            text: event handlers
-            text: event handler event type
-            text: event handler IDL attributes
-    urlPrefix: infrastructure.html
-        type: dfn
-            text: split a string on commas
-            text: skip whitespace
-            text: collect a sequence of characters
-            text: space character
-            text: converted to ascii lowercase
             text: rules for parsing integers
+    urlPrefix: window-object.html
+        type: method
+            text: open(url, target, features); for: Window; url: #dom-open
 urlPrefix: https://drafts.csswg.org/cssom/
     type: dfn
         text: parse a media query list
         text: serialize a media query list
-urlPrefix: https://dom.spec.whatwg.org/#
-    type: dfn
-        text: context object
-urlPrefix: https://dom.spec.whatwg.org/#concept-
-    type: dfn
-        text: event
-        text: event listener
-        text: quirks mode; url: document-quirks
-        text: fire an event; url: event-fire
-        text: node document
-urlPrefix: https://dom.spec.whatwg.org/
-    type: attribute;
-        for: Event; urlPrefix: #dom-event-
-            text: type
-            text: isTrusted
-        for: Range; urlPrefix: #dom-range-
-            text: startContainer
-            text: startOffset
-    type: dfn; text: dispatch flag
 urlPrefix: https://www.w3.org/TR/CSS21/visuren.html
     type: dfn; text: anonymous block box; url: #anonymous-block-level
-urlPrefix: http://heycam.github.io/webidl/
-    type: interface; urlPrefix: #idl-
-        text: double
-        text: long
-    type: dfn; text: converted to an IDL value; url: dfn-convert-ecmascript-to-idl-value
-url: https://www.w3.org/TR/DOM-Level-3-Events/#interface-MouseEvent; type: interface; text: MouseEvent
 url: https://drafts.csswg.org/mediaqueries-4/#mf-colors; type: dfn; text: color media query
 </pre>
 
@@ -93,7 +47,6 @@ url: https://drafts.csswg.org/mediaqueries-4/#mf-colors; type: dfn; text: color 
 spec:css-display-3; type:value; for:display; text:table
 spec:css-position-3; type:property; text:position
 spec:dom; type:interface; text:Document
-spec:html; type:dfn; text:case-sensitive
 </pre>
 
 <script src=https://resources.whatwg.org/file-issue.js async data-file-issue-url="https://github.com/w3c/csswg-drafts/issues/new?title=%5Bcssom-view%5D%20"></script>
@@ -319,7 +272,7 @@ The term <dfn>transforms</dfn> refers to SVG transforms and CSS transforms. [[!S
 When a method or an attribute is said to call another method or attribute, the user agent must invoke its internal API for that attribute or method so that
 e.g. the author can't change the behavior by overriding attributes or methods with custom properties or functions in ECMAScript.
 
-Unless otherwise stated, string comparisons are done in a <a>case-sensitive</a> manner.
+Unless otherwise stated, all string comparisons use [=string/is=].
 
 
 <h3 id=css-pixels>CSS pixels</h3>
@@ -468,7 +421,7 @@ When the <dfn method for=Window caniuse=matchmedia>matchMedia(<var>query</var>)<
  <a lt='parse a media query list'>parsing</a>
  <var>query</var>.
  <li>Return a new {{MediaQueryList}} object,
- with the <a>context object’s</a>
+ with [=this=]'s
  <a>associated <code>Document</code></a>
  as the <a for=MediaQueryList>document</a>,
  with <var>parsed media query list</var> as its associated <a>media query list</a>.
@@ -482,47 +435,38 @@ results when the {{Document}} is navigated.
 
 The <dfn method for=Window>moveTo(<var>x</var>, <var>y</var>)</dfn> method must follow these steps:
 
-1. Optionally, terminate these steps.
-1. Let <var>target</var> be the <a>browsing context</a> of the <a>context object</a>.
-1. Let <var>source</var> be the <a>responsible browsing context</a> of the <a>incumbent settings object</a>.
-1. If <var>source</var> is not <a>allowed to resize and move</a> <var>target</var>, terminate these steps.
+1. Optionally, return.
+1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
+1. If |target| is not an [=auxiliary browsing context=] that was created by a script (as opposed to by an action of the user), then return.
 1. Optionally, clamp <var>x</var> and <var>y</var> in a user-agent-defined manner so that the window does not move outside the available space.
 1. Move <var>target</var>’s window such that the window’s top left corner is at coordinates (<var>x</var>, <var>y</var>) relative to the top left corner of the output device, measured in <a lt=px value>CSS pixels</a> of <var>target</var>. The positive axes are rightward and downward.
 
 The <dfn method for=Window>moveBy(<var>x</var>, <var>y</var>)</dfn> method must follow these steps:
 
-1. Optionally, terminate these steps.
-1. Let <var>target</var> be the <a>browsing context</a> of the <a>context object</a>.
-1. Let <var>source</var> be the <a>responsible browsing context</a> of the <a>incumbent settings object</a>.
-1. If <var>source</var> is not <a>allowed to resize and move</a> <var>target</var>, terminate these steps.
+1. Optionally, return.
+1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
+1. If |target| is not an [=auxiliary browsing context=] that was created by a script (as opposed to by an action of the user), then return.
 1. Optionally, clamp <var>x</var> and <var>y</var> in a user-agent-defined manner so that the window does not move outside the available space.
 1. Move <var>target</var>'s window <var>x</var> <a lt=px value>CSS pixels</a> of <var>target</var> rightward and <var>y</var> <a lt=px value>CSS pixels</a> of <var>target</var> downward.
 
 
 The <dfn method for=Window>resizeTo(<var>width</var>, <var>height</var>)</dfn> method must follow these steps:
 
-1. Optionally, terminate these steps.
-1. Let <var>target</var> be the <a>browsing context</a> of the <a>context object</a>.
-1. Let <var>source</var> be the <a>responsible browsing context</a> of the <a>incumbent settings object</a>.
-1. If <var>source</var> is not <a>allowed to resize and move</a> <var>target</var>, terminate these steps.
+1. Optionally, return.
+1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
+1. If |target| is not an [=auxiliary browsing context=] that was created by a script (as opposed to by an action of the user), then return.
 1. Optionally, clamp <var>width</var> and <var>height</var> in a user-agent-defined manner so that the window does not get too small or bigger than the available space.
 1. Resize <var>target</var>'s window by moving its right and bottom edges such that the distance between the left and right edges of the viewport are <var>width</var> <a lt=px value>CSS pixels</a> of <var>target</var> and the distance between the top and bottom edges of the viewport are <var>height</var> <a lt=px value>CSS pixels</a> of <var>target</var>.
 1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does not grow outside the available space.
 
 The <dfn method for=Window>resizeBy(<var>x</var>, <var>y</var>)</dfn> method must follow these steps:
 
-1. Optionally, terminate these steps.
-1. Let <var>target</var> be the <a>browsing context</a> of the <a>context object</a>.
-1. Let <var>source</var> be the <a>responsible browsing context</a> of the <a>incumbent settings object</a>.
-1. If <var>source</var> is not <a>allowed to resize and move</a> <var>target</var>, terminate these steps.
+1. Optionally, return.
+1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
+1. If |target| is not an [=auxiliary browsing context=] that was created by a script (as opposed to by an action of the user), then return.
 1. Optionally, clamp <var>x</var> and <var>y</var> in a user-agent-defined manner so that the window does not get too small or bigger than the available space.
 1. Resize <var>target</var>'s window by moving its right edge <var>x</var> <a lt=px value>CSS pixels</a> of <var>target</var> rightward and its bottom edge <var>y</var> <a lt=px value>CSS pixels</a> of <var>target</var> downward.
 1. Optionally, move <var>target</var>'s window in a user-agent-defined manner so that it does not grow outside the available space.
-
-A <a>browsing context</a> <var>A</var> is <dfn>allowed to resize and move</dfn> a <a>browsing context</a> <var>B</var> if all the following conditions are met:
-
-* <var>B</var> is an <a>auxiliary browsing context</a> that was created by a script (as opposed to by an action of the user).
-* <var>A</var> is <a>familiar with</a> <var>B</var>.
 
 The <dfn attribute for=Window>innerWidth</dfn> attribute must return the <a>viewport</a> width including the size of a rendered
 scroll bar (if any), or zero if there is no <a>viewport</a>. <!--fingerprint-->
@@ -714,7 +658,7 @@ A <dfn export>supported <code>open()</code> feature name</dfn> is one of the fol
 
 <h3 id=the-mediaquerylist-interface>The {{MediaQueryList}} Interface</h3>
 
-This section integrates with the <a spec=html>event loop</a> defined in HTML. [[!HTML]]
+This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
 
 A {{MediaQueryList}} object has an associated <dfn>media query list</dfn>
 and an associated <dfn for=MediaQueryList>document</dfn> set on creation.
@@ -785,7 +729,7 @@ the associated <a>matches state</a>. <!--fingerprint-->
 The <dfn method for=MediaQueryList>addListener(<var>callback</var>)</dfn> method,
 when invoked, must run these steps:
 
-1. <a spec=dom>Add an event listener</a> with the <a spec=dom>context object</a>
+1. <a spec=dom>Add an event listener</a> with [=this=]
     and an <a spec=dom>event listener</a> whose
     <a spec=dom for="event listener">type</a> is <code>change</code>,
     and <a spec=dom for="event listener">callback</a> is |callback|.
@@ -793,13 +737,13 @@ when invoked, must run these steps:
 The <dfn method for=MediaQueryList>removeListener(<var>callback</var>)</dfn> method,
 when invoked, must run these steps:
 
-1. If the <a spec=dom>context object</a>’s <a spec=dom for=EventTarget>event listener list</a>
+1. If [=this=]’s <a spec=dom for=EventTarget>event listener list</a>
     <a for=list>contains</a> an <a>event listener</a> whose
     <a spec=dom for="event listener">type</a> is <code>change</code>,
     <a spec=dom for="event listener">callback</a> is |callback|,
     and <a spec=dom for="event listener">capture</a> is false,
     then <a spec=dom>remove an event listener</a> with
-    the <a spec=dom>context object</a> and that <a spec=dom>event listener</a>.
+    [=this=] and that <a spec=dom>event listener</a>.
 
 Note: This specification initially had a custom callback mechanism with {{addListener()}} and
 {{removeListener()}}, and the callback was invoked with the associated media query list as argument.
@@ -982,11 +926,11 @@ result of running these steps:
 
     <dl>
         <dt><a>caret node</a>
-        <dd>The {{Range/startContainer}}
+        <dd>The [=range/start node=]
             of the <a>caret range</a>.
 
         <dt><a>caret offset</a>
-        <dd>The {{Range/startOffset}} of
+        <dd>The [=range/start offset=] of
             the <a>caret range</a>.
     </dl>
 
@@ -1633,7 +1577,7 @@ method must run the following steps:
 
 <h3 id=resizing-viewports>Resizing viewports</h3>
 
-This section integrates with the <a spec=html>event loop</a> defined in HTML. [[!HTML]]
+This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
 
 When asked to <dfn>run the resize steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
@@ -1648,7 +1592,7 @@ When asked to <dfn>run the resize steps</dfn> for a {{Document}} <var>doc</var>,
 
 <h3 id=scrolling-events>Scrolling</h3>
 
-This section integrates with the <a spec=html>event loop</a> defined in HTML. [[!HTML]]
+This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
 
 Each {{Document}} has an associated list of <dfn>pending scroll event targets</dfn>, initially empty.
 
@@ -1773,7 +1717,7 @@ generally not listed.
 * Some readonly attributes on {{Window}} were annotated with <code>[Replaceable]</code> IDL extended
     attribute.
 * {{MediaQueryList}}, <a event>scroll</a> event and <a event>resize</a> event are integrated with
-    the <a spec=html>event loop</a> in HTML so they are synchronized with animation frames.
+    the <a for=/>event loop</a> in HTML so they are synchronized with animation frames.
 * The <code>instant</code> value of 'scroll-behavior' was renamed to ''scroll-behavior/auto''.
 * The origin of {{Element/scrollLeft}} on {{Element}} was changed (for RTL).
 * The {{Element/scrollIntoView()}} method on {{Element}} and {{Window/scroll()}},


### PR DESCRIPTION
Closes #1725 by removing the usage of incumbent settings object. I could find no evidence of such a check in the Blink, Gecko, or WebKit codebases. Indeed, such a check should not generally be necessary, as (unlike, e.g., window.close()) these methods are not accessible cross-origin.

Also includes various changes for things that have updated in other specs:

* Use "this" instead of "context object"
* Use "string is" instead of "case-sensitive"
* Use "start node" and "start offset" instead of referring to properties of Range (or now, AbstractRange)
* Link to the correct "event loop" definition
* Remove redundant anchor blocks, as these days most definitions are properly exported
