### PR TITLE
[css-fonts-4] [css-fonts-5] Fix font-technology grammar

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2047,7 +2047,7 @@ Then each component value is parsed according to this grammar:
 		| svg | truetype | woff | woff2 ]</pre>
 
 <pre class="prod"><dfn id="font-technology-values">&lt;font-technology&gt;</dfn>
-	 = <<font-feature-technology>> | <<color-font-technology>>
+	 = [<<font-feature-technology>> | <<color-font-technology>>
 		| variations | palettes | incremental ]</pre>
 
 <pre class="prod"><dfn id="font-feature-technology-values">&lt;font-feature-technology&gt;</dfn>

--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -363,7 +363,7 @@ Then each component value is parsed according to this grammar:
 		| svg | truetype | woff | woff2 ]</pre>
 
 <pre class="prod"><dfn id="font-technology-values">&lt;font-technology&gt;</dfn>
-	 = <<font-feature-technology>> | <<color-font-technology>>
+	 = [<<font-feature-technology>> | <<color-font-technology>>
 		| variations | palettes | incremental ]</pre>
 
 <pre class="prod"><dfn id="font-feature-technology-values">&lt;font-feature-technology&gt;</dfn>


### PR DESCRIPTION
Definition was invalid due to missing "[".
