### PR TITLE
[css-syntax-3] Fix typo in `<an+b>` value definition

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2980,7 +2980,7 @@ The <code>&lt;an+b></code> type</h3>
 		  '+'?<sup><a href="#anb-plus">†</a></sup> n- <var>&lt;signless-integer></var> |
 		  -n- <var>&lt;signless-integer></var> |
 
-		  <var>&lt;n-dimension></var> ['+' | '-'] <var>&lt;signless-integer></var>
+		  <var>&lt;n-dimension></var> ['+' | '-'] <var>&lt;signless-integer></var> |
 		  '+'?<sup><a href="#anb-plus">†</a></sup> n ['+' | '-'] <var>&lt;signless-integer></var> |
 		  -n ['+' | '-'] <var>&lt;signless-integer></var>
 	</pre>


### PR DESCRIPTION
Fixes #7030.