### PR TITLE
[css-syntax-3][css-values-3][css-cascade-4][css-fonts-4] Formalize fetching and resource timing reporting

### DIFF
--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -276,8 +276,11 @@ Processing Stylesheet Imports</h3>
 			|parentStylesheet|'s <a spec=cssom>location</a>. If the algorithm returns an error,
 			return. [[CSSOM]]
 
-		1. [=Fetch a style resource=] |parsedUrl|, with |parentStylesheet|, "style", "no-cors",
-		    and the following steps given [=/response=] |response|:
+		1. [=Fetch a style resource=] from |parsedUrl|, 
+			with stylesheet |parentStylesheet|, 
+			destination "style", 
+			CORS mode "no-cors",
+			and processResponse being the following steps given [=/response=] |response|:
 
 			1. If |response| is a [=network error=] or its [=response/status=] is not an
 				[=ok status=], return.

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -268,15 +268,16 @@ Processing Stylesheet Imports</h3>
 		1. Let |parentStylesheet| be |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>.
 			[[CSSOM]]
 
-		1. If |rule| has a <<supports-condition>>,
+		2. If |rule| has a <<supports-condition>>,
 			and that condition is not true,
 			return.
 
-		1. Let |parsedUrl| be the result of the [=URL parser=] steps with |relativeUrl| and
-			|parentStylesheet|'s <a spec=cssom>location</a>. If the algorithm returns an error,
+		3. Let |parsedUrl| be the result of the [=URL parser=] steps with |rule|'s URL and
+			|parentStylesheet|'s <a spec=cssom>location</a>.
+			If the algorithm returns an error,
 			return. [[CSSOM]]
 
-		1. [=Fetch a style resource=] from |parsedUrl|, 
+		4. [=Fetch a style resource=] from |parsedUrl|,
 			with stylesheet |parentStylesheet|, 
 			destination "style", 
 			CORS mode "no-cors",
@@ -285,24 +286,24 @@ Processing Stylesheet Imports</h3>
 			1. If |response| is a [=network error=] or its [=response/status=] is not an
 				[=ok status=], return.
 
-			1. If |parentStylesheet| is in [=quirks mode=]
+			2. If |parentStylesheet| is in [=quirks mode=]
 				and |response| is [=CORS-same-origin=],
 				let |content type| be <code>"text/css"</code>.
 				Otherwise, let |content type| be the Content Type metadata of |response|.
 
-			1. If |content type| is not <code>"text/css"</code>,
+			3. If |content type| is not <code>"text/css"</code>,
 				return.
 
-			1. Let |importedStylesheet| be the result of [=Parse a stylesheet|parsing=] |response|'s
+			4. Let |importedStylesheet| be the result of [=Parse a stylesheet|parsing=] |response|'s
 			    [=response/body=]'s [=body/stream=] given |parsedUrl|.
 
-			1. Set |importedStylesheet|'s <a spec=cssom>origin-clean flag</a> to
+			5. Set |importedStylesheet|'s <a spec=cssom>origin-clean flag</a> to
 				|parentStylesheet|'s <a spec=cssom>origin-clean flag</a>.
 
-			1. If |response| is not [=CORS-same-origin=], unset |importedStylesheet|'s
+			6. If |response| is not [=CORS-same-origin=], unset |importedStylesheet|'s
 				<a spec=cssom>origin-clean flag</a>.
 
-			1. Set |rule|'s {{CSSImportRule/styleSheet}} to |importedStylesheet|.
+			7. Set |rule|'s {{CSSImportRule/styleSheet}} to |importedStylesheet|.
 	</div>
 
 <h3 id='content-type'>

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -265,82 +265,42 @@ Processing Stylesheet Imports</h3>
 	<div algorithm>
 		To <dfn export>fetch an @import</dfn>, given an ''@import'' rule |rule|:
 
+		1. Let |parentStylesheet| be |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>.
+			[[CSSOM]]
+
 		1. If |rule| has a <<supports-condition>>,
 			and that condition is not true,
-			return nothing.
+			return.
 
-		1. [=Parse a URL=] given |rule|'s URL,
-			relative to |rule|'s [=CSSRule/parent CSS style sheet's=] [=CSSStyleSheet/location=].
+		1. Let |parsedUrl| be the result of the [=URL parser=] steps with |relativeUrl| and
+			|parentStylesheet|'s <a spec=cssom>location</a>. If the algorithm returns an error,
+			return. [[CSSOM]]
 
