### PR TITLE
[cssom-view] Add a "get the bounding box" algorithm for getBoundingClientRect() #5614 

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1057,16 +1057,22 @@ The <dfn method for=Element>getClientRects()</dfn> method, when invoked, must re
 
 Note: The {{DOMRect}} objects returned by {{Element/getClientRects()}} are not <a spec=html>live</a>.
 
-The <dfn method for=Element caniuse=getboundingclientrect>getBoundingClientRect()</dfn> method, when invoked, must return the result of the following
-algorithm:
+The <dfn method for=Element caniuse=getboundingclientrect>getBoundingClientRect()</dfn> method, when
+invoked on an element <var>element</var>, must return the result of
+<a>getting the bounding box</a> for <var>element</var>.
 
-1. Let <var>list</var> be the result of invoking {{Element/getClientRects()}} on the same element this method was invoked on.
-1. If the <var>list</var> is empty return a {{DOMRect}} object
-    whose {{DOMRect/x}}, {{DOMRect/y}}, {{DOMRect/width}} and {{DOMRect/height}} members are zero.
-1. If all rectangles in <var>list</var> have zero width or height, return the first rectangle in
-    <var>list</var>.
-1. Otherwise, return a {{DOMRect}} object describing the smallest rectangle that includes all
-    of the rectangles in <var>list</var> of which the height or width is not zero.
+<div algorithm>
+To <dfn export for=Element>get the bounding box</dfn> for <var>element</var>,
+run the following steps:
+    1. Let <var>list</var> be the result of invoking {{Element/getClientRects()}} on
+        <var>element</var>.
+    1. If the <var>list</var> is empty return a {{DOMRect}} object whose {{DOMRect/x}},
+        {{DOMRect/y}}, {{DOMRect/width}} and {{DOMRect/height}} members are zero.
+    1. If all rectangles in <var>list</var> have zero width or height, return the first rectangle in
+        <var>list</var>.
+    1. Otherwise, return a {{DOMRect}} object describing the smallest rectangle that includes all
+        of the rectangles in <var>list</var> of which the height or width is not zero.
+</div>
 
 Note: The {{DOMRect}} object returned by {{Element/getBoundingClientRect()}} is not <a spec=html>live</a>.
 


### PR DESCRIPTION
This way other specs like IntersectionObserver can call it.

See https://github.com/w3c/IntersectionObserver/issues/55
