### PR TITLE
[cssom-view-1] Fix dfns for events that target VisualViewport

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1790,8 +1790,8 @@ When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Docume
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
-    1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scroll</a> that bubbles at <var>target</var> and fire an event
-        named <a event>scroll</a> at the {{VisualViewport}} that is associated with with <var>target</var>.
+    1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scroll</a> that bubbles at <var>target</var> and <a>fire an event</a>
+        named <a event>scroll</a> at the {{VisualViewport}} that is associated with <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scroll</a> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1820,13 +1820,13 @@ Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent mus
    <th>Description
  <tbody>
   <tr>
-   <td><dfn event for=Window>resize</dfn>
+   <td><dfn event for="Window, VisualViewport">resize</dfn>
    <td>{{Event}}
    <td>{{Window}}, {{VisualViewport}}
    <td>Fired at the {{Window}} when the <a>viewport</a> is resized. Fired at {{VisualViewport}} when the <a>visual viewport</a> is resized
        or the <a>layout viewport</a> is scaled.
   <tr>
-   <td><dfn event for="Document, Element">scroll</dfn>
+   <td><dfn event for="Document, Element, VisualViewport">scroll</dfn>
    <td>{{Event}}
    <td>{{Document}}, elements, {{VisualViewport}}
    <td>Fired at the {{Document}} or element when the <a>viewport</a> or element is scrolled, respectively. Fired at the {{VisualViewport}}


### PR DESCRIPTION
The `resize` and `scroll` event definitions need to be completed to account for the newly introduced `VisualViewport` target.

This update also adjusts the firing phrasing related to `VisualViewport` for consistency with the rest of the spec (other alignments are covered in #7466) and fixes a typo.
