### PR TITLE
[css-contain-3] Make the query container an element, ++

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -25,6 +25,7 @@ spec:css-break-3; type:dfn; text:fragmentation
 spec:css-break-3; type:dfn; text:fragmentation container
 spec:css-break-3; type:dfn; text:fragmentation context
 spec:css-break-3; type:dfn; text:fragmented flow
+spec:css-contain-2; type:dfn; text:layout containment box
 spec:css-sizing-4; type:property; text:contain-intrinsic-size
 spec:css-sizing-4; type:property; text:aspect-ratio
 spec:intersection-observer; type:dfn; text:intersection root
@@ -169,11 +170,11 @@ Creating Query Containers: the 'container-type' property</h2>
 		Initial: none
 		Inherited: no
 		Applies to: all elements
-		Computed value: the keyword ''container-type/none'' or one or more of ''container-type/size'', ''container-type/inline-size'', ''container-type/style'', ''container-type/state''
+		Computed value: the keyword ''container-type/none'' or one or more of ''container-type/size'', ''container-type/inline-size'', ''container-type/block-size'', ''container-type/style'', ''container-type/state''
 		Animation type: not animatable
 	</pre>
 
-	The 'container-type' property establishes the [=principal box=]
+	The 'container-type' property establishes the element
 	as a <dfn export>query container</dfn> for the purpose of [=container queries=],
 	allowing [=style rules=] styling its descendants
 	to query various aspects of its sizing, layout, and style
@@ -192,7 +193,7 @@ Creating Query Containers: the 'container-type' property</h2>
 			Applies [=layout containment=],
 			[=style containment=],
 			and [=size containment=]
-			to this box.
+			the [=principal box=].
 		<dt><dfn>inline-size</dfn>
 		<dd>
 			Establishes a [=query container=] for [=dimensional queries=]
@@ -200,7 +201,7 @@ Creating Query Containers: the 'container-type' property</h2>
 			Applies [=layout containment=],
 			[=style containment=],
 			and [=inline-size containment=]
-			to this box.
+			the [=principal box=].
 		<dt><dfn>block-size</dfn>
 		<dd>
 			Establishes a [=query container=] for [=dimensional queries=]
@@ -208,7 +209,7 @@ Creating Query Containers: the 'container-type' property</h2>
 			Applies [=layout containment=],
 			[=style containment=],
 			and [=block-size containment=]
-			to this box.
+			the [=principal box=].
 		<dt><dfn>style</dfn>
 		<dd>
 			Establishes a [=query container=] for [=style queries=].
@@ -274,8 +275,7 @@ Naming Query Containers: the 'container-name' property</h2>
 	</pre>
 
 	The 'container-name' property
-	specifies a list of <dfn export lt="query container name">query container names</dfn>
-	that apply to the box if it is a [=query container=].
+	specifies a list of <dfn export lt="query container name">query container names</dfn>.
 	These names can be used by ''@container'' rules
 	to filter which [=query containers=] are targeted.
 
@@ -431,12 +431,18 @@ Container Features</h2>
 Dimensional Container Features</h3>
 
 	<dfn export>Dimensional queries</dfn> allow querying
-	the size of the [=query container=].
+	the size of the [=query container=]'s [=principal box=].
+
+	If the [=query container=] does not have a [=principal box=],
+	or the principal box is not a [=layout containment box=],
+	then the result of evaluating any dimensional container feature is "unknown".
 
 	[=Relative length=] units in [=container queries=]
-	are based on the the [=computed values=] of the [=query container=] element.
+	are based on the the [=computed values=] of the [=query container=].
 
 	Note: This is different from the handling of relative units in [=media queries=].
+
+	Issue: Evaluate to "unknown" if inline-/block-/size containment is missing.
 
 <h4 id="width">
 Width: the '@container/width' feature</h4>
@@ -547,7 +553,7 @@ Orientation: the '@container/orientation' feature</h4>
 Style Container Features</h3>
 
 	<dfn export>Style queries</dfn> allow querying
-	the [=computed values=] of the [=query container=] element.
+	the [=computed values=] of the [=query container=].
 
 	Issue(5989): "container width" and "container height" units
 


### PR DESCRIPTION
It is simpler to treat *elements* as query containers, and delay
interaction with the layout box until query-evaluation-time.
This makes it possible to answer the question "is this element a
container?" sooner, which is beneficial for implementing the feature.

It also seems to make more sense given that we're going to have
container features that don't really care about the layout box.

Also:

 - Require layout containment for dimensional queries.
 - Add 'block-size' as part of the computed value.
