### PR TITLE
[css-color-4] Add JSDoc comments to color example functions

### DIFF
--- a/css-color-4/hslToRgb.js
+++ b/css-color-4/hslToRgb.js
@@ -1,4 +1,10 @@
-function hslToRgb (hue, sat, light) {
+/**
+ * @param {number} hue - Hue as degrees 0..360
+ * @param {number} sat - Saturation as percentage 0..100
+ * @param {number} light - Lightness as percentage 0..100
+ * @return {number[]} Array of RGB components 0..1
+ */
+function hslToRgb(hue, sat, light) {
     hue = hue % 360;
 
     if (hue < 0) {

--- a/css-color-4/hwbToRgb.js
+++ b/css-color-4/hwbToRgb.js
@@ -1,9 +1,15 @@
+/**
+ * @param {number} hue -  Hue as degrees 0..360
+ * @param {number} white -  Whiteness as percentage 0..100
+ * @param {number} black -  Blackness as percentage 0..100
+ * @return {number[]} Array of RGB components 0..1
+ */
 function hwbToRgb(hue, white, black) {
     white /= 100;
     black /= 100;
     if (white + black >= 1) {
         let gray = white / (white + black);
-    return [gray, gray, gray];
+        return [gray, gray, gray];
     }
     let rgb = hslToRgb(hue, 100, 50);
     for (let i = 0; i < 3; i++) {

--- a/css-color-4/rgbToHsl.js
+++ b/css-color-4/rgbToHsl.js
@@ -1,3 +1,9 @@
+/**
+ * @param {number} red - Red component 0..1
+ * @param {number} green - Green component 0..1
+ * @param {number} blue - Blue component 0..1
+ * @return {number[]} Array of HSL values: Hue as degrees 0..360, Saturation and Lightness as percentages 0..100
+ */
 function rgbToHsl (red, green, blue) {
     let max = Math.max(red, green, blue);
     let min = Math.min(red, green, blue);

--- a/css-color-4/rgbToHwb.js
+++ b/css-color-4/rgbToHwb.js
@@ -1,3 +1,9 @@
+/**
+ * @param {number} red - Red component 0..1
+ * @param {number} green - Green component 0..1
+ * @param {number} blue - Blue component 0..1
+ * @return {number[]} Array of HWB values: Hue as degrees 0..360, Whiteness and Blackness as percentages 0..100
+ */
 function rgbToHwb(red, green, blue) {
     var hsl = rgbToHsl(red, green, blue);
     var white = Math.min(red, green, blue);


### PR DESCRIPTION
This adds JSDoc comments to the color conversion functions of css-color-4, in order to indicate the expected and returned value ranges.