### PR TITLE
[web-animations-2] Clean build warnings and remove obsolete hold phase

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -53,35 +53,49 @@ Ignored Vars: auto-rewind, current direction, index, initial progress,
 </pre>
 <pre class="anchors">
 urlPrefix: https://drafts.csswg.org/web-animations-1/; type: dfn; spec: web-animations-1
+    text: active-after boundary time
     text: active interval
     text: active phase
     text: active time
     text: after phase
     text: animation
+    text: animation direction
     text: animation playback rate
     text: animation effect
+    text: Apply any pending playback rate
+    text: associated effect end
+    text: before-active boundary time
     text: before flag
     text: before phase
     text: cancel an animation
     text: current iteration
+    text: current ready promise
     text: current time
     text: current finished promise
     text: directed progress
+    text: effective playback rate
     text: effect value
     text: end delay
+    text: end time
     text: fill mode
     text: finished play state
+    text: idle play state
     text: in effect
     text: iteration count
     text: iteration duration
     text: iteration progress
     text: iteration start
     text: keyframe effect
+    text: monotonically increasing
     text: not animatable
     text: overall progress
+    text: pending pause task
     text: pending play task
+    text: pending playback rate
     text: play an animation
+    text: play state
     text: playback direction
+    text: playback rate
     text: pause an animation
     text: ready
     text: set the timeline of an animation
@@ -96,7 +110,11 @@ urlPrefix: https://drafts.csswg.org/web-animations-1/; type: dfn; spec: web-anim
     text: update animations and send events
     text: update the timing properties of an animation effect
     text: unresolved
+    text: update an animation's finished state
+urlPrefix: https://heycam.github.io/webidl/; type: dfn; spec: webidl
+    text: resolve a promise; url: resolve
 urlPrefix: https://heycam.github.io/webidl/#dfn-; type: dfn; spec: webidl
+    text: present
     text: throw
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/#sec-; type: dfn; spec: ecma-262
     text: code realms
@@ -120,7 +138,6 @@ previous level of this specification:
     <a lt="animation effect playback rate">playback rate</a>,
 *   <a>custom effects</a>.
 *   Support for non-monotonic (scroll) timelines.
-*   Adds animation hold phase.
 
 <h2 id="timing-model">Timing model</h2>
 
@@ -166,7 +183,7 @@ Add:
 > maximum value a timeline may generate for its current time. This value is
 > used to calculate the [=intrinsic iteration duration=] for the target effect
 > of an animation that is associated with the timeline when the effect's
-> [=iteration duration=] is 'auto'. The value is computed such that the effect
+> [=iteration duration=] is "auto". The value is computed such that the effect
 > fills the available time. For a monotonic timeline, there is no upper bound
 > on current time, and [=timeline duration=] is unresolved. For a non-monotonic
 > (e.g. scroll) timeline, the duration has a fixed upper bound. In this
@@ -174,16 +191,6 @@ Add:
 > timeline</dfn>, and its [=timeline duration=] is 100%.
 
 <h3 id="animations">Animations</h3>
-
-After the paragraph on [=hold time=], add:
-
-> In addition to the <a>hold time</a>, an <a>animation</a> maintains a
-> <dfn>hold phase</dfn> which is set along with the <a>hold time</a> to
-> hold the effective timeline phase of an animation with a fixed
-> <a>current time</a>.
-> The <a>hold phase</a> has the same range of values as the associated
-> timeline's [=timeline phase=] and can be set or unset.
-> The <a>hold phase</a> is initially unset.
 
 Append:
 
@@ -201,7 +208,7 @@ Append:
 >         their values are expressed as times and not as percentages.
 >
 >     Otherwise:
->          1. Let <var>total time</var> be equal to |end time|
+>          1. Let <var>total time</var> be equal to [=end time=]
 >          1. Set [=start delay=] to be the result of evaluating
 >             <code>|specified start delay| / |total time| *
 >             |timeline duration|</code>.
@@ -220,14 +227,14 @@ Append:
 > Otherwise:
 >     1.   Set [=start delay=] = |specified start delay|
 >     1.   Set [=end delay=] = |specified end delay|
