### PR TITLE
[css-page-floats-3] Add missing CSS2 'both' keyword to 'clear' grammar

### DIFF
--- a/css-page-floats-3/Overview.bs
+++ b/css-page-floats-3/Overview.bs
@@ -464,7 +464,7 @@ The 'clear' property</h2>
 
   <pre class="propdef">
     Name: clear
-    Value: inline-start | inline-end | block-start | block-end | left | right | top | bottom | none
+    Value: inline-start | inline-end | block-start | block-end | both | left | right | top | bottom | none
     Initial: none
     Applies to: block-level elements, floats, regions, pages
     Inherited: no


### PR DESCRIPTION
Fixes #7350.

There has been no update to the spec since 1 year but I would hope that at least `both`, which is [defined in CSS 2](https://w3c.github.io/csswg-drafts/css2/#propdef-clear), could be re-included in the `value` definition of `clear`, for backward-compatibility, noting that: 

1. `both-inline` and `both-block` are also defined in prose in CSS Page Floats 3 but are missing in the `value` definition of `clear`
2. `both` is defined in CSS Page Floats 3 as equivalent to `both-inline`, which is defined as equivalent to `inline-start` and `inline-end`