### PR TITLE
[scroll-animations-1] Make view-timeline take a list of singles

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -274,13 +274,15 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef'>
 	Name: scroll-timeline-name
-	Value: none | <<custom-ident>>
+	Value: <<single-timeline-name>>
 	Initial: none
 	Applies to: [=scroll containers=]
 	Inherited: no
 	Computed value: the specified keyword
 	Animation type: not animatable
 	</pre>
+
+	<span class=prod><dfn>&lt;single-timeline-name></dfn> = none | <<custom-ident>></span>
 
 	Specifies a name for the [=scroll progress timeline=]
 	associated with this [=scroll container=].
@@ -290,13 +292,15 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef'>
 	Name: scroll-timeline-axis
-	Value: block | inline | vertical | horizontal
+	Value: <<single-timeline-axis>>
 	Initial: block
 	Applies to: [=scroll containers=]
 	Inherited: no
 	Computed value: the specified keyword
 	Animation type: not animatable
 	</pre>
+
+	<span class=prod><dfn>&lt;single-timeline-axis></dfn> = block | inline | vertical | horizontal</span>
 
 	Specifies an axis for the [=scroll progress timeline=]
 	associated with this [=scroll container=].
@@ -442,7 +446,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef'>
 	Name: view-timeline-name
-	Value: none | <<custom-ident>>#
+	Value: <<single-timeline-name>>#
 	Initial: none
 	Applies to: all elements
 	Inherited: no
@@ -461,7 +465,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef'>
 	Name: view-timeline-axis
-	Value: [ block | inline | vertical | horizontal ]#
+	Value: <<single-timeline-axis>>#
 	Initial: block
 	Applies to: all elements
 	Inherited: no
@@ -517,7 +521,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef shorthand'>
 	Name: view-timeline
-	Value: [ <<'view-timeline-name'>> || <<'view-timeline-axis'>> ]#
+	Value: [ <<single-timeline-name>> || <<single-timeline-axis>> ]#
 	Applies to: all elements
 	</pre>
 


### PR DESCRIPTION
Current grammar has two comma-separated lists inside an outer comma-
separated list. This means specifying two timelines would look like
"timeline1, timeline2, inline, block", which obviously isn't what we want.

Instead we should follow how the 'animation' shorthand works, and let
the outer comma-separated list take space-separated single items:
"timeline1 inline, timeline2 block".
