### PR TITLE
[css-images-4] Simplify linear-gradient syntax

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1199,7 +1199,7 @@ to customize color interpolation in gradients as described in [[css-color-4#inte
 
 <pre class=prod>
 		<dfn>linear-gradient()</dfn> = linear-gradient(
-			[ <<angle>> | to <<side-or-corner>> ]? || <<color-interpolation-method>>,
+			[ <<angle>> | to <<side-or-corner>> ] || <<color-interpolation-method>>,
 			<<color-stop-list>>
 		)
 		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]


### PR DESCRIPTION
`?` is not required in `[ <angle> | to <side-or-corner> ]? || ...` because *a double bar (`||`) separates two or more options: one or more of them must occur, in any order.*

https://drafts.csswg.org/css-values-4/#component-combinators