### PR TITLE
[css-highlight-api-1] Don't paint ranges positioned in a different window #6417

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -489,10 +489,10 @@ Range Updating and Invalidation</h3>
 		and recreating new ones.
 	</div>
 
-	When computing how to render the document,
+	When computing how to render a document,
 	if [=start node=] or [=end node=] of any [=range=]
-	in the [=highlight regsitry=]
-	refer to a {{Node}} which is no longer [=in a document tree=],
+	in the [=highlight registry=] associated with that document's window
+	refer to a {{Node}} whose [=shadow-including root=] is not that document,
 	the user agent must ignore that [=range=].
 	If the [=start offset=] or [=end offset=] of any [=range=]
 	are greater than the corresponding node’s <a spec=dom>length</a>,


### PR DESCRIPTION
Specify that when painting a document, the associated `HighlightRegistry`'s ranges that are positioned in a different document are not painted.

Also, fix a bug: the "no longer [in a document tree](https://dom.spec.whatwg.org/#in-a-document-tree)" check excluded ranges positioned inside a shadow tree, which is probably not what we want. Using the [shadow-including root](https://dom.spec.whatwg.org/#concept-shadow-including-root) instead fixes this.

Closes #6417.