### PR TITLE
[scroll-animations-1] Fix indentation and spacing for bikeshed.

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -405,6 +405,7 @@ The {{AnimationTimeline/Duration}} of a <a>scroll timeline</a> is 100%.
     1.  Assign the {{ScrollTimeline/orientation}} and
         {{ScrollTimeline/scrollOffsets}} properties of
         |timeline| to the corresponding value from |options|.
+
 </div>
 
 <div class="attributes">
@@ -1054,7 +1055,7 @@ interface CSSScrollTimelineRule : CSSRule {
             followed by a SEMICOLON (U+003B),
             followed by a SPACE (U+0020).
     1. If the 'scrollOffsets' descriptor is missing, the empty string.
-       Otherwise, the concatenation of the following:
+        Otherwise, the concatenation of the following:
         1. The string <code>"scrollOffsets:"</code>,
             followed by a SPACE (U+0020),
             followed by a LEFT SQUARE BRACKET (U+005B).


### PR DESCRIPTION
[scroll-animations-1] Fix a couple indentation bikeshed errors in spec.

The errors were as follows:
FATAL ERROR: Line 408 isn't indented enough (needs 1 indent) to be valid Markdown:
"</div>"
FATAL ERROR: Line 1058 isn't indented enough (needs 2 indents) to be valid Markdown:
"       Otherwise, the concatenation of the following:"