->     1.   If |iteration duration| is auto:
->              *   Set [=iteration duration=] = |intrinsic iteration duration|
+>     1.   If [=iteration duration=] is auto:
+>              *   Set [=iteration duration=] = [=intrinsic iteration duration=]
 >          Otherwise:
 >              *   Set [=iteration duration=] = |specified iteration duration|
 
-<h4 id="setting-the-timeline">Setting the timeline of an animation</h4>
+### Setting the timeline of an animation ### {#setting-the-timeline}
 
-The procedure to <dfn>set the timeline of an animation</dfn>,
+The procedure to <df export for=animation>set the timeline of an animation</dfn>,
 <var>animation</var>, to <var>new timeline</var> which may be null, is as
 follows:
 
@@ -237,7 +244,6 @@ follows:
     abort this procedure.
 1.  Let |previous play state| be |animation|'s [=play state=].
 1.  Let |previous current time| be the |animation|'s [=current time=].
-1.  Let |previous current phase| be the |animation|'s [=current phase=].
 1.  Set |previous progress| based in the first condition that applies:
     <dl class=switch>
         :   If |previous current time| is unresolved:
@@ -267,36 +273,36 @@ follows:
         :   If |to finite timeline|,
 
         ::  1.  [=Apply any pending playback rate=] on |animation|
-            1.  Let |seek time| be zero if [=playback=] rate &ge; 0, and
+            1.  Let |seek time| be zero if [=playback rate=] &ge; 0, and
                 |animation|'s <a>associated effect end</a> otherwise.
             1.  Update the animation based on the first matching condition if any:
 
                 <dl class="switch">
 
                     :   If <em>either</em> of the following conditions are true:
-                        *    |previous play state| is 'running' or,
-                        *    |previous play state| is 'finished'
+                        *    |previous play state| is "running" or,
+                        *    |previous play state| is "finished"
 
-                    ::  Set |animation|'s [=start time=] to |seek time|.
+                    ::  Set |animation|'s [=animation/start time=] to |seek time|.
 
-                    :   If |previous play state| is 'paused':
+                    :   If |previous play state| is "paused":
 
                     ::  If |previous progress| is resolved:
 
                         1.  Set the flag |reset current time on resume| to true.
-                        1.  Set [=start time=] to unresolved.
+                        1.  Set [=animation/start time=] to unresolved.
                         1.  Set [=hold time=] to |previous progress| *
                             [=end time=].
-                        1.  Set [=hold phase=] to |previous current phase|.
 
                         <p class="note">
                         This step ensures that |previous progress| is preserved
-                        even in the case of a pause-pending animation with a resolved [=start time=].
+                        even in the case of a pause-pending animation with a
+                        resolved [=animation/start time=].
                         <p>
 
                     :: Otherwise
 
-                        1. Set [=start time=] to |seek time|.
+                        1. Set [=animation/start time=] to |seek time|.
 
                 </dl>
 
@@ -307,9 +313,9 @@ follows:
 
     </dl>
 
-1.  If the [=start time=] of <var>animation</var> is <a
+1.  If the [=animation/start time=] of <var>animation</var> is <a
     lt=unresolved>resolved</a>, make <var>animation</var>'s <a>hold time</a>
-    <a>unresolved</a>, and make <a>hold phase</a> unset.
+    <a>unresolved</a>.
 
     <p class="note">
     This step ensures that the <a>finished play state</a> of
@@ -421,7 +427,7 @@ an animation, <var>animation</var>, to <var>seek time</var> is as follows:
 1.  If <var>valid seek time</var> is false, abort this procedure.
 
 1.  Update either <var>animation</var>'s <a>hold time</a> or
-    [=start time=] as follows:
+    [=animation/start time=] as follows:
 
     <dl class="switch">
 
@@ -429,7 +435,7 @@ an animation, <var>animation</var>, to <var>seek time</var> is as follows:
 
             *   <var>animation</var>'s <a>hold time</a> is
                 <a lt="unresolved">resolved</a>, or
