### PR TITLE
[css-values] Use fetch 'conclude' instead of 'finalize'

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1041,8 +1041,8 @@ URL Processing Model</h4>
 			set to the following steps given [=/response=] |res| and Null, failure or byte stream
 			|byteStream|:
 			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
-				[=finalize and report timing=] with |res|, |global|, and
-				<code>"css"</code>. [[CSSOM]]
+				[=fetch-controller/conclude=] |controller|, with <var ignore>initiatorType</var> set
+				to <code>"css"</code>. [[CSSOM]]
 
 			2. Call |processResponse| with |res| and |byteStream|.
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1037,9 +1037,9 @@ URL Processing Model</h4>
 			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
 			set, and whose [=request/referrer=] is |referrer|.
 
-		10. [=/Fetch=] |req|, with <var ignore>taskDestination</var> set to |global|, and <var ignore>processResponseConsumeBody</var>
-			set to the following steps given [=/response=] |res| and Null, failure or byte stream
-			|byteStream|:
+		10. Let |controller| be the result of [=/Fetch|fetching=] |req|, with <var ignore>taskDestination</var>
+            set to |global|, and <var ignore>processResponseConsumeBody</var> set to the following steps given
+            [=/response=] |res| and Null, failure or byte stream |byteStream|:
 			1. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
 				[=fetch-controller/conclude=] |controller|, with <var ignore>initiatorType</var> set
 				to <code>"css"</code>. [[CSSOM]]


### PR DESCRIPTION
[css-values-4] Fetch now exposes 'conclude' instead of 'finalize' which works with a `fetch controller` - this clarifies that resource timing entries are mapped to a fetch rather than to a response.