### PR TITLE
[css-fonts-4] Fix examples to match the spec

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6312,7 +6312,7 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
         Modify Handover Sans's color palette
 
         <pre>
-        @font-palette-values Augusta {
+        @font-palette-values --Augusta {
             font-family: Handover Sans;
             base-palette: 3;
             override-colors:
@@ -6348,13 +6348,13 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
 				src: url('./bungeehee.woff') format('woff');
 			}
 
-			@font-palette-values ToxicGreen {
+			@font-palette-values --ToxicGreen {
 			  font-family: Bixxxa;
 			  base-palette: 3; /* This is Bixxxa's green palette */
 			}
 
 
-			@font-palette-values ToxicGreen {
+			@font-palette-values --ToxicGreen {
 			  font-family: Bungeehee;
 			  base-palette: 7; /* This is Bungeehee's green palette... */
 			  2: lime; /* ...except this is pink, which I overwrite to lime */
@@ -6362,12 +6362,12 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
 
 			h1 {
 				font-family: Bixxxa;
-				font-palette: ToxicGreen;
+				font-palette: --ToxicGreen;
 			}
 
 			h2 {
 				font-family: Bungeehee;
-				font-palette: ToxicGreen;
+				font-palette: --ToxicGreen;
 			}
 		</pre>
 
@@ -6393,7 +6393,7 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
 		<pre class="lang-css">
 			h3 {
 				font-family: Bixxxa, Bungeehee;
-				font-palette: ToxicGreen;
+				font-palette: --ToxicGreen;
 			}
 		</pre>
 
@@ -6487,7 +6487,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
             Modify Banner Flag's color palette
 
             <pre>
-            @font-palette-values Festival {
+            @font-palette-values --Festival {
                 font-family: Banner Flag;
                 base-palette: 1;
                 override-colors:
@@ -6511,7 +6511,7 @@ Specifying the base palette: the 'base-palette' descriptor</h4>
         Rename Handover Sans's 3rd color palette
 
         <pre>
-        @font-palette-values Augusta {
+        @font-palette-values --Augusta {
             font-family: Handover Sans;
             base-palette: 3;
         }


### PR DESCRIPTION
From the spec 

> @font-palette-values \<<dashed-ident\>>