-            *   <var>animation</var>'s [=start time=]
+            *   <var>animation</var>'s [=animation/start time=]
                 is <a lt="unresolved">unresolved</a>, or
             *   <var>animation</var> has no associated <a>timeline</a> or
                 the associated <a>timeline</a> is
@@ -438,11 +444,9 @@ an animation, <var>animation</var>, to <var>seek time</var> is as follows:
 
         ::  1.  Set <var>animation</var>'s <a>hold time</a> to
                 <var>seek time</var>.
-            1.  Set <var>animation</var>'s <a>hold phase</a> to
-                the associated timeline's [=timeline phase=].
 
         :   Otherwise,
-        ::  Set <var>animation</var>'s [=start time=] to the result of
+        ::  Set <var>animation</var>'s [=animation/start time=] to the result of
             evaluating
             <code>|timeline time| - (|seek time| / [=playback rate=])</code>
             where <var>timeline time</var> is the current <a>time value</a>
@@ -452,15 +456,15 @@ an animation, <var>animation</var>, to <var>seek time</var> is as follows:
 
 1.  If <var>animation</var> has no associated <a>timeline</a> or the associated
     <a>timeline</a> is <a lt="inactive timeline">inactive</a>,
-    make <var>animation</var>'s [=start time=] <a>unresolved</a>.
+    make <var>animation</var>'s [=animation/start time=] <a>unresolved</a>.
 
     <p class=note>
       This preserves the invariant that when we don't have an active timeline it
-      is only possible to set <em>either</em> the [=start time=]
+      is only possible to set <em>either</em> the [=animation/start time=]
       <em>or</em> the animation's <a>current time</a>.
     </p>
 
-1.  Make <var>animation</var>'s <a>previous current time</a> <a>unresolved</a>.
+1.  Make <a>animation</a>'s <var>previous current time</var> <a>unresolved</a>.
 
 1. Set the |reset current time on resume| flag to false.
 
@@ -473,10 +477,8 @@ The procedure to <dfn>set the current time</dfn> of an animation,
 1.  If <var>animation</var> has a <a>pending pause task</a>, synchronously
     complete the pause operation by performing the following steps:
     1.  Set <var>animation</var>'s <a>hold time</a> to <var>seek time</var>.
-    1.  Set <var>animation</var>'s <a>hold phase</a> to the associated
-        timeline's [=timeline phase=].
     1.  [=Apply any pending playback rate=] to |animation|.
-    1.  Make <var>animation</var>'s [=start time=] <a>unresolved</a>.
+    1.  Make <var>animation</var>'s [=animation/start time=] <a>unresolved</a>.
     1.  Cancel the <a>pending pause task</a>.
     1.  <a lt="resolve a Promise">Resolve</a> <var>animation</var>'s
         <a>current ready promise</a> with <var>animation</var>.
@@ -506,11 +508,11 @@ is as follows:
 
 1.  If <var>timeline time</var> is <a>unresolved</a> and <var>new start
     time</var> is <a lt="unresolved">resolved</a>, make <var>animation</var>'s
-    <a>hold time</a> <a>unresolved</a> and make <a>hold phase</a> unset.
+    <a>hold time</a> <a>unresolved</a>.
 
     <p class=note>
       This preserves the invariant that when we don't have an active timeline it
-      is only possible to set <em>either</em> the [=start time=]
+      is only possible to set <em>either</em> the [=animation/start time=]
       <em>or</em> the animation's <a>current time</a>.
     </p>
 
@@ -521,31 +523,26 @@ is as follows:
     previous step which may cause the <a>current time</a> to become
     <a>unresolved</a>.
 
-1.  Let <var>previous current phase</var> be <var>animation</var>'s <a>current
-    phase</a>.
-
 1.  [=Apply any pending playback rate=] on |animation|.
 
-1.  Set <var>animation</var>'s [=start time=] to <var>new start time</var>.
+1.  Set <var>animation</var>'s [=animation/start time=] to
+    <var>new start time</var>.
 
 1.  Set the |reset current time on resume| flag to false.
 
