### PR TITLE
Pending transform operations before IntersectionObserver

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -616,7 +616,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 ## Monkey patches to rendering ## {#monkey-patch-to-rendering-algorithm}
 
 <div algorithm="monkey patch to rendering">
-    Run the following steps before [marking paint timing](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:mark-paint-timing) in the [=update the rendering=] steps:
+    Run the following steps before <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:run-the-update-intersection-observations-steps">intersection observer steps</a> in the [=update the rendering=] steps:
 
     1. For each [=fully active=] {{Document}} in <var ignore>docs</var>,
         [=perform pending transition operations=] for that {{Document}}.


### PR DESCRIPTION
[css-spec-shortname-1] Pending transform operations before IntersectionObserver

Input from the DOM to generate styles for pseudo-elements should happen after ResizeObserver but before IntersectionObserver.
