### PR TITLE
[css-easing-2] Adding multi-step linear-interpolated easing function

### DIFF
--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -304,9 +304,11 @@ It returns a [=linear spline easing function=].
 
                1.   Set |extraSerializablePoint|'s [=linear spline easing point/input=] to <<linear-spline-stop-length>>'s second <<percentage>> as a number.
 
-     1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|,
+     1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|, then:
 
-          then set |point|'s [=linear spline easing point/input=] to 0.
+          1.   Set |point|'s [=linear spline easing point/input=] to 0.
+
+          1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
 
      1.   Otherwise, if |stop| is the last [=list/item=] in |stopList|,
           then set |point|'s [=linear spline easing point/input=] to whichever is greater:

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -7,10 +7,12 @@ Level: 2
 Group: csswg
 ED: https://drafts.csswg.org/css-easing/
 TR: https://www.w3.org/TR/css-easing-2/
+Editor: Jake Archibald, Google, jakearchibald@google.com, w3cid 76394
 Editor: Brian Birtles, Mozilla https://www.mozilla.org/, bbirtles@mozilla.com, w3cid 43194
 Editor: Dean Jackson, Apple Inc https://www.apple.com/, dino@apple.com, w3cid 42080
 Editor: Matt Rakow, Microsoft, w3cid 62267
 Former Editor: Shane Stephens, Google, shans@google.com, w3cid 47691
+Markup Shorthands: markdown yes
 
 Abstract: This CSS module describes a way for authors to define a transformation
     that controls the rate of change of some value.
@@ -121,7 +123,6 @@ The syntax for specifying an [=easing function=] is as follows:
   <<cubic-bezier-easing-function>> |
   <<step-easing-function>></div>
 
-
 <h3 id=the-linear-easing-function oldids=linear-timing-function-section>The linear easing function: ''linear''</h3>
 
 The <dfn export lt="linear easing function|linear timing function">linear easing
@@ -132,6 +133,111 @@ meaning that its [=output progress value=] is equal to the
 The syntax for the [=linear easing function=] is simply the
 <dfn dfn-type=value for=easing-function>linear</dfn> keyword.
 
