### PR TITLE
[css-pseudo] clarify highlight color:currentColor + gCS (closes #6818)

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -935,7 +935,7 @@ Text and Text Decorations</h4>
 
   For this purpose,
   ''currentColor'' on a [=highlight pseudo-element=]’s 'color' property represents
-  the 'color' of the next <a>highlight pseudo-element</a> layer below,
+  the 'color' of the next <em>active</em> <a>highlight pseudo-element</a> layer below,
   falling back finally to the colors that would otherwise have been used
   (those applied by the [=originating element=] or
   an intervening [=pseudo-element=] such as ''::first-line'' or ''::first-letter'').
@@ -1294,6 +1294,18 @@ Additions to the CSS Object Model</h2>
   of the {{pseudo()}} method is still under discussion.
   See <a href="https://github.com/w3c/csswg-drafts/issues/3607">Issue 3607</a>
   and <a href="https://github.com/w3c/csswg-drafts/issues/3603">Issue 3603</a>.
+
+<h3 id="getComputedStyle">
+{{Window/getComputedStyle()}}</h3>
+
+When the second parameter <var>pseudoElt</var>
+refers to a [=highlight pseudo-element=],
+{{Window/getComputedStyle()}} returns styles
+as if that highlight is active
+and all other highlights are inactive.
+This avoids the potential
+ambiguity and privacy risks of returning a result
+that depends on the actual highlight state.
 
 <h2 id="css2-compat">
 Compatibility Syntax</h2>


### PR DESCRIPTION
This patch makes edits for #6818:

* clarifies that color:currentColor represents the color of the next *active* layer below (q1 resolved)
* states that gCS behaves as if the given highlight is active and all other highlights are inactive (q2 resolved)
    * note that q2 and the resolution deal with ‘color’ specifically, but it only makes sense to extend this to all styles returned by gCS, since other properties can depend on ‘color’ if they are set to ‘currentColor’