### PR TITLE
[web-animation-2] Making currentTime and startTime CSSNumerish

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -323,6 +323,33 @@ descendant effects and custom effects such that the first condition is:
 >     effect</a> or executing any <a>custom effects</a> associated with an
 >     <a>animation effect</a>.
 
+<h4 id='validating-a-css-numberish-time'>Validatring a CSSNumberish time</h4>
+
+The procedure to <dfn>validate a CSSNumberish time</dfn> for an input
+value of <var>time</var> is based on the first condition that matches:
+
+    <div class="switch">
+
+    :    If <em>all</em> of the following conditions are true:
+         * The animation is associated with a [=progress-based timeline=], and
+         * <var>time</var> is not a CSSNumeric value with percent units:
+
+    ::    <a>throw</a> a <span class="exceptionname">TypeError</span>.
+    ::    return false;
+
+    :    If <em>all</em> of the following conditions are true:
+         * The animation is not associated with a [=progress-based timeline=],
+           amd
+         * <var>time</var> is a CSSNumericValue:
+         * The units of time are not <a href="https://www.w3.org/TR/css3-values/#time">duration units</a>.
+
+    ::   <a>throw</a> a <span class="exceptionname">TypeError</span>.
+    ::   return false.
+
+    :    Oterwise
+    ::   return true.
+   </div>
+
 
 <h4 id='setting-the-current-time-of-an-animation'>Setting the current time of an
 Animation</h4>
@@ -341,6 +368,12 @@ an animation, <var>animation</var>, to <var>seek time</var> is as follows:
          <a>throw</a> a <span class=exceptionname>TypeError</span>.
 
     1.   Abort these steps.
+
+1.  Let <var>valid seek time</var> be the result of running the
+    [=validate a CSSNumberish time=] procedure with <var>seek time</var>
+    as the input.
+
+1.  If valid seek time is false, abort this procedure.
 
 1.  Update either <var>animation</var>'s <a>hold time</a> or
     [=start time=] as follows:
@@ -407,6 +440,12 @@ Animation</h4>
 The procedure to <dfn>set the start time</dfn>
 of <a>animation</a>, <var>animation</var>, to <var>new start time</var>,
 is as follows:
+
+1.  Let <var>valid start time</var> be the result of running the
+    [=validate a CSSNumberish time=] procedure with
+    <var>new start time</var> as the input.
+
+1.  If valid start time is false, abort this procedure.
 
 1.  Let <var>timeline time</var> be the current <a>time value</a> of the
     <a>timeline</a> that <var>animation</var> is associated with.
@@ -2004,6 +2043,34 @@ partial interface AnimationTimeline {
 
     </div>
 
+</div>
+
+<h3 id="the-animation-interface">The <code>Animation</code> interface</h3>
+<pre class="idl">
+[Exposed=Window]
+partial interface Animation : EventTarget {
+    attribute CSSNumberish?       startTime;
+    attribute CSSNumberish?       currentTime;
+};
+</pre>
+
+<div class='attributes'>
+:   <dfn attribute for=Animation>startTime</dfn>
+::  The [=start time=] of this animation. When associated with a
+    [=progress-based timeline=], [=start time=] must be returned as a
+    <a href="https://drafts.css-houdini.org/css-typed-om/#cssnumericvalue">
+    CSSNumericValue</a> with percent units. Otherwise [=start time=] must be
+    returned as a double value, representing the time in units of milliseconds.
+    Setting this attribute updates the [=start time=] using the procedure to
+    <a>set the start time</a> of this object to the new value.
+:   <dfn attribute for=Animation>currentTime</dfn>
+::  The <a>current time</a> of this animation. When associated with a
+    [=progress-based timeline=], <a>current time</a> must be returned as a
+    <a href="https://drafts.css-houdini.org/css-typed-om/#cssnumericvalue">
+    CSSNumericValue</a> with percent units. Otherwise <a>current time</a> must
+    be returned as a double value, representing the time in units of milliseconds.
+    Setting this attribute follows the procedure to <a>set the current time</a>
+    of this object to the new value.
 </div>
 
 <h3 id="the-animationeffect-interface">The <code>AnimationEffect</code> interface</h3>


### PR DESCRIPTION
[web-animation-2] Making currentTime and startTime CSSNumerish

The animation attributes currentTime and startTime were nullable doubles and represented times in units of milliseconds.  These units do not align well with progress based animations where it is more natural to work in percentages.

With this change, progress based animations expect and report times as percentages.  When setting current or start time, the value may be expressed as a double with implicit units of milliseconds, or as a CSSNumericValue with duration units ('s' or 'ms') when the animation is associated with a non-monotonic timeline. 

issue #6458