### PR TITLE
[css-easing-1] Some ideas for linear() easing

### DIFF
--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -127,12 +127,18 @@ The syntax for specifying an [=easing function=] is as follows:
 
 <h3 id=the-linear-easing-function oldids=linear-timing-function-section>The linear easing function: ''linear()''</h3>
 
-A <dfn export lt="linear easing function|linear timing function">linear easing
-function</dfn> is an easing function that interpolates linearly between its [=linear easing function/points=].
+A <dfn export lt="linear easing function|linear timing function">linear easing function</dfn>
+is an easing function
+that interpolates linearly
+between its [=linear easing function/points=].
 
-A [=linear easing function=] has <dfn for="linear easing function">points</dfn>, a [=/list=] of [=linear easing points=]. Initially a new empty [=/list=].
+A [=linear easing function=] has <dfn for="linear easing function">points</dfn>,
+a [=/list=] of [=linear easing points=].
+Initially a new empty [=/list=].
 
-A <dfn>linear easing point</dfn> is a [=/struct=] that has:
+A <dfn>linear easing point</dfn>
+is a [=/struct=]
+that has:
 
 <dl dfn-for="linear easing point">
 
@@ -145,17 +151,26 @@ A <dfn>linear easing point</dfn> is a [=/struct=] that has:
 
 <section algorithm="to calculate linear output progress">
 
-To <dfn export>calculate linear output progress</dfn> for a given [=linear easing function=] |linearEasingFunction|, and an [=input progress value=] |inputProgress|, perform the following. It returns an [=output progress value=].
+To <dfn export>calculate linear output progress</dfn>
+for a given [=linear easing function=] |linearEasingFunction|,
+and an [=input progress value=] |inputProgress|,
+perform the following.
+It returns an [=output progress value=].
 
-1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/is empty=], then return |inputProgress|.
+1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/is empty=],
+     then return |inputProgress|.
 
-1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/size=] is 1, then return |linearEasingFunction|'s [=linear easing function/points=][0]'s [=linear easing point/output=].
+1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/size=] is 1,
+     then return |linearEasingFunction|'s [=linear easing function/points=][0]'s [=linear easing point/output=].
 
-1.   Plot |linearEasingFunction|'s [=linear easing function/points=] points on a graph using [=linear easing point/input=] as the x-axis and [=linear easing point/output=] as the y-axis.
+1.   Plot |linearEasingFunction|'s [=linear easing function/points=] points on a graph
+     using [=linear easing point/input=] as the x-axis
+     and [=linear easing point/output=] as the y-axis.
 
 1.   Interpolate the points linearly.
 
-1.   Extend the ends of the graph to infinity using the final angle of the line at either end. If the line starts/ends with two points of the same position, the line should extend along the x-axis.
+1.   Extend the ends of the graph to infinity using the final angle of the line at either end.
+     If the line starts/ends with two points of the same position, the line should extend along the x-axis.
 
 1.   Return the y-axis value corresponding to the x-axis value of |inputProgress|.
 
