### PR TITLE
[scroll-animations-1] Fix formal syntax of animation-delay-(start|end)

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -727,7 +727,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class="propdef">
 		Name: animation-delay-start
-		Value: [ <<time>> | <<timeline-range-name>> <<percentage>>
+		Value: [ <<time>> | <<timeline-range-name>> <<percentage>> ]
 		Initial: 0s
 		Applies to: all elements
 		Inherited: no
@@ -753,7 +753,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class="propdef">
 		Name: animation-delay-end
-		Value: [ <<time>> | <<timeline-range-name>> <<percentage>>
+		Value: [ <<time>> | <<timeline-range-name>> <<percentage>> ]
 		Initial: 0s
 		Applies to: all elements
 		Inherited: no


### PR DESCRIPTION
Final `]` was missing.
