### PR TITLE
[css-animations-1] Add `constructor` type on `AnimationEvent`'s definition (fix #7424)

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -912,7 +912,7 @@ Attributes</h4>
 			target of the event is that element).
 	</dl>
 
-	<dfn>AnimationEvent(type, animationEventInitDict)</dfn> is an <a>event constructor</a>.
+	<dfn dfn-type=constructor for=AnimationEvent>AnimationEvent(type, animationEventInitDict)</dfn> is an <a>event constructor</a>.
 
 <h3 id="event-animationevent">
 Types of <code>AnimationEvent</code></h3>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/7424