### PR TITLE
[web-animations-2] [scroll-animations-1] Support automatic duration scroll animations

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -140,7 +140,6 @@ Using the CSS markup:
 <pre class='lang-css'>
 @media (prefers-reduced-motion: no-preference) {
   div.circle {
-    animation-duration: 1s;
     animation-timing-function: linear;
     animation-timeline: collision-timeline;
   }
@@ -191,13 +190,13 @@ if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
     scrollOffsets: [CSS.px(200), CSS.px(300)]
   });
 
-  const left = leftCircle.animate({ transform: 'translate(300px)' }, 1000);
+  const left = leftCircle.animate({ transform: 'translate(300px)' });
   left.timeline = collisionTimeline;
 
-  const right = leftCircle.animate({ transform: 'translate(350px)' }, 1000);
+  const right = leftCircle.animate({ transform: 'translate(350px)' });
   right.timeline = collisionTimeline;
 
-  const union = unionCircle.animate({ opacity: 1 }, { duration: 1000, fill: "forwards" });
+  const union = unionCircle.animate({ opacity: 1 }, { fill: "forwards" });
   union.timeline = new ScrollTimeline({
     source: scrollableElement,
     scrollOffsets: [CSS.px(250), CSS.px(300)]
@@ -253,7 +252,7 @@ If we use this API for this case, the example code will be as follow:
 
 <pre class='lang-javascript'>
 if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
-  var animation = div.animate({ width: '100%' }, { duration: 1000, fill: "forwards" });
+  var animation = div.animate({ width: '100%' }, { fill: "forwards" });
   animation.timeline = new ScrollTimeline(
     {
       scrollOffsets: [0, CSS.percent(100)]
@@ -360,7 +359,6 @@ dictionary ScrollTimelineOptions {
   Element? source;
   ScrollDirection orientation = "block";
   sequence&lt;ScrollTimelineOffset&gt; scrollOffsets = [];
-  (double or ScrollTimelineAutoKeyword) timeRange = "auto";
 };
 
 [Exposed=Window]
@@ -369,13 +367,14 @@ interface ScrollTimeline : AnimationTimeline {
   readonly attribute Element? source;
   readonly attribute ScrollDirection orientation;
   readonly attribute FrozenArray&lt;ScrollTimelineOffset&gt; scrollOffsets;
-  readonly attribute (double or ScrollTimelineAutoKeyword) timeRange;
 };
 </pre>
 
 A <dfn>scroll timeline</dfn> is an {{AnimationTimeline}} whose time values are
 determined not by wall-clock time, but by the progress of scrolling in a
 [=scroll container=].
+
+The {{AnimationTimeline/Duration}} of a <a>scroll timeline</a> is 100%.
 
 <div link-for-hint="ScrollTimeline">
 
@@ -403,10 +402,9 @@ determined not by wall-clock time, but by the progress of scrolling in a
 
     1.  Set the {{ScrollTimeline/source}} of |timeline| to |source|.
 
-    1.  Assign the {{ScrollTimeline/orientation}}, {{ScrollTimeline/scrollOffsets}}
-        and {{ScrollTimeline/timeRange}} properties of
+    1.  Assign the {{ScrollTimeline/orientation}} and
+        {{ScrollTimeline/scrollOffsets}} properties of
         |timeline| to the corresponding value from |options|.
-
 </div>
 
 <div class="attributes">
@@ -452,25 +450,6 @@ determined not by wall-clock time, but by the progress of scrolling in a
             {{SyntaxError}}.
 
         </div>
-
-:   <dfn attribute for=ScrollTimeline>timeRange</dfn>
-::  A time duration that allows mapping between a distance scrolled, and
-    quantities specified in time units, such as an animation's [=duration=] and
-    [=start delay=].
-
-    Conceptually, {{timeRange}} represents the number of milliseconds to map to
-    the scroll range defined by {{start}} and {{end}}. As a result, this value
-    does not have a correspondence to wall-clock time.
-
-    This value is used to compute the timeline's [=effective time range=], and
-    the mapping is then defined by mapping the scroll distance from
-    {{start}} to {{end}}, to the [=effective time range=].
-
-Issue(4862): We are working to remove the need for {{timeRange}} to be declared.
-The most recent work on this involved introduction of the concept of
-"progress-based animations" to web animations.
-
-</div>
 
 ### Scroll Timeline Offset ### {#scroll-timeline-offset-section}
 
@@ -711,8 +690,7 @@ if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
       transform: ['translateX(0)', 'translateX(50vw)'],
       opacity: [0, 1]
     }, {
-      timeline:timeline,
-      duration: 1000
+      timeline:timeline
     }
   );
 }
@@ -741,35 +719,11 @@ The same logic can be done in CSS markup:
 
   #target {
     animation-name: slide-in;
-    animation-duration: 1s;
     animation-timeline: image-in-scrollport;
   }
 
 }
 </pre>
