### PR TITLE
[css-flexbox-1] Add closing tag to the mocked markup

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -348,12 +348,12 @@ Overview</h3>
 		&lt;section id="deals">
 		  &lt;section class="sale-item">
 		    &lt;h1>Computer Starter Kit&lt;/h1>
-		    &lt;p>This is the best computer money can buy, if you don’t have much money.
+		    &lt;p>This is the best computer money can buy, if you don’t have much money.&lt;/p>
 		    &lt;ul>
-		      &lt;li>Computer
-		      &lt;li>Monitor
-		      &lt;li>Keyboard
-		      &lt;li>Mouse
+		      &lt;li>Computer&lt;/li>
+		      &lt;li>Monitor&lt;/li>
+		      &lt;li>Keyboard&lt;/li>
+		      &lt;li>Mouse&lt;/li>
 		    &lt;/ul>
 		    &lt;img src="images/computer.jpg"
 		         alt="You get: a white computer with matching peripherals.">


### PR DESCRIPTION
The mockup for the flex box demonstration was missing closing tags.

I believe this issue is `non-substantive`