### PR TITLE
[web-animations-2] Preserve animation progress when setting the timeline

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -213,9 +213,22 @@ follows:
     abort this procedure.
 1.  Let |previous play state| be |animation|'s [=play state=].
 1.  Let |previous current time| be the |animation|'s [=current time=].
-1.  Let |previous progress| = <code>|previous current time| /
-    [=end time=]</code> if |previous current time| is resolved and
-    unresolved otherwise.
+1.  Set |previous progress| based in the first condition that applies:
+    <div class="switch">
+
+    : If |previous current time| is unresolved:
+
+    :: Set |previous progress| to unresolved.
+
+    : If [=end time=] is zero:
+
+    :: Set |previous progress| to zero.
+
+    : Otherwise
+
+    :: Set |previous progress| = <code>|previous current time| /
+    [=end time=]</code>
+    </div>
 1.  Let |from finite timeline| be true if |old timeline| is not null and
     not [=monotonically increasing=].
 1.  Let |to finite timeline| be true if |timeline| is not null and not

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -213,6 +213,9 @@ follows:
     abort this procedure.
 1.  Let |previous play state| be |animation|'s [=play state=].
 1.  Let |previous current time| be the |animation|'s [=current time=].
+1.  Let |previous progress| = <code>|previous current time| /
+    [=end time=]</code> if |previous current time| is resolved and
+    unresolved otherwise.
 1.  Let |from finite timeline| be true if |old timeline| is not null and
     not [=monotonically increasing=].
 1.  Let |to finite timeline| be true if |timeline| is not null and not
@@ -241,14 +244,14 @@ follows:
 
             :   If |previous play state| is 'paused':
 
-            :: If |previous current time| is resolved:
+            :: If |previous progress| is resolved:
 
                 1.  Set the flag |reset current time on resume| to true.
                 1.  Set [=start time=] to unresolved.
-                1.  Set [=hold time=] to |previous current time|.
+                1.  Set [=hold time=] to |previous progress| * [=end time=].
 
                 <p class="note">
-                This step ensures that the [=current time=] is preserved
+                This step ensures that |previous progress| is preserved
                 even in the case of a pause-pending animation with a resolved [=start time=].
                 <p>
 
@@ -258,10 +261,10 @@ follows:
 
             </div>
 
-    :   If |from finite timeline| and |previous current time| is resolved,
+    :   If |from finite timeline| and |previous progress| is resolved,
 
     ::  Run the procedure to <a>set the current time</a> to
-        |previous current time|.
+        |previous progress| * [=end time=].
 
     </div>
 


### PR DESCRIPTION
[web-animations-2] Preserve animation progress when setting the timeline

When switching to a non-monotonic timeline on a paused animation, we set the hold time to the previous current time to prevent the animation from visually jumping until the animation is unpaused.

Similarly, when transition from a non-monotonic timeline to a monotonic timeline, we preserved current time to ensure smooth continuity in the animation.

This process worked well, when dealing exclusively with time-based timeline, but is not compatible with progress-based timelines. We address this by preserving previous progress in places where we previously preserved current time.  The change is compatible with time-based animations as the measured progress (current time / end time) is consistent for a time or progress based animation.

Issue #6452 
