### PR TITLE
[css-viewport-1] Add 'interactive-widgets' to viewport meta

### DIFF
--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -125,7 +125,7 @@ The recognized properties in the viewport
 	<li><code class="index">minimum-scale</code></li>
 	<li><code class="index">maximum-scale</code></li>
 	<li><code class="index">user-scalable</code></li>
-	<li><code class="index">interactive-widgets</code></li>
+	<li><code class="index">interactive-widget</code></li>
 </ul>
 
 <h3 id="parsing-algorithm">
@@ -261,18 +261,18 @@ as follows:
 
 Issue: Specify extend-to-zoom behavior by the viewport meta tag
 
-<h3 id="interactive-widgets-section">''interactive-widgets''</h3>
+<h3 id="interactive-widget-section">''interactive-widget''</h3>
 
 Issue: Move the definition of ''visual viewport'' from CSSOM-View to this spec.
 
-The <dfn><code>interactive-widgets</code></dfn> property specifies the effect that interactive UI
+The <dfn><code>interactive-widget</code></dfn> property specifies the effect that interactive UI
 widgets have on the page's viewports. It defines whether widgets overlay a given viewport or whether
 the viewport is shrunken so that it remains fully visible while the widget is showing. Interactive
 UI widgets are transient user agent or operating system UI through which a user can provide input.
 
 <div class="note">The most common such UI widget is a virtual keyboard.</div>
 
-The following is a list of valid values for [=interactive-widgets=] and the associated
+The following is a list of valid values for [=interactive-widget=] and the associated
 viewport-resizing behavior:
 
 <dl>
@@ -284,24 +284,24 @@ viewport-resizing behavior:
 		as when <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
 		VirtualKeyboard.overlaysContent</a> is set to <code>true</code>.
 	</dd>
-	<dt><dfn><code>resize-layout</code></dfn></dt>
+	<dt><dfn><code>resizes-document</code></dfn></dt>
 	<dd>
 		Interactive UI widgets MUST [=resize=] the [=initial viewport=] by the interactive widget.
 	</dd>
 	<div class="note">
 		Since the <a spec="CSSOM-VIEW">visual viewport</a>'s size is derived from the
-		[=initial viewport=], [=resize-layout=] will cause a resize of both the initial and visual
+		[=initial viewport=], [=resizes-document=] will cause a resize of both the initial and visual
 		viewports.
 	</div>
-	<dt><dfn><code>resize-visual</code></dfn></dt>
+	<dt><dfn><code>resizes-visual</code></dfn></dt>
 	<dd>
 		Interactive UI widgets MUST [=resize=] the <a spec="CSSOM-VIEW">visual viewport</a> but MUST
 		NOT [=resize=] the <a spec="CSS-VIEWPORT">initial viewport</a>.
 	</dd>
 </dl>
 
-If no value, or an invalid value, is set for [=interactive-widgets=], the behavior implied by
-[=resize-visual=] is used as the default.
+If no value, or an invalid value, is set for [=interactive-widget=], the behavior implied by
+[=resizes-visual=] is used as the default.
 
 To <dfn lt="resize">resize a viewport by an interactive widget</dfn>, subtract from it the
 intersection of the viewport rect with the widget's OS reported bounding rect. In cases where this
@@ -321,14 +321,14 @@ would result in a non-rectangular viewport, the behavior is user agent defined.
 The virtual-keyboard API provides an imperitive API to apply the [=overlays-content=] behavior via
 the <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
 virtualKeyboard.overlaysContent</a> attribute. This attribute shadows the value set to
-[=interactive-widgets=], namely:
+[=interactive-widget=], namely:
 
 When <code>virtualKeyboard.overlaysContent</code> is set to <code>true</code>, the UA MUST ignore
-any value set to [=interactive-widgets=] when determining the resizing behavior of interactive
+any value set to [=interactive-widget=] when determining the resizing behavior of interactive
 widgets.
 
 When <code>virtualKeyboard.overlaysContent</code> is set to <code>false</code>, the UA MUST use the
