### PR TITLE
[css-color-5] Fix typo in `<rgb()>` value definition

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -871,7 +871,7 @@ The grammar of the ''rgb()'' function is extended as follows:
 
 <pre class='prod'>
 	<dfn>rgb()</dfn> = rgb( [<<percentage>> | none]{3} [ / [<<alpha-value>> | none] ]? ) |
-				  rgb( [<<number>> | none]{3} [ / [<<alpha-value>> | none] ]?
+				  rgb( [<<number>> | none]{3} [ / [<<alpha-value>> | none] ]? ) |
 				  rgb( [ from <<color>> ]? [ <<number>> | <<percentage>> | none]{3} [ / [<<alpha-value>> | none] ]?  )
 	<dfn>&lt;alpha-value></dfn> = <<number>> | <<percentage>>
 	</pre>


### PR DESCRIPTION
Temporary fix of #7363 until spec authors decide to further edit the value definition.