### PR TITLE
[cssom] editorial: Remove another reference to unneeded and non-existing flag.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -68,10 +68,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: xhtml.html
         type: dfn
             text: xml parser
-    urlPrefix: semantics.html
-        type: dfn
-            text: a style sheet that is blocking scripts
-            text: style sheet ready
 urlPrefix: https://dom.spec.whatwg.org/#concept-
     type: dfn
         text: dispatch; url: event-dispatch
@@ -1588,7 +1584,7 @@ must be run:
 </ol>
 
 A style sheet referenced by a HTTP <code>Link</code> header using the rules in this section is said to be <a>a style sheet
-that is blocking scripts</a> if the style sheet was enabled when created, and the <a>style sheet ready</a> flag is not yet set,
+that is blocking scripts</a> if the style sheet was enabled when created,
 and the user agent hasn't given up on that particular style sheet yet. A user agent may give up on such a style sheet at any time.
 
 CSS Rules {#css-rules}


### PR DESCRIPTION
Part of #6463.