### PR TITLE
[css-highlight-api-1] Specify that custom highlights have no UA styles #6375

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -298,8 +298,8 @@ Applicable Properties</h4>
 <h4 id=default-styles>
 Default Styles</h4>
 
-	UAs must not define any styles for [=Custom highlight pseudo-elements=] in the default UA
-	stylesheet. A [=Custom highlight pseudo-element=] inherits the styles of its
+	UAs must not define any styles for [=custom highlight pseudo-elements=] in the default UA
+	stylesheet. A [=custom highlight pseudo-element=] inherits the styles of its
 	[=originating element=].
 
 <h4 id=c-and-h>

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -295,6 +295,13 @@ Applicable Properties</h4>
 	can only be styled with a limited set of properties.
 	See [[css-pseudo-4#highlight-styling]] for the full list.
 
+<h4 id=default-styles>
+Default Styles</h4>
+
+	UAs must not define any styles for [=Custom highlight pseudo-elements=] in the default UA
+	stylesheet. A [=Custom highlight pseudo-element=] inherits the styles of its
+	[=originating element=].
+
 <h4 id=c-and-h>
 Cascading and Inheritance</h4>
 


### PR DESCRIPTION
Per resolution of #6375, specify that:
- UAs do not provide any default styles for custom highlights.
- Custom highlights inherit the styles of their originating element.

Closes #6375.