### PR TITLE
[css-mediaqueries-5] nav-controls: Clarify use in a boolean context (closes #6785)

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -2273,25 +2273,11 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 			}
 		}</code></pre>
 
-		As this media feature can be used in a [=boolean context=],
-		the same example can be written with shorter syntax:
-
-		<pre><code class=lang-css>
-		@media (nav-controls) {
-			#back-button {
-				display: none;
-			}
-		}</code></pre>
-
-		Note: Theoretically, the two are not strictly equivalent,
-		as there could be new values in a future extension of this media feature
-		other than ''back''
-		that could match when ''back'' doesn't.
-		In that case, using the 'nav-controls' feature in a boolean context could be misleading.
-		However, given that navigation back is arguably the most fundamental navigation operation,
-		the CSS Working Group does not anticipate
-		user interfaces with explicit navigation controls but no back button,
-		so this problem is not expected to occur in practice.
+		Note: This media feature can also be used in a [=boolean context=], e.g.,
+		<code class=lang=css>@media (nav-controls)</code>. However, as there could be new values in a future
+		extension of this media feature other than ''back'', use of the ''nav-controls'' feature in a boolean
+		context could cause the page to incorrectly interpret some other control as a "back" button, and its
+		usage is therefore discouraged.
 	</div>
 
 	Whether [=obviously discoverable=] controls are active does not impact the evaluation of this media feature.


### PR DESCRIPTION
[css-mediaqueries-5] nav-controls: Clarify use in a boolean context (closes #6785)

Non-normative change: Remove the example of using nav-controls in a boolean
context and somewhat confusing note explaining its usage. Replaced with a note
explaining why it is not recommended that sites use nav-controls in a boolean
context.