### PR TITLE
[css-backgrounds-3] Updated omitted lengths sentence in section 6.1 (Drop Shadows: the box-shadow property) #5993

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -2727,7 +2727,7 @@ has been moved to the <a href="https://www.w3.org/TR/css3-break/">CSS Fragmentat
 
   <p>Each shadow is given as a <<shadow>>,
   represented by 2-4 length values, an optional color, and an optional ''box-shadow/inset'' keyword.
-  Omitted lengths are 0; omitted colors default to the value of the 'color' property.
+  Omitted lengths are 0; omitted colors default to currentColor.
   <pre class=prod>
   <dfn><<shadow>></dfn> = <<color>>? &amp;&amp; [<<length>>{2} <<length [0,&infin;]>>? <<length>>?] &amp;&amp; inset?</pre>
 


### PR DESCRIPTION
[css-backgrounds-3] Fixed a typo in section [6.1. Drop Shadows: the box-shadow property](https://www.w3.org/TR/css-backgrounds-3/#box-shadow)

The typo that needed to be changed was that in the section there was a sentence stating,  "Omitted lengths are 0; omitted colors default to the value of the color property. ". But later on in that section, it states, "Specifies the color of the shadow. If the color is absent, it defaults to currentColor. "

So I believe that instead of, "Omitted lengths are 0; omitted colors default to the value of the color property. " it should be
"Omitted lengths are 0; omitted colors default to currentColor. " as stated in the issue created.