### PR TITLE
Remove font-variant descriptor example

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6421,35 +6421,6 @@ Feature precedence examples</h3>
 	</pre>
 </div>
 
-<div class="example" id="ex-descriptor-only-that-rule">
-	When the <span>font-variant</span> descriptor
-	is used within an ''@font-face'' rule, it only
-	applies to the font defined by that rule.
-
-	<pre>
-	@font-face {
-	  font-family: MainText;
-	  src: url(http://example.com/font.woff);
-	  font-variant: oldstyle-nums proportional-nums styleset(1,3);
-	}
-
-	body {
-	  font-family: MainText, Helvetica;
-	}
-
-	table.prices td {
-	  font-variant-numeric: tabular-nums;
-	}
-	</pre>
-
-	In this case, old-style numerals will be used throughout but only
-	where the font "MainText" is used. Just as in the previous example,
-	tabular values will be used in price tables since ''tabular-nums''
-	appears in a general style rule and its use is mutually exclusive with
-	''proportional-nums''.  Stylistic alternate sets will only be used where
-	MainText is used.
-</div>
-
 <div class="example" id="ex-features-local">
 	The ''@font-face'' rule can also be used to access font features in locally available
 	fonts via the use of <code>local()</code> in the 'src!!descriptor' descriptor of the ''@font-face'' definition:


### PR DESCRIPTION
Removed font-variant descriptor example.

Changes from the March 15 2018 CSS Fonts 3 Candidate Recommendation ‘font-variant’ descriptor moved to CSS Fonts 4 due to lack of implementations  

And then…
17.5. Changes from the 20 September 2018 Working Draft Remove font-variant @font-face descriptor per WG resolution  

All references have been removed, other than this example.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
