### PR TITLE
[css-fonts-5] Fix typo in tech() function

### DIFF
--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -357,7 +357,7 @@ according to section [[css-syntax#parse-comma-separated-list-of-component-values
 Then each component value is parsed according to this grammar:
 
 
-<pre><<url>> [ format(<<font-format>>)]? [ techn( <<font-tech>>#)]? | local(<<font-face-name>>)</pre>
+<pre><<url>> [ format(<<font-format>>)]? [ tech( <<font-tech>>#)]? | local(<<font-face-name>>)</pre>
 
 <pre class="prod"><dfn id="font-format-values">&lt;font-format&gt;</dfn>
 	 = [<<string>> | collection | embedded-opentype | opentype


### PR DESCRIPTION
Correct typo techn() -> tech() for font technology function.

Follow up to 102da5ae79, also fixes #6791.
