### PR TITLE
[css-highlight-api] fix paired defaults terminology

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -320,7 +320,7 @@ Applicable Properties</h4>
 Default Styles</h4>
 
 	UAs must not define any default UA stylesheet rules
-	or <a spec=css-pseudo>default highlight colors</a>
+	or <a spec=css-pseudo>paired default highlight colors</a>
 	for any [=custom highlight pseudo-elements=].
 	In other words,
 	when some content is highlighted by an unstyled custom highlight,


### PR DESCRIPTION
#6665 rewrote #default-styles to align ::highlight() inheritance and paired defaults with the other highlight pseudos. The term “default highlight colors” was renamed to “paired default highlight colors” before merging, but I forgot to rename it in the highlight API spec. This patch fixes that.