### PR TITLE
[css-pseudo] allow underline-related properties on highlights (closes #7101)

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -675,11 +675,7 @@ Styling Highlights</h3>
     css/css-pseudo/active-selection-012.html
     css/css-pseudo/active-selection-031.html
     </wpt>
-    <li>'text-decoration' and its associated properties, including
-    <ul>
-      <li>'text-underline-position'
-      <li>'text-underline-offset'
-    </ul>
+    <li>'text-decoration' and its associated properties (including 'text-underline-position' and 'text-underline-offset')
     <wpt>
     css/css-pseudo/active-selection-004-manual.html
     css/css-pseudo/active-selection-014.html

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -691,7 +691,7 @@ Styling Highlights</h3>
     css/css-pseudo/spelling-error-002-manual.html
     css/css-pseudo/spelling-error-003-manual.html
     </wpt>
-    <li>'text-emphasis' and its associated properties
+    <li>'text-emphasis-color'
     <li>'text-shadow'
     <li>'stroke-color', 'fill-color', and 'stroke-width'
     <wpt>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -687,7 +687,6 @@ Styling Highlights</h3>
     css/css-pseudo/spelling-error-002-manual.html
     css/css-pseudo/spelling-error-003-manual.html
     </wpt>
-    <li>'text-emphasis-color'
     <li>'text-shadow'
     <li>'stroke-color', 'fill-color', and 'stroke-width'
     <wpt>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -675,7 +675,11 @@ Styling Highlights</h3>
     css/css-pseudo/active-selection-012.html
     css/css-pseudo/active-selection-031.html
     </wpt>
-    <li>'text-decoration' and its associated properties
+    <li>'text-decoration' and its associated properties, including
+    <ul>
+      <li>'text-underline-position'</li>
+      <li>'text-underline-offset'</li>
+    </ul>
     <wpt>
     css/css-pseudo/active-selection-004-manual.html
     css/css-pseudo/active-selection-014.html
@@ -687,6 +691,7 @@ Styling Highlights</h3>
     css/css-pseudo/spelling-error-002-manual.html
     css/css-pseudo/spelling-error-003-manual.html
     </wpt>
+    <li>'text-emphasis' and its associated properties
     <li>'text-shadow'
     <li>'stroke-color', 'fill-color', and 'stroke-width'
     <wpt>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -677,8 +677,8 @@ Styling Highlights</h3>
     </wpt>
     <li>'text-decoration' and its associated properties, including
     <ul>
-      <li>'text-underline-position'</li>
-      <li>'text-underline-offset'</li>
+      <li>'text-underline-position'
+      <li>'text-underline-offset'
     </ul>
     <wpt>
     css/css-pseudo/active-selection-004-manual.html


### PR DESCRIPTION
This patch makes edits for #7101, adding ‘text-underline-position’, ‘text-underline-offset’, ~~and ‘text-emphasis-color’~~ to the list of those applicable to highlight pseudos.