### PR TITLE
[css-fonts-3] Fix the mistake that the scheme is inconsistent, and improve comments

### DIFF
--- a/css-fonts-3/Overview.html
+++ b/css-fonts-3/Overview.html
@@ -3043,7 +3043,7 @@ h2 {
    CORS-enabled fetch method, is defined or required.
 
   <div class=example> For the examples given below, assume that a document is
-   located at <code>https://example.com/page.html</code> and all URL's link
+   located at <code>http://example.com/page.html</code> and all URL's link
    to valid font resources supported by the user agent. Fonts defined with
    the ‘<a href="#descdef-src"><code class=property>src</code></a>’
    descriptor values below will be loaded:
@@ -3061,11 +3061,11 @@ src: url(http://another.example.com/fonts/simple.woff);
    class=property>src</code></a>’ descriptor values below will fail to
    load:
    <pre>/* cross origin, different scheme */
-/* no Access-Control-xxx headers in response */
+/* no Access-Control prefixed headers are set correctly */
 src: url(https://example.com/fonts/simple.woff);
 
 /* cross origin, different domain */
-/* no Access-Control-xxx headers in response */
+/* no Access-Control prefixed headers are set correctly */
 src: url(http://another.example.com/fonts/simple.woff);
 </pre>
   </div>


### PR DESCRIPTION
Examples of different schemas and different domains are inconsistent with the given assumed URL.