### PR TITLE
[css-cascade-5] Make CSSImportRule.layerName nullable #6576

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1885,8 +1885,8 @@ Extensions to the <code>CSSImportRule</code> interface</h3>
 
 	Its <dfn attribute for=CSSImportRule>layerName</dfn> attribute represents
 	the [=layer name=] declared in the at-rule itself,
-	and is an empty string if the layer is anonymous, or null if the at-rule
-	does not declare a layer.
+	and is an empty string if the layer is anonymous, 
+	or null if the at-rule does not declare a layer.
 
 <h3 id="the-csslayerblockrule-interface">
 The <code>CSSLayerBlockRule</code> interface</h3>

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1879,13 +1879,14 @@ Extensions to the <code>CSSImportRule</code> interface</h3>
 
 	<pre class='idl'>
 	partial interface CSSImportRule {
-	  readonly attribute CSSOMString layerName;
+	  readonly attribute CSSOMString? layerName;
 	};
 	</pre>
 
 	Its <dfn attribute for=CSSImportRule>layerName</dfn> attribute represents
 	the [=layer name=] declared in the at-rule itself,
-	and is an empty string if the layer is anonymous.
+	and is an empty string if the layer is anonymous, or null if the at-rule
+	does not declare a layer.
 
 <h3 id="the-csslayerblockrule-interface">
 The <code>CSSLayerBlockRule</code> interface</h3>


### PR DESCRIPTION
So that we can distinguish whether an `@import` is unlayered or in an anonymous layer.