### PR TITLE
[web-animations-2]  Update ComputedEffectTiming

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2448,7 +2448,7 @@ partial dictionary ComputedEffectTiming {
     CSSNumberish         endTime;
     CSSNumberish         activeDuration;
     CSSNumberish?        localTime;
-    CSSNumberish?        progress;
+    double?              progress;
 };
 </pre>
 

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2448,7 +2448,6 @@ partial dictionary ComputedEffectTiming {
     CSSNumberish         endTime;
     CSSNumberish         activeDuration;
     CSSNumberish?        localTime;
-    double?              progress;
 };
 </pre>
 
@@ -2456,8 +2455,10 @@ partial dictionary ComputedEffectTiming {
 
 :   <dfn dict-member for=ComputedEffectTiming>startTime</dfn>
 ::  The <a lt='animation effect start time'>start time</a> of this
-    <a>animation effect</a> in milliseconds or as a percentage of the
+    <a>animation effect</a> expressed as a double in milliseconds
+    if [=timeline duration=] is unresolved or as a percentage of
     [=timeline duration=].
+
     This is the time at which the <a>parent group</a>, if
     any, has scheduled this child to run within its <a
     lt="transformed time">transformed time space</a>, that is, the
@@ -2468,23 +2469,36 @@ partial dictionary ComputedEffectTiming {
     the <a lt="animation effect start time">start time</a> and
     <a>start delay</a>.
 
-:   <dfn>endTime</dfn>
+:   <dfn dict-member for=ComputedEffectTiming>endTime</dfn>
 ::  Update the description as:
 
-    > The <a>end time</a> of the <a>animation effect</a> expressed
-    > in milliseconds in <a lt="inherited time">inherited time
-    > space</a> or as a percentage of the [=timeline duration=].
-
+    > The <a>end time</a> of the <a>animation effect</a> in
+    > <a lt="inherited time">inherited timespace</a>. The value is expressed as
+    > a double in milliseconds if [=timeline duration=] is unresolved or as a
+    > percentage of [=timeline duration=].
     > This corresponds to the end of the <a>animation effect</a>'s active
     > interval plus any <a>end delay</a>.
 
-:   <dfn>localTime</dfn>
+:   <dfn dict-member for=ComputedEffectTiming>activeDuration</dfn>
+::  Update the description as:
+
+    > The <a>active duration</a> of this <a>animation effect</a> expressed
+    > as a double in milliseconds if [=timeline duration=] is unresolved,
+    > or as a percentage of [=timeline duration=].
+
+:   <dfn dict-member for=ComputedEffectTiming>localTime</dfn>
 ::  Update the second paragraph as:
 
     > This will be <code>null</code> if this
     > <a>animation effect</a> is not
     > <a>associated with an animation</a> or if it has a
     > <a>parent group</a> that is not <a>in effect</a>.
+
+    Append:
+
+    > The value is expressed as a double in milliseconds if
+    > [=timeline duration=] is unresolved or as a percentage of
+    > [=timeline duration=].
 
 </div>
 


### PR DESCRIPTION
[web-animations-2]  Update ComputedEffectTiming

This PR fixes descriptions in ComputedEffectTiming to remove ambiguity over the return value types. Specifically, effects linked to animations with timelines that have an unresolved duration should return times expressed as doubles in milliseconds and not as CSSNumericValues.  Only progress based animations should return their time values expressed as CSS.percent.  

The progress attribute was previously changed to be of type CSSNumberish but without a description change. This property is a fraction and not a time.  Thus, it should not have been changed.  The change is  reverted in this PR.

A few formatting fixers were applied to clearly show the type for each attribute in the "members" section.