### PR TITLE
[css-fonts-4] Remove redundant grammar

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2449,7 +2449,7 @@ Font property descriptors: the 'font-style!!descriptor', 'font-weight!!descripto
 
 	<pre class='descdef'>
 	Name: font-style
-	Value: auto | normal | italic | oblique [ <<angle>> | <<angle>>{1,2} ]?
+	Value: auto | normal | italic | oblique [ <<angle>>{1,2} ]?
 	For: @font-face
 	Initial: auto
 	</pre>


### PR DESCRIPTION
https://drafts.csswg.org/css-fonts-4/#font-prop-desc

Remove redundant `<angle>` in the `font-style` `@font-face` descriptor. `<angle> | <angle>{1,2}` seems redundant.

It was introduced in https://github.com/w3c/csswg-drafts/pull/6162