### PR TITLE
[css-page] Fix typo in Overview.bs

### DIFF
--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -1812,7 +1812,7 @@ Page size: the 'size' property</h3>
 	property is relative to the page size so if the page sheet dimensions are 210mm
 	x 297mm (i.e., A4), the margins are 21mm and 29.7mm. Assuming there are no page
 	borders or padding set in the UA default style sheet, the resulting page area
-	is 189mm by 367.3mm (210mm-21mm by 297mm-29.7mm).
+	is 189mm by 267.3mm (210mm-21mm by 297mm-29.7mm).
 
 	<pre>
 	@page {


### PR DESCRIPTION
Resulting page area was incorrect in `EXAMPLE 24`.