### PR TITLE
[css-color-4] change text of MarkText example to match styling

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1755,7 +1755,7 @@ System Colors</h3>
 		<p>ButtonFace with GrayText <span style="background-color:ButtonFace; color:GrayText">GrayText</span></p>
 		<p>Field with FieldText <span style="background-color:Field; color:FieldText">FieldText</span></p>
 		<p>Field with GrayText <span style="background-color:Field; color:GrayText">GrayText</span></p>
-		<p>Mark with MarkText <span style="background-color:Mark; color:MarkText">FieldText</span></p>
+		<p>Mark with MarkText <span style="background-color:Mark; color:MarkText">MarkText</span></p>
 		<p>Mark with GrayText <span style="background-color:Mark; color:GrayText">GrayText</span></p>
 		<p>Highlight with HighlightText <span style="background-color:Highlight; color:HighlightText">HighlightText</span></p>
 		<p>Highlight with GrayText <span style="background-color:Highlight; color:GrayText">GrayText</span></p>


### PR DESCRIPTION
Fixes #6362.

Before:

![image](https://user-images.githubusercontent.com/218840/121207037-d0607d00-c82d-11eb-9956-aa6e9c10ec94.png)


After:

![image](https://user-images.githubusercontent.com/218840/121206868-a909b000-c82d-11eb-98bc-684c51e7f593.png)
