### PR TITLE
[css-color-5] possible typo (unnecessity `]`)

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1576,7 +1576,7 @@ the allowed [=channel keywords=] are:
 
 	If the specified color
 	is a [=valid color=]
-	but [=can't be displayed=]],
+	but [=can't be displayed=],
 	the used value is derived from the specified color,
 	<a>gamut-mapped</a> for display.
 


### PR DESCRIPTION
as title. one termref has additional closing bracket.
