### PR TITLE
[css-contain-2] Improve definition of contentvisibilityautostatechange event

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1690,41 +1690,43 @@ Using ''content-visibility: auto''</h3>
 		will be forced to rely on the ''200px'' height estimate.
 	</div>
 
-Detecting ''content-visibility: auto'' state changes: the <a event>contentvisibilityautostatechanged</a> event {#content-visibility-auto-state-changed}
+Detecting ''content-visibility: auto'' state changes: the <a event>contentvisibilityautostatechange</a> event {#content-visibility-auto-state-changed}
 --------------------------------------------------------------------------------------------------------------------------------------------
 
-The <dfn event dfn-for="Element">contentvisibilityautostatechanged</dfn> event is fired on an element with ''content-visibility: auto'' style when
-the rendering state changes and the element either becomes or stops being
-[=relevant to the user=].
+When the rendering state of an element with ''content-visibility: auto'' style
+changes and the element either becomes or stops being [=relevant to the user=],
+the user agent must [=fire an event=] named
+<dfn event dfn-for="Element">contentvisibilityautostatechange</dfn>
+at the element using {{ContentVisibilityAutoStateChangeEvent}}.
 
 This event is dispatched by posting a task at the time when the state change occurs.
 
 <pre class='idl'>
 [Exposed=Window]
-interface ContentVisibilityAutoStateChangedEvent : Event {
-  constructor(DOMString type, optional ContentVisibilityAutoStateChangedEventInit eventInitDict = {});
+interface ContentVisibilityAutoStateChangeEvent : Event {
+  constructor(DOMString type, optional ContentVisibilityAutoStateChangeEventInit eventInitDict = {});
   readonly attribute boolean skipped;
 };
-dictionary ContentVisibilityAutoStateChangedEventInit : EventInit {
+dictionary ContentVisibilityAutoStateChangeEventInit : EventInit {
   boolean skipped = false;
 };
 </pre>
 
 <div class="attributes">
 
-Description of ContentVisibilityAutoStateChangedEvent attributes:
+Description of ContentVisibilityAutoStateChangeEvent attributes:
 
-: <dfn attribute for=ContentVisibilityAutoStateChangedEvent>skipped</dfn>
+: <dfn attribute for=ContentVisibilityAutoStateChangeEvent>skipped</dfn>
 :: Set to true if target changed state to [=skip its contents=], and false otherwise.
 
 </div>
 
 <div class="members">
 
-Description of ContentVisibilityAutoStateChangedEventInit members:
+Description of ContentVisibilityAutoStateChangeEventInit members:
 
-: <dfn dict-member for=ContentVisibilityAutoStateChangedEventInit>skipped</dfn>
-:: See the description of the {{ContentVisibilityAutoStateChangedEvent/skipped}} attribute.
+: <dfn dict-member for=ContentVisibilityAutoStateChangeEventInit>skipped</dfn>
+:: See the description of the {{ContentVisibilityAutoStateChangeEvent/skipped}} attribute.
 
 </div>
 
@@ -2072,7 +2074,7 @@ Changes from <a href="https://www.w3.org/TR/2020/WD-css-contain-2-20201216/">202
 * Defined that elements having an ancestor with ''content-visibility: hidden'' don't generate boxes in the top layer
 * Defined that being in the top-layer makes an element relevant to the user
 * Noted that paint effects with non-local effects can limit certain optimization opportunities.
-* Add ContentVisibilityAutoStateChanged event
+* Add ContentVisibilityAutoStateChange event
 
 <h3 id="changes-since-2020-06-03">
 Changes from <a href="https://www.w3.org/TR/2020/WD-css-contain-2-20200603/">2020-06-03 Working Draft</a>


### PR DESCRIPTION
A [recent commit](https://github.com/w3c/csswg-drafts/commit/c3d88b28e594a665aca14b6a8fea7014e8dd8430) improved the definition of the event somehow but the link between the `contentvisibilityautostatechanged` event and the `ContentVisibilityAutoStateChanged` is not specified anywhere. This update switches to the usual phrasing used across specs for firing events to make the link between the event type and the interface explicit.

Also, Apart from a few exceptions in old specs, events are always named with verbs in the present tense. Accordingly, this update switches the event type to `contentvisibilityautostatechange` instead of `contentvisibilityautostatechanged` and also renames the IDL interfaces. For what it's worth, this guidance does not yet appear in the TAG's API design principles but is considered for inclusion in https://github.com/w3ctag/design-principles/issues/280

This partially addresses concerns raised in #7603. The spec would still need to define an `oncontentvisibilityautostatechange` event handler IDL attribute, which could perhaps be done by extending the `GlobalEventHandlers` mixin (to target `HTMLElement`, `MathMLElement` and `SVGElement` all at once) or by working with the WHATWG to integrate the change in HTML directly.
