### PR TITLE
Fix the auto-builder redirect pages to maintain the URL fragment

### DIFF
--- a/bin/templates/redirect.html.j2
+++ b/bin/templates/redirect.html.j2
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <meta charset="UTF-8" />
-<meta http-equiv="refresh" content="0; URL=../{{ spec_folder }}/" />
+<!--
+  We want the redirect to keep the current URL's fragment, but that can't be
+  done if without JS support. So we use a meta refresh inside a noscript for
+  browsers that don't support JS, and do a JS-based redirection otherwise.
+-->
+<noscript>
+  <meta http-equiv="refresh" content="0; URL=../{{ spec_folder }}/" />
+</noscript>
 <title>Redirecting...</title>
 <style>
   :root {
@@ -8,3 +15,10 @@
   }
 </style>
 <p>Redirecting to <a href="../{{ spec_folder }}/">{{ spec_folder }}</a>...</p>
+
+<script>
+  // JS-based redirection.
+  const url = new URL("../{{ spec_folder }}/", location.href);
+  url.hash = location.hash;
+  location.replace(url.href);
+</script>


### PR DESCRIPTION
In the https://w3c.github.io/csswg-drafts/ mirror, if you append a spec's shortname without a level to the URL (https://w3c.github.io/csswg-drafts/css-grid, for example), you land on a page that redirects you to the current work of that spec. However, if you add a fragment to the URL, that fragment goes away in the redirect. This is an issue for MDN, for example.

The fragment goes away because currently redirects happen with meta refresh. This change uses `<noscript>` to make sure such redirects keep working when scripting is disabled, and then does a JS-based redirect that does preserve the fragment.
