### PR TITLE
[css-cascade-5] Fix cross-link to CSSOM-1 for "final CSS style sheets" concept

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1035,7 +1035,7 @@ Cascade Sorting Order</h3>
 			For this purpose:
 
 			<ul>
-				<li>Style sheets are ordered as in {insert link to the "final CSS style sheets" concept from CSSOM-1}
+				<li>Style sheets are ordered as in [=final CSS style sheets=]}
         
         None of these link styles seem to properly link over to CSSOM:
         TRY 1: {{DocumentOrShadowRoot/final css style sheets}}

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1035,7 +1035,14 @@ Cascade Sorting Order</h3>
 			For this purpose:
 
 			<ul>
-				<li>Style sheets are ordered as in <a href="https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets">final CSS style sheets</a>.
+				<li>Style sheets are ordered as in {insert link to the "final CSS style sheets" concept from CSSOM-1}
+        
+        None of these link styles seem to properly link over to CSSOM:
+        TRY 1: {{DocumentOrShadowRoot/final css style sheets}}
+        TRY 2: [=documentorshadowroot/final css style sheets=]
+        TRY 3: <<final-css-style-sheets>>
+        EXPECTED FINAL LINK: <a href="https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets">final CSS style sheets</a>
+
 				<li>Declarations from <a at-rule lt="@import">imported style sheets</a>
 					are ordered as if their style sheets were substituted in place of the ''@import'' rule.
 				<li>Declarations from style sheets independently linked by the originating document


### PR DESCRIPTION
[css-cascade-5] Fix cross-link to CSSOM-1 for "final CSS style sheets" concept

This PR attempts to convert an `<a href` link into a bikeshed link.