### PR TITLE
[css-fonts-4] Use last key/palette index in override-colors, #7026

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6557,7 +6557,7 @@ Overriding a colors from a palette: The 'override-colors!!descriptor' descriptor
     Integer values are zero-indexed.
 
     If the keys of multiple distinct key/value pairs identify the same color index (either by name or by integer),
-    the first key is used for the purposes of rendering. However, for serialization purposes, both
+    the last key is used for the purposes of rendering. However, for serialization purposes, both
     key/value pairs are present.
 
     Note: This means that using 'font-palette' with the same value on two different elements


### PR DESCRIPTION
Improve consistency with other parts of CSS where later declarations
override earlier ones, fixes #7026.
