### PR TITLE
[css-selectors-4] Fix typo in selectors

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -3029,7 +3029,7 @@ Child-indexed Pseudo-classes</h3>
 <h3 id='typed-child-index'>
 Typed Child-indexed Pseudo-classes</h3>
 
-	The pseudo-elements in this section are similar to the <a href="#child-index">Child Index Pseudo-classes</a>,
+	The pseudo-classes in this section are similar to the <a href="#child-index">Child Index Pseudo-classes</a>,
 	but they resolve based on an element's index <strong>among elements of the same <a href="#type-selectors">type (tag name)</a></strong> in their sibling list.
 
 <h4 id="the-nth-of-type-pseudo">


### PR DESCRIPTION
All of the things talked about in [the subsections of 14.4](https://www.w3.org/TR/selectors/#typed-child-index) ('this section') are pseudo-classes, not pseudo-elements.

(Unless I'm misunderstanding or missing something, which is entirely possible!)