### PR TITLE
[css-fonts] [palettes] CSSFontPaletteValuesRule's maplike doesn't make much sense

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6852,9 +6852,9 @@ The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interfa
 
 [Exposed=Window]
 interface CSSFontPaletteValuesRule : CSSRule {
-  maplike&lt;unsigned long, CSSOMString>;
   attribute CSSOMString fontFamily;
   attribute CSSOMString basePalette;
+  attribute CSSOMString overrideColor;
 };</pre>
 
 The value of the 'maplike' function [=CSS/parses=] as a <<color>>. If it is not a color,


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6624.