+<h3 id=the-linear-spline-easing-function>The linear spline easing function: ''linear-spline()''</h3>
+
+A <dfn export>linear spline easing function</dfn>
+is an easing function
+that interpolates linearly
+between its [=linear spline easing function/points=].
+
+A [=linear spline easing function=] has:
+
+<dl dfn-for="linear spline easing function">
+
+:   <dfn>points</dfn>
+::  a [=/list=] of [=linear spline easing points=].
+    Initially a new empty [=/list=].
+
+:   <dfn>serializable points</dfn>
+::  a [=/list=] of [=linear spline easing points=].
+    Initially a new empty [=/list=].
+
+    Note: This is only used for producing a computed value.
+
+</dl>
+
+A <dfn>linear spline easing point</dfn>
+is a [=/struct=]
+that has:
+
+<dl dfn-for="linear spline easing point">
+
+: <dfn>input</dfn>
+:: A number or null
+
+: <dfn>output</dfn>
+:: A number
+
+</dl>
+
+<section algorithm="linear spline easing function">
+
+To get a [=linear spline easing function=]'s (|linearSplineEasingFunction|) <dfn for="linear spline easing function" export>computed value</dfn>
+perform the following.
+It returns a [=string=].
+
+1.   Let |output| be "`linear-spline(`".
+
+1.   [=list/For each=] |point| in |linearSplineEasingFunction|'s [=linear spline easing function/serializable points=]:
+
+     1.   If |point| is not the first [=list/item=] of |linearSplineEasingFunction|'s [=linear spline easing function/points=],
+          append "<code>, </code>" to |output|.
+
+     1.   Append the computed value of |point|'s [=linear spline easing point/output=],
+          as a <<number>>,
+          to |output|.
+
+     1.   If |point|'s [=linear spline easing point/input=] is not null, append "<code> </code>"
+          followed by the computed value of |point|'s [=linear spline easing point/input=],
+          as a <<percentage>>
+          to |output|.
+
+1.   Append "`)`" to |output|.
+
+1.   Return |output|.
+
+</section>
+
+<section algorithm="to calculate linear spline output progress">
+
+To <dfn export>calculate linear spline output progress</dfn>
+for a given [=linear spline easing function=] |linearSplineEasingFunction|,
+and an [=input progress value=] |inputProgress|,
+perform the following.
+It returns an [=output progress value=].
+
+Note: TODO explain this with diagrams
+
+1.   Let |points| be |linearSplineEasingFunction|'s [=linear spline easing function/points=].
+
+1.   Let |pointAIndex| be the last [=list/item=] in |points| with an [=linear spline easing point/input=] less than or equal to |inputProgress|,
+     or 0 if there is no match.
+
+1.   If |pointAIndex| is equal to |points| [=list/size=] minus 1,
+     decrement |pointAIndex| by 1.
+
+     Note: This ensures we have a next [=linear spline easing point|point=] to compare to.
+
+1.   Let |pointA| be |points|[pointAIndex].
+
+1.   Let |pointB| be |points|[pointAIndex + 1].
+
+1.   If |pointA|'s [=linear spline easing point/input=] is equal to |pointB|'s [=linear spline easing point/input=],
+     return |pointB|'s [=linear spline easing point/output=].
+
+1.   Let |progressFromPointA| be |inputProgress| minus |pointA|'s [=linear spline easing point/input=].
+
+1.   Let |pointInputRange| be |pointB|'s [=linear spline easing point/input=] minus |pointA|'s [=linear spline easing point/input=].
+
+1.   Let |progressBetweenPoints| be |progressFromPointA| divided by |pointInputRange|.
+
+1.   Let |pointOutputRange| be |pointB|'s [=linear spline easing point/output=] minus |pointA|'s [=linear spline easing point/output=].
+
+1.   Let |outputFromLastPoint| be |progressBetweenPoints| multiplied by |pointOutputRange|.
+
+1.   Return |pointA|'s [=linear spline easing point/output=] plus |outputFromLastPoint|.
+
+</section>
 
 <h3 id=cubic-bezier-easing-functions oldids=cubic-bezier-timing-functions>Cubic
 B&eacute;zier easing functions:

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -135,26 +135,27 @@ The syntax for the [=linear easing function=] is simply the
 
 <h3 id=the-linear-spline-easing-function>The linear spline easing function: ''linear-spline()''</h3>
 
+<dfn function lt="linear-spline()">linear-spline(<<linear-spline-stop-list>>)</dfn>
+
+<pre class="prod">
+  <dfn>&lt;linear-spline-stop-list></dfn> = [ <<linear-spline-stop>> ]#
+  <dfn>&lt;linear-spline-stop></dfn> = <<number>> && <<linear-spline-stop-length>>?
+  <dfn>&lt;linear-spline-stop-length></dfn> = <<percentage>>{1,2}
+</pre>
+
+''linear-spline()'' is parsed into a [=linear spline easing function=]
+by calling [=create a linear easing function=],
+passing in its <<linear-spline-stop-list>>.
+There must be at least two <<linear-spline-stop>>s.
+
 A <dfn export>linear spline easing function</dfn>
 is an easing function
 that interpolates linearly
 between its [=linear spline easing function/points=].
 
-A [=linear spline easing function=] has:
-
-<dl dfn-for="linear spline easing function">
-
-:   <dfn>points</dfn>
-::  a [=/list=] of [=linear spline easing points=].
-    Initially a new empty [=/list=].
-
-:   <dfn>serializable points</dfn>
-::  a [=/list=] of [=linear spline easing points=].
-    Initially a new empty [=/list=].
-
-    Note: This is only used for producing a computed value.
-
-</dl>
+A [=linear spline easing function=] has <dfn for="linear spline easing function">points</dfn>,
+a [=/list=] of [=linear spline easing points=].
+Initially a new empty [=/list=].
 
 A <dfn>linear spline easing point</dfn>
 is a [=/struct=]
@@ -165,20 +166,79 @@ that has:
 : <dfn>input</dfn>
 :: A number or null
 
+   Note: This is only null during [=create a linear easing function=].
+
 : <dfn>output</dfn>
 :: A number
 
 </dl>
 
