### PR TITLE
[selectors-4] Disallow nesting :has() inside :has(). #6952

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1194,6 +1194,8 @@ The Relational Pseudo-class: '':has()''</h3>
 	would match at least one element
 	when [=anchor element|anchored against=] this element.
 
+	'':has()'' pseudo-class cannot be nested; '':has()'' is not valid within '':has()''.
+
 	<div class='example'>
 		For example, the following selector matches only
 		<code>&lt;a></code> elements that contain an <code>&lt;img></code> child:


### PR DESCRIPTION
Add a simple sentence to apply the resolution of issue #6952:
- RESOLVED: Disallow nesting :has() inside :has()

https://github.com/w3c/csswg-drafts/issues/6952#issuecomment-1143812466