-			Issue: Make sure this is defined correctly,
-			drawing from the document when it's a <{style}> element, etc.
+		1. [=Fetch a style resource=] |parsedUrl|, with |parentStylesheet|, "style", "no-cors",
+		    and the following steps given [=/response=] |response|:
 
-			If that fails, then return nothing. Otherwise, let |url| be the [=resulting URL record=].
+			1. If |response| is a [=network error=] or its [=response/status=] is not an
+				[=ok status=], return.
 
-		2. Let |request| be a new [=/request=]
-			whose [=request/URL=] is |url|,
-			[=request/destination=] is <code>"style"</code>,
-			[=request/mode=] is <code>"no-cors"</code>,
-			[=request/credentials mode=] is <code>"include"</code>,
-			and whose [=request/use-URL-credentials flag=] is set.
-
-		3. Set |request|'s client to ????
-
-			Issue: The Fetch spec doesn't provide any information about what a client is
-			or what it does,
-			so I have no idea of what to provide here.
-
-		4. Run the following steps [=in parallel=]:
-
-			1. Let |response| be the result of [=/fetching=] |request|.
-
-			2. Let |success| initially be true.
-
-			3. If |response| is a [=network error=]
-				or its [=response/status=] is not an [=ok status=],
-				set |success| to false.
-
-			4. If |rule|'s [=CSSRule/parent style sheet=] is in [=quirks mode=]
+			1. If |parentStylesheet| is in [=quirks mode=]
 				and |response| is [=CORS-same-origin=],
 				let |content type| be <code>"text/css"</code>.
 				Otherwise, let |content type| be the Content Type metadata of |response|.
 
-			5. If |content type| is not <code>"text/css"</code>,
+			1. If |content type| is not <code>"text/css"</code>,
 				return.
 
-			6. Issue: Do we wait for sub-imports to run now?
-				Need to explore this.
+			1. Let |importedStylesheet| be the result of [=Parse a stylesheet|parsing=] |response|'s
+			    [=response/body=]'s [=body/stream=] given |parsedUrl|.
 
-			7. Let |global| be the result of [=finding the relevant global object for a stylesheet=]
-				given |rule|'s [=CSSRule/parent CSS style sheet=].
+			1. Set |importedStylesheet|'s <a spec=cssom>origin-clean flag</a> to
+				|parentStylesheet|'s <a spec=cssom>origin-clean flag</a>.
 
-			8. [=Queue a global task=],
-				given the [=networking task source=]
-				and |global|,
-				to [=process an imported stylesheet=]
-				given |rule|,
-				|success|,
-				and |response|.
-	</div>
+			1. If |response|'s [=response/url=]'s [=url/origin=] is not the [=same origin=] as
+			    |rule|'s [=relevant settings object=]'s [=environment settings object/origin=],
+				unset |importedStylesheet|'s <a spec=cssom>origin-clean flag</a>.
 
