### PR TITLE
[css-device-adapt][css-grid][css-shapes][css-speech] Add range notation

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -1509,11 +1509,11 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 		                        [ <<line-names>>? [ <<fixed-size>> | <<fixed-repeat>> ] ]* <<line-names>>?
 		<dfn>&lt;explicit-track-list></dfn> = [ <<line-names>>? <<track-size>> ]+ <<line-names>>?
 
-		<dfn>&lt;track-size></dfn>          = <<track-breadth>> | minmax( <<inflexible-breadth>> , <<track-breadth>> ) | fit-content( <<length-percentage>> )
+		<dfn>&lt;track-size></dfn>          = <<track-breadth>> | minmax( <<inflexible-breadth>> , <<track-breadth>> ) | fit-content( <<length-percentage [0,∞]>> )
 		<dfn>&lt;fixed-size></dfn>          = <<fixed-breadth>> | minmax( <<fixed-breadth>> , <<track-breadth>> ) | minmax( <<inflexible-breadth>> , <<fixed-breadth>> )
-		<dfn>&lt;track-breadth></dfn>       = <<length-percentage>> | <<flex>> | min-content | max-content | auto
-		<dfn>&lt;inflexible-breadth></dfn>  = <<length-percentage>> | min-content | max-content | auto
-		<dfn>&lt;fixed-breadth></dfn>       = <<length-percentage>>
+		<dfn>&lt;track-breadth></dfn>       = <<length-percentage [0,∞]>> | <<flex [0,∞]>> | min-content | max-content | auto
+		<dfn>&lt;inflexible-breadth></dfn>  = <<length-percentage [0,∞]>> | min-content | max-content | auto
+		<dfn>&lt;fixed-breadth></dfn>       = <<length-percentage [0,∞]>>
 		<dfn>&lt;line-names></dfn>          = '[' <<custom-ident>>* ']'
 	</pre>
 
@@ -1523,7 +1523,7 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 Track Sizes</h4>
 
 	<dl dfn-for="grid-template-columns, grid-template-rows" dfn-type=value>
-		<dt><dfn><<length-percentage>></dfn>
+		<dt><dfn><<length-percentage [0,∞]>></dfn>
 		<dd>
 			A non-negative length or percentage, as defined by CSS3 Values. [[!CSS-VALUES-3]]
 
@@ -1540,7 +1540,7 @@ Track Sizes</h4>
 			and then resolve against that resulting <a>grid container</a> size
 			for the purpose of laying out the <a>grid</a> and its items.
 
-		<dt><dfn><<flex>></dfn>
+		<dt><dfn><<flex [0,∞]>></dfn>
 		<dd>
 			A non-negative dimension with the unit ''fr'' specifying the track's <dfn dfn noexport>flex factor</dfn>.
 			Each <<flex>>-sized track takes a share of the remaining space in proportion to its <a>flex factor</a>.

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -1593,11 +1593,11 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 		<dfn>&lt;explicit-track-list></dfn> = [ <<line-names>>? <<track-size>> ]+ <<line-names>>?
 
 		<dfn>&lt;line-name-list></dfn>      = [ <<line-names>> | <<name-repeat>> ]+
-		<dfn>&lt;track-size></dfn>          = <<track-breadth>> | minmax( <<inflexible-breadth>> , <<track-breadth>> ) | fit-content( <<length-percentage>> )
+		<dfn>&lt;track-size></dfn>          = <<track-breadth>> | minmax( <<inflexible-breadth>> , <<track-breadth>> ) | fit-content( <<length-percentage [0,∞]>> )
 		<dfn>&lt;fixed-size></dfn>          = <<fixed-breadth>> | minmax( <<fixed-breadth>> , <<track-breadth>> ) | minmax( <<inflexible-breadth>> , <<fixed-breadth>> )
-		<dfn>&lt;track-breadth></dfn>       = <<length-percentage>> | <<flex>> | min-content | max-content | auto
-		<dfn>&lt;inflexible-breadth></dfn>  = <<length-percentage>> | min-content | max-content | auto
-		<dfn>&lt;fixed-breadth></dfn>       = <<length-percentage>>
+		<dfn>&lt;track-breadth></dfn>       = <<length-percentage [0,∞]>> | <<flex [0,∞]>> | min-content | max-content | auto
+		<dfn>&lt;inflexible-breadth></dfn>  = <<length-percentage [0,∞]>> | min-content | max-content | auto
+		<dfn>&lt;fixed-breadth></dfn>       = <<length-percentage [0,∞]>>
 		<dfn>&lt;line-names></dfn>          = '[' <<custom-ident>>* ']'
 	</pre>
 
@@ -1607,7 +1607,7 @@ Explicit Track Sizing: the 'grid-template-rows' and 'grid-template-columns' prop
 Track Sizes</h4>
 
 	<dl dfn-for="grid-template-columns, grid-template-rows" dfn-type=value>
-		<dt><dfn><<length-percentage>></dfn>
+		<dt><dfn><<length-percentage [0,∞]>></dfn>
 		<dd>
 			A non-negative length or percentage, as defined by CSS3 Values. [[!CSS-VALUES-3]]
 
@@ -1624,7 +1624,7 @@ Track Sizes</h4>
 			and then resolve against that resulting <a>grid container</a> size
 			for the purpose of laying out the <a>grid</a> and its items.
 
