### PR TITLE
[cssom] CSSKeyframesRule name serialization should sometimes be escaped

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1826,8 +1826,9 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
   The result of concatenating the following:
   <ol>
    <li>The literal string "<code>@keyframes</code>", followed by a single SPACE (U+0020).
-   <li>The <a lt="serialize an identifier">serialization as an identifier</a> of the
- {{CSSKeyframesRule/name}} attribute.
+   <li>The serialization of the {{CSSKeyframesRule/name}} attribute. If the attribute is a CSS wide keyword, or the value ''default'', or the value ''none'',
+	 then it is <a lt="serialize a string">serialized as a string</a>. Otherwise, it is <a lt="serialize an identifier">serialized as an identifier</a>.
+   <li>The string "<code> { </code>", i.e., a single SPACE (U+0020), followed by LEFT CURLY BRACKET (U+007B), followed by a single SPACE (U+0020).
    <li>The result of performing <a>serialize a CSS rule</a> on each rule in the rule's {{CSSKeyframesRule/cssRules}} list, separated by a newline and indented by two spaces.</li>
    <li>A newline, followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D)</li>
   </ol>
@@ -1837,7 +1838,7 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
   The result of concatenating the following:
   <ol>
    <li>The {{CSSKeyframeRule/keyText}}.
-   <li>The string "<code> { </code>", i.e., a single SPACE (U+0020), followed by LEFT CURLY BRACKET (U+007B),
+   <li>The string "<code> { </code>", i.e., a single SPACE (U+0020), followed by LEFT CURLY BRACKET (U+007B), followed by a single SPACE (U+0020).
    <li>The result of performing <a>serialize a CSS declaration block</a> on the rule's associated declarations.
    <li>If the rule is associated with one or more declarations, the string "<code> </code>", i.e., a single SPACE (U+0020).
    <li>The string "<code>}</code>", RIGHT CURLY BRACKET (U+007D).


### PR DESCRIPTION
The CSS Animations specification says that keyframe names that are CSS wide values, or "default", or "none", should be treated as strings when serialized.

This patch also adds a missing " { " output step.

This is already partially covered by the WPT css/cssom/CSSKeyframesRule.html.
