### PR TITLE
[css-highlight-api-1] Don't paint highlights that cross contain boundaries

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -511,18 +511,18 @@ Range Updating and Invalidation</h3>
 	following steps return false:
 
 	1. If the [=range=] is a {{StaticRange}} and is not <a spec=dom for="StaticRange">valid</a>,
-	   then return false.
+		then return false.
 	2. Let <var>start node</var> be the [=start node=] of the [=range=].
 	3. Let <var>end node</var> be the [=end node=] of the [=range=].
 	4. If the [=shadow-including root=] of either <var>start node</var> or <var>end node</var> is
-	   something other than that {{Document}}, then return false.
+		something other than that {{Document}}, then return false.
 	5. Let <var>start nearest contain ancestor</var> be <var>start node</var>'s nearest ancestor in
-	   the <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor)
-	   (See [[!CSS-CONTAIN-1]]).
+		the <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor)
+		(See [[!CSS-CONTAIN-1]]).
 	6. Let <var>end nearest contain ancestor</var> be <var>end node</var>'s nearest ancestor in the
-	   <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor).
+		<a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor).
 	7. If <var>start nearest contain ancestor</var> is not equal to
-	   <var>end nearest contain ancestor</var>, then return false.
+		<var>end nearest contain ancestor</var>, then return false.
 
 <h2 id=events>
 Event Handling</h2>

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -512,16 +512,16 @@ Range Updating and Invalidation</h3>
 
 	1. If the [=range=] is a {{StaticRange}} and is not <a spec=dom for="StaticRange">valid</a>,
 	   then return false.
-	1. Let <var>start node</var> be the [=start node=] of the [=range=].
-	1. Let <var>end node</var> be the [=end node=] of the [=range=].
-	1. If the [=shadow-including root=] of either <var>start node</var> or <var>end node</var> is
+	2. Let <var>start node</var> be the [=start node=] of the [=range=].
+	3. Let <var>end node</var> be the [=end node=] of the [=range=].
+	4. If the [=shadow-including root=] of either <var>start node</var> or <var>end node</var> is
 	   something other than that {{Document}}, then return false.
-	1. Let <var>start nearest contain ancestor</var> be <var>start node</var>'s nearest ancestor in
+	5. Let <var>start nearest contain ancestor</var> be <var>start node</var>'s nearest ancestor in
 	   the <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor)
 	   (See [[!CSS-CONTAIN-1]]).
-	1. Let <var>end nearest contain ancestor</var> be <var>end node</var>'s nearest ancestor in the
+	6. Let <var>end nearest contain ancestor</var> be <var>end node</var>'s nearest ancestor in the
 	   <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor).
-	1. If <var>start nearest contain ancestor</var> is not equal to
+	7. If <var>start nearest contain ancestor</var> is not equal to
 	   <var>end nearest contain ancestor</var>, then return false.
 
 <h2 id=events>

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -506,31 +506,23 @@ Range Updating and Invalidation</h3>
 		and recreating new ones.
 	</div>
 
-	When computing how to render a document,
-	if [=start node=] or [=end node=] of any [=range=]
-	in the [=highlight registry=] associated with that document's window
-	refer to a {{Node}} whose [=shadow-including root=] is not that document,
-	the user agent must ignore that [=range=].
-	If any {{StaticRange}} in the [=highlight registry=] associated with that document's window
-	is not <a spec=dom for="StaticRange">valid</a>,
-	the user agent must ignore that [=range=].
+	When computing how to render a {{Document}}, for each [=range=] in the [=highlight registry=]
+	associated with that {{Document}}'s {{Window}}, the user agent must ignore that [=range=] if the
+	following steps return false:
 
-	Issue(4598): The interaction of {{StaticRange}}s in a [=custom highlight=]
-	and [[css-contain-2]]
-	seems problematic:
-	on a fully contained element,
-	you should expect that DOM changes to descendants of that element
-	will not cause invalidation and restyling/repainting
-	of elements outside the contained one.
-	However, if a static range has a boundary point inside the contained subtree
-	and another boundary point outside of it,
-	and the DOM in the contained subtree is changed
-	so that the boundary point inside no longer points to a valid node,
-	the whole range should be ignored,
-	which would affect painting outside the contained subtree.
-	Is this a weakness of [=style containment=],
-	or of the invalidation logic above,
-	or something else?
+	1. If the [=range=] is a {{StaticRange}} and is not <a spec=dom for="StaticRange">valid</a>,
+	   then return false.
+	1. Let <var>start node</var> be the [=start node=] of the [=range=].
+	1. Let <var>end node</var> be the [=end node=] of the [=range=].
+	1. If the [=shadow-including root=] of either <var>start node</var> or <var>end node</var> is
+	   something other than that {{Document}}, then return false.
+	1. Let <var>start nearest contain ancestor</var> be <var>start node</var>'s nearest ancestor in
+	   the <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor)
+	   (See [[!CSS-CONTAIN-1]]).
+	1. Let <var>end nearest contain ancestor</var> be <var>end node</var>'s nearest ancestor in the
+	   <a>flat tree</a> that has <a>containment</a> (or null if there is no such ancestor).
+	1. If <var>start nearest contain ancestor</var> is not equal to
+	   <var>end nearest contain ancestor</var>, then return false.
 
 <h2 id=events>
 Event Handling</h2>


### PR DESCRIPTION
If a StaticRange crosses a `contain` boundary and the boundary point inside the contained element is removed, UAs would have to stop painting the full extent of the range. This would violate the `contain` invariant, since a change inside the element with `contain` would have affected the appearance of content outside of that element.

To eliminate this problem, never paint ranges that cross `contain` boundaries.

A slightly more scoped solution would be to apply this limitation only for highlights specified with `StaticRange`, but since there doesn't seem to be any use case for applying highlights across `contain` boundaries, the limitation is applied to live `Range`s as well for consistency's sake.

This PR changes the range-painting criteria into an algorithm, since precisely expressing the concept of "crossing a contain boundary" is clumsy in prose.

Resolves #4598.