### PR TITLE
[css-images-4] Fix escaping in object-view-box definition

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1936,7 +1936,7 @@ Setting The Viewbox: the 'object-view-box' property {#the-object-view-box}
 
 	<pre class=propdef>
 	Name: object-view-box
-	Value: none | <basic-shape-rect>
+	Value: none | <<basic-shape-rect>>
 	Initial: none
 	Applies to: [=replaced elements=]
 	Inherited: no


### PR DESCRIPTION
The `<basic-shape-rect>` construct introduced in #7058 needs to be wrapped in another pair of `<>`, otherwise it gets interpreted as an unknown custom markup tag and property value gets rendered as: `none |`.
