### PR TITLE
[cssom] Let getComputedStyle return an empty style for invalid pseudo-elements, and the element's style if the string doesn't begin with a colon.

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2968,10 +2968,10 @@ steps:
 <ol>
  <li>Let <var>doc</var> be <var>elt</var>'s <a>node document</a>.
  <li>Let <var>obj</var> be <var>elt</var>.
- <li>If <var>pseudoElt</var> is provided, and it's not the empty string, then:
+ <li>If <var>pseudoElt</var> is provided, is not the empty string, and starts with a colon, then:
   <ol>
     <li>[=CSS/Parse=] <var>pseudoElt</var> as a <<pseudo-element-selector>>, and let <var>type</var> be the result.
-    <li>If <var>type</var> is failure, or is an ''::slotted()'' or ''::part()'' pseudo-element, <a>throw</a> a {{TypeError}} exception.
+    <li>If <var>type</var> is failure, or is an ''::slotted()'' or ''::part()'' pseudo-element, let <var>obj</var> be null.
     <li>Otherwise let <var>obj</var> be the given pseudo-element of <var>elt</var>.
   </ol>
 
@@ -2980,7 +2980,8 @@ steps:
   match above.
 
  <li>Let <var>decls</var> be an empty list of <a>CSS declarations</a>.
- <li>If <var>elt</var> is <a>connected</a>, part of the <a>flat tree</a>,
+ <li>If <var>obj</var> is not null, and <var>elt</var> is <a>connected</a>,
+  part of the <a>flat tree</a>,
   and its <a>shadow-including root</a> has a <a>browsing context</a> which either
   doesn't have a <a>browsing context container</a>, or whose
   <a>browsing context container</a> is <a>being rendered</a>,


### PR DESCRIPTION
Fixes #6501.

Tests in https://github.com/web-platform-tests/wpt/pull/30140.