### PR TITLE
[css-fonts] [palettes] Properties in CSSFontPaletteValuesRule don't need to be mutable

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6852,9 +6852,9 @@ The <code id="cssfontpalettevaluesrule2">CSSFontPaletteValuesRule</code> interfa
 
 [Exposed=Window]
 interface CSSFontPaletteValuesRule : CSSRule {
-  maplike&lt;unsigned long, CSSOMString>;
-  attribute CSSOMString fontFamily;
-  attribute CSSOMString basePalette;
+  readonly maplike&lt;unsigned long, CSSOMString>;
+  readonly attribute CSSOMString fontFamily;
+  readonly attribute CSSOMString basePalette;
 };</pre>
 
 The value of the 'maplike' function [=CSS/parses=] as a <<color>>. If it is not a color,


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6645.