### PR TITLE
[cssom-view-1] Fix remaining IDL instances of "bool"

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1042,10 +1042,10 @@ dictionary ScrollIntoViewOptions : ScrollOptions {
 };
 
 dictionary IsVisibleOptions {
-    bool checkAriaHidden = false;
-    bool checkInert = false;
-    bool checkOpacity = false;
-    bool checkVisibilityCSS = false;
+    boolean checkAriaHidden = false;
+    boolean checkInert = false;
+    boolean checkOpacity = false;
+    boolean checkVisibilityCSS = false;
 };
 
 partial interface Element {


### PR DESCRIPTION
This is a follow-up to #7162 to fix occurrences of `bool` that were missed in the previous PR.

(Sorry I missed these in the first PR. I checked the resulting IDL this time, we should be all good.)