### PR TITLE
[css-contain-2] Change the requirement for content-visibility to apply only if size containment applies

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1255,7 +1255,7 @@ Suppressing An Element's Contents Entirely: the 'content-visibility' property {#
 	Value: visible | auto | hidden
 	Initial: visible
 	Inherited: no
-	Applies to: elements for which [=layout containment=] can apply
+	Applies to: elements for which [=size containment=] can apply
 	Animation type: not animatable
 	</pre>
 


### PR DESCRIPTION
[css-contain-2] Change the requirement for content-visibility to apply only if size containment applies

Fixes #7658 
