### PR TITLE
[css-text-decor-4] Clarified constraints for thickness length and percentage #7283

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -339,7 +339,8 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<length>></dfn>
 		<dd>
 			Specifies the thickness of text decoration lines as a fixed length.
-			The UA must floor the actual value at one device pixel.
+			The UA should round the actual value to the nearest integer,
+			and ensure it is at least one device pixel.
 
 			Note: A length will inherit as a fixed value,
 			and will not scale with the font.
@@ -347,7 +348,8 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<percentage>></dfn>
 		<dd>
 			<p>Specifies the thickness of text decoration lines as a percentage of ''1em''.
-			The UA must floor the actual value at one device pixel.
+			The UA should round the actual value to the nearest integer,
+			and ensure it is at least one device pixel.
 
 			Note: A percentage will inherit as a relative value,
 			and will therefore scale with changes in the font as it inherits.

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -339,7 +339,8 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<length>></dfn>
 		<dd>
 			Specifies the thickness of text decoration lines as a fixed length.
-			The UA should round to the nearest positive integer.
+			The UA should round the actual value to the nearest integer device pixel,
+			and ensure it is at least one device pixel.
 
 			Note: A length will inherit as a fixed value,
 			and will not scale with the font.
@@ -347,7 +348,8 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<percentage>></dfn>
 		<dd>
 			<p>Specifies the thickness of text decoration lines as a percentage of ''1em''.
-			The UA should round to the nearest positive integer.
+			The UA should round the actual value to the nearest integer device pixel,
+			and ensure it is at least one device pixel.
 
 			Note: A percentage will inherit as a relative value,
 			and will therefore scale with changes in the font as it inherits.

--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -339,8 +339,7 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<length>></dfn>
 		<dd>
 			Specifies the thickness of text decoration lines as a fixed length.
-			The UA should round the actual value to the nearest integer,
-			and ensure it is at least one device pixel.
+			The UA should round to the nearest positive integer.
 
 			Note: A length will inherit as a fixed value,
 			and will not scale with the font.
@@ -348,8 +347,7 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 		<dt><dfn><<percentage>></dfn>
 		<dd>
 			<p>Specifies the thickness of text decoration lines as a percentage of ''1em''.
-			The UA should round the actual value to the nearest integer,
-			and ensure it is at least one device pixel.
+			The UA should round to the nearest positive integer.
 
 			Note: A percentage will inherit as a relative value,
 			and will therefore scale with changes in the font as it inherits.


### PR DESCRIPTION
The current sentence could be interpreted as performing a `floor` on the actual calculated value, while it is actually rounded to the nearest integer, with a minimum value of one.
Equivalent to: `x = min(1, round(x))`

Fixes #7283
