### PR TITLE
[css-scroll-snap-1] Add missing Axis to sample code

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -451,7 +451,7 @@ Re-snapping After Layout Changes</h4>
 
 		<pre class="lang-css">
 			.log {
-			  scroll-snap-type: proximity;
+			  scroll-snap-type: y proximity;
 			  align-content: end;
 			}
 			.log::after {


### PR DESCRIPTION
This is a non-substantive contribution. 

Axis is a required value, but it was not included in the sample code.
The current sample code does not work correctly, so I added it. 
https://www.w3.org/TR/css-scroll-snap-1/#re-snap

If this is a misconception, please close.