### PR TITLE
[css-shapes-2] Add the "rotate" keyword to shape()

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -171,7 +171,7 @@ The ''shape()'' Function</h4>
 		<<curve-command>> = curve <<by-to>> <<coordinate-pair>> via <<coordinate-pair>>{1,2}
 		<<smooth-command>> = smooth <<by-to>> <<coordinate-pair>> [via <<coordinate-pair>>]?
 		<<arc-command>> = arc <<by-to>> <<coordinate-pair>> of <<length-percentage>>{1,2}
-		                    [ <<arc-sweep>> || <<arc-size>> || <<angle>> ]?
+		                    [ <<arc-sweep>> || <<arc-size>> || rotate <<angle>> ]?
 		<<arc-sweep>> = cw | ccw
 		<<arc-size>> = large | small
 	</pre>
@@ -258,7 +258,7 @@ The ''shape()'' Function</h4>
 			so the curve appears to smoothly continue from the previous command,
 			rather than possibly making a sudden direction change.
 
-		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<by-to>> <<coordinate-pair>> of <<length-percentage>>{1,2} [ <<arc-sweep>> || <<arc-size>> || <<angle>> ]
+		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<by-to>> <<coordinate-pair>> of <<length-percentage>>{1,2} [ <<arc-sweep>> || <<arc-size>> || rotate <<angle>> ]
 		<dd>
 			Add an <a href="https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands">elliptical arc</a> command
 			to the list of path data commands,


### PR DESCRIPTION
Avoids an ambiguity where the second radius and angle can both come from calc

Closes #6925