### PR TITLE
[mediaqueries-4] Former footnote is updated removing speech as it is a deprecated media type #6029.

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -2240,7 +2240,7 @@ The following changes were made to this specification since the
 		(They'll trigger a syntax error instead.)
 
 	<li>
-		All media types except for ''screen'', ''print'', ''speech'', and ''all'' are deprecated.
+		All media types except for ''screen'', ''print'', and ''all'' are deprecated.
 
 	<li>
 		Deprecated 'device-width', 'device-height', 'device-aspect-ratio',


### PR DESCRIPTION
This footnote under the "Changes Since Media Queries Level 3"  which can be found [here](https://www.w3.org/TR/mediaqueries-4/#ref-for-valdef-media-speech%E2%91%A2) still mentions speech as a remaining media type, but in the current level 4 TR it's deprecated, as mentioned [here](https://www.w3.org/TR/mediaqueries-4/#ref-for-valdef-media-speech%E2%91%A1). So I believe the former footnote should be changed by removing "speech" to avoid any further confusion.