-value set to [=interactive-widgets=], or the default behavior if a value is not set, when
+value set to [=interactive-widget=], or the default behavior if a value is not set, when
 determining the resizing behavior of interactive widgets.
 
 Getting the value of <code>virtualKeyboard.overlaysContent</code> MUST return only the value previously
@@ -336,7 +336,7 @@ set to it.
 
 <div class="note">
 	That is, unless previously set, <code>virtualKeyboard.overlaysContent</code> returns false
-	even if <code>interactive-widgets=overlays-content</code> is set via the <code>&ltmeta&gt</code>
+	even if <code>interactive-widget=overlays-content</code> is set via the <code>&ltmeta&gt</code>
 	tag.
 </div>
 

--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -289,13 +289,13 @@ viewport-resizing behavior:
 		as when {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} is set to
 		<code>true</code>.
 	</dd>
-	<dt><dfn><code>resizes-document</code></dfn></dt>
+	<dt><dfn><code>resizes-content</code></dfn></dt>
 	<dd>
 		Interactive UI widgets MUST [=resize=] the [=initial viewport=] by the interactive widget.
 	</dd>
 	<div class="note">
 		Since the <a spec="CSSOM-VIEW">visual viewport</a>'s size is derived from the
-		[=initial viewport=], [=resizes-document=] will cause a resize of both the initial and visual
+		[=initial viewport=], [=resizes-content=] will cause a resize of both the initial and visual
 		viewports.
 	</div>
 	<dt><dfn><code>resizes-visual</code></dfn></dt>

--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -279,14 +279,14 @@ viewport-resizing behavior:
 	<dt><dfn><code>overlays-content</code></dfn></dt>
 	<dd>
 		Interactive UI widgets MUST NOT [=resize=] the [=initial viewport=] nor
-		the the <a spec="CSSOM-VIEW">visual viewport</a>. The user agent must perform the same steps
+		the <a spec="CSSOM-VIEW">visual viewport</a>. The user agent must perform the same steps
 		<!--TODO I can't seem to autolink to overlaysContent, help?-->
 		as when <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
 		VirtualKeyboard.overlaysContent</a> is set to <code>true</code>.
 	</dd>
 	<dt><dfn><code>resize-layout</code></dfn></dt>
 	<dd>
-		Interactive UI widgets MUST [=resize=] the [=initial viewport=].
+		Interactive UI widgets MUST [=resize=] the [=initial viewport=] by the interactive widget.
 	</dd>
 	<div class="note">
 		Since the <a spec="CSSOM-VIEW">visual viewport</a>'s size is derived from the
@@ -309,7 +309,7 @@ would result in a non-rectangular viewport, the behavior is user agent defined.
 
 <div class="note">
 	Some examples where the result would non rectangular: a
-	<a href="https://support.apple.com/en-ca/HT207521">floating or split keyboard</a>, a keyboard that
+	<a href="https://support.apple.com/en-ca/HT207521">floating or split keyboard</a>, or a keyboard that
 	<a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/VirtualKeyboardAPI/explainer.md#motivation">
 	occupies only part</a> of the viewport.
 </div>
@@ -331,7 +331,7 @@ When <code>virtualKeyboard.overlaysContent</code> is set to <code>false</code>, 
 value set to [=interactive-widgets=], or the default behavior if a value is not set, when
 determining the resizing behavior of interactive widgets.
 
-Getting value of <code>virtualKeyboard.overlaysContent</code> MUST return only the value previously
+Getting the value of <code>virtualKeyboard.overlaysContent</code> MUST return only the value previously
 set to it.
 
 <div class="note">

--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -19,6 +19,12 @@ Issue Tracking: CSSWG GitHub https://github.com/w3c/csswg-drafts/labels/css-view
 Ignored Vars: <viewport-length>
 </pre>
 