-
-
-</div>
-
-### The effective time range of a {{ScrollTimeline}} ### {#effective-time-range-algorithm}
-
-The <dfn>effective time range</dfn> of a {{ScrollTimeline}} is calculated as
-follows:
-
-<div class="switch">
-
-:   If the {{timeRange}} has the value `"auto"`,
-::  The [=effective time range=] is the maximum value of the
-    [=target effect end=] of all animations
-    directly associated with this timeline.
-
-    If any animation directly associated with the timeline has a
-    [=target effect end=] of infinity, the [=effective time range=]
-    is zero.
-
-:   Otherwise,
-::  The [=effective time range=] is the {{ScrollTimeline}}'s
-    {{timeRange}}.
 
 </div>
 
@@ -910,7 +864,7 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
 
 :   If |current scroll offset| is greater than or equal to [=effective
     end offset=]:
-::  The [=current time=] is the [=effective time range=].
+::  The [=current time=] is the [=duration=].
 
 :   Otherwise,
 ::  1.  Let |progress| be a result of applying
@@ -918,7 +872,7 @@ The [=current time=] of a {{ScrollTimeline}} is calculated as follows:
     1.  The [=current time=] is the result of evaluating the following expression:
 
     <blockquote>
-      <code>|progress| &times; [=effective time range=]</code>
+      <code>|progress| &times; [=duration=]</code>
     </blockquote>
 
 </div>
@@ -1032,17 +986,6 @@ following:
       * {{ElementBasedOffset/threshold}} is the optional value <<number>>. If
         not provided it defaults to 0.
 
-</div>
-
-<pre class='descdef'>
-  Name: time-range
-  For: @scroll-timeline
-  Value: auto | <<time>>
-  Initial: auto
-</pre>
-
-'time-range' descriptor determines the scroll timeline's {{timeRange}}.
-
 </div>  <!-- link-for-hint="ScrollTimeline" -->
 
 ### The <dfn interface>CSSScrollTimelineRule</dfn> Interface ### {#the-css-scroll-timeline-rule-interface}
@@ -1054,7 +997,6 @@ interface CSSScrollTimelineRule : CSSRule {
     readonly attribute CSSOMString source;
     readonly attribute CSSOMString orientation;
     readonly attribute CSSOMString scrollOffsets;
-    readonly attribute CSSOMString timeRange;
 };
 </pre>
 
@@ -1078,11 +1020,6 @@ interface CSSScrollTimelineRule : CSSRule {
   <dt><dfn>scrollOffsets</dfn></dt>
   <dd>
     The 'scroll-offsets' descriptor associated with the ''@scroll-timeline'', or "none" if not specified.
-  </dd>
-
-  <dt><dfn>timeRange</dfn></dt>
-  <dd>
-    The 'time-range' descriptor associated with the ''@scroll-timeline'', or "auto" if not specified.
   </dd>
 </dl>
 
@@ -1212,7 +1149,6 @@ interface CSSScrollTimelineRule : CSSRule {
           { width: "100vw" }
         ],
         {
-          duration: 1000,
           easing: "linear",
           fill: "forwards"
         });