+<section algorithm="to create a linear easing function">
+
+  To <dfn>create a linear easing function</dfn>
+  from a <<linear-spline-stop-list>> |stopList|,
+  perform the following.
+  It returns a [=linear spline easing function=].
+
+  1.   Let |function| be a new [=linear spline easing function=].
+
+  1.   Let |largestInput| be negative infinity.
+
+  1.   For each |stop| in |stopList|:
+
+       1.   Let |point| be a new [=linear spline easing point=]
+            with its [=linear spline easing point/output=] set to |stop|'s <<number>> as a number.
+
+       1.   [=list/Append=] |point| to |function|'s [=linear spline easing function/points=].
+
+       1.   If |stop| has a <<linear-spline-stop-length>>, then:
+
+            1.   Set |point|'s [=linear spline easing point/input=] to whichever is greater:
+                 |stop|'s <<linear-spline-stop-length>>'s first <<percentage>> as a number,
+                 or |largestInput|.
+
+            1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
+
+            1.   If |stop|'s <<linear-spline-stop-length>> has a second <<percentage>>, then:
+
+                 1.   Let |extraPoint| be a new [=linear spline easing point=]
+                      with its [=linear spline easing point/output=] set to |stop|'s <<number>> as a number.
+
+                 1.   [=list/Append=] |extraPoint| to |function|'s [=linear spline easing function/points=].
+
+                 1.   Set |extraPoint|'s [=linear spline easing point/input=] to whichever is greater:
+                      |stop|'s <<linear-spline-stop-length>>'s second <<percentage>> as a number,
+                      or |largestInput|.
+
+                 1.   Set |largestInput| to |extraPoint|'s [=linear spline easing point/input=].
+
+       1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|, then:
+
+            1.   Set |point|'s [=linear spline easing point/input=] to 0.
+
+            1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
+
+       1.   Otherwise, if |stop| is the last [=list/item=] in |stopList|,
+            then set |point|'s [=linear spline easing point/input=] to whichever is greater:
+            1 or |largestInput|.
+
+  1.   For runs of [=list/items=] in |function|'s [=linear spline easing function/points=] that have a null [=linear spline easing point/input=],
+       assign a number to the [=linear spline easing point/input=] by linearly interpolating between the closest previous and next [=linear spline easing function/points=]
+       that have a non-null [=linear spline easing point/input=].
+
+  1.   Return |function|.
+
+  </section>
+
 <section algorithm="linear spline easing function">
 
-To get a [=linear spline easing function=]'s (|linearSplineEasingFunction|) <dfn for="linear spline easing function" export>computed value</dfn>
+To get a [=linear spline easing function=]'s (|linearSplineEasingFunction|) <dfn for="linear spline easing function" export>serialized computed value</dfn>
 perform the following.
 It returns a [=string=].
 
 1.   Let |output| be "`linear-spline(`".
 
-1.   [=list/For each=] |point| in |linearSplineEasingFunction|'s [=linear spline easing function/serializable points=]:
+1.   [=list/For each=] |point| in |linearSplineEasingFunction|'s [=linear spline easing function/points=]:
 
      1.   If |point| is not the first [=list/item=] of |linearSplineEasingFunction|'s [=linear spline easing function/points=],
           append "<code>, </code>" to |output|.
@@ -187,8 +247,9 @@ It returns a [=string=].
           as a <<number>>,
           to |output|.
 
-     1.   If |point|'s [=linear spline easing point/input=] is not null, append "<code> </code>"
-          followed by the computed value of |point|'s [=linear spline easing point/input=],
+     1.   Append "<code> </code>" to |output|.
+
+     1.   Append the computed value of |point|'s [=linear spline easing point/input=],
           as a <<percentage>>
           to |output|.
 
@@ -236,89 +297,6 @@ Note: TODO explain this with diagrams
 1.   Let |outputFromLastPoint| be |progressBetweenPoints| multiplied by |pointOutputRange|.
 
 1.   Return |pointA|'s [=linear spline easing point/output=] plus |outputFromLastPoint|.
