### PR TITLE
[css-animation-2] Setting `animation.effect.composite` should override any further change to `animation-composition`

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -144,6 +144,11 @@ the changes from the programming interface take precedence as follows:
     However, if the last matching ''@keyframes'' rule is removed
     the animation must still be canceled.
 
+*   After successfully setting the {{KeyframeEffect/composite}} of the
+    {{Animation/effect}} of a {{CSSAnimation}} to some {{CompositeOperation}}
+    other than the original {{CompositeOperation}}, any subsequent change to
+    'animation-composition' will not be reflected in that {{KeyframeEffect}}.
+
 Note, the reference to a successful call in the above rules
 is necessary to ensure that
 when an exception is thrown by any of these methods,


### PR DESCRIPTION
Much like setting other animation or animation effect property using the Web Animations API lead to further changes
to the matching CSS property to not be reflected on the animation or animation effect, changes to `animation-composition`
should no longer be reflected on the animation effect if `animation.effect.composite` is set.

Testing for this has already been landed as part of https://github.com/web-platform-tests/wpt/commit/52c5cb32bb28c90dde71de8f7bbd71ba7eec054f.