### PR TITLE
[css-contain-3] Exclude 'none' and 'not' from custom-ident. #7203

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -493,7 +493,7 @@ Naming Query Containers: the 'container-name' property</h3>
 	<dt><dfn><<custom-ident>></dfn>
 	<dd>
 		Specifies a [=query container name=] as an [=identifier=].
-		The keywords ''container-name/none'' and ''not'' are excluded from this <<custom-ident>>.
+		The keywords ''container-name/none'', ''and'', ''not'', and ''or'' are excluded from this <<custom-ident>>.
 	</dl>
 
 	<div class=example>

--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -493,6 +493,7 @@ Naming Query Containers: the 'container-name' property</h3>
 	<dt><dfn><<custom-ident>></dfn>
 	<dd>
 		Specifies a [=query container name=] as an [=identifier=].
+		The keywords ''container-name/none'' and ''not'' are excluded from this <<custom-ident>>.
 	</dl>
 
 	<div class=example>


### PR DESCRIPTION
Current proposal to disallow 'not' and 'none' as container-names.
