### PR TITLE
[css-backgrounds-4] 0% as initial value of logical background-position-*

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -114,7 +114,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 	<pre class="propdef">
 		Name: background-position-inline
 		Value: [ center | [ start | end ]? <<length-percentage>>? ]#
-		Initial: not applicable (initial value comes from physical property)
+		Initial: 0%
 		Inherited: no
 		Percentages: refer to inline-size of background positioning area <em>minus</em> inline-size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
@@ -127,7 +127,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 	<pre class="propdef">
 		Name: background-position-block
 		Value: [ center | [ start | end ]? <<length-percentage>>? ]#
-		Initial: not applicable (initial value comes from physical property)
+		Initial: 0%
 		Inherited: no
 		Percentages: refer to size of background positioning area <em>minus</em> size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword


### PR DESCRIPTION
All other specifications that define logical versions of properties use the initial values of their physical counterparts.

And as both `background-position-x` and `background-position-y` have `0%` as their initial value, this value is now also applied to `background-position-inline` and `background-position-block`.

Sebastian