### PR TITLE
[css-font-loading] Add IDL for discovery of information about a font

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -427,6 +427,54 @@ Interaction with CSS’s ''@font-face'' Rule</h3>
 	and <a>CSS-connected</a> to the ''@font-face''.
 	(This will also remove the old and add the new {{FontFace}} objects from any <a>font sources</a> they appear in.)
 
+<h3 id='discovery'>
+Discovery of information about a font</h3>
+
+	A {{FontFace}} object includes a variety of read-only information about the contents of the font file.
+
+	<xmp class="idl">
+		interface FontFaceFeatures {
+			/* The CSSWG is still discussing what goes in here */
+		};
+
+		interface FontFaceVariationAxis {
+			readonly attribute DOMString name;
+			readonly attribute DOMString axisTag;
+			readonly attribute double minimumValue;
+			readonly attribute double maximumValue;
+			readonly attribute double defaultValue;
+		};
+
+		interface FontFaceVariations {
+			readonly setlike<FontFaceVariationAxis>;
+		};
+
+		interface FontFacePalette {
+			iterable<DOMString>;
+			readonly attribute unsigned long length;
+			getter DOMString (unsigned long index);
+			readonly attribute bool usableWithLightBackground;
+			readonly attribute bool usableWithDarkBackground;
+		};
+
+		interface FontFacePalettes {
+			iterable<FontFacePalette>;
+			readonly attribute unsigned long length;
+			getter FontFacePalette (unsigned long index);
+		};
+
+		partial interface FontFace {
+			readonly attribute FontFaceFeatures features;
+			readonly attribute FontFaceVariations variations;
+			readonly attribute FontFacePalettes palettes;
+		};
+	</xmp>
+
+	Note: This read-only data is intended to help authors know which values are accepted by
+	'font-feature-settings!!property',
+	'font-variation-settings!!property',
+	and ''@font-palette-values''.
+
 <!--
 ████████  ███████  ██    ██ ████████ ████████    ███     ██████  ████████  ██████  ████████ ████████
 ██       ██     ██ ███   ██    ██    ██         ██ ██   ██    ██ ██       ██    ██ ██          ██


### PR DESCRIPTION
This is for https://github.com/w3c/csswg-drafts/issues/520.

The [resolution](https://github.com/w3c/csswg-drafts/issues/520#issuecomment-387799523) is:

> RESOLVED: [add this functionality to] css-font-loading, level TBD

I added this to level 3, because level 4 doesn't exist. If the editor prefers this go in a level 4, that's no problem.

The GitHub thread hasn't come to a conclusion about what should go in the `FontFaceFeatures` interface, so I left it blank for now.