@@ -166,8 +181,8 @@ To <dfn export>calculate linear output progress</dfn> for a given [=linear easin
 <pre class="prod">
   <dfn>&lt;linear-stop-list></dfn> =
     [ <<linear-hint>>? , <<linear-stop>> ]#
-  <dfn>&lt;linear-stop></dfn> = <<number>> && <<length-percentage>>?
-  <dfn>&lt;linear-hint></dfn> = <<length-percentage>>
+  <dfn>&lt;linear-stop></dfn> = <<number>> && <<percentage>>?
+  <dfn>&lt;linear-hint></dfn> = <<percentage>>
 </pre>
 
 TODO: I want to support syntax like <code>linear(0 0% 0%, 1 100% 100%)</code>, but I can't figure out how it's done. <code>linear-gradient</code> seems to support that syntax but <a href="https://drafts.csswg.org/css-images-3/#typedef-color-stop-list">I can't see it in the grammar</a>.

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -143,11 +143,13 @@ that has:
 <dl dfn-for="linear easing point">
 
 : <dfn>input</dfn>
-:: A number
-: <dfn>output</dfn>
 :: A number or null
 
-      Note: The [=linear easing point/output=] is only null during the [=create a linear easing function=] algorithm.
+      Note: The [=linear easing point/input=] is only null during the [=create a linear easing function=] algorithm.
+
+: <dfn>output</dfn>
+:: A number
+
 
 </dl>
 

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -145,7 +145,9 @@ that has:
 : <dfn>input</dfn>
 :: A number
 : <dfn>output</dfn>
-:: A number
+:: A number or null
+
+      Note: The [=linear easing point/output=] is only null during the [=create a linear easing function=] algorithm.
 
 </dl>
 
@@ -179,13 +181,64 @@ It returns an [=output progress value=].
 <dfn function lt="linear()">linear(<<linear-stop-list>>)</dfn>
 
 <pre class="prod">
-  <dfn>&lt;linear-stop-list></dfn> =
-    [ <<linear-hint>>? , <<linear-stop>> ]#
-  <dfn>&lt;linear-stop></dfn> = <<number>> && <<percentage>>?
-  <dfn>&lt;linear-hint></dfn> = <<percentage>>
+  <dfn>&lt;linear-stop-list></dfn> = [ <<linear-stop>> ]#
+  <dfn>&lt;linear-stop></dfn> = <<number>> && <<linear-stop-length>>?
+  <dfn>&lt;linear-stop-length></dfn> = <<percentage>>{1,2}
 </pre>
 
-TODO: I want to support syntax like <code>linear(0 0% 0%, 1 100% 100%)</code>, but I can't figure out how it's done. <code>linear-gradient</code> seems to support that syntax but <a href="https://drafts.csswg.org/css-images-3/#typedef-color-stop-list">I can't see it in the grammar</a>.
+<section algorithm="to create a linear easing function">
+
+To <dfn>create a linear easing function</dfn>
+from a <<linear-stop-list>> |stopList|,
+perform the following.
+It returns a [=linear easing function=].
+
+1.   Let |function| be a new [=linear easing function=].
+
+1.   Let |largestInput| be negative infinity.
+
+1.   For each |stop| in |stopList|:
+
+     1.   Let |point| be a new [=linear easing point=].
+
+     1.   [=list/Append=] |point| to |function|'s [=linear easing function/points=].
+
+     1.   Set |point|'s [=linear easing point/output=] to |stop|'s <<number>>.
+
+     1.   If |stop| has a <<linear-stop-length>>, then:
+
+          1.   Set |point|'s [=linear easing point/input=] to whichever is greater:
+               |stop|'s <<linear-stop-length>>'s first <<percentage>> as a number,
+               or |largestInput|.
+
+          1.   Set |largestInput| to |point|'s [=linear easing point/input=].
+
+          1.   If |stop|'s <<linear-stop-length>> has a second <<percentage>>, then:
+
+               1.   Let |extraPoint| be a new [=linear easing point=].
+
+               1.   [=list/Append=] |extraPoint| to |function|'s [=linear easing function/points=].
+
+               1.   Set |extraPoint|'s [=linear easing point/output=] to |stop|'s <<number>>.
+
+               1.   Set |extraPoint|'s [=linear easing point/input=] to whichever is greater:
+                    |stop|'s <<linear-stop-length>>'s second <<percentage>> as a number,
+                    or |largestInput|.
+
+               1.   Set |largestInput| to |extraPoint|'s [=linear easing point/input=].
+
+     1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|,
+          then set |point|'s [=linear easing point/input=] to 0.
+
+     1.   Otherwise, if |stop| is the last [=list/item=] in |stopList|,
+          then set |point|'s [=linear easing point/input=] to 1.
+
+1.   For runs of [=list/items=] in |function|'s [=linear easing function/points=] that have a null [=linear easing point/input=],
+     assign a number to the [=linear easing point/input=] by linearly interpolating between the previous and next [=linear easing function/points=] that have a non-null [=linear easing point/input=].
+
+1.   Return |function|.
+
+</section>
 
 <h3 id="the-linear-easing-keyword">The linear easing keyword: ''linear''</h3>
 

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -125,16 +125,62 @@ The syntax for specifying an [=easing function=] is as follows:
   <<step-easing-function>></div>
 
 
-<h3 id=the-linear-easing-function oldids=linear-timing-function-section>The linear easing function: ''linear''</h3>
+<h3 id=the-linear-easing-function oldids=linear-timing-function-section>The linear easing function: ''linear()''</h3>
 
-The <dfn export lt="linear easing function|linear timing function">linear easing
-function</dfn> is an identity function
-meaning that its [=output progress value=] is equal to the
-[=input progress value=] for all inputs.
+A <dfn export lt="linear easing function|linear timing function">linear easing
+function</dfn> is an easing function that interpolates linearly between its [=linear easing function/points=].
 
-The syntax for the [=linear easing function=] is simply the
-<dfn dfn-type=value for=easing-function>linear</dfn> keyword.
+A [=linear easing function=] has <dfn for="linear easing function">points</dfn>, a [=/list=] of [=linear easing points=]. Initially a new empty [=/list=].
 
+A <dfn>linear easing point</dfn> is a [=/struct=] that has:
+
+<dl dfn-for="linear easing point">
+
+: <dfn>position</dfn>
+:: A number
+: <dfn>value</dfn>
+:: A number
+
+</dl>
+
+<section algorithm="to calculate linear output progress">
+
+To <dfn>calculate linear output progress</dfn> for a given [=linear easing function=] |linearEasingFunction|, and an [=input progress value=] |inputProgress|, perform the following steps. They return an [=output progress value=].
+
+1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/is empty=], the return |inputProgress|.
+
+     Note: This is a special case that creates a pure identity function.
+
+1.   Let |previousPoint| be null.
+
+1.   Let |nextPoint| be null.
+
+1.   [=list/For each=] |point| of |linearEasingFunction|'s [=linear easing function/points=]:
+
+     1.   If |point|'s [=linear easing point/position=] is less than or equal to |inputProgress|, set |previousPoint| to |point|.
+
+     1.   Otherwise, set |nextPoint| to |point| and [=break=].
+
+1.   If |previousPoint| is null, then return |nextPoint|'s [=linear easing point/value=].
+
+1.   If |nextPoint| is null, then return |previousPoint|'s [=linear easing point/value=].
+
+1.   Let |progressBetweenPoints| be (|inputProgress| - |previousPoint|'s [=linear easing point/position=]) / (|nextPoint|'s [=linear easing point/position=] - |previousPoint|'s [=linear easing point/position=]).
+
+1.   Return |previousPoint|'s [=linear easing point/value=] + |progressBetweenPoints| * (|nextPoint|'s [=linear easing point/value=] - |previousPoint|'s [=linear easing point/value=]).
+
+</section>
+
+<dfn function lt="linear()">linear(<<linear-stop-list>>)</dfn>
+
+<pre class="prod">
+  <dfn>&lt;linear-stop-list></dfn> = [ <<linear-stop>> ]#
+  <dfn>&lt;linear-stop></dfn> = <<number>> && <<number>>?
+</pre>
+
+<h3 id="the-linear-easing-keyword">The linear easing keyword: ''linear''</h3>
+
+The <dfn dfn-type=value for=easing-function>linear</dfn> keyword is equivalent to ''linear()''.
 
 <h3 id=cubic-bezier-easing-functions oldids=cubic-bezier-timing-functions>Cubic
 B&eacute;zier easing functions:

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -136,47 +136,41 @@ A <dfn>linear easing point</dfn> is a [=/struct=] that has:
 
 <dl dfn-for="linear easing point">
 
-: <dfn>position</dfn>
+: <dfn>input</dfn>
 :: A number
-: <dfn>value</dfn>
+: <dfn>output</dfn>
 :: A number
 
 </dl>
 
 <section algorithm="to calculate linear output progress">
 
-To <dfn>calculate linear output progress</dfn> for a given [=linear easing function=] |linearEasingFunction|, and an [=input progress value=] |inputProgress|, perform the following steps. They return an [=output progress value=].
+To <dfn export>calculate linear output progress</dfn> for a given [=linear easing function=] |linearEasingFunction|, and an [=input progress value=] |inputProgress|, perform the following. It returns an [=output progress value=].
 
-1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/is empty=], the return |inputProgress|.
+1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/is empty=], then return |inputProgress|.
 
