### PR TITLE
[css-backgrounds-4] Added `border-*-radius` shorthands

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -289,15 +289,14 @@ The 'border-block-start-radius', 'border-block-end-radius',
 		Animatable: see individual properties
 	</pre>
 
-	<p>These properties correspond to the 'border-top-radius',
-	'border-right-radius', 'border-bottom-radius', and 'border-left-radius'
-	shorthand properties.
-	The mapping depends on the element’s 'writing-mode', 'direction',
-	and 'text-orientation',
-	with start/end referring to the axis orthogonal to the one given
-	by the first part of the name
-	(i.e. patterned as 'border-block-<i>inline</i>-radius' and
-	'border-inline-<i>block</i>-radius')
+	<p>These properties correspond to the 'border-start-start-radius',
+	'border-start-end-radius', 'border-end-start-radius',
+	and 'border-end-end-radius'	longhand properties.
+	The start/end refers to the axis given by the first part of the name
+	(i.e. 'border-start-<i>inline</i>-radius' for 'border-block-start-radius`,
+	'border-end-<i>inline</i>-radius' for 'border-block-end-radius',
+	'border-<i>block</i>-start-radius' for 'border-inline-start-radius', and
+	'border-<i>block</i>-end-radius' for 'border-inline-end-radius')
 	If values are given before and after the slash,
 	then the values before the slash set the
 	horizontal radius and the values after the slash set the vertical radius,

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -245,13 +245,16 @@ Corners</h2>
 <h3 id="corner-sizing">
 Corner Sizing: the 'border-radius' and 'border-*-radius' shorthand properties</h3>
 
-<h4 id="physical-corner-sizing">
-Physical Corner Sizing:
+<h4 id="corner-sizing-side-shorthands">
+Sizing The Corners Of One Side:
 The 'border-top-radius', 'border-right-radius',
-'border-bottom-radius', 'border-left-radius' side shorthands</h4>
+'border-bottom-radius', 'border-left-radius',
+'border-block-start-radius', 'border-block-end-radius',
+'border-inline-start-radius', 'border-inline-end-radius' shorthands</h4>
 
 	<pre class=propdef>
-		Name: border-top-radius, border-right-radius, border-bottom-radius, border-left-radius
+		Name: border-top-radius, border-right-radius, border-bottom-radius, border-left-radius,
+			border-block-start-radius, border-block-end-radius, border-inline-start-radius, border-inline-end-radius
 		Value: <<length-percentage [0,&infin;]>>{1,2} [ / <<length-percentage [0,&infin;]>>{1,2} ]?
 		Initial: 0
 		Applies to: all elements (but see prose)
@@ -268,43 +271,19 @@ The 'border-top-radius', 'border-right-radius',
 	If there is no slash, then the values set both radii equally.
 	The two values for the radii are given in the order
 	top-left, top-right for 'border-top-radius',
-	top-right, bottom-right for 'border-right-radius'
+	top-right, bottom-right for 'border-right-radius',
 	bottom-left, bottom-right for 'border-bottom-radius',
-	and top-left, bottom-left for 'border-left-radius'.
+	top-left, bottom-left for 'border-left-radius',
+	start-start, start-end for 'border-block-start-radius',
+	end-start, end-end for 'border-block-end-radius'
+	start-start, end-start for 'border-inline-start-radius',
+	and start-end, end-end for 'border-inline-end-radius'.
 	If the second value is omitted it is copied from the first.
 
 	<p class="issue">
-		Should the values be defined as left to right and top to bottom
+		Should the physical values all be defined as left to right and top to bottom
+		and the logical ones as start to end
 		or should they follow the clockwise order of ''border-radius''?
