### PR TITLE
[mediaqueries-4] Make <any-value> optional in <general-enclosed>, remove <ident>

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -866,7 +866,7 @@ Syntax</h2>
 	<dfn>&lt;mf-eq></dfn> = '='
 	<dfn>&lt;mf-comparison></dfn> = <<mf-lt>> | <<mf-gt>> | <<mf-eq>>
 
-	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>> ) ] | ( <<ident>> <<any-value>> )
+	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>>? ) ] | ( <<any-value>>? )
 	</pre>
 
 	The <<media-type>> production does not include the keywords ''only'', ''not'', ''and'', and ''or''.


### PR DESCRIPTION
This is to make it possible for the following things to match
`<general-enclosed>`:

 - `unknown()`
 - `(unknown)`
 - `(10px < unknown)`
 