### PR TITLE
[css-fonts] [css-device-adapt] [palettes] FONT_PALETTE_VALUES_RULE conflicts with VIEWPORT_RULE

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6846,11 +6846,7 @@ a single value.
 
 <h3 id="om-fontpalettevalues">
 The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interface</h3>
-<pre class='idl'>partial interface CSSRule {
-  const unsigned short FONT_PALETTE_VALUES_RULE = 15;
-};
-
-[Exposed=Window]
+<pre class='idl'>[Exposed=Window]
 interface CSSFontPaletteValuesRule : CSSRule {
   maplike&lt;unsigned long, CSSOMString>;
   attribute CSSOMString fontFamily;


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6623.