### PR TITLE
[cssom-1] Refactor CSSStyleSheet constructor and replaceSync to allow steps to be referenced from HTML spec

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -748,24 +748,28 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
 <dl>
   <dt><dfn constructor for=CSSStyleSheet>CSSStyleSheet(<var>options</var>)</dfn></dt>
   <dd>
-    When called, execute the steps to <a>construct a CSSStyleSheet</a> given <var>options</var> and return the result.
+    When called, execute these steps:
+    <ol>
+      <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var>.</li>
+      <li>Run the steps to <a>initialize a CSSStyleSheet</a> on <var>sheet</var> given <var>options</var>.
+      <li>Return <var>sheet</var>.</li>
+    </ol>
   </dd>
 
-  <dt>To <dfn export>construct a CSSStyleSheet</dfn></dt> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
+  <dt>To <dfn export>initialize a {{/CSSStyleSheet}}</dfn></dt> <var>sheet</var> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
   <dd>
     <ol>
-      <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var> with the following properties:
       <ul>
-        <li><a spec=cssom>location</a> set to the <a spec=html>base URL</a> of the <a>associated Document</a> for the <a>current global object</a>.
-        <li><a>stylesheet base URL</a> set to the {{CSSStyleSheetInit/baseURL}} attribute value from <var>options</var>.
-        <li>No <a spec=cssom>parent CSS style sheet</a>.
-        <li>No <a spec=cssom>owner node</a>.
-        <li>No <a spec=cssom>owner CSS rule</a>.
-        <li><a spec=cssom>title</a> set to the the empty string.
-        <li>Unset <a spec=cssom>alternate flag</a>.
-        <li>Set <a spec=cssom>origin-clean flag</a>.
-        <li>Set <a>constructed flag</a>.
-        <li><a>Constructor document</a> set to the <a>associated Document</a> for the <a>current global object</a>.
+        <li>Set <var>sheet</var>'s <a spec=cssom>location</a> to the <a spec=html>base URL</a> of the <a>associated Document</a> for the <a>current global object</a>.
+        <li>Set <var>sheet</var>'s <a>stylesheet base URL</a> to the {{CSSStyleSheetInit/baseURL}} attribute value from <var>options</var>.
+        <li>Set <var>sheet</var>'s <a spec=cssom>parent CSS style sheet</a> to null.
+        <li>Set <var>sheet</var>'s <a spec=cssom>owner node</a> to null.
+        <li>Set <var>sheet</var>'s <a spec=cssom>owner CSS rule</a> to null.
+        <li>Set <var>sheet</var>'s <a spec=cssom>title</a> to the the empty string.
+        <li>Unset <var>sheet</var>'s <a spec=cssom>alternate flag</a>.
+        <li>Set <var>sheet</var>'s <a spec=cssom>origin-clean flag</a>.
+        <li>Set <var>sheet</var>'s <a>constructed flag</a>.
+        <li>Set <var>sheet</var>'s <a>Constructor document</a> to the <a>associated Document</a> for the <a>current global object</a>.
       </ul>
       <li>If the {{CSSStyleSheetInit/media}} attribute of <var>options</var> is a string,
         <a>create a MediaList object</a> from the string

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -748,10 +748,10 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
 <dl>
   <dt><dfn constructor for=CSSStyleSheet>CSSStyleSheet(<var>options</var>)</dfn></dt>
   <dd>
-    When called, execute the steps to <a>create a CSSStyleSheet</a> given <var>options</var> and return the result.
+    When called, execute the steps to <a>create a constructed CSSStyleSheet</a> given <var>options</var> and return the result.
   </dd>
 
-  <dt>To <dfn export>create a {{/CSSStyleSheet}}</dfn></dt> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
+  <dt>To <dfn export>create a constructed {{/CSSStyleSheet}}</dfn></dt> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
   <dd>
     <ol>
       <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var>.</li>

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -748,29 +748,23 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
 <dl>
   <dt><dfn constructor for=CSSStyleSheet>CSSStyleSheet(<var>options</var>)</dfn></dt>
   <dd>
-    When called, execute these steps:
-    <ol>
-      <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var>.</li>
-      <li>Run the steps to <a>initialize a CSSStyleSheet</a> on <var>sheet</var> given <var>options</var>.
-      <li>Return <var>sheet</var>.</li>
-    </ol>
+    When called, execute the steps to <a>create a CSSStyleSheet</a> given <var>options</var> and return the result.
   </dd>
 
-  <dt>To <dfn export>initialize a {{/CSSStyleSheet}}</dfn></dt> <var>sheet</var> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
+  <dt>To <dfn export>create a {{/CSSStyleSheet}}</dfn></dt> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
   <dd>
     <ol>
