### PR TITLE
Audit specifications for correct handling of overflow:clip.

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -438,8 +438,8 @@ a comma-separated list of &lt;attachment&gt; keywords where
       with respect to the <a href="https://www.w3.org/TR/CSS2/page.html#page-box">page box</a>
       and therefore replicated on every page.
       <span class="note">Note that there is only one viewport per view.
-      Even if an element has a scrolling mechanism (see  the 'overflow'
-      property [[!CSS2]]), a ''fixed'' background doesn't move with the
+      Even if an element is a <a>scroll container</a>,
+      a ''fixed'' background doesn't move with the
       element.</span>
   <dt><dfn>local</dfn></dt>
     <dd>The background is fixed with regard to the element's contents:

--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -1952,7 +1952,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 				descendants of table cells whose height depends on percentages of their parent cell' height 
 				<a href="#appropriateness-of-child-percentage-resolution">(see section below)</a>
 				are considered to have an auto height
-					if they have 'overflow' set to <code>visible</code> or <code>hidden</code>
+					if they have 'overflow' set to ''overflow/visible'', ''overflow/clip'', or ''overflow/hidden''
 					or if they are replaced elements,
 				and a 0px height if they have not.
 			<a href="https://jsfiddle.net/0e12ve9b/">Testcase</a>

--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -528,7 +528,7 @@ and if so, along which axis/axes.
 Name: resize
 Value: none | both | horizontal | vertical
 Initial: none
-Applies to: elements with 'overflow' other than visible,
+Applies to: elements that are <a>scroll containers</a>
  and optionally replaced elements such as images, videos, and iframes
 Inherited: no
 Percentages: N/A
@@ -566,8 +566,7 @@ The resizing mechanism allows the user
 to determine the size of the element.
 
 The 'resize' property applies to elements
-whose computed 'overflow' value
-is something other than ''visible''.
+that are <a>scroll containers</a>.
 UAs may also apply it,
 regardless of the value of the 'overflow' property,
 to:
@@ -664,6 +663,7 @@ its <a>end</a> line box edge
 in the inline progression direction of its block container element ("the block")
 that has 'overflow'
 other than ''visible''.
+<!-- REVIEW: I *think* this should not include ''overflow/clip'' -->
 
 Text can overflow for example when it is prevented from wrapping
 (e.g. due to <code class="lang-css">white-space: nowrap</code>

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -473,7 +473,7 @@ and if so, along which axis/axes.
 Name: resize
 Value: none | both | horizontal | vertical | block | inline
 Initial: none
-Applies to: elements with 'overflow' other than visible,
+Applies to: elements that are <a>scroll containers</a>
  and optionally replaced elements such as images, videos, and iframes
 Inherited: no
 Percentages: N/A
@@ -523,8 +523,7 @@ The resizing mechanism allows the user
 to determine the size of the element.
 
 The 'resize' property applies to elements
-whose computed 'overflow' value
-is something other than ''overflow/visible''.
+that are <a>scroll containers</a>.
 UAs may also apply it,
 regardless of the value of the 'overflow' property,
 to:


### PR DESCRIPTION
This set of changes is the result of auditing all specification
Overview.bs other than CSS2 and css-overflow-* for correct handling of
overflow:clip, since many specifications have historically referenced
concepts like "overflow values other than visible".

It is related to #6212, but doesn't actually fix it, because it's really
only a bug in CSS2.