### PR TITLE
[cssom-1, css-cascade-5] Add adoptedStyleSheets using ObservableArray

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1035,7 +1035,7 @@ Cascade Sorting Order</h3>
 			For this purpose:
 
 			<ul>
-				<li>Style sheets are ordered as in <a href="https://www.w3.org/TR/cssom-1/#documentorshadowroot-final-css-style-sheets">final CSS style sheets</a>.
+				<li>Style sheets are ordered as in <a href="https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets">final CSS style sheets</a>.
 				<li>Declarations from <a at-rule lt="@import">imported style sheets</a>
 					are ordered as if their style sheets were substituted in place of the ''@import'' rule.
 				<li>Declarations from style sheets independently linked by the originating document

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1035,6 +1035,7 @@ Cascade Sorting Order</h3>
 			For this purpose:
 
 			<ul>
+				<li>Style sheets are ordered as in <a href="https://www.w3.org/TR/cssom-1/#documentorshadowroot-final-css-style-sheets">final CSS style sheets</a>.
 				<li>Declarations from <a at-rule lt="@import">imported style sheets</a>
 					are ordered as if their style sheets were substituted in place of the ''@import'' rule.
 				<li>Declarations from style sheets independently linked by the originating document

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1288,10 +1288,9 @@ partial interface mixin DocumentOrShadowRoot {
 The <dfn attribute for=DocumentOrShadowRoot>styleSheets</dfn> attribute must return a {{StyleSheetList}} collection representing
 the <a>document or shadow root CSS style sheets</a>.
 
-BROKEN: The [=observable array attribute/set an indexed value=] algorithm
-
-The <a href="https://heycam.github.io/webidl/#observable-array-attribute-set-an-indexed-value">set an indexed value</a> algorithm
-for <dfn attribute for="DocumentOrShadowRoot"><code>adoptedStyleSheets</code></dfn>, given <var>value</var> and <var>index</var>, is the following:
+The [=observable array attribute/set an indexed value=] algorithm for
+<dfn attribute for="DocumentOrShadowRoot"><code>adoptedStyleSheets</code></dfn>, given <var>value</var> and <var>index</var>,
+is the following:
 <ol>
   <li>If <var>value</var>'s <a>constructed flag</a> is not set, or its <a>constructor document</a> is not equal to this
   {{DocumentOrShadowRoot}}'s <a>node document</a>, throw a "{{NotAllowedError}}" {{DOMException}}.</li>

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1092,9 +1092,8 @@ an ordered list that contains:
 <ol>
   <li>Any <a>CSS style sheets</a> created from HTTP <code>Link</code> headers, in header order</li>
   <li>Any <a>CSS style sheets</a> associated with the {{DocumentOrShadowRoot}}, in <a>tree order</a></li>
-  <li>The contents of {{DocumentOrShadowRoot}}'s <a href="#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a>'
-  <a href="https://heycam.github.io/webidl/#observable-array-attribute-backing-list">backing list</a>,
-  in array order.</li>
+  <li>The contents of {{DocumentOrShadowRoot}}'s {{DocumentOrShadowRoot/adoptedStyleSheets}}'
+  [=observable array attribute/backing list=], in array order.</li>
 </ol>
 
 To <dfn export>create a CSS style sheet</dfn>, run these steps:
@@ -1288,6 +1287,8 @@ partial interface mixin DocumentOrShadowRoot {
 
 The <dfn attribute for=DocumentOrShadowRoot>styleSheets</dfn> attribute must return a {{StyleSheetList}} collection representing
 the <a>document or shadow root CSS style sheets</a>.
+
+BROKEN: The [=observable array attribute/set an indexed value=] algorithm
 
 The <a href="https://heycam.github.io/webidl/#observable-array-attribute-set-an-indexed-value">set an indexed value</a> algorithm
 for <dfn attribute for="DocumentOrShadowRoot"><code>adoptedStyleSheets</code></dfn>, given <var>value</var> and <var>index</var>, is the following:

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1078,19 +1078,26 @@ CSS Style Sheet Collections {#css-style-sheet-collections}
 Below various new concepts are defined that are associated with each
 {{DocumentOrShadowRoot}} object.
 
-Each {{DocumentOrShadowRoot}} has an associated list of zero or more
-<a>CSS style sheets</a>, named the
+Each {{DocumentOrShadowRoot}} has an associated list of zero or more <a>CSS style sheets</a>, named the
 <dfn export for=DocumentOrShadowRoot>document or shadow root CSS style sheets</dfn>. This is
-an ordered list that contains all
-<a>CSS style sheets</a> associated with the
-{{DocumentOrShadowRoot}}, in
-<a>tree order</a>, with
-<a>CSS style sheets</a> created from HTTP
-<code>Link</code> headers first, if any, in header
-order.
+an ordered list that contains:
+<ol>
+  <li>Any <a>CSS style sheets</a> created from HTTP <code>Link</code> headers, in header order</li>
+  <li>Any <a>CSS style sheets</a> associated with the {{DocumentOrShadowRoot}}, in <a>tree order</a></li>
+</ol>
 
-To <dfn export>create a CSS style sheet</dfn>, run these
-steps:
+Each {{DocumentOrShadowRoot}} has an associated list of zero or more <a>CSS style sheets</a>, named the
+<dfn export for=DocumentOrShadowRoot>final CSS style sheets</dfn>. This is
+an ordered list that contains:
+<ol>
+  <li>Any <a>CSS style sheets</a> created from HTTP <code>Link</code> headers, in header order</li>
+  <li>Any <a>CSS style sheets</a> associated with the {{DocumentOrShadowRoot}}, in <a>tree order</a></li>
+  <li>The contents of {{DocumentOrShadowRoot}}'s <a href="#dom-documentorshadowroot-adoptedstylesheets">adoptedStyleSheets</a>'
+  <a href="https://heycam.github.io/webidl/#observable-array-attribute-backing-list">backing list</a>,
+  in array order.</li>
+</ol>
+
+To <dfn export>create a CSS style sheet</dfn>, run these steps:
 
 <ol>
  <li>Create a new <a>CSS style sheet</a> object and set its
@@ -1275,11 +1282,19 @@ represented by the collection.
 <pre class=idl>
 partial interface mixin DocumentOrShadowRoot {
   [SameObject] readonly attribute StyleSheetList styleSheets;
+  attribute ObservableArray&lt;CSSStyleSheet> adoptedStyleSheets;
 };
 </pre>
 
 The <dfn attribute for=DocumentOrShadowRoot>styleSheets</dfn> attribute must return a {{StyleSheetList}} collection representing
 the <a>document or shadow root CSS style sheets</a>.
+
+The <a href="https://heycam.github.io/webidl/#observable-array-attribute-set-an-indexed-value">set an indexed value</a> algorithm
+for <dfn attribute for="DocumentOrShadowRoot"><code>adoptedStyleSheets</code></dfn>, given <var>value</var> and <var>index</var>, is the following:
+<ol>
+  <li>If <var>value</var>'s <a>constructed flag</a> is not set, or its <a>constructor document</a> is not equal to this
+  {{DocumentOrShadowRoot}}'s <a>node document</a>, throw a "{{NotAllowedError}}" {{DOMException}}.</li>
+</ol>
 
 Style Sheet Association {#style-sheet-association}
 --------------------------------------------------

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1090,8 +1090,7 @@ Each {{DocumentOrShadowRoot}} has an associated list of zero or more <a>CSS styl
 <dfn export for=DocumentOrShadowRoot>final CSS style sheets</dfn>. This is
 an ordered list that contains:
 <ol>
-  <li>Any <a>CSS style sheets</a> created from HTTP <code>Link</code> headers, in header order</li>
-  <li>Any <a>CSS style sheets</a> associated with the {{DocumentOrShadowRoot}}, in <a>tree order</a></li>
+  <li>The <a>document or shadow root CSS style sheets</a>.</li>
   <li>The contents of {{DocumentOrShadowRoot}}'s {{DocumentOrShadowRoot/adoptedStyleSheets}}'
   [=observable array attribute/backing list=], in array order.</li>
 </ol>


### PR DESCRIPTION
[cssom-1, css-cascade-5] Add adoptedStyleSheets using [ObservableArray](https://heycam.github.io/webidl/#idl-observable-array).

Some things I need input on:
 1. See [this discussion](https://github.com/WICG/construct-stylesheets/issues/118). I added a single list item to the Cascade-5 text to reference the new "final CSS style sheets" concept I added in CSSOM-1. We might (?) want to instead change the `styleSheets` property to explicitly exclude the contents of adoptedStyleSheets, and fold "final CSS style sheets" back into "document or shadow root CSS style sheets".
 2.  I can't seem to get the "link magic" working between cssom-1 and css-cascade-5. I tried various permutations of `<a for=foobar>concept name</a>` but nothing seemed to please bikeshed. So I resorted to `<a href=>`. Help appreciated.

Credit to @domenic for a [draft of this PR](https://github.com/WICG/construct-stylesheets/pull/117).

@emilio

Closes https://github.com/WICG/construct-stylesheets/issues/118, Closes https://github.com/WICG/construct-stylesheets/issues/93