-
-</section>
-
-<dfn function lt="linear-spline()">linear-spline(<<linear-spline-stop-list>>)</dfn>
-
-<pre class="prod">
-  <dfn>&lt;linear-spline-stop-list></dfn> = [ <<linear-spline-stop>> ]#
-  <dfn>&lt;linear-spline-stop></dfn> = <<number>> && <<linear-spline-stop-length>>?
-  <dfn>&lt;linear-spline-stop-length></dfn> = <<percentage>>{1,2}
-</pre>
-
-<section algorithm="to create a linear easing function">
-
-To <dfn>create a linear easing function</dfn>
-from a <<linear-spline-stop-list>> |stopList|,
-perform the following.
-It returns a [=linear spline easing function=].
-
-1.   Let |function| be a new [=linear spline easing function=].
-
-1.   Let |largestInput| be negative infinity.
-
-1.   For each |stop| in |stopList|:
-
-     1.   Let |point| be a new [=linear spline easing point=].
-
-     1.   Let |serializablePoint| be a new [=linear spline easing point=].
-
-     1.   [=list/Append=] |point| to |function|'s [=linear spline easing function/points=].
-
-     1.   [=list/Append=] |serializablePoint| to |function|'s [=linear spline easing function/serializable points=].
-
-     1.   Set |point|'s [=linear spline easing point/output=] to |stop|'s <<number>> as a number.
-
-     1.   Set |serializablePoint|'s [=linear spline easing point/output=] to |stop|'s <<number>> as a number.
-
-     1.   If |stop| has a <<linear-spline-stop-length>>, then:
-
-          1.   Set |point|'s [=linear spline easing point/input=] to whichever is greater:
-               |stop|'s <<linear-spline-stop-length>>'s first <<percentage>> as a number,
-               or |largestInput|.
-
-          1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
-
-          1.   Set |serializablePoint|'s [=linear spline easing point/input=] to <<linear-spline-stop-length>>'s first <<percentage>> as a number.
-
-          1.   If |stop|'s <<linear-spline-stop-length>> has a second <<percentage>>, then:
-
-               1.   Let |extraPoint| be a new [=linear spline easing point=].
-
-               1.   Let |extraSerializablePoint| be a new [=linear spline easing point=].
-
-               1.   [=list/Append=] |extraPoint| to |function|'s [=linear spline easing function/points=].
-
-               1.   [=list/Append=] |extraSerializablePoint| to |function|'s [=linear spline easing function/serializable points=].
-
-               1.   Set |extraPoint|'s [=linear spline easing point/output=] to |stop|'s <<number>>.
-
-               1.   Set |extraSerializablePoint|'s [=linear spline easing point/output=] to |stop|'s <<number>>.
-
-               1.   Set |extraPoint|'s [=linear spline easing point/input=] to whichever is greater:
-                    |stop|'s <<linear-spline-stop-length>>'s second <<percentage>> as a number,
-                    or |largestInput|.
-
-               1.   Set |largestInput| to |extraPoint|'s [=linear spline easing point/input=].
-
-               1.   Set |extraSerializablePoint|'s [=linear spline easing point/input=] to <<linear-spline-stop-length>>'s second <<percentage>> as a number.
-
-     1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|, then:
-
-          1.   Set |point|'s [=linear spline easing point/input=] to 0.
-
-          1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
-
-     1.   Otherwise, if |stop| is the last [=list/item=] in |stopList|,
-          then set |point|'s [=linear spline easing point/input=] to whichever is greater:
-          1 or |largestInput|.
-
-1.   For runs of [=list/items=] in |function|'s [=linear spline easing function/points=] that have a null [=linear spline easing point/input=],
-     assign a number to the [=linear spline easing point/input=] by linearly interpolating between the closest previous and next [=linear spline easing function/points=]
-     that have a non-null [=linear spline easing point/input=].
-
-1.   Return |function|.
 
 </section>
 

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -239,6 +239,87 @@ Note: TODO explain this with diagrams
 
 </section>
 
