### PR TITLE
[css-highlights-api] Restore check that range is in same document as the HighlightRegistry

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -507,7 +507,11 @@ Range Updating and Invalidation</h3>
 	</div>
 
 	When computing how to render a document,
-	if any {{StaticRange}} in the [=highlight registry=] associated with that document's window
+	if [=start node=] or [=end node=] of any [=range=]
+	in the [=highlight registry=] associated with that document's window
+	refer to a {{Node}} whose [=shadow-including root=] is not that document,
+	the user agent must ignore that [=range=].
+	If any {{StaticRange}} in the [=highlight registry=] associated with that document's window
 	is not <a spec=dom for="StaticRange">valid</a>,
 	the user agent must ignore that [=range=].
 	If the [=start offset=] or [=end offset=] of any [=range=]


### PR DESCRIPTION
This check was removed in https://github.com/w3c/csswg-drafts/commit/7e65e3821d011e3bd29b8aca6e8bb9d5a223bca5, but it's still needed per the resolution of #6417, which was that we should not paint ranges from documents other than the one associated with the current highlight registry.

This is separate from the validity question, because a range in a different document can be valid (or it could be a live range), but we still shouldn't paint it.