### PR TITLE
[scroll-animations-1] Allow reordering of scroll() keywords

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -130,13 +130,13 @@ spec: cssom-view-1; type: dfn;
 
 ### The ''scroll()'' notation ### {#scroll-notation}
 
-	The ''scroll()'' functional notation
+	The <dfn>scroll()</dfn> functional notation
 	can be used as a value of 'animation-timeline'
 	and specifies a [=scroll progress timeline=].
 	Its syntax is
 
 	<pre class="prod">
-		<dfn>scroll()</dfn> = scroll( <<axis>>? <<scroller>>? )
+		<<scroll()>> = scroll( [ <<scroller>> || <<axis>> ]? )
 		<dfn noexport><<axis>></dfn> = block | inline | vertical | horizontal
 		<dfn noexport><<scroller>></dfn> = root | nearest
 	</pre>


### PR DESCRIPTION
We generally allow reordering whenever it's not creating some kind of parsing ambiguity.