### PR TITLE
[css-contain-3] Remove leftover block-size container-type #1031

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -385,11 +385,11 @@ Creating Query Containers: the 'container-type' property</h3>
 
 	<pre class='propdef'>
 		Name: container-type
-		Value: none | style || state || [ size | inline-size | block-size ]
+		Value: none | style || state || [ size | inline-size ]
 		Initial: none
 		Inherited: no
 		Applies to: all elements
-		Computed value: the keyword ''container-type/none'' or one or more of ''container-type/size'', ''container-type/inline-size'', ''container-type/block-size'', ''container-type/style'', ''container-type/state''
+		Computed value: the keyword ''container-type/none'' or one or more of ''container-type/size'', ''container-type/inline-size'', ''container-type/style'', ''container-type/state''
 		Animation type: not animatable
 	</pre>
 
@@ -638,7 +638,7 @@ Container Queries: the ''@container'' rule</h3>
 	ISSUE(6393): Do we like this syntax for querying specific container types?
 
 	A [=query container=] with a 'container-type' of ''container-type/size''
-	is a match for both ''container-type/inline-size'' and ''container-type/block-size''.
+	is also a match for ''container-type/inline-size''.
 
 	Once an eligible [=query container=] has been selected for an element,
 	each [=container feature=] in the <<container-condition>>


### PR DESCRIPTION
The definition of container-type:block-size was removed when block-size
containment was removed, but the value syntax still had it.
