### PR TITLE
[css-pseudo] [css-variables] highlight pseudos and custom properties (closes #6264)

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -49,13 +49,6 @@ spec:fill-stroke-3; type:property; text:stroke-width
   and on their syntax and interaction with other <a>selectors</a>,
   see [[!SELECTORS-4]].
 
-<h2 id="styling">Styling Pseudo-elements</h2>
-  [=Custom properties=] [[!CSS-VARIABLES-1]] can be specified on--
-  and inherited into--
-  pseudo-elements,
-  even if they would not otherwise apply
-  due to the pseudo-element having a restricted set of applicable CSS properties.
-
 <h2 id="typographic-pseudos">
 Typographic Pseudo-elements</h2>
 

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -50,9 +50,11 @@ spec:fill-stroke-3; type:property; text:stroke-width
   see [[!SELECTORS-4]].
 
 <h2 id="styling">Styling Pseudo-elements</h2>
-
-  [=Custom properties=] [[!CSS-VARIABLES-1]] are always allowed in pseudo-element styles,
-  even if the pseudo-element has a restricted set of CSS properties applying to it.
+  [=Custom properties=] [[!CSS-VARIABLES-1]] can be specified on--
+  and inherited into--
+  pseudo-elements,
+  even if they would not otherwise apply
+  due to the pseudo-element having a restricted set of applicable CSS properties.
 
 <h2 id="typographic-pseudos">
 Typographic Pseudo-elements</h2>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -49,6 +49,11 @@ spec:fill-stroke-3; type:property; text:stroke-width
   and on their syntax and interaction with other <a>selectors</a>,
   see [[!SELECTORS-4]].
 
+<h2 id="styling">Styling Pseudo-elements</h2>
+
+  [=Custom properties=] [[!CSS-VARIABLES-1]] are always allowed in pseudo-element styles,
+  even if the pseudo-element has a restricted set of CSS properties applying to it.
+
 <h2 id="typographic-pseudos">
 Typographic Pseudo-elements</h2>
 

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -675,8 +675,9 @@ Cascading and Per-Element Highlight Styles</h3>
   When any supported property is not given a value by the cascade,
   it's value is determined by inheritance from
   the corresponding <a>highlight pseudo-element</a>
-  of its <a>originating element</a>'s parent element
-  (regardless of whether that property is an <a>inherited property</a>).
+  of its <a>originating element</a>'s parent element.
+  This occurs regardless of whether that property is an <a>inherited property</a>,
+  including [=registered custom properties=] where the [=inherits descriptor=] is false.
 
     <wpt>
     css/css-pseudo/active-selection-051.html

--- a/css-variables-1/Overview.bs
+++ b/css-variables-1/Overview.bs
@@ -86,7 +86,7 @@ Defining Custom Properties: the '--*' family of properties</h2>
 	Name: --*
 	Value: <<declaration-value>>?
 	Initial: the [=guaranteed-invalid value=]
-	Applies to: all elements
+	Applies to: all elements and all pseudo-elements (including those with restricted property lists)
 	Inherited: yes
 	Computed value: specified value with variables substituted, or the [=guaranteed-invalid value=]
 	Animation type: discrete


### PR DESCRIPTION
This patch makes edits for #6264:

* adds a section stating that custom properties are allowed on all pseudos
* explicitly clarifies that non-inherited registered customs are also inherited

One thing I’m unsure of… should we restate or refer to this near the lists of applicable properties? Especially with [the one for ::marker](https://drafts.csswg.org/css-lists/#marker-properties), which is in a separate spec, the reader could miss this if they’ve only read the section about a specific pseudo.