### PR TITLE
[css-text-3] The web de-facto requires NULL U+0000 to not be visible

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -1579,7 +1579,8 @@ White Space Processing &amp; Control Characters</h2>
 	[[CSS2]]
 
 	Control characters ([=Unicode category=] <code>Cc</code>)--
-	other than tabs (U+0009),
+	other than NULL (U+0000),
+	tabs (U+0009),
 	line feeds (U+000A),
 	carriage returns (U+000D)
 	and sequences that form a [=segment break=]--


### PR DESCRIPTION
Chrome and Firefox make it invisible, and WebKit has compat issues about it.

https://bugs.webkit.org/show_bug.cgi?id=235559