### PR TITLE
[web-animations-2] Fix style in dl.switch for web-animations-2 spec.

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -15,7 +15,6 @@ dl.switch  > [data-md] > p {
 dl.switch > dt > ul > li {
   text-indent: 0;
 }
-
 </style>
 
 <pre class='metadata'>

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -7,6 +7,15 @@
 }
 
 .constructors::before { content: 'Constructors' }
+
+dl.switch  > [data-md] > p {
+  display: inline;
+}
+
+dl.switch > dt > ul > li {
+  text-indent: 0;
+}
+
 </style>
 
 <pre class='metadata'>


### PR DESCRIPTION
[web-animations-2] Fix style in dl.switch for web-animations-2 spec.

This PR addresses two formatting glitches in the web-animations-2 spec: 1) paragraphs after a marker, and 2) indentation of bulleted lists. Both tweaks are for descendants of a dl.switch. Without the changes, a newline is inserted after a marker within the switch if the maker is followed by a paragraph.  List items within a dl.switch are outdented which causes the text to overlay the bullets.