+<pre class="anchors">
+spec: virtual-keyboard; urlPrefix: https://w3c.github.io/virtual-keyboard
+	type: interface; text: VirtualKeyboard; url: dom-virtualkeyboard
+	type: attribute; text: overlaysContent; for: VirtualKeyboard; url: dom-virtualkeyboard-overlayscontent
+</pre>
+
 
 <h2 id="intro">
 Introduction</h2>
@@ -280,9 +286,8 @@ viewport-resizing behavior:
 	<dd>
 		Interactive UI widgets MUST NOT [=resize=] the [=initial viewport=] nor
 		the <a spec="CSSOM-VIEW">visual viewport</a>. The user agent must perform the same steps
-		<!--TODO I can't seem to autolink to overlaysContent, help?-->
-		as when <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
-		VirtualKeyboard.overlaysContent</a> is set to <code>true</code>.
+		as when {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} is set to
+		<code>true</code>.
 	</dd>
 	<dt><dfn><code>resizes-document</code></dfn></dt>
 	<dd>
@@ -318,24 +323,23 @@ would result in a non-rectangular viewport, the behavior is user agent defined.
 	Interaction with virtualKeyboard.overlaysContent
 </h4>
 
-The virtual-keyboard API provides an imperitive API to apply the [=overlays-content=] behavior via
-the <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
-virtualKeyboard.overlaysContent</a> attribute. This attribute shadows the value set to
-[=interactive-widget=], namely:
+[[!VIRTUAL-KEYBOARD]] provides an imperitive API to apply the [=overlays-content=] behavior via
+the {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} attribute. This attribute
+shadows the value set to [=interactive-widget=], namely:
 
-When <code>virtualKeyboard.overlaysContent</code> is set to <code>true</code>, the UA MUST ignore
-any value set to [=interactive-widget=] when determining the resizing behavior of interactive
-widgets.
+When {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} is set to
+<code>true</code>, the UA MUST ignore any value set to [=interactive-widget=] when determining the
+resizing behavior of interactive widgets.
 
-When <code>virtualKeyboard.overlaysContent</code> is set to <code>false</code>, the UA MUST use the
-value set to [=interactive-widget=], or the default behavior if a value is not set, when
-determining the resizing behavior of interactive widgets.
+When {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} is set to
+<code>false</code>, the UA MUST use the value set to [=interactive-widget=], or the default behavior
+if a value is not set, when determining the resizing behavior of interactive widgets.
 
-Getting the value of <code>virtualKeyboard.overlaysContent</code> MUST return only the value previously
-set to it.
+Getting the value of {{VirtualKeyboard/overlaysContent|VirtualKeyboard.overlaysContent}} MUST return
+only the value previously set to it.
 
 <div class="note">
-	That is, unless previously set, <code>virtualKeyboard.overlaysContent</code> returns false
+	That is, unless previously set, <code>VirtualKeyboard.overlaysContent</code> returns false
 	even if <code>interactive-widget=overlays-content</code> is set via the <code>&ltmeta&gt</code>
 	tag.
 </div>

--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -125,6 +125,7 @@ The recognized properties in the viewport
 	<li><code class="index">minimum-scale</code></li>
 	<li><code class="index">maximum-scale</code></li>
 	<li><code class="index">user-scalable</code></li>
+	<li><code class="index">interactive-widgets</code></li>
 </ul>
 
 <h3 id="parsing-algorithm">
@@ -259,6 +260,85 @@ as follows:
 <h3 id="extend-to-zoom">''extend-to-zoom''</h3>
 
 Issue: Specify extend-to-zoom behavior by the viewport meta tag
