### PR TITLE
[css-fonts] Context for resolving override-color colors

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -399,11 +399,14 @@ Representing Colors: the <<color>> type</h2>
 	Colors in CSS are represented by the <dfn export><<color>></dfn> type:
 
 	<pre class='prod'>
-	&lt;color> = <<hex-color>> | <<named-color>> | currentcolor | transparent |
+	&lt;color> = <<absolute-color-base>> | currentcolor | <<system-color>> | <<device-cmyk()>>
+
+	<dfn>&lt;absolute-color></dfn> = <<absolute-color-base>> | <<absolute-device-cmyk>>
+
+	<dfn>&lt;absolute-color-base></dfn> = <<hex-color>> | <<named-color>> | transparent |
 	    <<rgb()>> | <<rgba()>> | <<hsl()>> | <<hsla()>> | <<hwb()>> |
 	    <<lab()>> | <<lch()>> |
-	    <<color()>> | <<device-cmyk()>> |
-	    <<system-color>>
+	    <<color()>>
 	</pre>
 
 	The <dfn export>color-functions</dfn> are <<rgb()>>, <<rgba()>>,
@@ -4288,6 +4291,7 @@ Uncalibrated CMYK Colors: the ''device-cmyk()'' function</h2>
 
 	<pre class='prod'>
 		<dfn>device-cmyk()</dfn> = device-cmyk( <<cmyk-component>>{4} [ / <<alpha-value>> ]? , <<color>>? )
+		<dfn>&lt;absolute-device-cmyk></dfn> = device-cmyk( <<cmyk-component>>{4} [ / <<alpha-value>> ]? , <<absolute-color>>? )
 		<dfn>&lt;cmyk-component></dfn> = <<number>> | <<percentage>>
 	</pre>
 

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6528,7 +6528,7 @@ Overriding a color from a palette: The 'override-color!!descriptor' descriptor</
 
     <pre class='descdef'>
     Name: override-color
-    Value: [ [ <<string>> | <<integer>> ] <<color>> ]#
+    Value: [ [ <<string>> | <<integer>> ] <<absolute-color>> ]#
     For: @font-palette-values
     Initial: N/A
     </pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6680.