### PR TITLE
[scroll-animations-1] Update reference to scrollSource

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1103,7 +1103,7 @@ interface CSSScrollTimelineRule : CSSRule {
 					fill: "forwards"
 				});
 			let timeline = new ScrollTimeline({
-				scrollSource: document.documentElement,
+				source: document.documentElement,
 				orientation: "vertical",
 			});
 			let animation = new Animation(effect, timeline);


### PR DESCRIPTION
[scroll-animations-1] Update reference to scrollSource

An example in the spec still used scrollSource rather than source.