### PR TITLE
[css-backgrounds-4] Added missing animation types to property definitions

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -91,6 +91,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Inherited: no
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
+		Animation type: repeatable list
 	</pre>
 
 	This property specifies the background position's horizontal component.
@@ -103,6 +104,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Inherited: no
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
+		Animation type: repeatable list
 	</pre>
 
 	This property specifies the background position's vertical component.
@@ -115,6 +117,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Inherited: no
 		Percentages: refer to inline-size of background positioning area <em>minus</em> inline-size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
+		Animation type: repeatable list
 	</pre>
 
 	This property specifies the background position's inline-axis component.
@@ -127,6 +130,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Inherited: no
 		Percentages: refer to size of background positioning area <em>minus</em> size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
+		Animation type: repeatable list
 	</pre>
 
 	This property specifies the background position's block-axis component.
@@ -136,10 +140,11 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 Painting Area: the 'background-clip' property</h3>
 
 	<pre class="propdef">
-	Name: background-clip
-	Value: <<bg-clip>>#
-	Initial: border-box
-	Inherited: no
+		Name: background-clip
+		Value: <<bg-clip>>#
+		Initial: border-box
+		Inherited: no
+		Animation type: repeatable list
 	</pre>
 
 	Determines the <dfn export>background painting area</dfn>,
@@ -185,7 +190,7 @@ Painting Area: the 'background-clip' property</h3>
 	Inherited: no
 	Percentages: n/a
 	Computed Value: the computed color
-	Animation Type: see prose
+	Animation type: see prose
 	</pre>
 
 	<pre class="propdef shorthand">
@@ -237,7 +242,7 @@ Painting Area: the 'background-clip' property</h3>
 Corners</h2>
 
 <h3 id=corner-sizing>
-Corner Sizing: the 'border-radius property</h3>
+Corner Sizing: the 'border-radius' property</h3>
 
 	<pre class="propdef">
 		Name: border-radius
@@ -245,6 +250,7 @@ Corner Sizing: the 'border-radius property</h3>
 		Initial: 0
 		Applies to: all elements, except table element when 'border-collapse' is ''collapse''
 		Inherited: no
+		Animation type: see individual properties
 	</pre>
 
 	See [[CSS3BG]].
@@ -253,11 +259,12 @@ Corner Sizing: the 'border-radius property</h3>
 Corner Shaping: the 'corner-shape' property</h3>
 
 	<pre class="propdef">
-		Name:            corner-shape
-		Value:           [ round | angle ]{1,4}
-		Initial:         round
-		Applies to:      all elements, except table element when 'border-collapse' is ''collapse''
-		Inherited:       no
+		Name: corner-shape
+		Value: [ round | angle ]{1,4}
+		Initial: round
+		Applies to: all elements, except table element when 'border-collapse' is ''collapse''
+		Inherited: no
+		Animation type: discrete
 	</pre>
 
 	By default, non-zero border-radii define
@@ -356,13 +363,14 @@ Partial borders</h2>
 Partial Borders: the 'border-limit' property</h3>
 
 	<pre class="propdef">
-  	Name: border-limit
-  	Value: all | [ sides | corners ] <<length-percentage [0,&infin;]>>?
-  				| [ top | right | bottom | left ] <<length-percentage [0,&infin;]>>
-  	Initial: round
-  	Applies to: all elements, except table element when 'border-collapse' is ''collapse''
-  	Inherited: no
-  	Percentages: relative to border-box
+		Name: border-limit
+		Value: all | [ sides | corners ] <<length-percentage [0,&infin;]>>?
+					| [ top | right | bottom | left ] <<length-percentage [0,&infin;]>>
+		Initial: round
+		Applies to: all elements, except table element when 'border-collapse' is ''collapse''
+		Inherited: no
+		Percentages: relative to border-box
+		Animation type: discrete
 	</pre>
 
 	<p>By default, the entire border is drawn. However, border rendering can be
@@ -418,6 +426,7 @@ The 'border-clip' properties</h3>
   		Inherited: no
   		Percentages: refer to length of border-edge side
   		Computed value: ''border-clip/normal'', or a list consisting of absolute lengths, or percentages as specified
+		Animation type: by computed value
 		</pre>
 
 		<p class=issue>Should these properties be simplified to only accept <code>normal | <<length-percentage>>+</code>?


### PR DESCRIPTION
In order to get the spec. compiled again by Bikeshed, it requires the property definition tables to include an animation type.

This change adds it whereever it was missing so far. The added types are either chosen to copy pre-existing ones of the previous level or by looking at the property's syntax.

Sebastian