### PR TITLE
Removed mentioning of orphans and widows

### DIFF
--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -84,9 +84,8 @@ Introduction</h2>
 		<li><a href="#page-breaks">page breaks</a> are created and avoided;
 		<li>the page properties such as size, orientation, margins, border, and
 		padding are specified;
-		<li>headers and footers are established within the page margins;
-		<li>content such as page counters are placed in the headers and footers; and
-		<li>orphans and widows can be controlled.
+		<li>headers and footers are established within the page margins; and
+		<li>content such as page counters are placed in the headers and footers;
 	</ul>
 
 	This module defines a <a href="#page-model">page model</a> that specifies how a


### PR DESCRIPTION
The `orphans` and `widows` properties were moved to CSS Fragmentation 3. Therefore they got removed.

Fixes #1573