### PR TITLE
[css-pseudo] no decoration propagation on highlights (closes #6829)

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -988,6 +988,23 @@ Text and Text Decorations</h4>
     </div>
   </div>
 
+  While the element’s own
+  <a href="https://www.w3.org/TR/css-text-decor/#line-decoration">line decorations</a>
+  are propagated from
+  containing <a spec=css-text-decor>decorating boxes</a>
+  as usual,
+  decorations introduced by [=highlight pseudo-elements=]
+  apply only to the text
+  directly associated with the [=originating element=]
+  (or intervening [=pseudo-element=] such as ''::first-line'' or ''::first-letter'').
+
+  Note: Because highlight decorations
+  are propagated through inheritance,
+  not through the box tree,
+  they can be declared on the root element
+  and still reliably decorate out-of-flow descendants,
+  which is not the case for non-highlight decorations.
+
 <h4 id="highlight-replaced">
 Replaced Elements</h4>
 

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -988,22 +988,15 @@ Text and Text Decorations</h4>
     </div>
   </div>
 
-  While the element’s own
-  <a href="https://www.w3.org/TR/css-text-decor/#line-decoration">line decorations</a>
-  are propagated from
-  containing <a spec=css-text-decor>decorating boxes</a>
-  as usual,
-  decorations introduced by [=highlight pseudo-elements=]
-  apply only to the text
-  directly associated with the [=originating element=]
-  (or intervening [=pseudo-element=] such as ''::first-line'' or ''::first-letter'').
+  <a href="https://www.w3.org/TR/css-text-decor/#line-decoration">Line decorations</a> introduced by [=highlight pseudo-elements=]
+  apply only to the text associated with their [=originating element=],
+  and are not propagated to descendants
+  except via property [=inheritance=] (as described [[#highlight-cascade|above]]).
 
-  Note: Because highlight decorations
-  are propagated through inheritance,
-  not through the box tree,
-  they can be declared on the root element
-  and still reliably decorate out-of-flow descendants,
-  which is not the case for the element’s own decorations.
+  Note: Unlike the element’s own decorations,
+  decorations declared on the root element’s highlights
+  propagate to [=out-of-flow|out-of-flow elements=] and [=inline blocks=],
+  with thickness and position varying between descendants.
 
 <h4 id="highlight-replaced">
 Replaced Elements</h4>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1003,7 +1003,7 @@ Text and Text Decorations</h4>
   not through the box tree,
   they can be declared on the root element
   and still reliably decorate out-of-flow descendants,
-  which is not the case for non-highlight decorations.
+  which is not the case for the element’s own decorations.
 
 <h4 id="highlight-replaced">
 Replaced Elements</h4>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -993,8 +993,8 @@ Text and Text Decorations</h4>
   and are not propagated to descendants
   except via property [=inheritance=] (as described [[#highlight-cascade|above]]).
 
-  Note: Unlike the element’s own decorations,
-  decorations declared on the root element’s highlights
+  Note: Unlike the originating element’s own decorations,
+  decorations declared on a highlight pseudo-element
   propagate to [=out-of-flow|out-of-flow elements=] and [=inline blocks=],
   with thickness and position varying between descendants.
 


### PR DESCRIPTION
This patch makes edits for #6829, stating that decorations introduced by highlight pseudos are propagated through inheritance rather than through decorating boxes (the opposite of originating decorations).