### PR TITLE
[css-images-3] Fix escaping in definition of <size>

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -508,7 +508,7 @@ Radial Gradients: the ''radial-gradient()'' notation {#radial-gradients}
 		  [ <<ending-shape>> || <<size>> ]? [ at <<position>> ]? ,
 		  <<color-stop-list>>
 		)
-		<dfn><<size>></dfn> = <extent-keyword> | <length [0,∞]> | <length-percentage [0,∞]>{2}
+		<dfn><<size>></dfn> = <<extent-keyword>> | <<length [0,∞]>> | <<length-percentage [0,∞]>>{2}
 		<dfn><<extent-keyword>></dfn> = closest-corner | closest-side | farthest-corner | farthest-side
 	</pre>
 


### PR DESCRIPTION
Definition of `<size>` currently appears as `<size> =  |  | {2}` in the [Editor's Draft](https://drafts.csswg.org/css-images-3/#typedef-size) because autolinks to types/productions need to be wrapped in `<<foo>>` to properly generate a `<foo>` construct (and not a `<foo>` HTML tag)