-	<div algorithm>
-		To <dfn export>find the relevant global object for a stylesheet</dfn> given a CSS style sheet |stylesheet|:
-
-		1. If |stylesheet| has a [=CSSStyleSheet/parent CSS style sheet=],
-			return the result of [=finding the relevant global object for a stylesheet=]
-			given the [=CSSStyleSheet/parent CSS style sheet=].
-
-		2. If |stylesheet| has an [=CSSStyleSheet/owner node=],
-			return the [=CSSStyleSheet/owner node's=] [=relevant global object=].
-	</div>
-
-	<div algorithm>
-		To <dfn export>process an imported stylesheet</dfn>
-		given a parent rule |rule|,
-		a success flag |success|,
-		and a response |response|:
-
-		Issue: Create a stylesheet, assign it to the parent rule.
+			1. Set |rule|'s {{CSSImportRule/styleSheet}} to |importedStylesheet|.
 	</div>
 
 <h3 id='content-type'>

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -281,10 +281,10 @@ Processing Stylesheet Imports</h3>
 			with stylesheet |parentStylesheet|, 
 			destination "style", 
 			CORS mode "no-cors",
-			and processResponse being the following steps given [=/response=] |response|:
+			and processResponse being the following steps given [=/response=] |response| and
+			byte stream, null or failure |byteStream|:
 
-			1. If |response| is a [=network error=] or its [=response/status=] is not an
-				[=ok status=], return.
+			1. If |maybeByteStream| is not a byte stream, return.
 
 			2. If |parentStylesheet| is in [=quirks mode=]
 				and |response| is [=CORS-same-origin=],
@@ -294,8 +294,8 @@ Processing Stylesheet Imports</h3>
 			3. If |content type| is not <code>"text/css"</code>,
 				return.
 
-			4. Let |importedStylesheet| be the result of [=Parse a stylesheet|parsing=] |response|'s
-			    [=response/body=]'s [=body/stream=] given |parsedUrl|.
+			4. Let |importedStylesheet| be the result of [=Parse a stylesheet|parsing=] |byteStram|
+			   given |parsedUrl|.
 
 			5. Set |importedStylesheet|'s <a spec=cssom>origin-clean flag</a> to
 				|parentStylesheet|'s <a spec=cssom>origin-clean flag</a>.

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -296,9 +296,8 @@ Processing Stylesheet Imports</h3>
 			1. Set |importedStylesheet|'s <a spec=cssom>origin-clean flag</a> to
 				|parentStylesheet|'s <a spec=cssom>origin-clean flag</a>.
 
-			1. If |response|'s [=response/url=]'s [=url/origin=] is not the [=same origin=] as
-			    |rule|'s [=relevant settings object=]'s [=environment settings object/origin=],
-				unset |importedStylesheet|'s <a spec=cssom>origin-clean flag</a>.
+			1. If |response| is not [=CORS-same-origin=], unset |importedStylesheet|'s
+				<a spec=cssom>origin-clean flag</a>.
 
 			1. Set |rule|'s {{CSSImportRule/styleSheet}} to |importedStylesheet|.
 	</div>

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -3997,7 +3997,7 @@ Specifying a color profile: the ''@color-profile'' at-rule</h3>
 		[=fetch a style resource=] given |rule|'s URL,
 		with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>,
 		destination "color-profile",
-		CORS mode "no-cors",
+		CORS mode "cors",
 		and processResponse being the following steps given [=/response=] |res| and null, failure or
 		a byte stream |byteStream|:
 			If |byteStream| is a byte stream,

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -3992,6 +3992,17 @@ Specifying a color profile: the ''@color-profile'' at-rule</h3>
 	which reference this profile
 	are <a>invalid color</a>s.
 
+	To <dfn>fetch an external color profile</dfn>, given a
+	''@color-profile'' rule |rule|,
+		[=fetch a style resource=] given |rule|'s URL,
+		with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>,
+		destination "color-profile",
+		CORS mode "no-cors",
+		and processResponse being the following steps given [=/response=] |res| and null, failure or
+		a byte stream |byteStream|:
+			If |byteStream| is a byte stream,
+			apply the color profile as parsed from |byteStream.
+
 	Note: The Internet Media Type ("MIME type")
 	for ICC profiles is
 	<a href="https://www.iana.org/assignments/media-types/application/vnd.iccprofile">application/vnd.iccprofile</a>.

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2944,9 +2944,18 @@ downloadable fonts to avoid large page reflows where possible.
 <h4 id="font-fetching-requirements" oldids="same-origin-restriction,allowing-cross-origin-font-loading">
 Font fetching requirements</h4>
 
-For font loads from @font-face rules, user agents must create a <a>request</a>
-whose <var>url</var> is the URL given by the @font-face rule, whose <var>referrer</var>
-is the stylesheet's URL, and whose <var>origin</var> is the URL of the containing document.
+<div algorithm>
+	To <dfn>fetch a font</dfn> given a selected [=/url=] |url| for ''@font-face'' |rule|,
+	[=fetch a style resource|fetch=] |url|, with |rule|'s
+	<a spec=cssom for=CSSRule>parent CSS style sheet</a>, "font", "cors" and the following steps
+	given [=/response=] |res|:
+
+	1. Let |body| be |res|'s [=response/body=].
+
+	1. If |body| is null, return.
+
+	1. ISSUE: Load a font from |body| according to its type.
+</div>
 
 Note: The implications of this for authors are that fonts
 will typically not be loaded cross-origin unless authors specifically

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2950,13 +2950,12 @@ Font fetching requirements</h4>
 	with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>, 
 	destination "font", 
 	CORS mode "cors",
-	and processResponse being the following steps given [=/response=] |res|:
+	and processResponse being the following steps given [=/response=] |res| and null, failure or a
+	byte stream |stream|:
 
-	1. Let |body| be |res|'s [=response/body=].
+	1. If |stream| is null, return.
 
-	1. If |body| is null, return.
-
-	1. ISSUE: Load a font from |body| according to its type.
+	2. ISSUE: Load a font from |stream| according to its type.
 </div>
 
 Note: The implications of this for authors are that fonts

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2946,9 +2946,11 @@ Font fetching requirements</h4>
 
 <div algorithm>
 	To <dfn>fetch a font</dfn> given a selected [=/url=] |url| for ''@font-face'' |rule|,
-	[=fetch a style resource|fetch=] |url|, with |rule|'s
-	<a spec=cssom for=CSSRule>parent CSS style sheet</a>, "font", "cors" and the following steps
-	given [=/response=] |res|:
+	[=fetch a style resource|fetch=] |url|, 
+	with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>, 
+	destination "font", 
+	CORS mode "cors",
+	and processResponse being the following steps given [=/response=] |res|:
 
 	1. Let |body| be |res|'s [=response/body=].
 

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1,4 +1,4 @@
-<pre class='metadata'>
+uel<pre class='metadata'>
 Title: CSS Images Module Level 4
 Status: ED
 Work Status: Exploring
@@ -138,6 +138,18 @@ Image References: the ''url()'' notation {#url-notation}
 
 Note: No change from [[css3-images]].
 
+
+Fetching External Images
+------------------------------------------------------------------------------------------
+To <dfn>fetch an external image for a stylesheet</dfn>,
+	given a [=/url=] |url| and {{CSSStyleSheet}} sheet,
+	[=fetch a style resource=] given |url|,
+	with stylesheet {{CSSStyleSheet}},
+	destination "image",
+	CORS mode "no-cors",
+	and processResponse being the following steps given [=/response=] |res| and null, failure or
+	a byte stream |byteStream|:
+		If |byteStream| is a byte stream, load the image from the byte stream.
 
 
 <!--

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -427,13 +427,8 @@ Shapes from Image</h3>
 Fetching external shapes</h2>
 
 	To <dfn>fetch an external resource for a shape</dfn>, either an SVG or an image, given a
-	{{CSSStyleRule}} |rule|:
-	1. Let |parsedUrl| be the result of the [=URL parser=] steps with |rule|'s URL and |rule|'s
-		|parentStylesheet|'s <a spec=cssom>location</a>.
-		If the algorithm returns an error,
-		return. [[CSSOM]]
-
-	2. [=Fetch a style resource=] given |parsedUrl|,
+	{{CSSStyleRule}} |rule|,
+		[=fetch a style resource=] given |rule|'s URL,
 		with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>,
 		destination "image",
 		CORS mode "cors",

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -423,6 +423,27 @@ Shapes from Image</h3>
 	that determines the relevant pixels to use
 	(both for defining a shape and for display).
 
+<h2 id="fetching-external-shapes">
+Fetching external shapes</h2>
+
+	To <dfn>fetch an external resource for a shape</dfn>, either an SVG or an image, given a
+	{{CSSStyleRule}} |rule|:
+	1. Let |parsedUrl| be the result of the [=URL parser=] steps with |rule|'s URL and |rule|'s
+		|parentStylesheet|'s <a spec=cssom>location</a>.
+		If the algorithm returns an error,
+		return. [[CSSOM]]
+
+	2. [=Fetch a style resource=] given |parsedUrl|,
+		with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>,
+		destination "image",
+		CORS mode "cors",
+		and processResponse being the following steps given [=/response=] |res| and null, failure or
+		a byte stream |byteStream|:
+			If |byteStream| is a byte stream,
+			apply the image or SVG to the appropriate shape-accepting property.
+
+		Note: shapes require CORS mode as their effect is detected by the document.
+
 
 <h2 id="shapes-from-box-values">
 Shapes from Box Values</h2>

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2121,7 +2121,8 @@ Parse A Comma-Separated List According To A CSS Grammar</h4>
 Parse a stylesheet</h4>
 
 	<div algorithm>
-		To <dfn export>parse a stylesheet</dfn> from an |input|:
+		To <dfn export>parse a stylesheet</dfn> from an |input| given [=/url=] or Null |location|
+		(default null):
 
 		<ol>
 			<li>
@@ -2134,7 +2135,7 @@ Parse a stylesheet</h4>
 				and set |input| to the result.
 
 			<li>
-				Create a new stylesheet.
+				Create a new stylesheet, with its <a spec=cssom>location</a> set to |location|.
 
 			<li>
 				<a>Consume a list of rules</a> from |input|,

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2121,8 +2121,8 @@ Parse A Comma-Separated List According To A CSS Grammar</h4>
 Parse a stylesheet</h4>
 
 	<div algorithm>
-		To <dfn export>parse a stylesheet</dfn> from an |input| given [=/url=] or Null |location|
-		(default null):
+		To <dfn export>parse a stylesheet</dfn> from an |input| 
+		given an optional [=/url=] |location|:
 
 		<ol>
 			<li>
@@ -2135,7 +2135,7 @@ Parse a stylesheet</h4>
 				and set |input| to the result.
 
 			<li>
-				Create a new stylesheet, with its <a spec=cssom>location</a> set to |location|.
+				Create a new stylesheet, with its <a spec=cssom>location</a> set to |location| (or null, if |location| was not passed).
 
 			<li>
 				<a>Consume a list of rules</a> from |input|,

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1006,18 +1006,27 @@ URL processing model</h4>
 
 		3. Let |documentBase| be |environmentSettings|'s [=API base URL=].
 
-		4. Let |handleResourceFetchDone| be to do nothing.
+		4. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
 
-		5. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		5. Let |referrer| be |documentBase|.
+
+		6. Let |handleResourceFetchDone| be to do nothing.
+
+		7. If |base| is null, set |base| to |documentBase|.
+
+		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		6. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		9. If |corsMode| is "cors", set |referrer| to |sheet|'s
+			<a spec=cssom>location</a>. [[CSSOM]]
+
+		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
 			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
-			set, and whose [=request/referrer=] is |documentBase|.
+			set, and whose [=request/referrer=] is |referrer|.
 
-		7. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
+		11. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
 			set to the following steps given [=/response=] |res| and Null, failure or byte stream
 			|byteStream|:
 			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1006,27 +1006,18 @@ URL processing model</h4>
 
 		3. Let |documentBase| be |environmentSettings|'s [=API base URL=].
 
-		4. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
+		4. Let |handleResourceFetchDone| be to do nothing.
 
-		5. Let |referrer| be |documentBase|.
-
-		6. Let |handleResourceFetchDone| be to do nothing.
-
-		7. If |base| is null, set |base| to |documentBase|.
-
-		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		5. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		9. If |corsMode| is "cors", set |referrer| to |sheet|'s
-			<a spec=cssom>location</a>. [[CSSOM]]
-
-		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		6. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
 			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
-			set, and whose [=request/referrer=] is |referrer|.
+			set, and whose [=request/referrer=] is |documentBase|.
 
-		11. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
+		7. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
 			set to the following steps given [=/response=] |res| and Null, failure or byte stream
 			|byteStream|:
 			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -993,9 +993,11 @@ URL Modifiers</h4>
 URL processing model</h4>
 
 	<div algorithm>
-		To <dfn export>fetch a style resource</dfn> [=/url=] |url|, given a {{CSSStyleSheet}}
-		|sheet|, a string |destination|, a "no-cors" or "cors" |corsMode|, and an algorithm
-		|processResponse| accepting a [=/response=]:
+		To <dfn export>fetch a style resource</dfn> from [=/url=] |url|, 
+		given a {{CSSStyleSheet}} |sheet|, 
+		a string |destination| matching a {{RequestDestination}}, 
+		a "no-cors" or "cors" |corsMode|, 
+		and an algorithm |processResponse| accepting a [=/response=]:
 
 		1. Let |environmentSettings| be |sheet|'s [=relevant settings object=].
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1014,8 +1014,7 @@ URL processing model</h4>
 		1. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		1. If |corsMode| is not "cors", or |url| is the [=same origin=] as |environmentSettings|'s
-			[=environment settings object/origin=], set |referrer| to |sheet|'s
+		1. If |corsMode| is "cors", set |referrer| to |sheet|'s
 			<a spec=cssom>location</a>. [[CSSOM]]
 
 		1. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1009,29 +1009,29 @@ URL processing model</h4>
 
 		5. Let |referrer| be |documentBase|.
 
-		6. Let |handleResourceFetchDone| be to do nothing.
+		6. If |base| is null, set |base| to |documentBase|.
 
-		7. If |base| is null, set |base| to |documentBase|.
-
-		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		7. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		9. If |corsMode| is "cors", set |referrer| to |sheet|'s
+		8. If |corsMode| is "cors", set |referrer| to |sheet|'s
 			<a spec=cssom>location</a>. [[CSSOM]]
 
-		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		9. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |mode|, [=request/origin=]
 			is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
 			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
 			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.
 
-		11. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
-			given [=/response=] |res| to [=finalize and report timing=] with |res|, |global|, and
-			<code>"css"</code>. [[CSSOM]]
+		10. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponse| set to
+			the following steps given [=/response=] |res|:
 
-		12. [=/Fetch=] |req|, with |processResponseDone| set to |handleResourceFetchDone|,
-			|taskDestination| set to |global|, and |processResponse| set to |processResponse|.
+			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
+				given [=/response=] |res| to [=finalize and report timing=] with |res|, |global|, and
+				<code>"css"</code>. [[CSSOM]]
+
+			2. Call |processResponseDone| with |res|.
 	</div>
 
 <h2 id="numeric-types">

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1021,8 +1021,8 @@ URL processing model</h4>
 			<a spec=cssom>location</a>. [[CSSOM]]
 
 		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
-			[=request/destination=] is |destination|, [=request/mode=] is |mode|, [=request/origin=]
-			is |environmentSettings|'s [=environment settings object/origin=],
+			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
+			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
 			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
 			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1001,36 +1001,36 @@ URL processing model</h4>
 
 		1. Let |environmentSettings| be |sheet|'s [=relevant settings object=].
 
-		1. Let |global| be |environmentSettings|'s [=environment settings object/global object=].
+		2. Let |global| be |environmentSettings|'s [=environment settings object/global object=].
 
-		1. Let |documentBase| be |environmentSettings|'s [=API base URL=].
+		3. Let |documentBase| be |environmentSettings|'s [=API base URL=].
 
-		1. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
+		4. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
 
-		1. Let |referrer| be |documentBase|.
+		5. Let |referrer| be |documentBase|.
 
-		1. Let |handleResourceFetchDone| be to do nothing.
+		6. Let |handleResourceFetchDone| be to do nothing.
 
-		1. If |base| is null, set |base| to |documentBase|.
+		7. If |base| is null, set |base| to |documentBase|.
 
-		1. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		1. If |corsMode| is "cors", set |referrer| to |sheet|'s
+		9. If |corsMode| is "cors", set |referrer| to |sheet|'s
 			<a spec=cssom>location</a>. [[CSSOM]]
 
-		1. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |mode|, [=request/origin=]
 			is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
 			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
 			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.
 
-		1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
+		11. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
 			given [=/response=] |res| to [=finalize and report timing=] with |res|, |global|, and
 			<code>"css"</code>. [[CSSOM]]
 
-		1. [=/Fetch=] |req|, with |processResponseDone| set to |handleResourceFetchDone|,
+		12. [=/Fetch=] |req|, with |processResponseDone| set to |handleResourceFetchDone|,
 			|taskDestination| set to |global|, and |processResponse| set to |processResponse|.
 	</div>
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1024,8 +1024,7 @@ URL processing model</h4>
 			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
 			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
-			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
-			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.
+			set, and whose [=request/referrer=] is |referrer|.
 
 		11. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
 			set to the following steps given [=/response=] |res| and Null, failure or byte stream

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -989,6 +989,50 @@ URL Modifiers</h4>
 	Note: A <<url>> that is either unquoted or not wrapped in ''url()'' notation
 	cannot accept any <<url-modifier>>s.
 
+<h4 id='prcoessing-model'>
+URL processing model</h4>
+
+	<div algorithm>
+		To <dfn export>fetch a style resource</dfn> [=/url=] |url|, given a {{CSSStyleSheet}}
+		|sheet|, a string |destination|, a "no-cors" or "cors" |corsMode|, and an algorithm
+		|processResponse| accepting a [=/response=]:
+
+		1. Let |environmentSettings| be |sheet|'s [=relevant settings object=].
+
+		1. Let |global| be |environmentSettings|'s [=environment settings object/global object=].
+
+		1. Let |documentBase| be |environmentSettings|'s [=API base URL=].
+
+		1. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
+
+		1. Let |referrer| be |documentBase|.
+
+		1. Let |handleResourceFetchDone| be to do nothing.
+
+		1. If |base| is null, set |base| to |documentBase|.
+
+		1. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+			If the algorithm returns an error, return.
+
+		1. If |corsMode| is not "cors", or |url| is the [=same origin=] as |environmentSettings|'s
+			[=environment settings object/origin=], set |referrer| to |sheet|'s
+			<a spec=cssom>location</a>. [[CSSOM]]
+
+		1. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+			[=request/destination=] is |destination|, [=request/mode=] is |mode|, [=request/origin=]
+			is |environmentSettings|'s [=environment settings object/origin=],
+			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
+			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
+			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.
+
+		1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
+			given [=/response=] |res| to [=finalize and report timing=] with |res|, |global|, and
+			<code>"css"</code>. [[CSSOM]]
+
+		1. [=/Fetch=] |req|, with |processResponseDone| set to |handleResourceFetchDone|,
+			|taskDestination| set to |global|, and |processResponse| set to |processResponse|.
+	</div>
+
 <h2 id="numeric-types">
 Numeric Data Types</h2>
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -997,7 +997,8 @@ URL processing model</h4>
 		given a {{CSSStyleSheet}} |sheet|, 
 		a string |destination| matching a {{RequestDestination}}, 
 		a "no-cors" or "cors" |corsMode|, 
-		and an algorithm |processResponse| accepting a [=/response=]:
+		and an algorithm |processResponse| accepting a [=/response=] and a null, failure or byte
+		stream:
 
 		1. Let |environmentSettings| be |sheet|'s [=relevant settings object=].
 
@@ -1009,29 +1010,32 @@ URL processing model</h4>
 
 		5. Let |referrer| be |documentBase|.
 
-		6. If |base| is null, set |base| to |documentBase|.
+		6. Let |handleResourceFetchDone| be to do nothing.
 
-		7. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		7. If |base| is null, set |base| to |documentBase|.
+
+		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
 
-		8. If |corsMode| is "cors", set |referrer| to |sheet|'s
+		9. If |corsMode| is "cors", set |referrer| to |sheet|'s
 			<a spec=cssom>location</a>. [[CSSOM]]
 
-		9. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		10. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |mode|, [=request/origin=]
 			is |environmentSettings|'s [=environment settings object/origin=],
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
 			set, and whose [=request/header list=] is a [=/header list=] containing a [=header=]
 			with its [=header/name=] set to "referrer" and its [=header/value=] set to |referrer|.
 
-		10. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponse| set to
-			the following steps given [=/response=] |res|:
-
-			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |handleResourceFetchDone|
-				given [=/response=] |res| to [=finalize and report timing=] with |res|, |global|, and
+		11. [=/Fetch=] |req|, with |taskDestination| set to |global|, and |processResponseEndOfBody|
+			set to the following steps given [=/response=] |res| and Null, failure or byte stream
+			|byteStream|:
+			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
+				[=finalize and report timing=] with |res|, |global|, and
 				<code>"css"</code>. [[CSSOM]]
 
-			2. Call |processResponseDone| with |res|.
+			2. Call |processResponse| with |res| and |byteStream|.
+
 	</div>
 
 <h2 id="numeric-types">


### PR DESCRIPTION
Add a generic method to fetch style resources, and make use of it in
fonts & imports.

[css-syntax-3]: Make sure we have a location when parsing a stylesheet, as the location is necessary for parsing import rules.
[css-values-3]: Add a reusable method to fetch a style-originated
resource.
[css-cascade-4]: Formalize the import algorithm to use the new fetch
method.
[css-fonts-4]: Formalize font loading to use the new fetch method. Removed some of the font loading "guidelines" as they are now baked in to the algorithm.
[css-shapes-2]: Load css-shapes external images/SVG using fetch style resoure

See https://github.com/w3c/csswg-drafts/issues/562

Fixes #6076

Tests: https://github.com/web-platform-tests/wpt/pull/31344