### PR TITLE
[css-fonts-4] Color fonts are not enabled by default

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6174,13 +6174,11 @@ Animation type: discrete
 <dl dfn-for=font-palette dfn-type=value>
 	<dt><dfn>normal</dfn>
 	<dd>
-		User-Agents attempt to treat the color font
-		as closely as possible to a non-color font.
-		In particular, user-agents use a palette which will yield the best default result for reading.
-		User-agents may take the computed value of the 'color' property into consideration
-		when making this decision.
-		User agents may also construct and use a palette not defined in the font.
+		User-Agents display the color font with the default palette or default glyph colorisation. User-agents should take the computed value of the color property into consideration when a color font format requires use of the foreground color
 
+		<div class="example">In the <code>COLR</code> [[!OPENTYPE]] table, color index 0xFFFF should be rendered according the 'color' property.</div>
+
+		<div class="example">For <code>COLR</code>/<code>CPAL</code> [[!OPENTYPE]] fonts, 'font-palette': ''font-palette/normal'' usually means rendering the font with the palette in the font at index 0.</div>
 
 	<dt><dfn>light</dfn>
 	<dd>


### PR DESCRIPTION
This uses @drott's proposed text.

Fixes https://github.com/w3c/csswg-drafts/issues/7093.