-
-<h4 id="flow-relative-corner-sizing">
-Flow-Relative Corner Sizing:
-The 'border-block-start-radius', 'border-block-end-radius',
-'border-inline-start-radius', and 'border-inline-end-radius' side shorthands</h4>
-
-	<pre class=propdef>
-		Name: border-block-start-radius, border-block-end-radius, border-inline-start-radius, border-inline-end-radius
-		Value: <<length-percentage [0,&infin;]>>{1,2} [ / <<length-percentage [0,&infin;]>>{1,2} ]?
-		Initial: 0
-		Applies to: all elements (but see prose)
-		Inherited: no
-		Percentages: Refer to corresponding dimension of the <a>border box</a>.
-		Computed value: see individual properties
-		Animatable: see individual properties
-	</pre>
-
-	<p>These properties correspond to the 'border-start-start-radius',
-	'border-start-end-radius', 'border-end-start-radius',
-	and 'border-end-end-radius'	longhand properties.
-	The start/end refers to the axis given by the first part of the name
-	(i.e. 'border-start-<i>inline</i>-radius' for 'border-block-start-radius`,
-	'border-end-<i>inline</i>-radius' for 'border-block-end-radius',
-	'border-<i>block</i>-start-radius' for 'border-inline-start-radius', and
-	'border-<i>block</i>-end-radius' for 'border-inline-end-radius')
-	If values are given before and after the slash,
-	then the values before the slash set the
-	horizontal radius and the values after the slash set the vertical radius,
-	like for the physical properties.
 
 <h4 id="corner-sizing-shorthand">
 Sizing All Corners At Once:

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -273,6 +273,10 @@ The 'border-top-radius', 'border-right-radius',
 	and top-left, bottom-left for 'border-left-radius'.
 	If the second value is omitted it is copied from the first.
 
+	<p class="issue">
+		Should the values be defined as left to right and top to bottom
+		or should they follow the clockwise order of ''border-radius''?
+
 <h4 id="flow-relative-corner-sizing">
 Flow-Relative Corner Sizing:
 The 'border-block-start-radius', 'border-block-end-radius',

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -245,9 +245,10 @@ Corners</h2>
 <h3 id="corner-sizing">
 Corner Sizing: the 'border-radius' and 'border-*-radius' shorthand properties</h3>
 
-<h4 id="page-relative-corner-sizing">
-Page-Relative (Physical) Corner Sizing:
-The 'border-top-radius', 'border-right-radius', 'border-bottom-radius', 'border-left-radius' shorthands</h4>
+<h4 id="physical-corner-sizing">
+Physical Corner Sizing:
+The 'border-top-radius', 'border-right-radius',
+'border-bottom-radius', 'border-left-radius' side shorthands</h4>
 
 	<pre class=propdef>
 		Name: border-top-radius, border-right-radius, border-bottom-radius, border-left-radius
@@ -274,8 +275,8 @@ The 'border-top-radius', 'border-right-radius', 'border-bottom-radius', 'border-
 
 <h4 id="flow-relative-corner-sizing">
 Flow-Relative Corner Sizing:
-the 'border-start-start-radius', 'border-start-end-radius',
-'border-end-start-radius', 'border-end-end-radius' properties</h4>
+The 'border-block-start-radius', 'border-block-end-radius',
+'border-inline-start-radius', and 'border-inline-end-radius' side shorthands</h4>
 
 	<pre class=propdef>
 		Name: border-block-start-radius, border-block-end-radius, border-inline-start-radius, border-inline-end-radius
@@ -299,8 +300,8 @@ the 'border-start-start-radius', 'border-start-end-radius',
 	'border-inline-<i>block</i>-radius')
 	If values are given before and after the slash,
 	then the values before the slash set the
-	horizontal radius and the values after the slash set the vertical radius
-	like for the page-relative properties.
+	horizontal radius and the values after the slash set the vertical radius,
+	like for the physical properties.
 
 <h4 id="corner-sizing-shorthand">
 Sizing All Corners At Once:

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -242,8 +242,69 @@ Painting Area: the 'background-clip' property</h3>
 <h2 id="corners">
 Corners</h2>
 