-1.  Update <var>animation</var>'s <a>hold time</a> and <a>hold phase</a> based
+1.  Update <var>animation</var>'s <a>hold time</a> based
     on the first matching condition from the following,
 
     <dl class="switch">
 
         :   If <var>new start time</var> is <a lt="unresolved">resolved</a>,
         ::  If <var>animation</var>'s [=playback rate=] is not zero,
-            make <var>animation</var>'s <a>hold time</a> <a>unresolved</a>
-            and make <a>hold phase</a> unset.
+            make <var>animation</var>'s <a>hold time</a> <a>unresolved</a>.
 
         :   Otherwise (<var>new start time</var> is <a>unresolved</a>),
         ::  1.  Set <var>animation</var>'s <a>hold time</a> to
                 <var>previous current time</var> even if
                 <var>previous current time</var> is <a>unresolved</a>.
-            2.  Set <var>animation</var>'s <a>hold phase</a> to
-                <var>previous current phase</var>.
 
     </dl>
 
@@ -625,21 +622,18 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
         <dl class="switch">
 
             :   If |has finite timeline| is true,
-            ::  1.  Set <var>animation</var>'s <a>start time</a> to
+            ::  1.  Set <var>animation</var>'s [=animation/start time=] to
                     <var>seek time</var>.
-                1.  Let |animation|'s [=hold time=] be <a>unresolved</a> and
-                    <a>hold phase</a> be unset.
+                1.  Let |animation|'s [=hold time=] be <a>unresolved</a>.
                 1.  [=Apply any pending playback rate=] on |animation|.
 
             :   Otherwise,
             ::  1.  Set <var>animation</var>'s <a>hold time</a> to
                     <var>seek time</var>.
-                1.  Set <var>animation</var>'s <a>hold phase</a> to
-                    [=timeline active phase|active=].
         </dl>
 
 1.  If <var>animation</var>'s <a>hold time</a> is <a lt=unresolved>resolved</a>,
-    let its [=start time=] be <a>unresolved</a>.
+    let its [=animation/start time=] be <a>unresolved</a>.
 
 1.  If <var>animation</var> has a <a>pending play task</a> or a
     <a>pending pause task</a>,
@@ -663,8 +657,8 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
 1.  Schedule a task to run as soon as <var>animation</var> is <a>ready</a>.
     The task shall perform the following steps:
 
-    1.  Assert that at least one of |animation|'s [=start time=] or [=hold
-        time=] is <a lt=unresolved>resolved</a>.
+    1.  Assert that at least one of |animation|'s [=animation/start time=] or
+        [=hold time=] is <a lt=unresolved>resolved</a>.
 
     1.  Let <var>ready time</var> be the <a>time value</a> of
         the <a>timeline</a> associated with <var>animation</var> at the moment
@@ -685,24 +679,23 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
                     If the [=playback rate=] is zero, let
                     |new start time| be simply |ready time|.
 
-                1.  Set the [=start time=] of |animation| to |new start time|.
+                1.  Set the [=animation/start time=] of |animation| to
+                    |new start time|.
 
                 1.  If |animation|'s [=playback rate=] is not 0, make
-                    |animation|'s [=hold time=] [=unresolved=] and make
-                    [=hold phase=] unset.
+                    |animation|'s [=hold time=] [=unresolved=].
 
-            :   If |animation|'s [=start time=] is resolved and |animation| has
-                a [=pending playback rate=],
+            :   If |animation|'s [=animation/start time=] is resolved and
+                |animation| has a [=pending playback rate=],
 
             ::  1.  Let |current time to match| be the result of evaluating
-                    <code>(|ready time| - [=start time=]) &times;
+                    <code>(|ready time| - [=animation/start time=]) &times;
                     [=playback rate=]</code> for |animation|.
 
                 1.  [=Apply any pending playback rate=] on |animation|.
 
                 1.  If |animation|'s [=playback rate=] is zero, let
-                    |animation|'s [=hold time=] be |current time to match| and
-                    let [=hold phase=] be the |timeline|'s [=current phase=].
+                    |animation|'s [=hold time=] be |current time to match|.
 
                 1.  Let |new start time| be the result of evaluating
                     <code>|ready time| - |current time to match| /
