### PR TITLE
[css-fonts] [palettes] Remove the <string> values from override-color and base-palette

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6465,7 +6465,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
 
     <pre class='descdef'>
     Name: base-palette
-    Value: light | dark | <<integer [0, ∞]>> | <<string>>
+    Value: light | dark | <<integer [0, ∞]>>
     For: @font-palette-values
     Initial: N/A
     </pre>
@@ -6495,11 +6495,6 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
 	<dd>
 		Identifies a (zero-based) numerical palette index within the font.
 
-
-	<dt><dfn type><<string>></dfn>
-	<dd>
-		Identifies a named palette within the font.
-
 </dl>
 
     <div class="example">
@@ -6508,11 +6503,11 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
             <pre>
             @font-palette-values Festival {
                 font-family: Banner Flag;
-                base-palette: 'Dark';
+                base-palette: 1;
                 override-colors:
-                    'Outline' rgb(123, 64, 27),
-                    'Base Glyph' currentColor,
-                    'Glints' var(--highlight);
+                    0 rgb(123, 64, 27),
+                    1 currentColor,
+                    2 var(--highlight);
             }
             </pre>
         </div>
@@ -6546,16 +6541,12 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
     Colors in the palette can be overridden
     by using the 'override-color!!descriptor' descriptor in the ''@font-palette-values'' rule.
 
-    Strings specified in the value of this descriptor
-    are matched
-    according to [[#localized-name-matching]].
-
 <h4 id="override-color">
 Overriding a colors from a palette: The 'override-colors!!descriptor' descriptor</h4>
 
     <pre class='descdef'>
     Name: override-colors
-    Value: [ [ <<string>> | <<integer [0, ∞]>> ] <<absolute-color>> ]#
+    Value: [ <<integer [0, ∞]>> <<absolute-color>> ]#
     For: @font-palette-values
     Initial: N/A
     </pre>
@@ -6574,12 +6565,7 @@ Overriding a colors from a palette: The 'override-colors!!descriptor' descriptor
 
     Palette index entries
     in the ''@font-palette-values/override-colors'' descriptor
-    are either a (zero-based) palette index entry, or
-    a string, which corresponds to a named palette entry
-    in the selected palette.
-
-    Strings specified in the value of this descriptor
-    are matched according to [[#localized-name-matching]].
+    are a (zero-based) palette index entry.
 
     Integer values are zero-indexed.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6627.