### PR TITLE
[web-animations-2][scroll-animations-1]Update timeline currentTime

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -358,7 +358,7 @@ A <dfn>scroll timeline</dfn> is an {{AnimationTimeline}} whose time values are
 determined not by wall-clock time, but by the progress of scrolling in a
 [=scroll container=].
 
-The {{EffectTiming/duration}} of a <a>scroll timeline</a> is 100%.
+The {{AnimationTimeline/duration}} of a <a>scroll timeline</a> is 100%.
 
 <dl class="constructors">
 	:   <dfn constructor for=ScrollTimeline lt="ScrollTimeline(options)">ScrollTimeline(options)</dfn>

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -838,12 +838,12 @@ The [=timeline/current time=] of a {{ScrollTimeline}} is calculated as follows:
 
 		:   If |current scroll offset| is greater than or equal to [=effective
 			end offset=]:
-		::  The [=timeline/current time=] is the {{EffectTiming/duration}}.
+		::  The [=timeline/current time=] is the {{AnimationTimeline/duration}}.
 
 		:   Otherwise,
 		::  1.  Let |progress| be a result of applying
 				[=calculate scroll timeline progress=] procedure for <var>current scroll offset</var>.
-			1.  The [=timeline/current time=] is <code>|progress| &times; {{EffectTiming/duration}}</code>
+			1.  The [=timeline/current time=] is <code>|progress| &times; {{AnimationTimeline/duration}}</code>
 	</dl>
 
 Note: To be considered active a scroll timeline requires its [=effective scroll

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2182,12 +2182,22 @@ Items sorted earlier are executed before those sorted later.
 <pre class="idl">
 [Exposed=Window]
 partial interface AnimationTimeline {
+    readonly attribute CSSNumberish? currentTime;
     readonly attribute CSSNumberish? duration;
     Animation play (optional AnimationEffect? effect = null);
 };
 </pre>
 
 <div class='attributes'>
+
+Update the attribute type for currentTime.
+
+:   <dfn attribute for=AnimationTimeline>currentTime</dfn>
+::  Returns the <a lt="timeline current time">current time</a> for this
+    timeline or <code>null</code> if this timeline is
+    <a lt="inactive timeline">inactive</a>.  The value is expressed as a
+    percentage for a [=progress-based timeline=], or as a double in
+    milliseconds otherwise.
 
 :   <dfn attribute for=AnimationTimeline>duration</dfn>
 ::  Returns the <a lt="timeline duration">duration</a> for this timeline.


### PR DESCRIPTION
[web-animations-2][scroll-animations-1]Update timeline currentTime

Timeline current time should be a percentage for progress-based animations.
