### PR TITLE
[css-fonts-5] absolutize axis of font-size-adjust metrics #6288

### DIFF
--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -95,7 +95,7 @@ Relative sizing: the 'font-size-adjust' property</h3>
 
 	<pre class="propdef">
 	Name: font-size-adjust
-	Value: none | [ ex | cap | ch | ic ]? [ from-font | <<number>> ]
+	Value: none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <<number>> ]
 	Initial: none
 	Applies to: all elements and text
 	Inherited: yes
@@ -133,32 +133,38 @@ Relative sizing: the 'font-size-adjust' property</h3>
 		<dd>
 			No special 'font-size' adjustment is applied.
 
-		<dt><dfn>ex | cap | ch | ic</dfn>
+		<dt><dfn>ex-height | cap-height | ch-width | ic-width | ic-height</dfn>
 		<dd>
 			Specifies the font metric to normalize,
-			defaulting to ''font-size-adjust/ex'':
+			defaulting to ''font-size-adjust/ex-height'':
 
 			<dl>
-				<dt><dfn>ex</dfn>
+				<dt><dfn>ex-height</dfn>
 				<dd>
 					Normalize the <dfn dfn>aspect value</dfn> of the fonts,
 					using the x-height divided by the font size.
 
-				<dt><dfn>cap</dfn>
+				<dt><dfn>cap-height</dfn>
 				<dd>
 					Normalize the cap-height of the fonts,
 					using the cap-height by the font size.
 
-				<dt><dfn>ch</dfn>
+				<dt><dfn>ch-width</dfn>
 				<dd>
-					Normalize the narrow pitch of the fonts,
-					using the advance measure of “0” (ZERO, U+0030)
+					Normalize the horizontal narrow pitch of the fonts,
+					using the advance width of “0” (ZERO, U+0030)
 					divided by the font size.
 
-				<dt><dfn>ic</dfn>
+				<dt><dfn>ic-width</dfn>
 				<dd>
-					Normalize the wide pitch of the font,
-					using the advance measure of “水” (CJK water ideograph, U+6C34)
+					Normalize the horizontal wide pitch of the font,
+					using the advance width of “水” (CJK water ideograph, U+6C34)
+					divided by the font size.
+
+				<dt><dfn>ic-height</dfn>
+				<dd>
+					Normalize the vertical wide pitch of the font,
+					using the advance height of “水” (CJK water ideograph, U+6C34)
 					divided by the font size.
 			</dl>
 


### PR DESCRIPTION
switches `ex | cap | ch | ic` to `ex-height | cap-height | ch-width | ic-width | ic-height`

Possible alternative: `ex | cap | ch | ic` to `ex | cap | ch-width | ic-width | ic-height`