### PR TITLE
[css-highlight-api-1] Clarifying that user agents must not use live ranges internally for static ranges #4597

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -482,6 +482,9 @@ Range Updating and Invalidation</h3>
 	in response to DOM changes,
 	nor can they be modified by the author after creation.
 
+	Note: In other words, the user agent is expected to store the actual
+	static ranges, rather than backing them up with live ranges.
+
 	<div class=advisement>
 		Updating all {{Range}} objects as the DOM is modified
 		has a significant performance cost.

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -481,9 +481,8 @@ Range Updating and Invalidation</h3>
 	the user agent must not adjust the [=boundary points=] of {{StaticRange}}s
 	in response to DOM changes,
 	nor can they be modified by the author after creation.
-
-	Note: In other words, the user agent is expected to store the actual
-	{{StaticRange}}s, rather than backing them up with live {{Range}}s.
+	The user agent is expected to store the actual {{StaticRange}}s, rather than backing
+	them up with live {{Range}}s.
 
 	<div class=advisement>
 		Updating all {{Range}} objects as the DOM is modified

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -483,7 +483,7 @@ Range Updating and Invalidation</h3>
 	nor can they be modified by the author after creation.
 
 	Note: In other words, the user agent is expected to store the actual
-	static ranges, rather than backing them up with live ranges.
+	{{StaticRange}}s, rather than backing them up with live {{Range}}s.
 
 	<div class=advisement>
 		Updating all {{Range}} objects as the DOM is modified


### PR DESCRIPTION
Per [resolution](https://github.com/w3c/csswg-drafts/issues/4597#issuecomment-905688814) in #4597, clarify that when authors uses StaticRange highlights, UAs should use the actual static ranges rather than backing them with live ranges.