### PR TITLE
[web-animations-2] Remove inheritance from partial interface definition

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2076,7 +2076,7 @@ Update the startTime and currentTime of the Animation interface as follows:
 
 <pre class="idl">
 [Exposed=Window]
-partial interface Animation : EventTarget {
+partial interface Animation {
     attribute CSSNumberish?       startTime;
     attribute CSSNumberish?       currentTime;
 };


### PR DESCRIPTION
Inheritance is already set in the main interface declaration, and is syntactically forbidden at the partial level.
