### PR TITLE
[css-flexbox-1] [css-grid-2] [css-ruby-1] Flag "New values" tables for display property as informative

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -539,10 +539,12 @@ Flex Layout Box Model and Terminology</h2>
 <h2 id='flex-containers'>
 Flex Containers: the ''flex'' and ''inline-flex'' 'display' values</h2>
 
-	<pre class="propdef partial">
-	Name: display
-	New values: flex | inline-flex
-	</pre>
+	<div class="informative">
+		<pre class="propdef partial">
+		Name: display
+		New values: flex | inline-flex
+		</pre>
+	</div>
 
 	<dl dfn-type=value dfn-for=display>
 		<dt><dfn>flex</dfn>

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -895,10 +895,12 @@ Grid Containers</h2>
 <h3 id='grid-containers'>
 Establishing Grid Containers: the ''display/grid'' and ''inline-grid'' 'display' values</h3>
 
-	<pre class="propdef partial">
-	Name: display
-	New values: grid | inline-grid
-	</pre>
+	<div class="informative">
+		<pre class="propdef partial">
+		Name: display
+		New values: grid | inline-grid
+		</pre>
+	</div>
 
 	<dl dfn-for="display" dfn-type=value>
 		<dt><dfn>grid</dfn>

--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -204,10 +204,12 @@ Ruby-specific 'display' Values</h3>
 	authors must map document language elements to ruby elements;
 	this is done with the 'display' property.
 
-	<pre class=propdef partial>
-	Name: display
-	New values: ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container
-	</pre>
+	<div class="informative">
+		<pre class=propdef partial>
+		Name: display
+		New values: ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container
+		</pre>
+	</div>
 
 	The following new 'display' values assign ruby layout roles to an arbitrary element:
 


### PR DESCRIPTION
Via https://github.com/mdn/yari/pull/4656#issuecomment-1113508815

The CSS Display spec defines [possible values for the `display` property](https://drafts.csswg.org/css-display/#propdef-display). This includes `flex`, `grid`, `ruby` and associated values, whose meanings are normatively defined in CSS Flexbox, CSS Grid and CSS Ruby.

On top of meanings, the CSS Flexbox, CSS Grid and CSS Ruby specs actually redefine the values themselves through a "New Values" table. This is fully clear for humans, but a naive attempt to extract formal value definitions from CSS specs ends up with the impression that `flex`, `grid` and `ruby` are actually normatively defined twice.

This update proposes to flag the "New values" tables in CSS Flexbox, CSS Grid and CSS Ruby as "informative" so that extraction tools can understand that the values themselves are actually defined in CSS Display. This does not introduce any visual change.

(Note the "informative" class cannot be added to the `<pre>` tag directly as Bikeshed does not preserve the class when it generates the spec)