### PR TITLE
[css-fonts-4] Group font-variant sub-property symbols

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -5828,7 +5828,7 @@ Overall shorthand for font rendering: the 'font-variant!!property' property</h3>
 <pre class="propdef">
 Name: font-variant
 
-Value: 	normal | none | [ <<common-lig-values>> || <<discretionary-lig-values>> || <<historical-lig-values>> || <<contextual-alt-values>> || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<<feature-value-name>>) || historical-forms || styleset(<<feature-value-name>>#) || character-variant(<<feature-value-name>>#) || swash(<<feature-value-name>>) || ornaments(<<feature-value-name>>) || annotation(<<feature-value-name>>) ]  || <<numeric-figure-values>> || <<numeric-spacing-values>> || <<numeric-fraction-values>> || ordinal || slashed-zero || <<east-asian-variant-values>> || <<east-asian-width-values>> || ruby || [ sub | super ] || [ text | emoji | unicode ] ]
+Value: 	normal | none | [ [ <<common-lig-values>> || <<discretionary-lig-values>> || <<historical-lig-values>> || <<contextual-alt-values>> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<<feature-value-name>>) || historical-forms || styleset(<<feature-value-name>>#) || character-variant(<<feature-value-name>>#) || swash(<<feature-value-name>>) || ornaments(<<feature-value-name>>) || annotation(<<feature-value-name>>) ] || [ <<numeric-figure-values>> || <<numeric-spacing-values>> || <<numeric-fraction-values>> || ordinal || slashed-zero ] || [ <<east-asian-variant-values>> || <<east-asian-width-values>> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]
 Initial: normal
 Applies to: all elements and text
 Inherited: yes


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/7683.