### PR TITLE
Correct `rgb()` to a`rgba()`

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -792,7 +792,7 @@ so it has meaningful values for the channels.
 	<pre highlight=css>
 	html { --bg-color: blue; }
 	.overlay {
-		background: rgb(from var(--bg-color) r g b / 80%);
+		background: rgba(from var(--bg-color) r g b / 80%);
 	}
 	</pre>
 


### PR DESCRIPTION
Clarifying that setting the alpha channel can only be done on an `rgba()` color, not an `rgb()` definition.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.

Closes #7625.
