### PR TITLE
[css-fonts] [palettes] Can't get the palette name from CSSFontPaletteValuesRule

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6852,6 +6852,7 @@ The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interfa
 
 [Exposed=Window]
 interface CSSFontPaletteValuesRule : CSSRule {
+  attribute CSSOMString name;
   maplike&lt;unsigned long, CSSOMString>;
   attribute CSSOMString fontFamily;
   attribute CSSOMString basePalette;


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6625.