+<dfn function lt="linear-spline()">linear-spline(<<linear-spline-stop-list>>)</dfn>
+
+<pre class="prod">
+  <dfn>&lt;linear-spline-stop-list></dfn> = [ <<linear-spline-stop>> ]#
+  <dfn>&lt;linear-spline-stop></dfn> = <<number>> && <<linear-spline-stop-length>>?
+  <dfn>&lt;linear-spline-stop-length></dfn> = <<percentage>>{1,2}
+</pre>
+
+<section algorithm="to create a linear easing function">
+
+To <dfn>create a linear easing function</dfn>
+from a <<linear-spline-stop-list>> |stopList|,
+perform the following.
+It returns a [=linear spline easing function=].
+
+1.   Let |function| be a new [=linear spline easing function=].
+
+1.   Let |largestInput| be negative infinity.
+
+1.   For each |stop| in |stopList|:
+
+     1.   Let |point| be a new [=linear spline easing point=].
+
+     1.   Let |serializablePoint| be a new [=linear spline easing point=].
+
+     1.   [=list/Append=] |point| to |function|'s [=linear spline easing function/points=].
+
+     1.   [=list/Append=] |serializablePoint| to |function|'s [=linear spline easing function/serializable points=].
+
+     1.   Set |point|'s [=linear spline easing point/output=] to |stop|'s <<number>> as a number.
+
+     1.   Set |serializablePoint|'s [=linear spline easing point/output=] to |stop|'s <<number>> as a number.
+
+     1.   If |stop| has a <<linear-spline-stop-length>>, then:
+
+          1.   Set |point|'s [=linear spline easing point/input=] to whichever is greater:
+               |stop|'s <<linear-spline-stop-length>>'s first <<percentage>> as a number,
+               or |largestInput|.
+
+          1.   Set |largestInput| to |point|'s [=linear spline easing point/input=].
+
+          1.   Set |serializablePoint|'s [=linear spline easing point/input=] to <<linear-spline-stop-length>>'s first <<percentage>> as a number.
+
+          1.   If |stop|'s <<linear-spline-stop-length>> has a second <<percentage>>, then:
+
+               1.   Let |extraPoint| be a new [=linear spline easing point=].
+
+               1.   Let |extraSerializablePoint| be a new [=linear spline easing point=].
+
+               1.   [=list/Append=] |extraPoint| to |function|'s [=linear spline easing function/points=].
+
+               1.   [=list/Append=] |extraSerializablePoint| to |function|'s [=linear spline easing function/serializable points=].
+
+               1.   Set |extraPoint|'s [=linear spline easing point/output=] to |stop|'s <<number>>.
+
+               1.   Set |extraSerializablePoint|'s [=linear spline easing point/output=] to |stop|'s <<number>>.
+
+               1.   Set |extraPoint|'s [=linear spline easing point/input=] to whichever is greater:
+                    |stop|'s <<linear-spline-stop-length>>'s second <<percentage>> as a number,
+                    or |largestInput|.
+
+               1.   Set |largestInput| to |extraPoint|'s [=linear spline easing point/input=].
+
+               1.   Set |extraSerializablePoint|'s [=linear spline easing point/input=] to <<linear-spline-stop-length>>'s second <<percentage>> as a number.
+
+     1.   Otherwise, if |stop| is the first [=list/item=] in |stopList|,
+
+          then set |point|'s [=linear spline easing point/input=] to 0.
+
+     1.   Otherwise, if |stop| is the last [=list/item=] in |stopList|,
+          then set |point|'s [=linear spline easing point/input=] to whichever is greater:
+          1 or |largestInput|.
+
+1.   For runs of [=list/items=] in |function|'s [=linear spline easing function/points=] that have a null [=linear spline easing point/input=],
+     assign a number to the [=linear spline easing point/input=] by linearly interpolating between the closest previous and next [=linear spline easing function/points=]
+     that have a non-null [=linear spline easing point/input=].
+
+1.   Return |function|.
+
+</section>
+
 <h3 id=cubic-bezier-easing-functions oldids=cubic-bezier-timing-functions>Cubic
 B&eacute;zier easing functions:
 ''ease'', ''ease-in'', ''ease-out'', ''ease-in-out'', ''cubic-bezier()''</h3>


### PR DESCRIPTION
This PR defines `linear-spline()`, a way to create custom easings, as discussed in https://github.com/w3c/csswg-drafts/issues/229#issuecomment-861247074.

TODO:

- [x] Plug in "create a linear easing function"
- [ ] Create diagrams to explain the feature
- [ ] Add a note at the start, explaining the feature for developers