### PR TITLE
[cssom-1] Move the camel-cased-attribute definition a bit further up.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2513,7 +2513,7 @@ attribute, on getting, must return the result of invoking
 Any exceptions thrown must be re-thrown.
 
 For each CSS property <var>property</var> that is a <a>supported CSS property</a>,
-the following partial interface applies where <var>camel-cased attribute</var>
+the following partial interface applies where <dfn attribute for=CSSStyleDeclaration>camel-cased attribute</dfn>
 is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 <var>property</var>.
 
@@ -2523,7 +2523,7 @@ partial interface CSSStyleDeclaration {
 };
 </pre>
 
-The <dfn attribute for=CSSStyleDeclaration><var>camel-cased attribute</var></dfn> attribute, on getting, must return the
+The <a attribute for=CSSStyleDeclaration><var>camel-cased attribute</var></a> attribute, on getting, must return the
 result of invoking {{CSSStyleDeclaration/getPropertyValue()}} with the
 argument being the result of running the <a>IDL attribute to CSS property</a>
 algorithm for <var>camel-cased attribute</var>.


### PR DESCRIPTION
Not sure if this is 100% worth it but it should close #6421, and I think
it's better.