### PR TITLE
[css-grid-2] Remove U+0323 COMBINING DOT BELOW

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -5010,7 +5010,7 @@ Resolve Intrinsic Track Sizes</h3>
 	when items span across multiple tracks.
 	This algorithm embodies a number of heuristics
 	which have been seen to deliver good results on real-world use-cases,
-	such as the “game”̣ examples earlier in this specification.
+	such as the “game” examples earlier in this specification.
 	This algorithm may be updated in the future
 	to take into account more advanced heuristics as they are identified.
 


### PR DESCRIPTION
Looked like dust on the screen, but then it scrolled with the text.
