### PR TITLE
[css-contain-2] Fix two mispellings of "though"

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1394,7 +1394,7 @@ Using ''content-visibility: hidden''</h3>
 		using something like ''position: absolute; left: -100000px;'',
 		then calling an API like {{Element/getBoundingClientRect()}}.
 
-		Unfortunately, even tho the page never intends to display this content,
+		Unfortunately, even though the page never intends to display this content,
 		the user agent will still have to do full styling, layout, and rendering for the content,
 		<em>just in case</em> it affects what's shown on screen.
 		The author also can't,
@@ -1691,7 +1691,7 @@ Restrictions and Clarifications {#cv-notes}
 
 	Note: This is similar to an element switching from ''display:none''
 	to a non-''display/none'' value--
-	even tho the styles are <em>technically</em> changing in that case
+	even though the styles are <em>technically</em> changing in that case
 	(from their initial values
 	to their "proper" values from the cascade),
 	no transitions are started.


### PR DESCRIPTION
[css-contain-2] Fix two mispellings of "though"

This fixes two small typos and doesn't introduce any semantic changes.

