### PR TITLE
[css-cascade-5] remove the duplicated note in the used values section

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -625,17 +625,6 @@ Used Values</h3>
 		For example, the 'flex' property has no <a>used value</a>
 		on elements that aren't <a>flex items</a>.
 
-	Note: A property defined to apply to “all elements”
-	applies to all elements and [=display types=],
-	but not necessarily to all [=pseudo-element=] types,
-	since pseudo-elements often have their own specific rendering models
-	or other restrictions.
-	The ''::before'' and ''::after'' pseudo-elements, however,
-	are defined to generate boxes almost exactly like normal elements
-	and are therefore defined accept all properties that apply to “all elements”.
-	See [[CSS-PSEUDO-4]]
-	for more information about [=pseudo-elements=].
-
 <h4 id="applies-to">
 Applicable Properties</h4>
 


### PR DESCRIPTION
That note was duplicated in https://github.com/w3c/csswg-drafts/commit/aba0111820c853888a158e99ebb284e18281de22 . This removes the first one to align with the Level 4 draft.
