### PR TITLE
[css-color] Use absolute value in lin_ProPhoto

### DIFF
--- a/css-color-4/conversions.js
+++ b/css-color-4/conversions.js
@@ -129,7 +129,7 @@ function lin_ProPhoto(RGB) {
 			return val / 16;
 		}
 
-		return sign * Math.pow(val, 1.8);
+		return sign * Math.pow(abs, 1.8);
 	});
 }
 


### PR DESCRIPTION
This matches the behavior of the other color conversions and avoids returning `NaN` if `val < -Et2`, which I assume was not the intention.