### PR TITLE
[css-values-3, css-values-4] Updated the equivalence for points in the absolute-lengths table #6409.

### DIFF
--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -1283,7 +1283,7 @@ Absolute Lengths: the ''cm'', ''mm'', ''Q'', ''in'', ''pt'', ''pc'', ''px'' unit
 		    <td>1pc = 1/6th of 1in
 		<tr><th><dfn id="pt">pt</dfn>
 		    <td>points
-		    <td>1pt = 1/72th of 1in
+		    <td>1pt = 1/72nd of 1in
 		<tr><th><dfn id="px" lt="px">px</dfn>
 		    <td>pixels
 		    <td>1px = 1/96th of 1in

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2021,7 +2021,7 @@ Absolute Lengths: the ''cm'', ''mm'', ''Q'', ''in'', ''pt'', ''pc'', ''px'' unit
 		    <td>1pc = 1/6th of 1in
 		<tr><th><dfn id="pt">pt</dfn>
 		    <td>points
-		    <td>1pt = 1/72th of 1in
+		    <td>1pt = 1/72nd of 1in
 		<tr><th><dfn id="px" lt="px">px</dfn>
 		    <td>pixels
 		    <td>1px = 1/96th of 1in


### PR DESCRIPTION
Small typo update to the absolute lengths table where I changed the equivalence in terms of inches given for points. 
Before it was 1pt = 1/72th of 1in, and I believe it should be 1pt=1/72nd of 1in. That section of the page can be found [here for css-values-3](https://www.w3.org/TR/css-values-3/#pt) and [here for css-values-4](https://www.w3.org/TR/css-values-4/#pt) page.

