### PR TITLE
[css-nesting-1] fix nesting example

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -673,7 +673,7 @@ Mixing Nesting Rules and Declarations {#mixing}
 		<xmp highlight=css>
 			article {
 				color: blue;
-				&:where(&) { color: red; }
+				@nest :where(&) { color: red; }
 			}
 		</xmp>
 

--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -673,7 +673,7 @@ Mixing Nesting Rules and Declarations {#mixing}
 		<xmp highlight=css>
 			article {
 				color: blue;
-				:where(&) { color: red; }
+				&:where(&) { color: red; }
 			}
 		</xmp>
 


### PR DESCRIPTION
[css-nesting-1] fix the nesting example

This changes adds a missing nesting selector (`&`) to [an example in the CSS Nesting specification](https://drafts.csswg.org/css-nesting-1/#mixing).

The current example, without a nesting selector:

```css
article {
  color: blue;
  :where(&) { color: red; }
}
```

The fixed example, with a nesting selector:

```css
article {
  color: blue;
  &:where(&) { color: red; }
}
```