### PR TITLE
[css-scroll-snap-2] harmonize JavaScript spelling

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -27,7 +27,7 @@ Introduction {#intro}
 
 	Scroll experiences don't always start at the beginning. Interactions with
 	carousels, swipe controls, and listviews often start somewhere in the middle,
-	and each require Javascript to set this position on page load.
+	and each require JavaScript to set this position on page load.
 	By enabling CSS to specify this scroll start position,
 	both users, page authors and browsers benefit.
 
@@ -267,7 +267,7 @@ Snap Events {#snap-events}
 
 	CSS scroll snap points are often used as a mechanism to
 	create scroll interactive "selection" components,
-	where selection is determined with javascript intersection observers
+	where selection is determined with JavaScript intersection observers
 	and a scroll end guestimate. By creating a built-in event,
 	the invisible state will become actionable,
 	at the right time, and always correct.


### PR DESCRIPTION
[css-scroll-snap-2] just a non-substantive spelling change 0:-)

Mh, the GitHub Editor seems to have added a newline in the end, should I remove that again?