### PR TITLE
[css-syntax-3] Note: surrogate can only be produced by OM operation

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -433,6 +433,8 @@ Preprocessing the input stream</h3>
 			<li>
 				Replace any U+0000 NULL or <a>surrogate</a> <a>code points</a> in |input|
 				with U+FFFD REPLACEMENT CHARACTER (�).
+
+				Note: The only way to produce a <a>surrogate</a> <a>code point</a> in CSS content is by directly assigning a <code>DOMString</code> with one in it via an OM operation.
 		</ul>
 	</div>
 


### PR DESCRIPTION
In the “filter code points” step of the “Preprocessing the input stream” section at https://drafts.csswg.org/css-syntax/#css-filter-code-points, this change adds a non-normative Note to clarify that the only way to produce a surrogate code point in CSS content is by directly assigning a `DOMString` with one in it via an OM operation.