@@ -1255,7 +1191,6 @@ interface CSSScrollTimelineRule : CSSRule {
         /* This name is used to select both the keyframes and the
            scroll-timeline at-rules. */
         animation-name: progress;
-        animation-duration: 1s;
         animation-fill-mode: forwards;
         animation-timing-function: linear;
       }

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -153,39 +153,53 @@ Add:
 > used to calculate the [=intrinsic iteration duration=] for the target effect
 > of an animation that is associated with the timeline when the effect's
 > [=iteration duration=] is 'auto'. The value is computed such that the effect
-> fills the available time.  For a monotonic timeline, there is no upper bound
-> on current time, and [=timeline duration=] is unresolved. For a progress based
-> timeline, the [=timeline duration=] is 100%.
+> fills the available time. For a monotonic timeline, there is no upper bound
+> on current time, and [=timeline duration=] is unresolved. For a non-monotonic
+> (i.e. scroll) timeline, the duration has a fixed upper bound. In this
+> case, the timeline is a <dfn lt="progress-based timeline">progress-based
+> timeline</dfn>, and its [=timeline duration=] is 100%.
 
 <h3 id="animations">Animations</h3>
 
 Add:
 
-> Animation effects associated with a progress-based timeline require their
+> Animation effects associated with a [=progress-based timeline=] require their
 > timing properties to be converted to proportions. The procedure for converting
-> a <dfn lt="time-based animation to a proportional animation"></dnf> is as
+> a <dfn lt="time-based animation to a proportional animation"></dfn> is as
 > follows:
 >
 > 1.  If the [=iteration duration=] is auto, then perform the following steps.
+>         * Set [=start delay=] and [=end delay=] to 0, as it is not
+>           possible to mix time and proportions.
+>           <div class='note'>
+>           Future versions may allow these properties to be assigned
+>           percentages, at which point the delays are only to be ignored if
+>           their values are expressed as times and not as percentages.
+>           </div>
+>     Otherwise:
+>          1. Let <var>total time</var> be equal to |end time|
+>          1. Set [=start delay=] to be the result of evaluating
+>             <code>|specified start delay| / |total time| *
+>             |timeline duration|</code>.
+>          1. Set [=iteration duration=] to be the result of evaluating
+>             <code>|specified iteration duration| / |total time| *
+>             |timeline duration|</code>.
+>          1. Set [=end delay=] to be the result of evaluating
+>             <code>|specified end delay| / |total time| *
+>             |timeline duration|</code>.
 >
->     1.   Compute [=start delay=] and [=end delay=] to 0, as it is not possible
->          to mix time and proportions. Future versions may allow these properties
->          to be assigned percentages.
+> The procedure to <dfn>normalize specified timing</dfn> is as follows:
 >
-> 1.  Otherwise,
->
-> 1.  Let <var>total time</var> be equal to the result of evaluating
->     <code>|start delay| + |iteration count| * |iteration duration| +
->     |end delay|</code>.
->
-> 1.  Compute [=start delay=] to be the result of evaluating
->     <code>|start delay| / |total time| * |timeline duration|</code>.
->
-> 1.  Compute [=iteration duration=] to be the result of evaluating
->     <code>|iteration duration| / |total time| * |timeline duration|</code>.
->
-> 1.  Compute [=end delay=] to be the result of evaluating
->     <code>|end delay| / |total time| * |timeline duration|</code>.
+> If [=timeline duration=] is resolved:
+>     * Follow the procedure to convert a [=time-based animation to a
+>       proportional animation=]
+> Otherwise:
+>     1.   Set [=start delay=] = |specified start delay|
+>     1.   Set [=end delay=] = |specified end delay|
+>     1.   If |iteration duration| is auto:
+>              * Set [=iteration duration=] = |intrinsic iteration duration|
+>          Otherwise:
+>              * Set [=iteration duration=] = |specified iteration duration|
 
 <h4 id="setting-the-timeline">Setting the timeline of an animation</h4>
 
@@ -859,9 +873,6 @@ The <dfn>local time</dfn> of an <a>animation effect</a> is the
 lt="animation effect start time">start time</a>.
 If the <a>inherited time</a> is <a>unresolved</a> then the local time
 is also <a>unresolved</a>.
-
-
-
 
 
 <h4 id="animation-effect-phases-and-states">Animation effect phases and
