### PR TITLE
[css-animations-2] Account for `animation-composition` when merging keyframes (closes #6935)

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -259,6 +259,8 @@ and the position of the animation in |element|'s 'animation-name' list,
      repeating the list as necessary as described in
      [[CSS-ANIMATIONS-1#animation-name]].
 
+1.   Let |default composite| be ''replace''.
+
 1.   Find the last ''@keyframes'' at-rule in document order
      with <<keyframes-name>> matching |name|.
 
@@ -285,15 +287,21 @@ and the position of the animation in |element|'s 'animation-name' list,
           specified on the keyframe block, or,
           if there is no such valid declaration, |default timing function|.
 
+     1.   Let |keyframe composite| be the value of
+          the last valid declaration of 'animation-composition'
+          specified on the keyframe block, or,
+          if there is no such valid declaration, |default composite|.
+
      1.   After converting |keyframe timing function| to its canonical form
           (e.g. such that ''step-end'' becomes ''steps(1, end)'')
           let |keyframe| refer to the existing keyframe in |keyframes| with
-          matching keyframe offset and timing function, if any.
+          matching keyframe offset, timing function and composite, if any.
 
           If there is no such existing keyframe,
           let |keyframe| be a new empty keyframe with
           offset, |keyframe offset|,
-          and timing function, |keyframe timing function|,
+          timing function, |keyframe timing function|,
+          composite, |keyframe composite|,
           and prepend it to |keyframes|.
 
      1.   Iterate over all declarations in the keyframe block and
@@ -324,11 +332,13 @@ and the position of the animation in |element|'s 'animation-name' list,
      not all of the properties in |animated properties| are present,
 
      1.   Let |initial keyframe| be the [=keyframe=] in |keyframes|
-          with offset 0 and timing function |default timing function|.
+          with offset 0, timing function |default timing function|
+          and composite |default composite|.
 
           If there is no such keyframe,
           let |initial keyframe| be a new empty keyframe with offset 0,
-          and timing function |default timing function|,
+          timing function |default timing function|,
+          composite |default composite,
           and add it to |keyframes| after the last keyframe with offset 0.
 
      1.   For each property in |animated properties| that is not present
@@ -341,11 +351,13 @@ and the position of the animation in |element|'s 'animation-name' list,
      not all of the properties in |animated properties| are present,
 
      1.   Let |final keyframe| be the [=keyframe=] in |keyframes|
-          with offset 1 and timing function |default timing function|.
+          with offset 1, timing function |default timing function|
+          and composite |default composite|.
 
           If there is no such keyframe,
           let |final keyframe| be a new empty keyframe with offset 1,
-          and timing function |default timing function|,
+          timing function |default timing function|
+          and composite |default composite|,
           and add it to |keyframes| after the last keyframe with offset 1.
 
      1.   For each property in |animated properties| that is not present


### PR DESCRIPTION
Keyframes should only be merged when they have matching keyframe offset, timing function _and_ composite.
