### PR TITLE
[css-fonts] [palettes] base-palette and override-color should have their integer values be required to be nonnegative

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6466,7 +6466,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
 
     <pre class='descdef'>
     Name: base-palette
-    Value: <<integer>> | <<string>>
+    Value: <<integer [0, ∞]>> | <<string>>
     For: @font-palette-values
     Initial: N/A
     </pre>
@@ -6528,7 +6528,7 @@ Overriding a color from a palette: The 'override-color!!descriptor' descriptor</
 
     <pre class='descdef'>
     Name: override-color
-    Value: [ [ <<string>> | <<integer>> ] <<color>> ]#
+    Value: [ [ <<string>> | <<integer [0, ∞]>> ] <<color>> ]#
     For: @font-palette-values
     Initial: N/A
     </pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6626.