### PR TITLE
[css-contain-2] Fix typo (just dropping a stray 'and') from css-contain-2

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -923,7 +923,7 @@ Possible Layout-Containment Optimizations</h4>
 Style Containment</h3>
 
 	Giving an element <dfn export>style containment</dfn>
-	and has the following effects:
+	has the following effects:
 
 	1. The 'counter-increment' and 'counter-set' properties
 		must be <a for=property>scoped to the element's sub-tree</a>


### PR DESCRIPTION
[css-contain-2] Fix typo (just dropping a stray 'and') from css-contain-2.

(just an editorial typo fix; no semantic change)