### PR TITLE
[css-color-4] fix typo in conversions.js

### DIFF
--- a/css-color-4/conversions.js
+++ b/css-color-4/conversions.js
@@ -462,7 +462,7 @@ function rectangular_un_premultiply(color, alpha) {
 // given a premultiplied color in a rectangular orthogonal colorspace
 // and an alpha value
 // return the actual color
-	if (alpha = 0) {
+	if (alpha === 0) {
 		return color; // avoid divide by zero
 	}
 	return color.map((c) => c / alpha)

--- a/css-color-4/conversions.js
+++ b/css-color-4/conversions.js
@@ -485,7 +485,7 @@ function polar_un_premultiply(color, alpha, hueIndex) {
 	// the hueIndex says which entry in the color array corresponds to hue angle
 	// for example, in OKLCH it would be 2
 	// while in HSL it would be 0
-	if (alpha = 0) {
+	if (alpha === 0) {
 		return color; // avoid divide by zero
 	}
 	return color.map((c, i) => c / (hueIndex === i? 1 : alpha))


### PR DESCRIPTION
[css-color-4] fix typo

Current code behaves like this (which I think is a typo) :

```js
var alpha = 1;
if (alpha = 0) {
 console.log('truthy')
} else {
 console.log(5 / alpha);
}

> Infinity
```
