### PR TITLE
[css-highlight-api-1] Specify that highlight repaints must be async

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -520,7 +520,8 @@ Repaints</h3>
 	or to the [=boundary points=] of {{Range}}s
 	of a [=registered=] [=custom highlight=].
 
-	Issue(4596): How should we specify the timing (and synchronicity) of this reevaluation?
+	This repaint is asynchronous, and the APIs mentioned above must not block while waiting for the
+	repaint to happen.
 
 <h3 id=range-invalidation>
 Range Updating and Invalidation</h3>


### PR DESCRIPTION
Specify that repaints of highlights triggered by addition or removal of ranges, or by changes to highlight properties, should be asynchronous.

Closes #4596