@@ -1557,7 +1568,7 @@ number of <a>child effects</a> as follows.
         after calculating the <a>end time</a> of each <a>child
         effect</a> in the group. The <a>end time</a> may be
         expressed as a time or a percentage (in the case of a
-        progress based animation). In the event of mixed time and
+        [=progress-based animation=]). In the event of mixed time and
         percentage <a>end time</a>s, the largest time based value
         equates to 100% for the purpose of time scaling.
     2.  The <a>intrinsic iteration duration</a> is the result of
@@ -2113,40 +2124,34 @@ partial dictionary OptionalEffectTiming {
 :   <dfn>delay</dfn>
 ::  Update the description as:
 
-    > The <a>start delay</a> which represents the number of milliseconds from an
-    > <a>animation effect</a>'s <a lt="animation effect start time">start
-    > time</a> to the start of the <a>active interval</a>.
-    > If the <a lt="timeline duration">duration</dfn> of the Animation's
-    > <a>timeline</a> is a percentage, the start delay will be treated as the
-    > result of applying the procedure to convert a
-    > [=time-based animation to a proportional animation=].
+    > The <dfn>specified start delay</dfn> which represents the number of
+    > milliseconds from an <a>animation effect</a>'s
+    > <a lt="animation effect start time">start time</a> to the start of the
+    > <a>active interval</a>.
+    > The |specified start delay| is converted to a <a>start delay</a> following
+    > the [=normalize specified timing=] procedure.
 
 :   <dfn>endDelay</dfn>
 ::  Update the description as:
 
-    > The <a>end delay</a> which represents the number of milliseconds
+    > The <dfn>specified end delay</dfn> which represents the number of milliseconds
     > from the end of an <a>animation effect</a>'s <a>active interval</a>
     > until the <a lt='animation effect start time'>start time</a> of any
-    > <a>animation effect</a> that may
-    > follow, for example, in a <a>sequence effect</a>.
-    > If the <a lt="timeline duration">duration</dfn> of the Animation's
-    > <a>timeline</a> is a percentage, the end delay will be treated as the
-    > result of applying the procedure to convert a
-    > [=time-based animation to a proportional animation=].
-
-</div>
+    > <a>animation effect</a> that may follow, for example, in a <a>sequence
+    >  effect</a>. The |specified end delay| is converted to an <a>end delay</a>
+    > following the [=normalize specified timing=] procedure.
 
 :   <dfn>duration</dfn>
-::  Add:
+::  Update the description as:
 
-    > If the <a lt="timeline duration">duration</dfn> of the Animation's
-    > <a>timeline</a> is a percentage, a non <code>auto</code> duration will
-    > be treated as the result of applying the procedure to convert a
-    > [=time-based animation to a proportional animation=].
-
-    > The string value <code>auto</code> is used to indicate that the
+    > The <dfn>specified iteration duration</dfn> which is a real number greater
+    > than or equal to zero (including positive infinity) representing the
+    > time taken to complete a single iteration of the <a>animation
+    > effect</a>, or the string value <code>auto</code> to indicate that the
     > <a>iteration duration</a> reflects the animation effect's
-    > <a>intrinsic iteration duration</a>.
+    > <a>intrinsic iteration duration</a>.  The |specified iteration duration|
+    > is converted to an <a>iteration duration</a> following  the
+    > [=normalize specified timing=] procedure.
 
 :   <dfn dict-member for=EffectTiming>playbackRate</dfn>
 ::  The <a>animation effect</a>'s <a
@@ -2155,6 +2160,47 @@ partial dictionary OptionalEffectTiming {
     causing the effect to run at a different rate to its natural speed.
 
 </div>
+
+<h3 id="updating-animationeffect-timing">Updating the timing of an
+AnimationEffect</h3>
+
+Replace:
+
+> Assign each member <a>present</a> in |input| to the corresponding timing
+>    property of |effect| as follows:
+>
+>    *   {{EffectTiming/delay}} &rarr; [=start delay=]
+>    *   {{EffectTiming/endDelay}} &rarr; [=end delay=]
+>    *   {{EffectTiming/fill}} &rarr; [=fill mode=]
+>    *   {{EffectTiming/iterationStart}} &rarr; [=iteration start=]
+>    *   {{EffectTiming/iterations}} &rarr; [=iteration count=]
+>    *   {{EffectTiming/duration}} &rarr; [=iteration duration=]
+>    *   {{EffectTiming/direction}} &rarr; [=playback direction=]
+>    *   {{EffectTiming/easing}} &rarr; [=timing function=]
+
+with:
+
+> Assign each member <a>present</a> in |input| to the corresponding timing
+>    property of |effect| as follows:
+>
+>    *   {{EffectTiming/delay}} &rarr; [=specified start delay=]
+>    *   {{EffectTiming/endDelay}} &rarr; [=specified end delay=]
+>    *   {{EffectTiming/fill}} &rarr; [=fill mode=]
+>    *   {{EffectTiming/iterationStart}} &rarr; [=iteration start=]
+>    *   {{EffectTiming/iterations}} &rarr; [=iteration count=]
+>    *   {{EffectTiming/duration}} &rarr; [=specified iteration duration=]
+>    *   {{EffectTiming/direction}} &rarr; [=playback direction=]
+>    *   {{EffectTiming/easing}} &rarr; [=timing function=]
+
+Add:
+
+>    Follow the procedure to [=normalize specified timing=].
+>
+>    <p class="note">
+>    Timing properties may also be updated due to a style change. Any change to
+>    a CSS animation property that affects timing requres rerunning the
+>    procedure to [=normalize specified timing=].
+>    </p>
 
 <h3 id="the-computedeffecttiming-dictionary">The
   <code>ComputedEffectTiming</code> dictionary</h3>

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -1555,7 +1555,11 @@ number of <a>child effects</a> as follows.
 
     1.  Let <var>maximum end time</var> be the maximum value
         after calculating the <a>end time</a> of each <a>child
-        effect</a> in the group.
+        effect</a> in the group. The <a>end time</a> may be
+        expressed as a time or a percentage (in the case of a
+        progress based animation). In the event of mixed time and
+        percentage <a>end time</a>s, the largest time based value
+        equates to 100% for the purpose of time scaling.
     2.  The <a>intrinsic iteration duration</a> is the result of
         evaluating <code>max(0, <var>maximum end
         time</var>)</code>.

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -144,9 +144,48 @@ Along with the following updated description:
 </div>
 
 
+<h3 id="timelines">Timelines</h3>
+
+Add:
+
+> The <dfn lt="timeline duration">duration</dfn> of a timeline gives the
+> maximum value a timeline may generate for its current time. This value is
+> used to calculate the [=intrinsic iteration duration=] for the target effect
+> of an animation that is associated with the timeline when the effect's
+> [=iteration duration=] is 'auto'. The value is computed such that the effect
+> fills the available time.  For a monotonic timeline, there is no upper bound
+> on current time, and [=timeline duration=] is unresolved. For a progress based
+> timeline, the [=timeline duration=] is 100%.
+
 <h3 id="animations">Animations</h3>
 
-<div class="informative-bg"><em>This section is non-normative</em>
+Add:
+
+> Animation effects associated with a progress-based timeline require their
+> timing properties to be converted to proportions. The procedure for converting
+> a <dfn lt="time-based animation to a proportional animation"></dnf> is as
+> follows:
+>
+> 1.  If the [=iteration duration=] is auto, then perform the following steps.
+>
+>     1.   Compute [=start delay=] and [=end delay=] to 0, as it is not possible
+>          to mix time and proportions. Future versions may allow these properties
+>          to be assigned percentages.
+>
+> 1.  Otherwise,
+>
+> 1.  Let <var>total time</var> be equal to the result of evaluating
+>     <code>|start delay| + |iteration count| * |iteration duration| +
+>     |end delay|</code>.
+>
+> 1.  Compute [=start delay=] to be the result of evaluating
+>     <code>|start delay| / |total time| * |timeline duration|</code>.
+>
+> 1.  Compute [=iteration duration=] to be the result of evaluating
+>     <code>|iteration duration| / |total time| * |timeline duration|</code>.
+>
+> 1.  Compute [=end delay=] to be the result of evaluating
+>     <code>|end delay| / |total time| * |timeline duration|</code>.
 
 <h4 id="setting-the-timeline">Setting the timeline of an animation</h4>
 
@@ -944,13 +983,24 @@ Add:
 
 >     The initial <a>iteration duration</a> of an animation effect is simply its
 >     <a>intrinsic iteration duration</a>.
+>     The <dfn>intrinsic iteration duration</dfn> is calculated from the first
+>     matching condition from below:
 >
->     The <dfn>intrinsic iteration duration</dfn> of an animation effect is
->     zero, however some specific types of animation effect such as
->     <a>group effects</a> override this behavior and provide an
->     alternative intrinsic duration (see
->     [[#the-intrinsic-iteration-duration-of-a-group-effect]] and
->     [[#the-intrinsic-iteration-duration-of-a-sequence-effect]]).
+> <div class="switch">
+> :   If the animation effect is a <a>group effect</a>,
+> ::  Follow the procedure in
+>     [[#the-intrinsic-iteration-duration-of-a-group-effect]]
+>
+> :   If the animation effect is a <a>sequence effect</a>,
+> ::  Follow the procedure in
+>     [[#the-intrinsic-iteration-duration-of-a-sequence-effect]]
+>
+> :   If [=timeline duration=] is unresolved,
+> ::  Return 0
+>
+> :   Otherwise
+> ::  Return  [=timeline duration=] / <a>iteration count</a>
+> </div>
 >
 >     The <a>iteration duration</a> of an <a>animation effect</a> may be set
 >     by the author to represent a value other than the <a>intrinsic
@@ -1886,9 +1936,17 @@ Items sorted earlier are executed before those sorted later.
 <pre class="idl">
 [Exposed=Window]
 partial interface AnimationTimeline {
+    readonly attribute CSSNumberish? duration;
     Animation play (optional AnimationEffect? effect = null);
 };
 </pre>
+
+<div class='attributes'>
+
+:   <dfn attribute for=AnimationTimeline>duration</dfn>
+::  Returns the <a lt="timeline duration">duration</a> for this timeline.
+
+</div>
 
 <div class='methods'>
 
@@ -2054,6 +2112,10 @@ partial dictionary OptionalEffectTiming {
     > The <a>start delay</a> which represents the number of milliseconds from an
     > <a>animation effect</a>'s <a lt="animation effect start time">start
     > time</a> to the start of the <a>active interval</a>.
+    > If the <a lt="timeline duration">duration</dfn> of the Animation's
+    > <a>timeline</a> is a percentage, the start delay will be treated as the
+    > result of applying the procedure to convert a
+    > [=time-based animation to a proportional animation=].
 
 :   <dfn>endDelay</dfn>
 ::  Update the description as:
@@ -2063,11 +2125,20 @@ partial dictionary OptionalEffectTiming {
     > until the <a lt='animation effect start time'>start time</a> of any
     > <a>animation effect</a> that may
     > follow, for example, in a <a>sequence effect</a>.
+    > If the <a lt="timeline duration">duration</dfn> of the Animation's
+    > <a>timeline</a> is a percentage, the end delay will be treated as the
+    > result of applying the procedure to convert a
+    > [=time-based animation to a proportional animation=].
 
 </div>
 
 :   <dfn>duration</dfn>
 ::  Add:
+
+    > If the <a lt="timeline duration">duration</dfn> of the Animation's
+    > <a>timeline</a> is a percentage, a non <code>auto</code> duration will
+    > be treated as the result of applying the procedure to convert a
+    > [=time-based animation to a proportional animation=].
 
     > The string value <code>auto</code> is used to indicate that the
     > <a>iteration duration</a> reflects the animation effect's
@@ -2086,7 +2157,11 @@ partial dictionary OptionalEffectTiming {
 
 <pre class='idl'>
 partial dictionary ComputedEffectTiming {
-    double startTime;
+    CSSNumberish         startTime;
+    CSSNumberish         endTime;
+    CSSNumberish         activeDuration;
+    CSSNumberish?        localTime;
+    CSSNumberish?        progress;
 };
 </pre>
 
@@ -2094,7 +2169,8 @@ partial dictionary ComputedEffectTiming {
 
 :   <dfn dict-member for=ComputedEffectTiming>startTime</dfn>
 ::  The <a lt='animation effect start time'>start time</a> of this
-    <a>animation effect</a> in milliseconds.
+    <a>animation effect</a> in milliseconds or as a percentage of the
+    [=timeline duration=].
     This is the time at which the <a>parent group</a>, if
     any, has scheduled this child to run within its <a
     lt="transformed time">transformed time space</a>, that is, the
@@ -2110,7 +2186,7 @@ partial dictionary ComputedEffectTiming {
 
     > The <a>end time</a> of the <a>animation effect</a> expressed
     > in milliseconds in <a lt="inherited time">inherited time
-    > space</a>.
+    > space</a> or as a percentage of the [=timeline duration=].
 
     > This corresponds to the end of the <a>animation effect</a>'s active
     > interval plus any <a>end delay</a>.
@@ -2478,8 +2554,8 @@ Replace:
 
 with:
 
->     If the duration is not specified, the <a>intrinsic iteration
->     duration</a> is used which, for a <a>keyframe effect</a>, is zero.
+>     If the duration is not specified, the [=intrinsic iteration duration=] is
+>     used.
 
 Add:
 

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -1006,11 +1006,16 @@ Add:
 > ::  Follow the procedure in
 >     [[#the-intrinsic-iteration-duration-of-a-sequence-effect]]
 >
-> :   If [=timeline duration=] is unresolved,
+> :   If [=timeline duration=] is unresolved or <a>iteration count</a> is zero,
 > ::  Return 0
 >
 > :   Otherwise
-> ::  Return  [=timeline duration=] / <a>iteration count</a>
+> ::  Return <code>(100% - <a>start delay</a> - <a>end delay</a>) /
+>     <a>iteration count</a></code>
+>     <p class="note">
+>     Presently start and end delays are zero until such time as percentage
+>     based delays are supported.
+>     </p>
 > </div>
 >
 >     The <a>iteration duration</a> of an <a>animation effect</a> may be set

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -155,7 +155,7 @@ Add:
 > [=iteration duration=] is 'auto'. The value is computed such that the effect
 > fills the available time. For a monotonic timeline, there is no upper bound
 > on current time, and [=timeline duration=] is unresolved. For a non-monotonic
-> (i.e. scroll) timeline, the duration has a fixed upper bound. In this
+> (e.g. scroll) timeline, the duration has a fixed upper bound. In this
 > case, the timeline is a <dfn lt="progress-based timeline">progress-based
 > timeline</dfn>, and its [=timeline duration=] is 100%.
 
@@ -2142,9 +2142,9 @@ partial dictionary OptionalEffectTiming {
     > The <dfn>specified end delay</dfn> which represents the number of milliseconds
     > from the end of an <a>animation effect</a>'s <a>active interval</a>
     > until the <a lt='animation effect start time'>start time</a> of any
-    > <a>animation effect</a> that may follow, for example, in a <a>sequence
-    >  effect</a>. The |specified end delay| is converted to an <a>end delay</a>
-    > following the [=normalize specified timing=] procedure.
+    > <a>animation effect</a> that may follow, for example, in a
+    > <a>sequence effect</a>. The |specified end delay| is converted to an
+    > <a>end delay</a> following the [=normalize specified timing=] procedure.
 
 :   <dfn>duration</dfn>
 ::  Update the description as:


### PR DESCRIPTION
Change the implicit handling of auto duration animations to use the duration of the supplied timeline if resolved.   Scroll-timelines have an implicit timeline duration and the intrinsic iteration duration can be calculated based on this value.  Document timelines will have an unresolved timeline duration, which will translate to an intrinsic iteration duration of zero consistent with the currently specified behavior.  

If the timeline duration is resolved, effect timing is normalized based on this duration.

This pull request is a replacement for https://github.com/w3c/csswg-drafts/pull/4890.

