### PR TITLE
Tipo about lime

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1178,7 +1178,7 @@ The RGB Hexadecimal Notations: ''#RRGGBB''</h3>
 			The alpha channel of the color is fully opaque.
 
 			<div class='example' id="ex-hex6">
-				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a "lime" color).
+				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a lime green).
 			</div>
 
 		<dt>8 digits

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1178,7 +1178,7 @@ The RGB Hexadecimal Notations: ''#RRGGBB''</h3>
 			The alpha channel of the color is fully opaque.
 
 			<div class='example' id="ex-hex6">
-				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a lime).
+				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a "lime" color).
 			</div>
 
 		<dt>8 digits

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -505,7 +505,7 @@ Foreground Color: the 'color' property</h3>
 
 	<div class="example" id="ex-lime">
 		The <<color>> type provides multiple ways to syntactically specify a given color.
-		For example, the following declarations all specify the sRGB color “lime green”:
+		For example, the following declarations all specify the sRGB color “lime”:
 		<pre class="lang-css">
 		em { color: <span class="swatch" style="--color: lime"></span>&nbsp;lime; }   /* color keyword  */
 		em { color: <span class="swatch" style="--color: lime"></span>&nbsp;rgb(0 255 0); } /* RGB range 0-255   */
@@ -1178,7 +1178,7 @@ The RGB Hexadecimal Notations: ''#RRGGBB''</h3>
 			The alpha channel of the color is fully opaque.
 
 			<div class='example' id="ex-hex6">
-				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a lime green).
+				In other words, <span class="swatch" style="--color: #00ff00"></span>  ''#00ff00'' represents the same color as <span class="swatch" style="--color: #00ff00"></span> ''rgb(0 255 0)'' (a lime).
 			</div>
 
 		<dt>8 digits


### PR DESCRIPTION
I suspect typos in example 4 and example 26.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
