### PR TITLE
[css-contain-3] Pseudo elements and shadow DOM #5984 #6711

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -307,26 +307,30 @@ Container Queries</h2>
 	the <a>shadow-including inclusive ancestors</a> of the <a>ultimate
 	originating element</a>.
 
-	It follows that:
+	<div class=note>
+		It follows that:
 
-	* Pseudo elements themselves can not be query containers
-	* ''::before'', ''::after'', ''::marker'', and ''::backdrop'' query their
-		originating elements
-	* ''::first-letter'' and ''::first-line'' queries its originating element,
-		even if the <a>fictional tag sequence</a> may push the ''::first-line''
-		past other elements for the purpose of inheritance and rendering
-	* Multiple pseudo elements do not allow pseudo elements to be query
-		containers for other pseudo elements. E.g., the host, but not the part()
-		can be the query container for ''::before'' in ''host::part()::before''
-		Similarly, the ''::before element'' can not be the query container for the
-		''::marker'' in ''div::before::marker''
-	* ''::slotted()'' selectors can query containers inside the shadow tree,
-		including the slot itself
-	* ''::part()'' selectors can query its originating host, but not internal
-		query containers inside the shadow tree
-	* ''::placeholder'' and ''::file-selector-button'' can query the input
-		element, but do not expose any internal containers if the input element is
-		implemented using a shadow tree
+		* Pseudo elements themselves can not be query containers
+		* ''::before'', ''::after'', ''::marker'', and ''::backdrop'' query their
+			originating elements
+		* ''::first-letter'' and ''::first-line'' query their originating elements,
+			even if the <a>fictional tag sequence</a> may push the
+			<code>::first-line</code> past other elements for the purpose of
+			inheritance and rendering
+		* Multiple pseudo elements do not allow pseudo elements to be query
+			containers for other pseudo elements. E.g., the host, but not the
+			<code>::part()</code>, can be the query container for
+			<code>::before</code> in <code>host::part()::before</code>. Similarly,
+			<code>::before</code> can not be the query container for the
+			<code>::marker</code> in <code>div::before::marker</code>
+		* ''::slotted()'' selectors can query containers inside the shadow tree,
+			including the slot itself
+		* ''::part()'' selectors can query its originating host, but not internal
+			query containers inside the shadow tree
+		* ''::placeholder'' and ''::file-selector-button'' can query the input
+			element, but do not expose any internal containers if the input element is
+			implemented using a shadow tree
+	</div>
 
 	<div class=example>
 		A ::before selector querying the size of the originating element:

--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -273,8 +273,8 @@ Container Queries</h2>
 	A [=query container=] is established by specifying
 	the possible query types using the 'container-type' property
 	(or the 'container' [=shorthand=]).
-	Style rules applying to its descendants can then be conditioned
-	by querying against it,
+	Style rules applying to its <a>shadow-including descendants</a> can then be
+	conditioned by querying against it,
 	using the ''@container'' [=conditional group rule=].
 
 	<div class=example>
@@ -301,6 +301,79 @@ Container Queries</h2>
 
 		Media objects in the main and sidebar areas
 		will each respond to their own container context.
+	</div>
+
+	For selectors with pseudo elements, query containers can be established by
+	the <a>shadow-including inclusive ancestors</a> of the <a>ultimate
+	originating element</a>.
+
+	It follows that:
+
+	* Pseudo elements themselves can not be query containers
+	* ''::before'', ''::after'', ''::marker'', and ''::backdrop'' query their
+		originating elements
+	* ''::first-letter'' and ''::first-line'' queries its originating element,
+		even if the <a>fictional tag sequence</a> may push the ''::first-line''
+		past other elements for the purpose of inheritance and rendering
+	* Multiple pseudo elements do not allow pseudo elements to be query
+		containers for other pseudo elements. E.g., the host, but not the part()
+		can be the query container for ''::before'' in ''host::part()::before''
+		Similarly, the ''::before element'' can not be the query container for the
+		''::marker'' in ''div::before::marker''
+	* ''::slotted()'' selectors can query containers inside the shadow tree,
+		including the slot itself
+	* ''::part()'' selectors can query its originating host, but not internal
+		query containers inside the shadow tree
+	* ''::placeholder'' and ''::file-selector-button'' can query the input
+		element, but do not expose any internal containers if the input element is
+		implemented using a shadow tree
+
+	<div class=example>
+		A ::before selector querying the size of the originating element:
+
+		<pre class=lang-html>
+			&lt;style>
+				#container {
+					width: 100px;
+					container-type: inline-size;
+				}
+				@container size(inline-size < 150px) {
+					#inner::before {
+						content: "BEFORE";
+					}
+				}
+			&lt;/style>
+			&lt;div id=container>
+				&lt;span id=inner>&lt;/span>
+			&lt;/div>
+		</pre>
+	</div>
+
+	<div class=example>
+		A ::slotted() selector for styling a shadow host child can query a
+		container in the shadow tree:
+
+		<pre class=lang-html>
+			&lt;div id=host style="width:200px">
+				&lt;template shadowroot=open>
+					&lt;style>
+						#container {
+							width: 100px;
+							container-type: inline-size;
+						}
+						@container size(inline-size < 150px) {
+							::slotted(span) {
+								color: green;
+							}
+						}
+					&lt;/style>
+					&lt;div id=container>
+						&lt;slot />
+					&lt;/div>
+				&lt;/template>
+				&lt;span id=slotted>Green&lt;/span>
+			&lt;/div>
+		</pre>
 	</div>
 
 <h3 id="container-type">


### PR DESCRIPTION
Per resolution for issues #5984 and #6711:

https://github.com/w3c/csswg-drafts/issues/5984#issuecomment-1028488562
https://github.com/w3c/csswg-drafts/issues/6711#issuecomment-1028487865

Test coverage:

https://wpt.live/css/css-contain/container-queries/pseudo-elements-001.html
https://wpt.live/css/css-contain/container-queries/pseudo-elements-002.tentative.html
https://wpt.live/css/css-contain/container-queries/pseudo-elements-003.tentative.html
https://wpt.live/css/css-contain/container-queries/container-for-shadow-dom.tentative.html