@@ -710,7 +703,8 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
                     If the [=playback rate=] is zero, let |new start time| be simply
                     |ready time|.
 
-                1.  Set the [=start time=] of |animation| to |new start time|.
+                1.  Set the [=animation/start time=] of |animation| to
+                    |new start time|.
 
         </dl>
 
@@ -777,45 +771,8 @@ The procedure to [=pause an animation=] needs to refer not only to the
 Likewise, the procedure to [=pause an animation=] needs to include scheduling
 a task for updating [=custom effects=].
 
-Update the procedure to [=pause an animation=] as follows:
-
-Replace:
-
->   ::  Set <var>animation</var>'s <a>hold time</a> to <var>seek time</var>.
-
-with:
-
->   ::  1.  Set <var>animation</var>'s <a>hold time</a> to
->           <var>seek time</var>.
->       1.  Set <var>animation</var>'s <a>hold phase</a> to the associated
->           associated timeline's [=timeline phase=].
-
-Replace:
-
->    1.  If <var>animation</var>'s [=start time=]
->        is <a lt=unresolved>resolved</a> and its <a>hold time</a> is
->        <em>not</em> resolved,
->        let <var>animation</var>'s <a>hold time</a> be the result of evaluating
->        <code>(<var>ready time</var> - [=start time=]) &times;
->        [=playback rate=]</code>.
-
-with:
-
->    1.  If <var>animation</var>'s [=start time=]
->        is <a lt=unresolved>resolved</a> and its <a>hold time</a> is
->        <em>not</em> resolved,
->        let <var>animation</var>'s <a>hold time</a> be the result of evaluating
->        <code>(<var>ready time</var> - [=start time=]) &times;
->        [=playback rate=]</code> and let <var>animation</var>'s
->        <a>hold phase</a> be the associated timeline's [=timeline phase=].
 
 <h4 id='canceling-an-animation-section'>Canceling an animation</h4>
-
-Update the procedure to [=cancel an animation=] as follows:
-
-After resetting the hold time add the step:
-
->    1.  Make <var>animation</var>'s <a>hold phase</a> unset.
 
 Append the final step:
 
@@ -1069,10 +1026,6 @@ condition:
 Add the following definitions to the list used in determining the phase of
 an <a>animation effect</a>.
 
-:   <dfn>effective timeline phase</dfn>
-::  The associated <a>animation</a>'s <a>hold phase</a> if resolved, otherwise
-    the <a>animation</a> timeline's [=timeline phase=].
-
 :   <dfn>at progress timeline boundary</dfn>
 ::  Determined using the following procedure:
 
@@ -1085,12 +1038,24 @@ an <a>animation effect</a>.
 
         return false
 
-    1.  Let <var>effective start time</var> be the <a>animation</a>'s
-        [=start time=] if resolved, or zero otherwise.
+   1.  Let <var>effective start time</var> be the <a>animation</a>'s
+        [=animation/start time=] if resolved, or zero otherwise.
+
+    1.  Set <var>unlimited current time</var> based on the first matching
+        condition:
+
+        :   [=animation/start time=] is resolved:
+
+        ::  <code>(<var>timeline time</var> - [=animation/start time=])
+            &times; [=playback rate=]</code>
+
+        :   Otherwise
+
+        ::  <code>animation's [=current time=]</code>
 
     1.  Let <var>effective timeline time</var> be
-        <code><a>animation</a>'s <a>current time</a> / <a>animation</a>'s
-        [=playback rate=] + <var>effective start time</var></code>
+        <code>|unlimited current time| / <a>animation</a>'s
+        [=playback rate=] + |effective start time|</code>
 
     1.  Let <var>effective timeline progress</var> be
         <code><var>effective timeline time</var> / [=timeline duration=]</code>
@@ -1100,8 +1065,15 @@ an <a>animation effect</a>.
 
 Issue: This procedure is not strictly correct for a paused
 animation if the <a>animation</a>'s current time is explicitly set, as this can
