### PR TITLE
[css-nesting] Fix Nesting Conditional Rules example

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -553,11 +553,13 @@ Nesting Conditional Rules {#conditionals}
 			}
 		}
 		/* equivalent to
-			.foo { display: grid; }
-
-			@media (orientation: landscape) {
-				& {
-					grid-auto-flow: column;
+			.foo {
+				display: grid;
+				
+				@media (orientation: landscape) {
+					& {
+						grid-auto-flow: column;
+					}
 				}
 			}
 		*/


### PR DESCRIPTION
Current example on [Nesting Conditional Rules](https://www.w3.org/TR/css-nesting-1/#conditionals) (§ 2.3) has an invalid parentless `& { ... }` rule:

```css
/* equivalent to
  .foo { display: grid; }

  @media (orientation: landscape) {
    & {                             <--- what does & represent here?
      grid-auto-flow: column;
    }
  }
*/
```

Updated version repositions it inside `.foo`:

```css
/* equivalent to
	  .foo {
		  display: grid;
	  
		  @media (orientation: landscape) {
			  & {                           <--- & represents .foo
				  grid-auto-flow: column;
			  }
		  }
	  }
*/
```

Great proposal otherwise! Really excited for this one :)