-     Note: This is a special case that creates a pure identity function.
+1.   If |linearEasingFunction|'s [=linear easing function/points=] [=list/size=] is 1, then return |linearEasingFunction|'s [=linear easing function/points=][0]'s [=linear easing point/output=].
 
-1.   Let |previousPoint| be null.
+1.   Plot |linearEasingFunction|'s [=linear easing function/points=] points on a graph using [=linear easing point/input=] as the x-axis and [=linear easing point/output=] as the y-axis.
 
-1.   Let |nextPoint| be null.
+1.   Interpolate the points linearly.
 
-1.   [=list/For each=] |point| of |linearEasingFunction|'s [=linear easing function/points=]:
+1.   Extend the ends of the graph to infinity using the final angle of the line at either end. If the line starts/ends with two points of the same position, the line should extend along the x-axis.
 
-     1.   If |point|'s [=linear easing point/position=] is less than or equal to |inputProgress|, set |previousPoint| to |point|.
-
-     1.   Otherwise, set |nextPoint| to |point| and [=break=].
-
-1.   If |previousPoint| is null, then return |nextPoint|'s [=linear easing point/value=].
-
-1.   If |nextPoint| is null, then return |previousPoint|'s [=linear easing point/value=].
-
-1.   Let |progressBetweenPoints| be (|inputProgress| - |previousPoint|'s [=linear easing point/position=]) / (|nextPoint|'s [=linear easing point/position=] - |previousPoint|'s [=linear easing point/position=]).
-
-1.   Return |previousPoint|'s [=linear easing point/value=] + |progressBetweenPoints| * (|nextPoint|'s [=linear easing point/value=] - |previousPoint|'s [=linear easing point/value=]).
+1.   Return the y-axis value corresponding to the x-axis value of |inputProgress|.
 
 </section>
 
 <dfn function lt="linear()">linear(<<linear-stop-list>>)</dfn>
 
 <pre class="prod">
-  <dfn>&lt;linear-stop-list></dfn> = [ <<linear-stop>> ]#
-  <dfn>&lt;linear-stop></dfn> = <<number>> && <<number>>?
+  <dfn>&lt;linear-stop-list></dfn> =
+    [ <<linear-hint>>? , <<linear-stop>> ]#
+  <dfn>&lt;linear-stop></dfn> = <<number>> && <<length-percentage>>?
+  <dfn>&lt;linear-hint></dfn> = <<length-percentage>>
 </pre>
+
+TODO: I want to support syntax like <code>linear(0 0% 0%, 1 100% 100%)</code>, but I can't figure out how it's done. <code>linear-gradient</code> seems to support that syntax but <a href="https://drafts.csswg.org/css-images-3/#typedef-color-stop-list">I can't see it in the grammar</a>.
 
 <h3 id="the-linear-easing-keyword">The linear easing keyword: ''linear''</h3>
 


### PR DESCRIPTION
This is an attempt to make some progress on custom easing functions, specifically https://github.com/w3c/csswg-drafts/issues/229#issuecomment-861247074

I've never edited a CSS spec before, so I don't really know what I'm doing. Sorry if this isn't helpful in any way. Here's what I'm trying to do:

**Edit**: I've updated this following discussion below.

There's already a `linear` keyword. I figured we could overload that, so `linear` is a shorthand for `linear()`.

The arguments are a comma-separated groups of:

- Output (number)
- Start input (optional, percentage)
- End input (optional, percentage)

The values work very similar to `linear-gradient`.

`linear(0, 0.7, 0.87, 0.98, 1)` - this creates 5 points:

<img width="432" alt="Screenshot 2021-08-23 at 13 11 21" src="https://user-images.githubusercontent.com/93594/130444902-68fde7bc-c8d9-4b10-837f-3e2bd79b931f.png">

Which is equivalent to `linear(0 0%, 0.7 25%, 0.87 50%, 0.98 75%, 1 100%)`, as points without a 'start input' are given one automatically (using the same process as linear gradients).

The third value, again similar to gradients, can be used to create an extra point using the same output value. So `linear(0, 0.5 25% 75%, 1)` creates 4 points:

<img width="432" alt="Screenshot 2021-08-23 at 08 52 21" src="https://user-images.githubusercontent.com/93594/130410833-eba70188-f844-47ce-ae5e-82dc078c910d.png">

Output values will typically be 0-1, but can be outside of that, as they can with `cubic-bezier`. A likely usage here will be elastic/spring easings.

Similarly, input values will typically be 0%-100%, but can extend beyond that to provide points for edge-cases where easings are chained.

The ends of the graph automatically extend beyond their specified point using their final angle, so the previous easing (`linear(0, 0.5 25% 75%, 1)`) would extend like this:

<img width="435" alt="Screenshot 2021-08-23 at 09 00 32" src="https://user-images.githubusercontent.com/93594/130411964-bbc668db-8331-41c8-b75f-42ce76306b89.png">

However, if the final two points are in the same position, the line extends horizontally, so `linear(0, 0.5 25% 75%, 1 100% 100%)` (the difference being the `100% 100%` at the end), would be:

<img width="433" alt="Screenshot 2021-08-23 at 09 02 27" src="https://user-images.githubusercontent.com/93594/130412244-10550d78-7dc6-4032-95f0-559ab4e7a859.png">

Some edge cases: `linear()` is equivalent to `linear` (as in, an identity function). If only one value is provided, then the output value is always that value, so `linear(0.5)` always outputs `0.5`.

The overall goal is to allow something like:

```css
.whatever {
  animation-timing-function: linear(0, 0.003, 0.013, 0.03, 0.05, 0.08, 0.11, 0.15, 0.2, 0.26, 0.31, 0.38, 0.45, 0.53, 0.62, 0.71, 0.81, 0.9, 0.99, 0.94, 0.89, 0.85, 0.82, 0.79, 0.77, 0.76, 0.752, 0.75, 0.755, 0.77, 0.78, 0.81, 0.84, 0.87, 0.92, 0.97, 0.99, 0.97, 0.95, 0.94, 0.938, 0.94, 0.949, 0.96, 0.99, 0.994, 0.986, 0.985, 0.989, 1 100% 100%);
}
```

…which would graph like this:

<img width="433" alt="Screenshot 2021-08-23 at 11 45 53" src="https://user-images.githubusercontent.com/93594/130435372-05471f97-7e33-4876-ac45-cc7073eb1f5c.png">

And here's a demo of how that would animate: https://static-misc-3.glitch.me/linear-easing/