### PR TITLE
[cssom-view-1] Fix invalid "bool" IDL type

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1047,7 +1047,7 @@ partial interface Element {
   DOMRectList getClientRects();
   [NewObject] DOMRect getBoundingClientRect();
 
-  bool isVisible(optional IsVisibleOptions options = {});
+  boolean isVisible(optional IsVisibleOptions options = {});
 
   undefined scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg = {});
   undefined scroll(optional ScrollToOptions options = {});


### PR DESCRIPTION
`bool` is `boolean` in Web IDL.
