### PR TITLE
[css-text-3][css-text-4] Fix grammar and have better/more consistent wording in § 4.1.2

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -2104,9 +2104,8 @@ Phase II: Trimming and Positioning</h4>
 			</wpt>
 
 		<li>
-			A sequence at the end of a line
-			of [=collapsible=] [=spaces=]
-			is removed,
+			A sequence of [=collapsible=] [=spaces=]
+			at the end of a line is removed,
 			as well as any trailing U+1680 &#x1680; OGHAM SPACE MARK
 			whose 'white-space' property is ''white-space/normal'', ''white-space/nowrap'', or ''pre-line''.
 
@@ -2197,7 +2196,7 @@ Phase II: Trimming and Positioning</h4>
 					If 'white-space' is set to ''pre-wrap'',
 					the UA must (unconditionally) [=hang=] this sequence,
 					unless the sequence is followed by a [=forced line break=],
-					in which case it must [=conditionally hang=] the sequence is instead.
+					in which case it must [=conditionally hang=] the sequence instead.
 					It may also visually collapse the character advance widths
 					of any that would otherwise overflow.
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -3038,9 +3038,8 @@ Phase II: Trimming and Positioning</h4>
 			</wpt>
 
 		<li>
-			A sequence at the end of a line
-			of [=collapsible=] [=spaces=]
-			is removed,
+			A sequence of [=collapsible=] [=spaces=]
+			at the end of a line is removed,
 			as well as any trailing U+1680 &#x1680; OGHAM SPACE MARK
 			whose 'white-space' property is ''white-space/normal'', ''white-space/nowrap'', or ''pre-line''.
 
@@ -3131,7 +3130,7 @@ Phase II: Trimming and Positioning</h4>
 					If 'white-space' is set to ''pre-wrap'',
 					the UA must (unconditionally) [=hang=] this sequence,
 					unless the sequence is followed by a [=forced line break=],
-					in which case it must [=conditionally hang=] the sequence is instead.
+					in which case it must [=conditionally hang=] the sequence instead.
 					It may also visually collapse the character advance widths
 					of any that would otherwise overflow.
 


### PR DESCRIPTION
Fix a small grammar issue by removing an extra "is" that shouldn't be there, and have better/more consistent wording by switching around parts of a sentence, which makes it easier to read and makes it consistent with the way it's written elsewhere in the spec.