-		<dt><dfn><<flex>></dfn>
+		<dt><dfn><<flex [0,∞]>></dfn>
 		<dd>
 			A non-negative dimension with the unit ''fr'' specifying the track's <dfn dfn noexport>flex factor</dfn>.
 			Each <<flex>>-sized track takes a share of the remaining space in proportion to its <a>flex factor</a>.

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -1089,7 +1089,7 @@ Expanding a Shape: the 'shape-margin' property</h3>
 
 	<pre class='propdef'>
 		Name: shape-margin
-		Value: <<length-percentage>>
+		Value: <<length-percentage [0,∞]>>
 		Initial: 0
 		Applies to: floats
 		Inherited: no
@@ -1099,7 +1099,7 @@ Expanding a Shape: the 'shape-margin' property</h3>
 	</pre>
 
 	<dl dfn-type="value" dfn-for="shape-margin">
-		<dt><dfn><<length-percentage>></dfn></dt>
+		<dt><dfn><<length-percentage [0,∞]>></dfn></dt>
 		<dd>
 			Sets the margin of the shape to the specified value.
 	</dl>

--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -568,7 +568,7 @@ The 'pause-before' and 'pause-after' properties</h3>
 
 	<pre class=propdef>
 	Name: pause-before, pause-after
-	Value: &lt;time&gt; | none | x-weak | weak | medium | strong | x-strong
+	Value: &lt;time [0s,∞]&gt; | none | x-weak | weak | medium | strong | x-strong
 	Initial: none
 	Applies to: all elements
 	Inherited: no
@@ -589,7 +589,7 @@ The 'pause-before' and 'pause-after' properties</h3>
 	requires special considerations (e.g. <a href="#collapsed-pauses">"collapsed" pauses</a>).
 
 	<dl dfn-type=value dfn-for="pause-before,pause-after">
-		<dt><dfn><<time>></dfn>
+		<dt><dfn><<time [0s,∞]>></dfn>
 		<dd>
 			Expresses the pause in absolute time units
 			(seconds and milliseconds, e.g. "+3s", "250ms").
@@ -687,7 +687,7 @@ The 'rest-before' and 'rest-after' properties</h3>
 
 	<pre class=propdef>
 	Name: rest-before, rest-after
-	Value: <<time>> | none | x-weak | weak | medium | strong | x-strong
+	Value: <<time [0s,∞]>> | none | x-weak | weak | medium | strong | x-strong
 	Initial: none
 	Applies to: all elements
 	Inherited: no
@@ -706,7 +706,7 @@ The 'rest-before' and 'rest-after' properties</h3>
 	requires special considerations (e.g. interspersed audio cues, additive adjacent rests).
 
 	<dl dfn-type=value dfn-for="rest-before,rest-after">
-		<dt><dfn><<time>></dfn>
+		<dt><dfn><<time [0s,∞]>></dfn>
 		<dd>
 			Expresses the rest in absolute time units (seconds and milliseconds, e.g. "+3s", "250ms").
 			Only non-negative values are allowed.
@@ -1111,7 +1111,7 @@ The 'voice-rate' property</h3>
 
 	<pre class=propdef>
 	Name: voice-rate
-	Value: [normal | x-slow | slow | medium | fast | x-fast] || <<percentage>>
+	Value: [normal | x-slow | slow | medium | fast | x-fast] || <<percentage [0,∞]>>
 	Initial: normal
 	Applies to: all elements
 	Inherited: yes
@@ -1143,7 +1143,7 @@ The 'voice-rate' property</h3>
 			For example, typical values for the English language are
 			(in words per minute) x-slow = 80, slow = 120, medium = between 180 and 200, fast = 500.
 
-		<dt><dfn><<percentage>></dfn>
+		<dt><dfn><<percentage [0,∞]>></dfn>
 		<dd>
 			<p>Only non-negative [=percentage=] values are allowed.
 			This represents a change relative to the given keyword value (see enumeration above),
@@ -1535,7 +1535,7 @@ The 'voice-duration' property</h3>
 
 	<pre class=propdef>
 	Name: voice-duration
-	Value: auto | &lt;time&gt;
+	Value: auto | &lt;time [0s,∞]&gt;
 	Initial: auto
 	Applies to: all elements
 	Inherited: no
@@ -1565,7 +1565,7 @@ The 'voice-duration' property</h3>
 			Resolves to a used value corresponding to the duration of the speech synthesis
 			when using the inherited 'voice-rate'.
 
-		<dt><dfn><<time>></dfn>
+		<dt><dfn><<time [0s,∞]>></dfn>
 		<dd>
 			Specifies a value in absolute time units
 			(seconds and milliseconds, e.g. "+3s", "250ms").


### PR DESCRIPTION
Add range notation to some productions used to define a track list.

This change assumes that out of range values are invalid (they are in Chrome/Firefox). This is not explicitly defined in prose, as it is often the case in other specs that use range notation.

**EDIT:**

After searching for `non-negative` in all specs, I added a non-negative range notation for:

  - `zoom`, `min-zoom`, `max-zoom`, in CSS Device Adapt
  - `<track-size>`, `<track-breadth>`, `<inflexible-breadth>`, `<fixed-breadth>`, in CSS Grid 1-2
  - `shape-margin` in CSS Shapes
  - `pause-before`, `pause-after`, `rest-before`, `rest-after`, `voice-rate`, in CSS Speech

I ignored `min-width` and `max-width` (descriptors for `@viewport`) in CSS Device Adapt because there is a note about removing them.