### PR TITLE
[css-nesting] Syntax preference feedback

### DIFF
--- a/css-nesting-1/proposals.md
+++ b/css-nesting-1/proposals.md
@@ -143,7 +143,7 @@ If it were up to you, what syntax would you prefer for CSS Nesting?
 | mirisuzanne | 3          | 2.iii      | 4          |
 | romainmenke | 1          | 3          | 4          |
 | FremyCompany | 4.iii     | 1          | 3          |
-| dbaron | 3 [*](https://github.com/w3c/csswg-drafts/issues/7834#issuecomment-1283019419) | 1 | 2.iii [*](https://github.com/w3c/csswg-drafts/issues/7834#issuecomment-1283019419) |
+| alohci      | 3          | 1          | 4          |
 
 ***Note:** It is not required to be a WG member to add your name to this list,
 only to have followed the [discussion](https://github.com/w3c/csswg-drafts/issues/7834)


### PR DESCRIPTION
Added my preference to the table

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
