### PR TITLE
[css-syntax-3] Fix serialization matrix related to CDC-token

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -3654,16 +3654,16 @@ Serialization</h2>
 				<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td>
 			<tr>
 				<th>#
-				<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td> <td>
+				<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td>
 			<tr>
 				<th>-
-				<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td> <td>
+				<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td>
 			<tr>
 				<th>number
-				<td>✗<td>✗<td>✗<td>✗<td> <td>✗<td>✗<td>✗<td> <td> <td> <td>✗
+				<td>✗<td>✗<td>✗<td>✗<td> <td>✗<td>✗<td>✗<td>✗<td> <td> <td>✗
 			<tr>
 				<th>@
-				<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td> <td> <td> <td> <td>
+				<td>✗<td>✗<td>✗<td>✗<td>✗<td> <td> <td> <td>✗<td> <td> <td>
 			<tr>
 				<th>.
 				<td> <td> <td> <td> <td> <td>✗<td>✗<td>✗<td> <td> <td> <td>


### PR DESCRIPTION
Since double dash `--` is a valid identifier by the spec the `CDC-token` is breaking "round-trip" with parsing now when follows after `#`, `-`, number or `@`:

* `#-->` = `#--` (hash-token) + `>` (delim-token)
* `--->` = `---` (ident-token) + `>` (delim-token)
* `number-->` = `number--` (dimension-token) + `>` (delim-token)
* `@-->` = `@--` (at-keyword-token) + `>` (delim-token)