-<h3 id=corner-sizing>
-Corner Sizing: the 'border-radius' property</h3>
+<h3 id="corner-sizing">
+Corner Sizing: the 'border-radius' and 'border-*-radius' shorthand properties</h3>
+
+<h4 id="page-relative-corner-sizing">
+Page-Relative (Physical) Corner Sizing:
+The 'border-top-radius', 'border-right-radius', 'border-bottom-radius', 'border-left-radius' shorthands</h4>
+
+	<pre class=propdef>
+		Name: border-top-radius, border-right-radius, border-bottom-radius, border-left-radius
+		Value: <<length-percentage [0,&infin;]>>{1,2} [ / <<length-percentage [0,&infin;]>>{1,2} ]?
+		Initial: 0
+		Applies to: all elements (but see prose)
+		Inherited: no
+		Percentages: Refer to corresponding dimension of the <a>border box</a>.
+		Computed value: see individual properties
+		Animatable: see individual properties
+	</pre>
+
+	<p>The 'border-*-radius' shorthands set the two 'border-*-*-radius'
+	longhand properties of the related side. If values are given before
+	and after the slash, then the values before the slash set the
+	horizontal radius and the values after the slash set the vertical radius.
+	If there is no slash, then the values set both radii equally.
+	The two values for the radii are given in the order
+	top-left, top-right for 'border-top-radius',
+	top-right, bottom-right for 'border-right-radius'
+	bottom-left, bottom-right for 'border-bottom-radius',
+	and top-left, bottom-left for 'border-left-radius'.
+	If the second value is omitted it is copied from the first.
+
+<h4 id="flow-relative-corner-sizing">
+Flow-Relative Corner Sizing:
+the 'border-start-start-radius', 'border-start-end-radius',
+'border-end-start-radius', 'border-end-end-radius' properties</h4>
+
+	<pre class=propdef>
+		Name: border-block-start-radius, border-block-end-radius, border-inline-start-radius, border-inline-end-radius
+		Value: <<length-percentage [0,&infin;]>>{1,2} [ / <<length-percentage [0,&infin;]>>{1,2} ]?
+		Initial: 0
+		Applies to: all elements (but see prose)
+		Inherited: no
+		Percentages: Refer to corresponding dimension of the <a>border box</a>.
+		Computed value: see individual properties
+		Animatable: see individual properties
+	</pre>
+
+	<p>These properties correspond to the 'border-top-radius',
+	'border-right-radius', 'border-bottom-radius', and 'border-left-radius'
+	shorthand properties.
+	The mapping depends on the element’s 'writing-mode', 'direction',
+	and 'text-orientation',
+	with start/end referring to the axis orthogonal to the one given
+	by the first part of the name
+	(i.e. patterned as 'border-block-<i>inline</i>-radius' and
+	'border-inline-<i>block</i>-radius')
+	If values are given before and after the slash,
+	then the values before the slash set the
+	horizontal radius and the values after the slash set the vertical radius
+	like for the page-relative properties.
+
+<h4 id="corner-sizing-shorthand">
+Sizing All Corners At Once:
+The 'border-radius' shorthand</h4>
 
 	<pre class="propdef">
 		Name: border-radius


### PR DESCRIPTION
Defined the page-relative (physical) shorthand properties `border-top-radius`, `border-right-radius`, `border-bottom-radius`, and `border-left-radius` and the flow-relative (logical) shorthand properties `border-block-start-radius`, `border-block-end-radius`, `border-inline-start-radius`, `border-inline-end-radius`.

The page-relative shorthands were initially [suggested ten years ago](https://lists.w3.org/Archives/Public/www-style/2012Oct/0314.html). And the flow-relative ones are a logical (note the double sense 😃) complement for them.

Note that I explicitly defined the two radii for the corners to be in physical order even for the logical properties. This was not explicitly mentioned in the [definition of the longhands in CSS Logical Properties and Values 1](https://drafts.csswg.org/css-logical-1/#border-radius-properties) but implictily given by referring the value to [<'border-top-left-radius'>](https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius). And this is also what user agents currently implement.
So I thought it would be better to clarify this.

@LeaVerou I assigned you as reviewer because it was your suggestion back then.

Sebastian