### PR TITLE
[cssom] editorial: Remove reference to non-existing flag.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1503,8 +1503,9 @@ A style sheet referenced by an <a>xml-stylesheet processing instruction</a> usin
 the {{Document}} of an <a>XML parser</a> is said to be
 <a>a style sheet that is blocking scripts</a> if the <code>ProcessingInstruction</code>
 <a>node</a> was created by that {{Document}}'s parser, and the style sheet was
-enabled when the node was created by the parser, and the <a>style sheet ready</a> flag is not yet set, and, the last time the
-<a>event loop</a> reached step 1, the node was in that Document, and the user agent hasn't given up on that particular style sheet
+enabled when the node was created by the parser, the last time the
+<a>event loop</a> reached step 1, the node was in that Document,
+and the user agent hasn't given up on loading that particular style sheet
 yet. A user agent may give up on such a style sheet at any time.
 
 ### Requirements on user agents Implementing the HTTP Link Header ### {#requirements-on-user-agents-implementing-the-http-link-header}


### PR DESCRIPTION
The fact that we haven't given-up loading the style sheet is enough,
there's no need for a specific flag. This is what...

  https://html.spec.whatwg.org/#contributes-a-script-blocking-style-sheet

... does as well.

Part of #6463