### PR TITLE
[css-color-4] Fix incorrect casing in 6.2 System Colors

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -2109,7 +2109,7 @@ System Colors</h3>
 		* ''Mark'' background with ''MarkText'' foreground
 		* ''ButtonFace'' or ''Field'' background with a ''ButtonBorder'' border and adjacent color ''Canvas'''
 		* ''Highlight'' background with ''HighlightText'' foreground.
-		* ''SelectedItem'' background with ''SelectedItemTExt'' foreground.
+		* ''SelectedItem'' background with ''SelectedItemText'' foreground.
 	</ul>
 
 	Additionally, ''GrayText'' is expected to be readable,


### PR DESCRIPTION
Replace 'SelectedItemTExt' with correctly-cased 'SelectedItemText'.