-introduce a lead or lag, between the <a>timeline<a>'s current time and
+introduce a lead or lag, between the <a>timeline</a>'s current time and
 <a>animation</a>'s current time.
+
+Issue: This procedure can likely be simplified, and instead determine if at a
+scrolling boundary regardless of playback rate or start time. The surprising
+behavior that this is trying to prevent is an animation becoming inactive
+precisely at the scroll limit, alleviating the need for set a fill-mode with a ScrollTimeline. Checking if timeline [=timeline current time|current time=] is
+0 or timeline duration may be sufficient.
+
 
 Replace:
 
@@ -1116,19 +1088,16 @@ Replace:
 
 with:
 
-> An <a>animation effect</a> is in the <dfn for="animation effect">before
-> phase</dfn> if the animation effect's <a>local time</a> is not
-> <a>unresolved</a> and <em>any</em> of the following conditions are met:
+> An <a>animation effect</a> is in the before phase if the animation effect's
+> <a>local time</a> is not <a>unresolved</a> and <em>either</em> of the
+> following conditions are met:
 >
-> 1.  [=effective timeline phase=] is [=timeline/before phase|before=],
+> 1.  the <a>local time</a> is less than the <a>before-active boundary time</a>,
 >     <em>or</em>
-> 1.  [=effective timeline phase=] is [=timeline/active phase|active=],
->     <em>and</em> <em>either</em> of the following conditions are met:
->     1.  the <a>local time</a> is less than the <a>before-active boundary
->         time</a>, <em>or</em>
->     1.  The <a>animation direction</a> is "backwards", the <a>local time</a>
->         is equal to the <a>before-active boundary time</a> and not
->         <a>at progress timeline boundary</a>.
+> 1.  the <a>animation direction</a> is "backwards" and the <a>local
+>     time</a> is equal to the <a>before-active boundary time</a>  and not
+>     <a>at progress timeline boundary</a>.
+
 
 Replace:
 
@@ -1143,19 +1112,16 @@ Replace:
 
 with:
 
-> An <a>animation effect</a> is in the <dfn for="animation effect">after
-> phase</dfn> if the animation effect's <a>local time</a> is not
-> <a>unresolved</a> and <em>any</em> of the following conditions are met:
+> An <a>animation effect</a> is in the after phase if the animation
+> effect's <a>local time</a> is not <a>unresolved</a> and <em>either</em> of the
+> following conditions are met:
 >
-> 1.  [=effective timeline phase=] is [=timeline/after phase|after=],
->     <em>or</em>
-> 1.  [=effective timeline phase=] is [=timeline/active phase|active=],
->     <em>and</em> <em>either</em> of the following conditions are met:
->     1.  the <a>local time</a> is greater than the <a>active-after boundary
->         time</a>, <em>or</em>
->     1.  the <a>animation direction</a> is "forwards", the <a>local time</a>
->         is equal to the <a>active-after boundary time</a> and not
->         <a>at progress timeline boundary</a>.
+> 1.  the <a>local time</a> is greater than the <a>active-after boundary
+>     time</a>, <em>or</em>
+> 1.  the <a>animation direction</a> is "forwards" and the <a>local
+>     time</a> is equal to the <a>active-after boundary time</a> and not
+>     <a>at progress timeline boundary</a>.
+
 
 <h4 id="fill-modes">Fill modes</h4>
 
@@ -1799,7 +1765,7 @@ number of <a>child effects</a> as follows.
             after calculating the <a>end time</a> of each <a>child
             effect</a> in the group. The <a>end time</a> may be
             expressed as a time or a percentage (in the case of a
-            [=progress-based animation=]). In the event of mixed time and
+            [=progress-based timeline=]). In the event of mixed time and
             percentage <a>end time</a>s, the largest time based value
             equates to 100% for the purpose of time scaling.
         2.  The <a>intrinsic iteration duration</a> is the result of
@@ -2244,19 +2210,20 @@ partial interface Animation {
 };
 </pre>
 
-Replace [=start time=] and [=current time=] attribute descriptions with:
+Replace [=animation/start time=] and [=current time=] attribute descriptions with:
 
 <div class='attributes'>
 
 :   <dfn attribute for=Animation>startTime</dfn>
 ::  Update the description as:
 
