### PR TITLE
[scroll-animations-1] Add predefined `@scroll-timeline` to spec

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1222,12 +1222,12 @@ state of a scroll-driven animation may be inconsistent in the composited frame.
 <h2 id="predefined-scroll-timelines">
 Predefined Scroll Timelines</h2>
 
-  The following stylesheet fragments provide the normative definition 
-  for predefined scroll timelines that can be used by authors:
+The following stylesheet fragments provide the normative definition 
+for predefined scroll timelines that can be used by authors:
 
-  <pre class='stylesheet'><bdo dir=ltr>
-    @scroll-timeline document-timeline {}
-  </bdo></pre>
+<pre class='stylesheet'><bdo dir=ltr>
+@scroll-timeline document-scroll-timeline {}
+</bdo></pre>
 
 <h2 id="appendix-a-considerations-for-security-and-privacy">Appendix A. Considerations for Security and Privacy</h2>
 

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1219,6 +1219,15 @@ run), the user agent may likewise choose not to sample scroll-driven animations
 for that composited frame. In such cases, the rendered scroll offset and the
 state of a scroll-driven animation may be inconsistent in the composited frame.
 
+<h2 id="predefined-scroll-timelines">
+Predefined Scroll Timelines</h2>
+
+  The following stylesheet fragments provide the normative definition 
+  for predefined scroll timelines that can be used by authors:
+
+  <pre class='stylesheet'><bdo dir=ltr>
+    @scroll-timeline document-timeline {}
+  </bdo></pre>
 
 <h2 id="appendix-a-considerations-for-security-and-privacy">Appendix A. Considerations for Security and Privacy</h2>
 


### PR DESCRIPTION
just like how `css-counter-styles` ships with [predefined sets](https://drafts.csswg.org/css-counter-styles/#predefined-counters) for authors, I think `scroll-animations` could/should as well. This PR starts the conversation by including a very generic and super common scroll-timeline for authors to use `document-timeline`, so they don't have to create it themselves:

```css
@scroll-timeline document-scroll-timeline {}
```

This gives a common name to a (arguably the most common) timeline that authors will make. 
