### PR TITLE
[scroll-animations-1]  Mark 'set the offset value' as an abstract-op

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -400,7 +400,7 @@ The {{EffectTiming/duration}} of a <a>scroll timeline</a> is 100%.
 		offset=]s in the direction specified by {{ScrollTimeline/orientation}} that constitute the
 		equally-distanced in progress intervals in which the timeline is active.
 
-		The procedure to <dfn>set the offset value</dfn> with |val| as the provided
+		The procedure to <dfn abstract-op>set the offset value</dfn> with |val| as the provided
 		value, |pos| as the position in {{ScrollTimeline/scrollOffsets}} and |size|
 		as the {{ScrollTimeline/scrollOffsets}} array size has the following steps:
 


### PR DESCRIPTION
Otherwise it inherits the dfn type `attribute` set on the encloding `<dl>`

Not sure if the `dfn-for` should also be overridden, and if so, by what.