-    > The [=start time=] of this animation. When associated with a
-    > [=progress-based timeline=], [=start time=] must be returned as a
-    > {{CSSNumericValue}} with percent units. Otherwise [=start time=] must be
-    > returned as a double value, representing the time in units of
-    > milliseconds. Setting this attribute updates the [=start time=] using the
-    > procedure to <a>set the start time</a> of this object to the new value.
+    > The [=animation/start time=] of this animation. When associated with a
+    > [=progress-based timeline=], [=animation/start time=] must be returned as
+    > a {{CSSNumericValue}} with percent units. Otherwise
+    > [=animation/start time=] must be returned as a double value, representing
+    > the time in units of milliseconds. Setting this attribute updates the
+    > [=animation/start time=] using the procedure to <a>set the start time</a>
+    > of this object to the new value.
 
 :   <dfn attribute for=Animation>currentTime</dfn>
 ::  update the description as:
@@ -2296,7 +2263,7 @@ partial interface AnimationEffect {
     the current calculated value of the
     <a>intrinsic iteration duration</a>, which may be a expressed as a double
     representing the duration in milliseconds or a percentage when the effect
-    is associated with a [=progress based timeline=].
+    is associated with a [=progress-based timeline=].
 
 :   <dfn attribute for=AnimationEffect>parent</dfn>
 ::  The <a>parent group</a> of this <a>animation effect</a> or
@@ -2382,6 +2349,8 @@ simply as removing the animation from its animation?
 
 <pre class="idl">
 partial dictionary EffectTiming {
+    double delay;
+    double endDelay;
     double playbackRate = 1.0;
     (unrestricted double or CSSNumericValue or DOMString) duration = "auto";
 };
@@ -2399,7 +2368,8 @@ where the unit is a valid time unit or percent.
 
 <div class="attributes">
 
-:   <dfn>delay</dfn>
+:   <dfn dict-member for=EffectTiming>delay</dfn><dfn dict-member
+    for=OptionalEffectTiming lt=delay></dfn>
 ::  Update the description as:
 
     > The <dfn>specified start delay</dfn> which represents the number of
@@ -2409,7 +2379,8 @@ where the unit is a valid time unit or percent.
     > The |specified start delay| is converted to a <a>start delay</a> following
     > the [=normalize specified timing=] procedure.
 
-:   <dfn>endDelay</dfn>
+:   <dfn dict-member for=EffectTiming>endDelay</dfn><dfn dict-member
+    for=OptionalEffectTiming lt=endDelay></dfn>
 ::  Update the description as:
 
     > The <dfn>specified end delay</dfn> which represents the number of milliseconds
@@ -2419,7 +2390,8 @@ where the unit is a valid time unit or percent.
     > <a>sequence effect</a>. The |specified end delay| is converted to an
     > <a>end delay</a> following the [=normalize specified timing=] procedure.
 
-:   <dfn>duration</dfn>
+:   <dfn dict-member for=EffectTiming>duration</dfn><dfn dict-member
+    for=OptionalEffectTiming lt=duration></dfn>
 ::  Update the description as:
 
     > The <dfn>specified iteration duration</dfn> which is a real number greater
@@ -2822,8 +2794,7 @@ interface SequenceEffect : GroupEffect {
 </pre>
 
 <div class="contructors">
-
-:   <dfn constructor for=SequenceEffect lt="SequenceEffect()">constructor (sequence&lt;AnimationEffect&gt;? children,
+:   <dfn constructor for=SequenceEffect lt="SequenceEffect(children, timing)">constructor (sequence&lt;AnimationEffect&gt;? children,
     optional (unrestricted double or EffectTiming) timing)</dfn>
 ::  The meaning and handling of each of the parameters in this
     constructor is identical to the {{GroupEffect()}} constructor.


### PR DESCRIPTION
[web-animations-2]: Cleanup all build warnings in prep for transition to editor's draft.  As before and after phases for timelines have been deprecated, these are also removed as part of the cleanup.
