### PR TITLE
Fix description and sample code for "longer"

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4709,13 +4709,13 @@ Hue Interpolation</h3>
 <h4 id="hue-longer">
 <dfn export>longer</dfn></h4>
 
-	Angles are adjusted so that |θ₂ - θ₁| ∈ {0, [180, 360)}. In pseudo-Javascript:
+	Angles are adjusted so that |θ₂ - θ₁| ∈ {(-360, -180], [180, 360]}. In pseudo-Javascript:
 		<pre>
 		if (0 < θ₂ - θ₁ < 180) {
-			θ₂ += 360;
+			θ₁ += 360;
 		}
 		else if (-180 < θ₂ - θ₁ <= 0) {
-			θ₁ += 360;
+			θ₂ += 360;
 		}
 		</pre>
 


### PR DESCRIPTION
The previous algorithm was incorrect, producing sweeps that were either too short or too long. Also, the description of the post-conditions was wrong.