### PR TITLE
[css-values-4] Add `revert` and `revert-layer` to CSS-wide keywords.

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -604,16 +604,28 @@ Pre-defined Keywords</h3>
 	</div>
 
 <h4 id="common-keywords">
-CSS-wide keywords: ''initial'', ''inherit'' and ''unset''</h4>
+CSS-wide keywords: ''initial'', ''inherit'', ''unset'', ''revert'' and ''revert-layer''</h4>
 
 	As defined <a href="#component-types">above</a>,
 	all properties accept the <dfn export>CSS-wide keywords</dfn>,
 	which represent value computations common to all CSS properties.
 
-	The ''initial'' keyword represents the value specified as the property's initial value.
-	The ''inherit'' keyword represents the computed value of the property on the element's parent.
-	The ''unset'' keyword acts as either ''inherit'' or ''initial'',
-	depending on whether the property is inherited or not.
+	<ul>
+		<li>
+		The ''initial'' keyword represents the value specified as the property's initial value.
+		</li>
+		<li>
+		The ''inherit'' keyword represents the computed value of the property on the element's parent.
+		</li>
+		<li>
+		The ''unset'' keyword acts as either ''inherit'' or ''initial'',
+		depending on whether the property is inherited or not.
+		</li>
+		<li>
+		The ''revert'' and ''revert-layer'' keywords is defined in [[!css-cascade-5]] <a href="https://www.w3.org/TR/css-cascade-5/#defaulting-keywords">Explicit Defaulting</a>.
+		</li>
+	</ul>
+
 	All of these keywords are normatively defined in the Cascade module. [[!CSS3CASCADE]]
 
 	<wpt>


### PR DESCRIPTION
Fixes: #7439

@dbaron @tabatkins PTAL.