### PR TITLE
Fix grouping in <general-enclosed> and apply earlier fixes to mediaqueries-5.

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -871,7 +871,7 @@ Syntax</h2>
 	<dfn>&lt;mf-eq></dfn> = '='
 	<dfn>&lt;mf-comparison></dfn> = <<mf-lt>> | <<mf-gt>> | <<mf-eq>>
 
-	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>>? ) ] | ( <<any-value>>? )
+	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>>? ) ] | [ ( <<any-value>>? ) ]
 	</pre>
 
 	The <<media-type>> production does not include the keywords ''only'', ''not'', ''and'', ''or'', and ''layer''.

--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -869,7 +869,7 @@ Syntax</h2>
 	<dfn>&lt;mf-eq></dfn> = '='
 	<dfn>&lt;mf-comparison></dfn> = <<mf-lt>> | <<mf-gt>> | <<mf-eq>>
 
-	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>> ) ] | ( <<ident>> <<any-value>> )
+	<dfn>&lt;general-enclosed></dfn> = [ <<function-token>> <<any-value>>? ) ] | [ ( <<any-value>>? ) ]
 	</pre>
 
 	The <<media-type>> production does not include the keywords ''only'', ''not'', ''and'', ''or'', and ''layer''.


### PR DESCRIPTION
This fixes the grouping in the `<general-enclosed>` production so that
both sides of the | are grouped with [].

It also applies that fix and the prior fix in #6799 to mediaqueries-5.