### PR TITLE
[css-display-3] Fix a minor typo in the introduction #7652

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -81,7 +81,7 @@ Introduction</h2>
 	and renders it onto a <a href="https://www.w3.org/TR/CSS2/intro.html#canvas">canvas</a>
 	such as your screen, a piece of paper, or an audio stream.
 	Although any such source document can be rendered with CSS,
-	the most commonly used type is the the DOM. [[DOM]]
+	the most commonly used type is the DOM. [[DOM]]
 	(Some of these more complex tree types might have additional types of nodes,
 	such as the comment nodes in the DOM.
 	For the purposes of CSS,


### PR DESCRIPTION
This text in the Introduction:

> the most commonly used type is the the Dom

The extra 'the' was removed


