### PR TITLE
[gh-pages] Do full clone rather than shallow clone

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This change causes the GH Pages build to do a full clone rather than a shallow clone. This is necessary in order to get the correct timestamps for all sources (see https://github.com/w3c/csswg-drafts/pull/7898).

Otherwise, without this change, git doesn’t report accurate timestamps for any sources; instead it reports the same timestamp for all of them — which is apparently whatever the current time is when git creates the (shallow) clone.
