### PR TITLE
[css-contain-3] Add APIs section with CSSContainerRules #7033

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -992,6 +992,19 @@ Container Relative Lengths: the ''cqw'', ''cqh'', ''cqi'', ''cqb'', ''cqmin'', '
 		</pre>
 	</div>
 
+<h2 id="apis">APIs</h2>
+
+<h3 id="the-csscontainerrule-interface">
+	The <code>CSSContainerRule</code> interface</h3>
+
+	The {{CSSContainerRule}} interface represents an ''@container'' rule.
+
+	<pre class='idl'>
+	[Exposed=Window]
+	interface CSSContainerRule : CSSConditionRule {
+	};
+	</pre>
+
 
 Suppressing An Element’s Contents Entirely: the 'content-visibility' property {#content-visibility}
 =================


### PR DESCRIPTION
Might need to add @container specifics prose for conditionText like we
have for @support, but the syntax is e.g. currently missing
<general-enclosed>.
