### PR TITLE
[cascade-5] Fix CSSOM example in legacy alias name

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -394,7 +394,7 @@ Property Aliasing</h3>
 				<css>old-name</css> is a <a>legacy name alias</a> for <css>new-name</css>,
 				<code>getComputedStyle(el).oldName</code>
 				will return the computed style of the <code>newName</code> property,
-				and <code>el.style.setPropertyValue("old-name", "value")</code>
+				and <code>el.style.setProperty("old-name", "value")</code>
 				will set the <css>new-name</css> property to <code>"value"</code>.
 			</div>
 


### PR DESCRIPTION
There is no `setPropertyValue()` method, change to `setProperty()`
