### PR TITLE
[web-animation-2] Resolution of fill=auto for progress-based timelines

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2240,6 +2240,25 @@ partial dictionary OptionalEffectTiming {
     > <a>sequence effect</a>. The |specified end delay| is converted to an
     > <a>end delay</a> following the [=normalize specified timing=] procedure.
 
+:   <dfn>fill</dfn>
+::  Update the rules for resolving the special string value <code>auto</code>
+    in timing calculations as:
+
+    > <dl class="switch">
+    >
+    >     :   If <em>either</em> of the following conditions are true:
+    >         *    the <a>animation effect</a> to which the fill mode is being
+    >              is applied is not a <a>keyframe effect</a>,
+    >         *    the <a>animation effect</a> is associated with a
+    >              [=progress-based timeline=]
+    >     ::  Use <span class="enum-value">both</span> as the
+    >         <a>fill mode</a>.
+    >     :   Otherwise,
+    >     ::  Use <span class="enum-value">none</span> as the
+    >         <a>fill mode</a>.
+    >
+    > </dl>
+
 :   <dfn>duration</dfn>
 ::  Update the description as:
 


### PR DESCRIPTION
[web-animation-2] Resolution of fill=auto for progress-based timelines

Update the rules for resolving a fill mode of 'auto' in timeline calculations based on discussion in github.com/w3c/csswg-drafts/issues/5223

