### PR TITLE
[mediaqueries-4] Lift parens to <media-in-parens>

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -850,9 +850,9 @@ Syntax</h2>
 	<dfn>&lt;media-not></dfn> = not <<media-in-parens>>
 	<dfn>&lt;media-and></dfn> = and <<media-in-parens>>
 	<dfn>&lt;media-or></dfn> = or <<media-in-parens>>
-	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | <<media-feature>> | <<general-enclosed>>
+	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | ( <<media-feature>> ) | <<general-enclosed>>
 
-	<dfn>&lt;media-feature></dfn> = ( [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ] )
+	<dfn>&lt;media-feature></dfn> = [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ]
 	<dfn>&lt;mf-plain></dfn> = <<mf-name>> : <<mf-value>>
 	<dfn>&lt;mf-boolean></dfn> = <<mf-name>>
 	<dfn>&lt;mf-range></dfn> = <<mf-name>> <<mf-comparison>> <<mf-value>>


### PR DESCRIPTION
For container queries (css-contain-3), it would be convenient to
be able to reference paren-less `<media-feature>`, since that grammar
wants to wrap the value in a function rather than plain parentheses.

As far as I can tell, `<media-feature>` is only used by `<media-in-parens>`,
so this should be safe.