### PR TITLE
[css-conditional-3] Remove "unknown" value concept

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -238,7 +238,8 @@ tied to the support for certain features, as is the case for use of new
 layout system features.
 
 The syntax of the condition in the ''@supports'' rule
-is similar to that defined for <<media-condition>> in [[MEDIAQUERIES-4]]:
+is similar to that defined for <<media-condition>> in [[MEDIAQUERIES-4]],
+but without the "unknown" value logic:
 
 * negation is needed so that
 	the new-feature styles and the fallback styles
@@ -250,10 +251,6 @@ is similar to that defined for <<media-condition>> in [[MEDIAQUERIES-4]]:
 * disjunction (or) is needed
 	when there are multiple alternative features for a set of styles,
 	particularly when some of those alternatives are vendor-prefixed properties or values.
-* "unknown" values (neither true nor false) are needed
-	to allow for future-compatibility,
-	so new types of support queries can be added
-	and treated sensibly in older UAs.
 
 Therefore, the syntax of the ''@supports'' rule allows
 testing for property:value pairs, and arbitrary conjunctions (and),
@@ -297,19 +294,16 @@ as follows:
 
 : not <<supports-in-parens>>
 :: The result is the negation of the <<supports-in-parens>> term.
-	The negation of unknown is unknown.
 
 : <<supports-in-parens>> [ and <<supports-in-parens>> ]*
 ::
 	The result is true if all of the <<supports-in-parens>> child terms are true,
-	false if at least one of the <<supports-in-parens>> is false,
-	and unknown otherwise.
+	and false otherwise.
 
 : <<supports-in-parens>> [ or <<supports-in-parens>> ]*
 ::
 	The result is false if all of the <<supports-in-parens>> child terms are false,
-	true if at least one of the <<supports-in-parens>> is true,
-	and unknown otherwise.
+	and true otherwise.
 
 : <<supports-decl>>
 ::
@@ -317,7 +311,7 @@ as follows:
 
 : <<general-enclosed>>
 ::
-	The result is unknown.
+	The result is false.
 
 	Authors must not use <<general-enclosed>> in their stylesheets.
 	<span class='note'>It exists only for future-compatibility,


### PR DESCRIPTION
The <general-enclosed> production now just produces "false".

See Issue #6175.
