### PR TITLE
[css-syntax-3] Fix two typos in `<urange>` parsing algorithm

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -3173,7 +3173,7 @@ The <<urange>> type</h3>
 		this is an invalid <<urange>>,
 		and this algorithm must exit.
 
-	3. Consume as many <a>hex digits</a> from <var>text</var> as possible.
+	3. Consume as many <a>hex digits</a> from <var>text</var> as possible,
 		then consume as many U+003F QUESTION MARK (?) <a>code points</a> as possible.
 		If zero <a>code points</a> were consumed,
 		or more than six <a>code points</a> were consumed,
@@ -3202,7 +3202,7 @@ The <<urange>> type</h3>
 		This is the <var>start value</var>.
 
 	4. If there are no <a>code points</a> left in <var>text</var>,
-		The <var>end value</var> is the same as the <var>start value</var>.
+		the <var>end value</var> is the same as the <var>start value</var>.
 		Exit this algorithm.
 
 	5. If the next <a>code point</a> in <var>text</var> is U+002D HYPHEN-MINUS (-),


### PR DESCRIPTION
Noticed these while implementing this yesterday.