### PR TITLE
[css-conditional-4] Extend supports feature to express font capabilities

### DIFF
--- a/css-conditional-4/Overview.bs
+++ b/css-conditional-4/Overview.bs
@@ -34,8 +34,12 @@ Issue: In the future, copy the contents of [[css3-conditional]] into this docume
 This level of the specification extends the <<supports-feature>> syntax as follows:
 
 <pre class="prod def" nohighlight>
-	<dfn>&lt;supports-feature></dfn> = <<supports-selector-fn>> | <<supports-decl>>
+	<dfn>&lt;supports-feature></dfn> = <<supports-selector-fn>> | <<supports-font-technology-fn>> | <<supports-decl>>
 	<dfn>&lt;supports-selector-fn></dfn> = selector( <<complex-selector>> )
+  <dfn>&lt;supports-font-technology-fn></dfn> = font-technology ( <<font-technology>> )
+  <dfn>&lt;font-technology></dfn> = [ features-opentype | features-aat | features-graphite
+                      | color-colrv0 | color-colrv1 | color-svg | color-sbix | color-cbdt
+                      | variations | palettes | incremental ]
 </pre>
 
 : <<supports-selector-fn>>
@@ -43,6 +47,13 @@ This level of the specification extends the <<supports-feature>> syntax as follo
 	The result is true if the UA
 	<a href="#dfn-support-selector">supports the selector</a>
 	provided as an argument to the function.
+
+: <<supports-font-technology-fn>>
+::
+    The result is true if the UA
+    <a href="dfn-support-font-technology">supports the font technology</a>
+    provided as an argument to the function.
+
 
 <h3 id="support-definition-ext">Extensions to the definition of support</h3>
 
@@ -52,5 +63,10 @@ if it accepts that selector (rather than discarding it as a
 parse error), and that selector doesn't contain
 <a>unknown -webkit- pseudo-elements</a>.
 
-<h2 class=no-num id="acknowledgments">Acknowledgments</h2>
+A CSS processor is considered to
+<dfn export for=CSS id="dfn-support-font-technology">support a font technology</dfn>
+when the text and layout processing engine ingesting
+this CSS text is capable of utilising the specified font-technology
+in layout and rendering.
 
+<h2 class=no-num id="acknowledgments">Acknowledgments</h2>


### PR DESCRIPTION
Define criteria for enabling @supports to distinguish support for
a set of font technologies defined in the grammar.

Addresses resolution in #6520 to add criteria for font technologies as a
first step.

Incorporates @LeaVerou 's feedback from [1]

[1] https://github.com/w3c/csswg-drafts/issues/6520#issuecomment-904703888
