### PR TITLE
[css-contain-3] Disallow not/none for container-name in @-rule. #7203

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -593,7 +593,7 @@ Container Queries: the ''@container'' rule</h3>
 	                      | <<general-enclosed>>
 	</pre>
 
-	The keywords ''container-name/none'' and ''not'' are excluded from the <<custom-ident>> above.
+	The keywords ''container-name/none'', ''and'', ''not'', and ''or'' are excluded from the <<custom-ident>> above.
 
 	For each element,
 	the [=query container=] to be queried

--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -577,6 +577,7 @@ Container Queries: the ''@container'' rule</h3>
 	where:
 
 	<pre class="prod def">
+	<dfn id="query-container-name"><<container-name>></dfn> = <<custom-ident>>
 	<dfn><<container-condition>></dfn> = not <<query-in-parens>>
 	                      | <<query-in-parens>> [ [ and <<query-in-parens>> ]* | [ or <<query-in-parens>> ]* ]
 	<dfn><<query-in-parens>></dfn>     = ( <<container-condition>> )
@@ -592,6 +593,7 @@ Container Queries: the ''@container'' rule</h3>
 	                      | <<general-enclosed>>
 	</pre>
 
+	The keywords ''container-name/none'' and ''not'' are excluded from the <<custom-ident>> above.
 
 	For each element,
 	the [=query container=] to be queried
@@ -599,7 +601,7 @@ Container Queries: the ''@container'' rule</h3>
 	that have a valid 'container-type'
 	for all the [=container features=]
 	in the <<container-condition>>.
-	The optional <dfn><<container-name>></dfn>
+	The optional <<container-name>>
 	filters the set of [=query containers=] considered
 	to just those with a matching [=query container name=].
 


### PR DESCRIPTION
Use a separate definition of container-name in the @container syntax to
disallow 'none' and 'not'.
