### PR TITLE
[css-font-loading-3] FontFaceSet.clear() should not clear CSS-connected items

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -550,7 +550,7 @@ The <code>FontFaceSet</code> Interface</h2>
 			When the {{clear()}} method is called,
 			execute the following steps:
 
-			1. Remove all items from the {{FontFaceSet}}’s [=FontFaceSet/set entries=],
+			1. Remove all non-<a>CSS-connected</a> items from the {{FontFaceSet}}’s [=FontFaceSet/set entries=],
 				its {{[[LoadedFonts]]}} list,
 				and its {{[[FailedFonts]]}} list.
 			2. If the {{FontFaceSet}}’s {{[[LoadingFonts]]}} list is non-empty,


### PR DESCRIPTION
The spec says in https://drafts.csswg.org/css-font-loading-3/#document-font-face-set:

> The set entries for a document’s font source must be initially populated with all the CSS-connected FontFace objects from all of the CSS @font-face rules.

And in https://drafts.csswg.org/css-font-loading-3/#font-face-css-connection

> There is a two-way connection between [FontFace objects and @font-face rules]: any change made to a @font-face descriptor is immediately reflected in the corresponding FontFace attribute, and vice versa.

And, finally, in https://drafts.csswg.org/css-font-loading-3/#dom-fontfaceset-clear

> Remove all items from the FontFaceSet’s set entries.

It seems like `clear()` shouldn't delete CSS-connected FontFaces. This is also what Firefox and Chrome both do. I'm updating WebKit to do this in https://bugs.webkit.org/show_bug.cgi?id=229643.

