### PR TITLE
[css-font-loading] Fix invalid IDL

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -433,10 +433,12 @@ Discovery of information about a font</h3>
 	A {{FontFace}} object includes a variety of read-only information about the contents of the font file.
 
 	<xmp class="idl">
+		[Exposed=(Window,Worker)]
 		interface FontFaceFeatures {
 			/* The CSSWG is still discussing what goes in here */
 		};
 
+		[Exposed=(Window,Worker)]
 		interface FontFaceVariationAxis {
 			readonly attribute DOMString name;
 			readonly attribute DOMString axisTag;
@@ -445,18 +447,21 @@ Discovery of information about a font</h3>
 			readonly attribute double defaultValue;
 		};
 
+		[Exposed=(Window,Worker)]
 		interface FontFaceVariations {
 			readonly setlike<FontFaceVariationAxis>;
 		};
 
+		[Exposed=(Window,Worker)]
 		interface FontFacePalette {
 			iterable<DOMString>;
 			readonly attribute unsigned long length;
 			getter DOMString (unsigned long index);
-			readonly attribute bool usableWithLightBackground;
-			readonly attribute bool usableWithDarkBackground;
+			readonly attribute boolean usableWithLightBackground;
+			readonly attribute boolean usableWithDarkBackground;
 		};
 
+		[Exposed=(Window,Worker)]
 		interface FontFacePalettes {
 			iterable<FontFacePalette>;
 			readonly attribute unsigned long length;


### PR DESCRIPTION
This fixes invalid IDL syntax introduced in:
https://github.com/w3c/csswg-drafts/pull/6591

Errors were:
- Interfaces must have an `[Exposed]` extended attribute.
- `bool` does not exist in Web IDL. Correct type is `boolean`.
