### PR TITLE
[cssom-view-1] editorial: Fix linking errors

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -98,7 +98,7 @@ An element <var>body</var> (which will be <a>the <code>body</code> element</a>) 
 Note: A <{body}> element that is <a>potentially scrollable</a> might not have a <a>scrolling box</a>.
 For instance, it could have a used value of 'overflow' being ''overflow/auto'' but not have its content overflowing its content area.
 
-A <a>scrolling box</a> of a <a>viewport</a> or element has two <dfn>overflow directions</dfn>, which are the <a>block-end</a> and <a>inline-end</a> directions for that viewport or element.
+A <dfn>scrolling box</dfn> of a <a>viewport</a> or element has two <dfn>overflow directions</dfn>, which are the <a>block-end</a> and <a>inline-end</a> directions for that viewport or element.
 Note that the initial scroll position might not be aligned with the [=scrolling area origin=]
 depending on the [=content-distribution properties=], see [[css-align-3#overflow-scroll-position]].
 
@@ -337,8 +337,8 @@ the following steps must be run:
    'scroll-behavior' property is ''scroll-behavior/smooth''
    <li><var>behavior</var> is <code>smooth</code>
   </ul>
-  ...then perform a <a>smooth scroll</a> of <var>box</var> to <var>position</var>. Once the position has finished updating, emit the <a>scrollend</a> event.
-  Otherwise, perform an <a>instant scroll</a> of <var>box</var> to <var>position</var>. After an <a>instant scroll</a> emit the <a>scrollend</a> event.
+  ...then perform a <a>smooth scroll</a> of <var>box</var> to <var>position</var>. Once the position has finished updating, emit the <a event>scrollend</a> event.
+  Otherwise, perform an <a>instant scroll</a> of <var>box</var> to <var>position</var>. After an <a>instant scroll</a> emit the <a event>scrollend</a> event.
 </ol>
 
 Scroll is <dfn lt="scroll completed">completed</dfn> when the scroll position has no more pending updates or translations. This includes smooth or instant mouse wheel scrolling, keyboard scrolling, scroll-snap events, or other APIs and gestures which cause the scroll position to update and possibly interpolate.
@@ -1669,6 +1669,8 @@ This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTM
 
 Each {{Document}} has an associated list of <dfn for=Document>pending scroll event targets</dfn>, initially empty.
 
+Each {{Document}} has an associated list of <dfn for=Document>pending scrollend event targets</dfn>, initially empty.
+
 Whenever a <a>viewport</a> gets scrolled (whether in response to user interaction or by an API), the user agent must run these steps:
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
@@ -1693,7 +1695,7 @@ When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Docume
 Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent must run these steps:
 
 1. If scrolling was done on a <a>viewport</a>, let <var>doc</var> be the <a>viewport’s</a> associated {{Document}} and <var>target</var> be the <a>viewport</a>.
-Otherwise, scrolling is done on an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
+    Otherwise, scrolling is done on an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
 1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
 1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
@@ -1728,7 +1730,7 @@ Otherwise, scrolling is done on an element and let <var>doc</var> be the element
    <td><dfn event for="Document, Element">scrollend</dfn>
    <td>{{Event}}
    <td>{{Document}}, elements
-   <td>Fired at the {{Document}} or element when scroll is <dfn lt="scroll completed">completed</dfn>: the <a>viewport</a> or element has been scrolled, the scroll sequence has ended and any scroll offset changes have been applied.
+   <td>Fired at the {{Document}} or element when scroll is <a lt="scroll completed">completed</a>: the <a>viewport</a> or element has been scrolled, the scroll sequence has ended and any scroll offset changes have been applied.
 </table>
 
 
@@ -1748,7 +1750,7 @@ This section documents some of the changes between publications of this specific
 generally not listed.
 
 <h3 id='changes-from-2022-06-22' class=no-num>Changes From 22 June 2022</h3>
-* Adam Argyle moved the 'scrollend' event from <a href="https://wicg.github.io/overscroll-scrollend-events/">WICG 'overscroll-scrollend-events'</a> to [[CSSOM-VIEW-1]]
+* Adam Argyle moved the <a event>scrollend</a> event from <a href="https://wicg.github.io/overscroll-scrollend-events/">WICG overscroll-scrollend-events</a> to [[CSSOM-VIEW-1]]
 
 <h3 id='changes-from-2020-10-19' class=no-num>Changes From 19 October 2020</h3>
 * Added the "Security and Privacy Considerations" section


### PR DESCRIPTION
Fixes a couple of bikeshed errors in cssom-view-1:

* Missing indentation on newline in ordered list
* Duplicate definitions for "scroll completed"
* Missing definition for "scrolling box"
* Wrong type for "scrollend" links
* Missing definition for "pending scrollend event targets"
