### PR TITLE
[css-color-adjust] Define color-scheme: normal to be hookable by HTML.

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -159,15 +159,20 @@ Opting Into a Preferred Color Scheme: the 'color-scheme' property {#color-scheme
 	user agents cannot automatically adapt the colors used in elements under their control,
 	as it might cause unreadable color contrast with the surrounding page.
 
+	Host languages can define the <dfn export>page's supported color schemes</dfn>,
+	a list of [=color schemes=] supported by default for all elements on that page.
+
+	Note: [[HTML]] specifies a
+	<a href="https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme">color-scheme</a>
+	<{meta}> tag which can be used to set the [=page's supported color schemes=].
+
 	Values are defined as follows:
 
 	<dl dfn-type=value dfn-for=color-scheme>
 		: <dfn>normal</dfn>
 		::
-			Indicates that the element doesn't support [=color schemes=] at all,
-			and so the element should be rendered with the browser's default [=color scheme=].
-
-			(This is typically, tho not always, similar to ''light''.)
+			Indicates that the element supports the [=page's supported color schemes=],
+			if they are set, or that it supports no [=color schemes=] at all otherwise.
 
 		: <dfn>light</dfn>
 		::
@@ -316,11 +321,6 @@ Opting Into a Preferred Color Scheme: the 'color-scheme' property {#color-scheme
 		will be opted into the ''light'' or ''dark'' themes specifically;
 		the rest of the page will respect the user's preference.
 	</div>
-
-	Note: [[HTML]] specifies a
-	<a href="https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme">color-scheme</a>
-	<{meta}> tag which can be used to set the color-scheme on the root element as
-	a [[css-cascade-4#preshint|non-CSS presentational hint]].
 
 	Note: Repeating a keyword, such as ''color-scheme: light light'',
 	is valid but has no additional effect


### PR DESCRIPTION
This allows HTML to "set" the used value of the color-scheme property,
via a meta tag.

Part of https://github.com/whatwg/html/issues/7213
Closes https://github.com/w3c/csswg-drafts/issues/6726