### PR TITLE
Fix bikeshed indentation errors in web-animations-2 diff spec.

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -169,13 +169,13 @@ Add:
 > follows:
 >
 > 1.  If the [=iteration duration=] is auto, then perform the following steps.
->         * Set [=start delay=] and [=end delay=] to 0, as it is not
->           possible to mix time and proportions.
->           <div class='note'>
->           Future versions may allow these properties to be assigned
->           percentages, at which point the delays are only to be ignored if
->           their values are expressed as times and not as percentages.
->           </div>
+>         *   Set [=start delay=] and [=end delay=] to 0, as it is not
+>             possible to mix time and proportions.
+>             <div class='note'>
+>             Future versions may allow these properties to be assigned
+>             percentages, at which point the delays are only to be ignored if
+>             their values are expressed as times and not as percentages.
+>             </div>
 >     Otherwise:
 >          1. Let <var>total time</var> be equal to |end time|
 >          1. Set [=start delay=] to be the result of evaluating
@@ -191,15 +191,15 @@ Add:
 > The procedure to <dfn>normalize specified timing</dfn> is as follows:
 >
 > If [=timeline duration=] is resolved:
->     * Follow the procedure to convert a [=time-based animation to a
->       proportional animation=]
+>     *   Follow the procedure to convert a [=time-based animation to a
+>         proportional animation=]
 > Otherwise:
 >     1.   Set [=start delay=] = |specified start delay|
 >     1.   Set [=end delay=] = |specified end delay|
 >     1.   If |iteration duration| is auto:
->              * Set [=iteration duration=] = |intrinsic iteration duration|
+>              *   Set [=iteration duration=] = |intrinsic iteration duration|
 >          Otherwise:
->              * Set [=iteration duration=] = |specified iteration duration|
+>              *   Set [=iteration duration=] = |specified iteration duration|
 
 <h4 id="setting-the-timeline">Setting the timeline of an animation</h4>
 
@@ -216,18 +216,19 @@ follows:
 1.  Set |previous progress| based in the first condition that applies:
     <div class="switch">
 
-    : If |previous current time| is unresolved:
+    :   If |previous current time| is unresolved:
 
-    :: Set |previous progress| to unresolved.
+    ::  Set |previous progress| to unresolved.
 
-    : If [=end time=] is zero:
+    :   If [=end time=] is zero:
 
-    :: Set |previous progress| to zero.
+    ::  Set |previous progress| to zero.
 
-    : Otherwise
+    :   Otherwise
 
-    :: Set |previous progress| = <code>|previous current time| /
-    [=end time=]</code>
+    ::  Set |previous progress| = <code>|previous current time| /
+        [=end time=]</code>
+
     </div>
 1.  Let |from finite timeline| be true if |old timeline| is not null and
     not [=monotonically increasing=].
@@ -1014,6 +1015,7 @@ Add:
 >     matching condition from below:
 >
 > <div class="switch">
+>
 > :   If the animation effect is a <a>group effect</a>,
 > ::  Follow the procedure in
 >     [[#the-intrinsic-iteration-duration-of-a-group-effect]]
@@ -1032,6 +1034,7 @@ Add:
 >     Presently start and end delays are zero until such time as percentage
 >     based delays are supported.
 >     </p>
+>
 > </div>
 >
 >     The <a>iteration duration</a> of an <a>animation effect</a> may be set


### PR DESCRIPTION
[web-animations-2] Fix bikeshed indentation errors.

The spec had several incorrect indents that lead to failures running bikeshed on it.