-      <ul>
-        <li>Set <var>sheet</var>'s <a spec=cssom>location</a> to the <a spec=html>base URL</a> of the <a>associated Document</a> for the <a>current global object</a>.
-        <li>Set <var>sheet</var>'s <a>stylesheet base URL</a> to the {{CSSStyleSheetInit/baseURL}} attribute value from <var>options</var>.
-        <li>Set <var>sheet</var>'s <a spec=cssom>parent CSS style sheet</a> to null.
-        <li>Set <var>sheet</var>'s <a spec=cssom>owner node</a> to null.
-        <li>Set <var>sheet</var>'s <a spec=cssom>owner CSS rule</a> to null.
-        <li>Set <var>sheet</var>'s <a spec=cssom>title</a> to the the empty string.
-        <li>Unset <var>sheet</var>'s <a spec=cssom>alternate flag</a>.
-        <li>Set <var>sheet</var>'s <a spec=cssom>origin-clean flag</a>.
-        <li>Set <var>sheet</var>'s <a>constructed flag</a>.
-        <li>Set <var>sheet</var>'s <a>Constructor document</a> to the <a>associated Document</a> for the <a>current global object</a>.
-      </ul>
+      <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var>.</li>
+      <li>Set <var>sheet</var>'s <a spec=cssom>location</a> to the <a spec=html>base URL</a> of the <a>associated Document</a> for the <a>current global object</a>.
+      <li>Set <var>sheet</var>'s <a>stylesheet base URL</a> to the {{CSSStyleSheetInit/baseURL}} attribute value from <var>options</var>.
+      <li>Set <var>sheet</var>'s <a spec=cssom>parent CSS style sheet</a> to null.
+      <li>Set <var>sheet</var>'s <a spec=cssom>owner node</a> to null.
+      <li>Set <var>sheet</var>'s <a spec=cssom>owner CSS rule</a> to null.
+      <li>Set <var>sheet</var>'s <a spec=cssom>title</a> to the the empty string.
+      <li>Unset <var>sheet</var>'s <a spec=cssom>alternate flag</a>.
+      <li>Set <var>sheet</var>'s <a spec=cssom>origin-clean flag</a>.
+      <li>Set <var>sheet</var>'s <a>constructed flag</a>.
+      <li>Set <var>sheet</var>'s <a>Constructor document</a> to the <a>associated Document</a> for the <a>current global object</a>.
       <li>If the {{CSSStyleSheetInit/media}} attribute of <var>options</var> is a string,
         <a>create a MediaList object</a> from the string
         and assign it as <var>sheet</var>'s <a spec=cssom>media</a>.

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -748,7 +748,11 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
 <dl>
   <dt><dfn constructor for=CSSStyleSheet>CSSStyleSheet(<var>options</var>)</dfn></dt>
   <dd>
-    When called, execute these steps:
+    When called, execute the steps to <a>construct a CSSStyleSheet</a> given <var>options</var> and return the result.
+  </dd>
+
+  <dt>To <dfn export>construct a CSSStyleSheet</dfn></dt> given {{CSSStyleSheetInit}} <var>options</var>, run these steps:
+  <dd>
     <ol>
       <li>Construct a new {{/CSSStyleSheet}} object <var>sheet</var> with the following properties:
       <ul>
@@ -1027,14 +1031,17 @@ The <dfn method for=CSSStyleSheet>replace(<a for=CSSRule>text</a>)</dfn> method 
  <li>Return <var>promise</var>.
 </ol>
 
-The <dfn method for=CSSStyleSheet>replaceSync(<a for=CSSRule>text</a>)</dfn> method must run the following steps:
+The <dfn method for=CSSStyleSheet>replaceSync(<a for=CSSRule>text</a>)</dfn> method must run the
+steps to <a>synchronously replace the rules of a CSSStyleSheet</a> on this {{CSSStyleSheet}} given <var>text</var>.
+
+To <dfn export>synchronously replace the rules of a CSSStyleSheet</dfn> on <var>sheet</var> given <var>text</var>, run these steps:
 <ol>
  <li>If the <a>constructed flag</a> is not set, or the <a>disallow modification flag</a> is set, throw a {{NotAllowedError}}
  {{DOMException}}.
  <li>Let <var>rules</var> be the result of running <a>parse a list of rules</a> from <var>text</var>. If <var>rules</var> is
  not a list of rules (i.e. an error occurred during parsing), set <var>rules</var> to an empty list.
  <li>If <var>rules</var> contains one or more <a>@import</a> rules, <a lt="remove a CSS rule">remove those rules</a> from <var>rules</var>.
- <li>Set <a>CSS rules</a> to <var>rules</var>.
+ <li>Set <var>sheet</var>'s <a>CSS rules</a> to <var>rules</var>.
 </ol>
 
 #### Deprecated CSSStyleSheet members #### {#legacy-css-style-sheet-members}


### PR DESCRIPTION
[cssom-1] Refactor CSSStyleSheet constructor and replaceSync to allow steps to be referenced from HTML spec

The [CSS module scripts](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/css-modules-v1-explainer.md) feature is being specified in HTML using several algorithms defined in cssom-1 on the `CSSStyleSheet` interface. In the review of the CSS module scripts HTML spec PR https://github.com/whatwg/html/pull/4898, there was a [concern ](https://github.com/whatwg/html/pull/4898#discussion_r324088522) that referencing the CSSStyleSheet methods directly implies that if these methods were overridden by user script, the UA should call the user script instead.

This change pulls the steps for the `CSSStyleSheet` constructor and `replaceSynce` method into separate algorithms so that they can be safely referenced from the HTML spec.