### PR TITLE
Update Overview.bs

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -62,7 +62,7 @@ Introduction</h2>
 	When different declarations try to set a value for the same element/property combination,
 	the conflicts must somehow be resolved.
 
-	The opposite problem arises when no declarations try to set a the value for an element/property combination.
+	The opposite problem arises when no declarations try to set a value for an element/property combination.
 	In this case, a value is be found by way of <a>inheritance</a>
 	or by looking at the property's <a>initial value</a>.
 


### PR DESCRIPTION
Fixed typo “a the”

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
