### PR TITLE
[css-fonts-4] #7010 Remove `currentcolor` from `override-colors:` example

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6492,7 +6492,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
                 base-palette: 1;
                 override-colors:
                     0 rgb(123, 64, 27),
-                    1 currentColor,
+                    1 darkblue,
                     2 var(--highlight);
             }
             </pre>


### PR DESCRIPTION
Current color excluded from possible values for override-colors:
entries, see discussion in
https://github.com/w3c/csswg-drafts/issues/7010
