### PR TITLE
Functions and relative lengths in palettes are evaluated within the root element's context

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6272,6 +6272,10 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
     a palette which has missing colors. If colors would be missing, they are taken
     from the palette within the font identified by the 'base-palette' descriptor.
 
+    Functions such as ''calc()'', ''var()'', and ''env()'' are valid within the braces of a
+    ''@font-palette-values'' rule. They are evaluated within the context of the root
+    element. Relative units are also evaluated within the context of the root element.
+
     The ''@font-palette-values'' rule consists of the ''@font-palette-values'' at-keyword
     followed by a block of descriptor declarations.
     It has the following syntax:


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/6631.