### PR TITLE
[css-scoping-module]: host-selector specificity replication removal

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -271,7 +271,6 @@ Selecting Into the Light: the '':host'', '':host()'', and '':host-context()'' ps
 	In any other context,
 	it matches nothing.
 
-	The [=specificity=] of '':host'' is that of a pseudo-class.
 	The [=specificity=] of '':host()'' is that of a pseudo-class,
 	plus the [=specificity=] of its argument.
 


### PR DESCRIPTION
I updated the CSS Scoping Module host selector specification after I noticed a replication in the definition