### PR TITLE
[css-cascade-5] fix example syntax error for `@import layer;`

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -177,7 +177,7 @@ Importing Style Sheets: the ''@import'' rule</h2>
 
 		<pre>
 		@import url("tabs.css") layer(framework.component);
-		@import url("override.css") layer();
+		@import url("override.css") layer;
 		</pre>
 	</div>
 


### PR DESCRIPTION
The `<<layer-name>>` in the `layer()` function in the `@import` syntax cannot be omitted.

```
@import [ <<url>> | <<string>> ]
		        [ layer | layer(<<layer-name>>) ]?
		        <<import-condition>> ;
```

This means that the following example is wrong, `()` should be removed.

```css
@import url("override.css") layer();
```
