### PR TITLE
[scroll-animations-1] Update serialization of CSSScrollTimelineRule.

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1053,38 +1053,20 @@ interface CSSScrollTimelineRule : CSSRule {
             on the value of the 'orientation' descriptor,
             followed by a SEMICOLON (U+003B),
             followed by a SPACE (U+0020).
-    1. If the 'start' descriptor is missing, the empty string.
-        Otherwise, the concatenation of the following:
-        1. The string <code>"start:"</code>,
-            followed by a SPACE (U+0020).
-        1. The result of performing <a>serialize a scroll timeline offset</a>
-            on the rule's 'start' descriptor,
+    1. If the 'scrollOffsets' descriptor is missing, the empty string.
+       Otherwise, the concatenation of the following:
+        1. The string <code>"scrollOffsets:"</code>,
+            followed by a SPACE (U+0020),
+            followed by a BRACKETLEFT (U+005B).
+        1. For each value in the list for the rule's 'scroll-offsets'
+            descriptor:
+            1. The result of performing
+                <a>serialize a scroll timeline offset</a> on the value.
+            1. If not the last value,
+                A COMMA (U+002C), followed by a SPACE (U+0020).
+        1. A BRACKETRIGHT (U+005D),
             followed by a SEMICOLON (U+003B),
             followed by a SPACE (U+0020).
-    1. If the 'end' descriptor is missing, the empty string.
-        Otherwise, the concatenation of the following:
-        1. The string <code>"end:"</code>,
-            followed by a SPACE (U+0020).
-        1. The result of performing <a>serialize a scroll timeline offset</a>
-            on the rule's 'end' descriptor,
-            followed by a SEMICOLON (U+003B),
-            followed by a SPACE (U+0020).
-    1. If the 'time-range' descriptor is missing, the empty string.
-        Otherwise, the concatenation of the following:
-        1. The string <code>"time-range:"</code>,
-            followed by a SPACE (U+0020).
-        1. One of the following,
-            depending on the value of the 'time-range' descriptor:
-            <dl class=switch>
-              : an identifier
-              :: The result of performing <a>serialize an identifier</a>
-                 on that identifier.
-              : &lt;time>
-              :: The result of performing <a>serialize a CSS component value</a>
-                 on that value.
-                </dl>
-        1. A single SEMICOLON (U+003B), followed by a SPACE (U+0020).
-    1. A single RIGHT CURLY BRACKET (U+007D).
 </div>
 
 <div algorithm>

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1057,16 +1057,17 @@ interface CSSScrollTimelineRule : CSSRule {
        Otherwise, the concatenation of the following:
         1. The string <code>"scrollOffsets:"</code>,
             followed by a SPACE (U+0020),
-            followed by a BRACKETLEFT (U+005B).
+            followed by a LEFT SQUARE BRACKET (U+005B).
         1. For each value in the list for the rule's 'scroll-offsets'
             descriptor:
             1. The result of performing
                 <a>serialize a scroll timeline offset</a> on the value.
             1. If not the last value,
                 A COMMA (U+002C), followed by a SPACE (U+0020).
-        1. A BRACKETRIGHT (U+005D),
+        1. A RIGHT SQUARE BRACKET (U+005D),
             followed by a SEMICOLON (U+003B),
             followed by a SPACE (U+0020).
+    1. A single RIGHT CURLY BRACKET (U+007D).
 </div>
 
 <div algorithm>


### PR DESCRIPTION
[scroll-animations-1] Update serialization of CSSScrollTimelineRule.

The serialization process contained stale references to 'start', 'end' and 'time-range' rule descriptors.
Removed 'time-range' and replaced 'start' and 'end' with 'scrollOffsets'.

