### PR TITLE
[web-animations-2] Make active boundary times inclusive if timeline duration is finite

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -1096,8 +1096,9 @@ with:
 >     <em>and</em> <em>either</em> of the following conditions are met:
 >     1.  the <a>local time</a> is less than the <a>before-active boundary
 >         time</a>, <em>or</em>
->     1.  the <a>animation direction</a> is "backwards" and the
->         <a>local time</a> is equal to the <a>before-active boundary time</a>.
+>     1.  [=timeline duration=] is unresolved, the <a>animation direction</a>
+>         is "backwards" and the <a>local time</a> is equal to the
+>         <a>before-active boundary time</a>.
 
 Replace:
 
@@ -1122,8 +1123,9 @@ with:
 >     <em>and</em> <em>either</em> of the following conditions are met:
 >     1.  the <a>local time</a> is greater than the <a>active-after boundary
 >         time</a>, <em>or</em>
->     1.  the <a>animation direction</a> is "forwards" and the <a>local time</a>
->         is equal to the <a>active-after boundary time</a>.
+>     1.  [=timeline duration=] is unresolved, the <a>animation direction</a> is
+>         "forwards" and the <a>local time</a> is equal to the
+>         <a>active-after boundary time</a>.
 
 <h4 id="fill-modes">Fill modes</h4>
 


### PR DESCRIPTION
[web-animations-2] Make active boundary times inclusive if timeline duration is finite

Addresses issue #5223. The discussion suggested adding rules for resolving fill "auto".  This approach introduces edge cases as indicated in comments on https://github.com/w3c/csswg-drafts/pull/6673.  In short, resolving fill 'auto' introduces potential surprising behavior when delays or timeline offsets are non-zero.  The before and after phase calculations had explicit rules to make an active boundary exclusive depending on the direction of the animation.  This PR restricts these exclusion rules to non-finite timelines.