### PR TITLE
[css-images-4] Fix format() typo in image-set()

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -234,7 +234,7 @@ Resolution/Type Negotiation: the ''image-set()'' notation {#image-set-notation}
 		(This has no effect on the validity of the ''image-set()'' function.)
 
 		It does not have any effect on the image itself;
-		an <<image-set-option>> like <code highlight=css>url("picture.png") 1x format("image/jpeg")</code> is valid,
+		an <<image-set-option>> like <code highlight=css>url("picture.png") 1x type("image/jpeg")</code> is valid,
 		and if chosen will display the linked PNG image,
 		even though it was declared to be a JPEG.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/7803.