### PR TITLE
[css-fonts] [palettes] override-color takes a list but isn't plural

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6371,7 +6371,7 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
         @font-palette-values Cooler {
             font-family: Bixa;
             base-palette: 1;
-            override-color:
+            override-colors:
                 1 #7EB7E4;
         }
 		</pre>
@@ -6391,7 +6391,7 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
         @font-palette-values Augusta {
             font-family: Handover Sans;
             base-palette: 3;
-            override-color:
+            override-colors:
                 1 rgb(43, 12, 9),
                 3 var(--highlight);
         }
@@ -6482,7 +6482,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
             @font-palette-values Festival {
                 font-family: Banner Flag;
                 base-palette: 'Dark';
-                override-color:
+                override-colors:
                     'Outline' rgb(123, 64, 27),
                     'Base Glyph' currentColor,
                     'Glints' var(--highlight);
@@ -6492,10 +6492,10 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
 
     This descriptor specifies a palette in the font
     which the containing ''@font-palette-values'' rule uses as an initial value.
-    If no <<override-color>> key is present in the ''@font-palette-values'' rule,
+    If no <<override-colors>> key is present in the ''@font-palette-values'' rule,
     then the ''@font-palette-values'' rule represents the palette in the font
     with the same index as the value of this descriptor.
-    If a <<override-color>> key is present in the ''@font-palette-values'' rule,
+    If a <<override-colors>> key is present in the ''@font-palette-values'' rule,
     each item in the value of that descriptor overrides a single color
     in the color palette represented by this ''@font-palette-values'' block.
 
@@ -6524,10 +6524,10 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
     according to [[#localized-name-matching]].
 
 <h4 id="override-color">
-Overriding a color from a palette: The 'override-color!!descriptor' descriptor</h4>
+Overriding a colors from a palette: The 'override-colors!!descriptor' descriptor</h4>
 
     <pre class='descdef'>
-    Name: override-color
+    Name: override-colors
     Value: [ [ <<string>> | <<integer>> ] <<color>> ]#
     For: @font-palette-values
     Initial: N/A
@@ -6546,12 +6546,12 @@ Overriding a color from a palette: The 'override-color!!descriptor' descriptor</
     an entry into the palette
     an a color to replace it with.
 
-    The '@font-palette-values/override-color' descriptor takes
+    The '@font-palette-values/override-colors' descriptor takes
     a comma-separated list
     of palette index entries and colors.
 
     Palette index entries
-    in the ''@font-palette-values/override-color'' descriptor
+    in the ''@font-palette-values/override-colors'' descriptor
     are either a (zero-based) palette index entry, or
     a string, which corresponds to a named palette entry
     in the selected palette.


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6630.