### PR TITLE
[css-highlights-api] StaticRange validity updates

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -514,16 +514,6 @@ Range Updating and Invalidation</h3>
 	are greater than the corresponding node’s <a spec=dom>length</a>,
 	The user agent must behave as if it was equal to that <a spec=dom>length</a>.
 
-	Issue(4597): As far as I am aware,
-	prior uses of {{StaticRange}}s were for [=ranges=] created by the user agent
-	and passed to the author.
-	Here, it's the other way around,
-	which raises (for the first time?)
-	the question of invalidation of static ranges.
-	Can the above work?
-	Is it Fast enough that it's worth distinguishing static and live ranges?
-	Would some alternative handling be better?
-
 	Issue(4598): The interaction of {{StaticRange}}s in a [=custom highlight=]
 	and [[css-contain-2]]
 	seems problematic:

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -510,9 +510,6 @@ Range Updating and Invalidation</h3>
 	if any {{StaticRange}} in the [=highlight registry=] associated with that document's window
 	is not <a spec=dom for="StaticRange">valid</a>,
 	the user agent must ignore that [=range=].
-	If the [=start offset=] or [=end offset=] of any [=range=]
-	are greater than the corresponding node’s <a spec=dom>length</a>,
-	The user agent must behave as if it was equal to that <a spec=dom>length</a>.
 
 	Issue(4598): The interaction of {{StaticRange}}s in a [=custom highlight=]
 	and [[css-contain-2]]


### PR DESCRIPTION
Remove Issue block now that #4597 has been resolved.

Remove start/end offset clipping behavior since we resolved to just use the DOM spec's validity definition.