### PR TITLE
Remove font-palette: none; example

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6229,12 +6229,6 @@ Animation type: discrete
 	</pre>
 </div>
 
-<div class="example">When color is not supported at all, select the monochrome glyphs rather than rendering the colored glyphs in monochrome:
-	<pre>@media not (color) {
-		font-palette: none;
-	}</pre>
-</div>
-
 Issue: Add more examples and pictures.
 
 <!--


### PR DESCRIPTION
The `none` keyword was removed in #6646.
Fixes #6877.
