### PR TITLE
[css-fonts] [palettes] base-palette should be able to reference "dark" or "light" (just like font-palette can)

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6466,14 +6466,42 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
 
     <pre class='descdef'>
     Name: base-palette
-    Value: <<integer>> | <<string>>
+    Value: light | dark | <<integer>> | <<string>>
     For: @font-palette-values
     Initial: N/A
     </pre>
 
-    The ''@font-palette-values/base-palette'' descriptor accepts either
-    a (zero-based) numerical palette index, or
-    a string, which corresponds to a named palette.
+<dl dfn-for=base-palette dfn-type=value>
+	<dt><dfn>light</dfn>
+	<dd>
+		Some color font formats include metadata
+		marking certain palettes as applicable on a light (close to white) background.
+		This keyword identifies the first available palette in the font file marked this way.
+		If the font file format does not account for this metadata,
+		or no palette in the font is marked this way,
+		this value behaves as 0.
+
+
+	<dt><dfn>dark</dfn>
+	<dd>
+		Some color font formats include metadata
+		marking certain palettes as applicable on a dark (close to black) background.
+		This keyword identifies the first available palette in the font file marked this way.
+		If the font file format does not account for this metadata,
+		or no palette in the font is marked this way,
+		this value behaves as 0.
+
+
+	<dt><dfn type><<integer>></dfn>
+	<dd>
+		Identifies a (zero-based) numerical palette index within the font.
+
+
+	<dt><dfn type><<string>></dfn>
+	<dd>
+		Identifies a named palette within the font.
+
+</dl>
 
     <div class="example">
             Modify Banner Flag's color palette


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6678.