### PR TITLE
[css-selectors-4] Mention :defined in change history

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -4000,6 +4000,7 @@ Changes since the 21 November 2018 Working Draft</h3>
 		<li>Removed the Selector profiles, marked '':has()'' as optional and at-risk instead.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/3925">Issue 3925</a>)
 		<li>Added [[#sub-pseudo-elements]] to define [=sub-pseudo-elements=] and related terminology.
+		<li>Added '':defined''.
 	</ul>
 
 <h3 id="changes-2018-02">


### PR DESCRIPTION
This was added in #3735 but isn't mentioned yet in the changes section.
