### PR TITLE
[resize-observer-1] Include SVG elements that generate CSS layout boxes #4032

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -385,8 +385,8 @@ Watching content rect means that:
 
 * observations will not be triggered by CSS transforms.
 
-Web content can also contain SVG elements. SVG Elements define <a>bounding box</a> instead of a content box.
-Content rect for <a>SVGGraphicsElement</a>s is a rect whose:
+Web content can also contain SVG elements. SVG elements that do not have associated CSS layout boxes define <a>bounding box</a> instead of a content box.
+Content rect for the <a>SVGGraphicsElement</a>s without CSS layout boxes is a rect whose:
 
 * width is <a>bounding box</a> width
 * height is <a>bounding box</a> height
@@ -454,13 +454,13 @@ run these steps:
 
 6. Set |this|.{{ResizeObserverEntry/contentRect}} to logical |this|.{{ResizeObserverEntry/contentBoxSize}} given |target| and observedBox of "content-box".
 
-7. If |target| is not an SVG element do these steps:
+7. If |target| is not an SVG element or |target| is an SVG element with an associated CSS layout box do these steps:
 
     1. Set |this|.|contentRect|.top to |target|.<a>padding top</a>.
 
     2. Set |this|.|contentRect|.left to |target|.<a>padding left</a>.
 
-8. If |target| is an SVG element do these steps:
+8. If |target| is an SVG element without an associated CSS layout box do these steps:
 
     1. Set |this|.|contentRect|.top and |this|.contentRect.left to 0.
 
@@ -526,12 +526,12 @@ To <dfn>calculate depth for node</dfn>, given a |node|, run these steps:
 
 This algorithm computes |target| {{Element}}'s observed box size. Type of box is
 described by {{ResizeObserverBoxOptions}}.
-SVG Elements are an exception. SVG size is always its bounding box size, because SVG
-elements do not use standard CSS box model.
+The SVG elements which don't have associated CSS layout boxes are an exception. The sizes of these elements are always their bounding box sizes, because
+these elements do not use standard CSS box model.
 
 To <dfn>calculate box size</dfn>, given |target| and |observedBox|, run these steps:
 
-    1. If |target| is an {{SVGGraphicsElement}}
+    1. If |target| is an {{SVGGraphicsElement}} that does not have an associated CSS layout box
 
         1. If |observedBox| is "border-box" or "content-box"
 
@@ -545,7 +545,7 @@ To <dfn>calculate box size</dfn>, given |target| and |observedBox|, run these st
 
             2. Set |computedSize|.blockSize to |target|'s <a>bounding box</a> block length, in integral device pixels.
 
-    2. If |target| is not an {{SVGGraphicsElement}}
+    2. If |target| is not an {{SVGGraphicsElement}} or |target| is an {{SVGGraphicsElement}} that has an associated CSS layout box
 
         1. If |observedBox| is "border-box"
 


### PR DESCRIPTION
This PR incorporates [this resolution](https://github.com/w3c/csswg-drafts/issues/4032#issuecomment-510137495) on the interactions between SVG and ResizeObserver into the spec:

> RESOLVED: svg elements generating css layout boxes are included as part of resize observer and resize observer rectangles with a definition of `svg:root, *:not(svg|*) > svg, svg|foreignObject > svg { /* SVG elements with CSS layout box */}

I wonder if this resolution is still intended to be included in the spec. This PR can be closed if not. Thanks!