+
+<h3 id="interactive-widgets-section">''interactive-widgets''</h3>
+
+Issue: Move the definition of ''visual viewport'' from CSSOM-View to this spec.
+
+The <dfn><code>interactive-widgets</code></dfn> property specifies the effect that interactive UI
+widgets have on the page's viewports. It defines whether widgets overlay a given viewport or whether
+the viewport is shrunken so that it remains fully visible while the widget is showing. Interactive
+UI widgets are transient user agent or operating system UI through which a user can provide input.
+
+<div class="note">The most common such UI widget is a virtual keyboard.</div>
+
+The following is a list of valid values for [=interactive-widgets=] and the associated
+viewport-resizing behavior:
+
+<dl>
+	<dt><dfn><code>overlays-content</code></dfn></dt>
+	<dd>
+		Interactive UI widgets MUST NOT [=resize=] the [=initial viewport=] nor
+		the the <a spec="CSSOM-VIEW">visual viewport</a>. The user agent must perform the same steps
+		<!--TODO I can't seem to autolink to overlaysContent, help?-->
+		as when <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
+		VirtualKeyboard.overlaysContent</a> is set to <code>true</code>.
+	</dd>
+	<dt><dfn><code>resize-layout</code></dfn></dt>
+	<dd>
+		Interactive UI widgets MUST [=resize=] the [=initial viewport=].
+	</dd>
+	<div class="note">
+		Since the <a spec="CSSOM-VIEW">visual viewport</a>'s size is derived from the
+		[=initial viewport=], [=resize-layout=] will cause a resize of both the initial and visual
+		viewports.
+	</div>
+	<dt><dfn><code>resize-visual</code></dfn></dt>
+	<dd>
+		Interactive UI widgets MUST [=resize=] the <a spec="CSSOM-VIEW">visual viewport</a> but MUST
+		NOT [=resize=] the <a spec="CSS-VIEWPORT">initial viewport</a>.
+	</dd>
+</dl>
+
+If no value, or an invalid value, is set for [=interactive-widgets=], the behavior implied by
+[=resize-visual=] is used as the default.
+
+To <dfn lt="resize">resize a viewport by an interactive widget</dfn>, subtract from it the
+intersection of the viewport rect with the widget's OS reported bounding rect. In cases where this
+would result in a non-rectangular viewport, the behavior is user agent defined.
+
+<div class="note">
+	Some examples where the result would non rectangular: a
+	<a href="https://support.apple.com/en-ca/HT207521">floating or split keyboard</a>, a keyboard that
+	<a href="https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/VirtualKeyboardAPI/explainer.md#motivation">
+	occupies only part</a> of the viewport.
+</div>
+
+<h4 id="interaction-with-virtualkeyboard-overlayscontent">
+	Interaction with virtualKeyboard.overlaysContent
+</h4>
+
+The virtual-keyboard API provides an imperitive API to apply the [=overlays-content=] behavior via
+the <a href="https://www.w3.org/TR/virtual-keyboard/#dom-virtualkeyboard-overlayscontent">
+virtualKeyboard.overlaysContent</a> attribute. This attribute shadows the value set to
+[=interactive-widgets=], namely:
+
+When <code>virtualKeyboard.overlaysContent</code> is set to <code>true</code>, the UA MUST ignore
+any value set to [=interactive-widgets=] when determining the resizing behavior of interactive
+widgets.
+
+When <code>virtualKeyboard.overlaysContent</code> is set to <code>false</code>, the UA MUST use the
+value set to [=interactive-widgets=], or the default behavior if a value is not set, when
+determining the resizing behavior of interactive widgets.
+
+Getting value of <code>virtualKeyboard.overlaysContent</code> MUST return only the value previously
+set to it.
+
+<div class="note">
+	That is, unless previously set, <code>virtualKeyboard.overlaysContent</code> returns false
+	even if <code>interactive-widgets=overlays-content</code> is set via the <code>&ltmeta&gt</code>
+	tag.
+</div>
 
 <pre class=biblio>
 {


### PR DESCRIPTION
[css-viewport-1] Add 'interactive-widgets' to viewport meta

This describes the proposed `interactive-widgets` property of the viewport meta tag for describing the expected behavior when a virtual-keyboard-like widget is shown.
