### PR TITLE
[css-view-transitions-1] Rename all CSS properties and associated concepts

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -78,34 +78,34 @@ in the {{ViewTransition}} section.
 After the callback has finished running, the user-agent creates a structure of
 pseudo-elements that represent both the "before" and "after" states of the
 transition. The structure of the pseudo-elements is dictated by the
-''page-transition-tag'' property. Specifically, each element that is "tagged"
-with a ''page-transition-tag'' creates a separate snapshot and thus a separate
+''view-transition-name'' property. Specifically, each element that is "tagged"
+with a ''view-transition-name'' creates a separate snapshot and thus a separate
 group of pseudo-elements that are animated independently from the rest. Note
 that for convenience, the root element is tagged with name "root" in the
 user-agent style sheet.
 
-The groups induced by the ''page-transition-tag'' are all positioned within a
+The groups induced by the ''view-transition-name'' are all positioned within a
 common pseudo-element root, which itself is attached to the root element of the
 page.
 
 Each of the groups is comprised of up to four pseudo elements:
-* Container pseudo-element: this element initially mirrors the size and
+* Group pseudo-element: this element initially mirrors the size and
     position of the "before" state element that it represents (i.e. the tagged
     element that caused this group to be created). The element is animated to
     the "after" state and position.
-* Wrapper pseudo-element: this element is a child of the container element and
+* Image-Pair pseudo-element: this element is a child of the container element and
     provides ''isolation: isolate'' for its children. It's needed so that its
     children can be blended with non-normal blend modes without affecting other
     visual outputs.
-* Outgoing image: this element is a child of the wrapper element. It is a
+* Old image: this element is a child of the image-pair element. It is a
     replaced element that produced the visual representation of the "before"
     state taken from user-agent provided snapshots. Note that the contents of
     this element can be manipulated with ''object-*'' properties in the same way
     that other replaced elements can be.
-* Incoming image: this element is a child of the wrapper element. It is a
+* New image: this element is a child of the image-pair element. It is a
     replaced element that produces the visual representation of the "after"
     state, taken from the page's visual output of the represented elements. Like
-    outgoing image, the contents can be manipulated with ''object-*'' properties.
+    old image, the contents can be manipulated with ''object-*'' properties.
     Note that because this element's snapshots are taken from the pages output,
     the visual output changes if the visual output of the represented element
     changes. This is similar to how an '<a
@@ -135,10 +135,10 @@ Note that because these APIs are an enhancement to the DOM change, some principl
 
 # CSS properties # {#css-properties}
 
-## 'page-transition-tag' ## {#page-transition-tag-prop}
+## 'view-transition-name' ## {#view-transition-name-prop}
 
 <pre class=propdef>
-Name: page-transition-tag
+Name: view-transition-name
 Value: none | <<custom-ident>>
 Initial: none
 Inherited: no
@@ -147,29 +147,29 @@ Computed Value: as specified
 Animation type: discrete
 </pre>
 
-The 'page-transition-tag' property "tags" an element
-as participating in a page transition.
+The 'view-transition-name' property "tags" an element
+as participating in a view transition.
 
-<dl dfn-type=value dfn-for=page-transition-tag>
+<dl dfn-type=value dfn-for=view-transition-name>
     : <dfn>none</dfn>
-    :: The element will not participate in a page transition.
+    :: The element will not participate in a view transition.
 
     : <dfn><<custom-ident>></dfn>
-    :: The element can participate in a page transition,
-        as either an outgoing or incoming element,
-        with a <dfn dfn for>page transition tag</dfn>
+    :: The element can participate in a view transition,
+        as either an old or new element,
+        with a <dfn dfn for>view transition name</dfn>
         equal to the <<custom-ident>>'s value.
 
         The value <css>none</css>
         is invalid as a <<custom-ident>>.
 </dl>
 
-The root element participates in a page transition by default using
+The root element participates in a view transition by default using
 the following style in the [=user-agent origin=].
 
 <pre><code highlight=css>
     html {
-      page-transition-tag: root;
+      view-transition-name: root;
     }
  </code></pre>
 
@@ -186,23 +186,23 @@ the same conceptual page entity, that we happen to call element.
 
 # Pseudo-elements # {#pseudo}
 
-While the UA is [=animating a page transition=],
-it creates the following <dfn export>page-transition pseudo-elements</dfn>,
+While the UA is [=animating a view transition=],
+it creates the following <dfn export>view-transition pseudo-elements</dfn>,
 to represent the various items being animated.
 
-The ''::page-transition'' pseudo-element acts as a grouping element for other
-[=page-transition pseudo-elements=] and has the document's root element as its
+The ''::view-transition'' pseudo-element acts as a grouping element for other
+[=view-transition pseudo-elements=] and has the document's root element as its
 [=originating element=].
 
-<p class="note">For example, '':root::page-transition'' selector matches this
-pseudo-element, but ''div::page-transition'' does not.
+<p class="note">For example, '':root::view-transition'' selector matches this
+pseudo-element, but ''div::view-transition'' does not.
 </p>
 
-Other [=page-transition pseudo-elements=] take a <<pt-tag-selector>> argument
-to specify which elements tagged with ''page-transition-tag'' are affected.
+Other [=view-transition pseudo-elements=] take a <<pt-tag-selector>> argument
+to specify which elements tagged with ''view-transition-name'' are affected.
 
 There can be multiple pseudo-elements of the same type,
-one for each ''page-transition-tag'' participating in a transition.
+one for each ''view-transition-name'' participating in a transition.
 
 The <<pt-tag-selector>> is defined as follows:
 
@@ -211,52 +211,52 @@ The <<pt-tag-selector>> is defined as follows:
 </pre>
 
 A value of ''*'' makes the corresponding selector apply to all pseudo elements
-of the specified type. The specificity of a page-transition selector with a
+of the specified type. The specificity of a view-transition selector with a
 ''*'' argument is zero.
 
 The <<custom-ident>> value makes the corresponding selector apply to exactly
 one pseudo element of the specified type, namely the pseudo-element that is
-created as a result of the ''page-transition-tag'' property on an element with
-the same <<custom-ident>> value. The specificity of a page-transition selector
+created as a result of the ''view-transition-name'' property on an element with
+the same <<custom-ident>> value. The specificity of a view-transition selector
 with a <<custom-ident>> argument is the same as for other pseudo-elements, and
 is equivalent to a [=type selector=].
 
-The following describes all of the [=page-transition pseudo-elements=] and
+The following describes all of the [=view-transition pseudo-elements=] and
 their function:
 
-: <dfn>::page-transition</dfn>
+: <dfn>::view-transition</dfn>
 :: This pseudo-element is the grouping container of all the other
-    [=page-transition pseudo-elements=].  Its [=originating element=] is the
+    [=view-transition pseudo-elements=].  Its [=originating element=] is the
     document's root element.
 
     The following [=user-agent origin=] styles apply to this element:
 
     <pre><code highlight=css>
-    html::page-transition {
+    html::view-transition {
       position: fixed;
       inset: 0;
     }
     </code></pre>
 
     Note: This pseudo-element provides a containing block for all
-    ::page-transition-container pseudo-elements. The aim of the style is to
+    ::view-transition-group pseudo-elements. The aim of the style is to
     size the pseudo-element to cover the [=large viewport size=] and position
-    all ::page-transition-container pseudo-elements relative to the origin of
+    all ::view-transition-group pseudo-elements relative to the origin of
     the large viewport.
 
-: <dfn>::page-transition-container( <<pt-tag-selector>> )</dfn>
+: <dfn>::view-transition-group( <<pt-tag-selector>> )</dfn>
 ::  One of these pseudo-elements exists
-    for each ''page-transition-tag'' in a page transition,
+    for each ''view-transition-name'' in a view transition,
     and holds the rest of the pseudo-elements corresponding
-    to this ''page-transition-tag''.
+    to this ''view-transition-name''.
 
-    Its [=originating element=] is the ''::page-transition''
+    Its [=originating element=] is the ''::view-transition''
     pseudo-element.
 
     The following [=user-agent origin=] styles apply to this element:
 
     <pre><code highlight=css>
-    html::page-transition-container(*) {
+    html::view-transition-group(*) {
       position: absolute;
       top: 0;
       left: 0;
@@ -267,31 +267,31 @@ their function:
     </code></pre>
 
     Note: The aim of the style is to position the element relative to its
-    ::page-transition parent.
+    ::view-transition parent.
 
     In addition to above, styles in the [=user-agent origin=] animate this
-    pseudo-element's 'width' and 'height' from the size of the outgoing element's
-    [=border box=] to that of the incoming element's [=border box=]. Also the
-    element's 'transform' is animated from the outgoing element's screen space
-    transform to the incoming element's screen space transform. This style is
+    pseudo-element's 'width' and 'height' from the size of the old element's
+    [=border box=] to that of the new element's [=border box=]. Also the
+    element's 'transform' is animated from the old element's screen space
+    transform to the new element's screen space transform. This style is
     generated dynamically since the values of animated properties are determined
     at the time that the transition begins.
 
     Issue: The selector for this and subsequently defined pseudo-elements is
     likely to change to indicate position in the pseudo-tree hierarchy.
 
-: <dfn>::page-transition-image-wrapper( <<pt-tag-selector>> )</dfn>
+: <dfn>::view-transition-image-pair( <<pt-tag-selector>> )</dfn>
 ::  One of these pseudo-elements exists
-    for each page-transition-tag being in a page transition,
-    and holds the images of the outgoing and incoming elements.
+    for each view-transition-name being in a view transition,
+    and holds the images of the old and new elements.
 
-    Its [=originating element=] is the ''::page-transition-container()''
+    Its [=originating element=] is the ''::view-transition-group()''
     pseudo-element with the same tag.
 
     The following [=user-agent origin=] styles apply to this element:
 
     <pre><code highlight=css>
-    html::page-transition-image-wrapper(*) {
+    html::view-transition-image-pair(*) {
       position: absolute;
       inset: 0;
 
@@ -302,30 +302,30 @@ their function:
 
     In addition to above, styles in the [=user-agent origin=] add ''isolation:
     isolate'' to this pseudo-element if it has both
-    ''::page-transition-incoming-image'' and ''::page-transition-outgoing-image'' as
+    ''::view-transition-new'' and ''::view-transition-old'' as
     descendants.
 
     Note: The aim of the style is to position the element to occupy the same space
-    as its ::page-transition-container element and provide isolation for
+    as its ::view-transition-group element and provide isolation for
     blending.
 
     Issue: Isolation is only necessary to get the right cross-fade between
-    incoming and outgoing image pixels. Would it be simpler to always add it
+    new and old image pixels. Would it be simpler to always add it
     and try to optimize in the implementation?
 
-: <dfn>::page-transition-outgoing-image( <<pt-tag-selector>> )</dfn>
+: <dfn>::view-transition-old( <<pt-tag-selector>> )</dfn>
 ::  One of these pseudo-elements exists
-    for each element in the outgoing DOM being animated by the page transition,
-    and is a [=replaced element=] displaying the outgoing element's snapshot image.
+    for each element in the old DOM being animated by the view transition,
+    and is a [=replaced element=] displaying the old element's snapshot image.
     It has [=natural dimensions=] equal to the snapshot's size.
 
-    Its [=originating element=] is the ''::page-transition-image-wrapper()''
+    Its [=originating element=] is the ''::view-transition-image-pair()''
     pseudo-element with the same tag.
 
     The following [=user-agent origin=] styles apply to this element:
 
     <pre><code highlight=css>
-    html::page-transition-outgoing-image(*) {
+    html::view-transition-old(*) {
       position: absolute;
       inset-block-start: 0;
       inline-size: 100%;
@@ -341,20 +341,20 @@ their function:
 
     In addition to above, styles in the [=user-agent origin=] add
     ''mix-blend-mode:plus-lighter'' to this pseudo element if the ancestor
-    ''::page-transition-image-wrapper'' has both
-    ''::page-transition-incoming-image'' and ''::page-transition-outgoing-image'' as
+    ''::view-transition-image-pair'' has both
+    ''::view-transition-new'' and ''::view-transition-old'' as
     descendants.
 
     Note: mix-blend-mode value of plus-lighter ensures that the blending of identical
-    pixels from the outgoing and incoming images results in the same color value
+    pixels from the old and new images results in the same color value
     as those pixels.
 
     Additional [=user-agent origin=] styles added to animate these pseudo-elements
-    are detailed in [=Animate a page transition=].
+    are detailed in [=Animate a view transition=].
 
-: <dfn>::page-transition-incoming-image( <<pt-tag-selector>> )</dfn>
-::  Identical to ''::page-transition-outgoing-image()'',
-    except it deals with the incoming element instead.
+: <dfn>::view-transition-new( <<pt-tag-selector>> )</dfn>
+::  Identical to ''::view-transition-old()'',
+    except it deals with the new element instead.
 
 The precise tree structure, and in particular the order of sibling
 pseudo-elements, is defined in the [=Create transition pseudo-elements=]
@@ -380,31 +380,31 @@ description of the phases below tries to be as precise as possible, with an
 intent to provide an unambiguous set of steps for implementors to follow in
 order to produce a spec-compliant implementation.
 
-## The [=page-transition layer=] stacking layer ## {#page-transition-stacking-layer}
+## The [=view-transition layer=] stacking layer ## {#view-transition-stacking-layer}
 
 This specification introduces a stacking layer to the
 <a href="https://www.w3.org/TR/CSS2/zindex.html">Elaborate description of Stacking Contexts</a>.
 
-The ''::page-transition'' pseudo-element generates a new stacking context
-called <dfn>page-transition layer</dfn> with the following characteristics:
+The ''::view-transition'' pseudo-element generates a new stacking context
+called <dfn>view-transition layer</dfn> with the following characteristics:
 
 1. Its parent stacking context is the root stacking context.
 
-1. If the ''page-transition'' pseudo-element exists, a new stacking
+1. If the ''view-transition'' pseudo-element exists, a new stacking
     context is created for the
     <a href="https://dom.spec.whatwg.org/#concept-tree-root">root</a>
     and <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>
     elements.
-    The ''page-transition layer'' is a sibling of this stacking context.
+    The ''view-transition layer'' is a sibling of this stacking context.
 
-1. The ''page-transition layer'' paints after the stacking context for the
+1. The ''view-transition layer'' paints after the stacking context for the
      <a href="https://dom.spec.whatwg.org/#concept-tree-root">root</a>
     and <a href="https://fullscreen.spec.whatwg.org/#top-layer">top layer</a>
     elements.
 
 Note: The intent of the feature is to be able to capture the contents of the
 page, which includes the top layer elements. In order to accomplish that, the
-''page-transition layer'' cannot be a part of the captured top layer context,
+''view-transition layer'' cannot be a part of the captured top layer context,
 since that results in a circular dependency. Instead, this stacking context is a
 sibling of other page contents.
 
@@ -416,17 +416,17 @@ layer elements has filters and effects coming from the root element's style?
 A <dfn>captured element</dfn> is a [=struct=] with the following:
 
 <dl dfn-for="captured element">
-    : <dfn>outgoing image</dfn>
+    : <dfn>old image</dfn>
     :: an image or null. Initially null.
 
         Issue: The type of "image" needs to be linked or defined.
 
-    : <dfn>outgoing styles</dfn>
+    : <dfn>old styles</dfn>
     :: a set of styles or null. Initially null.
 
         Issue: The type of "a set of styles" needs to be linked or defined.
 
-    : <dfn>incoming element</dfn>
+    : <dfn>new element</dfn>
     :: an element or null. Initially null.
 
         Issue: The type of "element" needs to be linked or defined.
@@ -474,7 +474,7 @@ callback UpdateDOMCallback = Promise<any> ();
 
     1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-    1. If |document|'s [=active DOM transition=] is not null, then [=skip the page transition=] |document|'s [=active DOM transition=]
+    1. If |document|'s [=active DOM transition=] is not null, then [=skip the view transition=] |document|'s [=active DOM transition=]
         with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
 
         Note: This can result in two asynchronous [=ViewTransition/DOM update
@@ -486,7 +486,7 @@ callback UpdateDOMCallback = Promise<any> ();
 
     1. Set |document|'s [=active DOM transition=] to |transition|.
 
-        Note: The process continues in [=perform an outgoing capture=] which is executed at the next [=rendering opportunity=].
+        Note: The process continues in [=perform an old capture=] which is executed at the next [=rendering opportunity=].
 
         Issue: Waiting on [html/8469](https://github.com/whatwg/html/pull/8468) to reference "rendering opportunity".
 
@@ -494,9 +494,9 @@ callback UpdateDOMCallback = Promise<any> ();
 </div>
 
 <div class=example>
-    If the default animations for the page transition are acceptable,
+    If the default animations for the view transition are acceptable,
     then kicking off a transition
-    requires nothing more than setting 'page-transition-tag' in the page's CSS,
+    requires nothing more than setting 'view-transition-name' in the element's CSS,
     and a single line of script to start it:
 
     <pre highlight=js>
@@ -510,13 +510,13 @@ callback UpdateDOMCallback = Promise<any> ();
 
     <pre highlight=js>
         async function doTransition() {
-            // Specify "outgoing" elements. The tag is used to match against
-            // "incoming" elements they should transition to, and to refer to
+            // Specify "old" elements. The tag is used to match against
+            // "new" elements they should transition to, and to refer to
             // the transitioning pseudo-element.
-            document.querySelector('.old-message').style.pageTransitionTag = 'message';
+            document.querySelector('.old-message').style.viewTransitionName = 'message';
 
             const transition = document.startViewTransition(async () => {
-                // This callback is invoked by the browser when "outgoing"
+                // This callback is invoked by the browser when "old"
                 // capture finishes and the DOM can be switched to the new
                 // state. No frames are rendered until this callback returns.
 
@@ -524,9 +524,9 @@ callback UpdateDOMCallback = Promise<any> ();
                 await coolFramework.changeTheDOMToPageB();
 
                 // Tagging elements during the callback marks them as
-                // "incoming", to be matched up with the same-tagged "outgoing"
+                // "new", to be matched up with the same-tagged "old"
                 // elements marked previously and transitioned between.
-                document.querySelector('.new-message').style.pageTransitionTag =
+                document.querySelector('.new-message').style.viewTransitionName =
                     'message';
               });
 
@@ -537,7 +537,7 @@ callback UpdateDOMCallback = Promise<any> ();
 
             document.documentElement.animate(keyframes, {
                 ...animationOptions,
-                pseudoElement: '::page-transition-container(message)',
+                pseudoElement: '::view-transition-group(message)',
             });
 
             // When the finished promise resolves, that means the transition is
@@ -571,7 +571,7 @@ A {{ViewTransition}} has the following:
 <dl dfn-for="ViewTransition">
     : <dfn>tagged elements</dfn>
     :: a [=/map=],
-        whose keys are [=page transition tags=] and whose values are [=captured elements=].
+        whose keys are [=view transition names=] and whose values are [=captured elements=].
         Initially a new [=map=].
 
     : <dfn>phase</dfn>
@@ -610,7 +610,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
     The [=method steps=] for <dfn method for="ViewTransition">skipTransition()</dfn> are:
 
     1. If [=this=]'s [=ViewTransition/phase=] is not "`done`",
-        then [=skip the page transition=] for [=this=]
+        then [=skip the view transition=] for [=this=]
         with an "{{AbortError}}" {{DOMException}}.
 </div>
 
@@ -661,15 +661,15 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
     1. If |document|'s [=document/active DOM transition=] is not null, then:
 
-        1. If |document|'s [=document/active DOM transition=]'s [=ViewTransition/phase=] is "`pending-capture`", then [=perform an outgoing capture=] with |document|'s [=document/active DOM transition=].
+        1. If |document|'s [=document/active DOM transition=]'s [=ViewTransition/phase=] is "`pending-capture`", then [=perform an old capture=] with |document|'s [=document/active DOM transition=].
 
         1. Otherwise, if |document|'s [=document/active DOM transition=]'s [=ViewTransition/phase=] is "`animating`", then [=update transition DOM=] for |document|'s [=document/active DOM transition=].
 </div>
 
-## [=Perform an outgoing capture=] ## {#perform-an-outgoing-capture-algorithm}
+## [=Perform an old capture=] ## {#perform-an-old-capture-algorithm}
 
 <div algorithm>
-    To <dfn>perform an outgoing capture</dfn> given a {{ViewTransition}} |transition|,
+    To <dfn>perform an old capture</dfn> given a {{ViewTransition}} |transition|,
         perform the following steps:
 
     1. Let |taggedElements| be |transition|'s [=ViewTransition/tagged elements=].
@@ -684,9 +684,9 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
         Issue: The link for "paint order" doesn't seem right.
             Is there a more canonical definition?
 
-        1. Let |transitionTag| be the [=computed value=] of 'page-transition-tag' for |element|.
+        1. Let |transitionTag| be the [=computed value=] of 'view-transition-name' for |element|.
 
-        1. If |transitionTag| is ''page-transition-tag/none'',
+        1. If |transitionTag| is ''view-transition-name/none'',
             or |element| is [=element-not-rendered|not rendered=],
             then [=continue=].
 
@@ -698,7 +698,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
             * |element| is not |element|'s [=tree/root=] and |element| allows [=fragmentation=].
 
-            Then [=skip the page transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}}
+            Then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}}
                 in |transition|'s [=relevant Realm=],
                 and return.
 
@@ -706,9 +706,9 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
         1. Let |capture| be a new [=captured element=] struct.
 
-        1. Set |capture|'s [=outgoing image=] to the result of [=capturing the image=] of |element|.
+        1. Set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
 
-        1. Set |capture|'s [=outgoing styles=] to the following:
+        1. Set |capture|'s [=old styles=] to the following:
 
             : 'transform'
             :: A CSS transform that would place |element|
@@ -722,7 +722,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
             : 'object-view-box'
             :: An 'object-view-box' value that,
-                when applied to the outgoing image,
+                when applied to the old image,
                 will cause the view box to coincide with |element|'s [=border box=]
                 in the image.
 
@@ -749,7 +749,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
         1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
 
-            Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
+            Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
         1. [=Call the DOM update callback=] of |transition|.
 
@@ -759,15 +759,15 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
                 1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
 
-                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
+                    Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
-                1. [=Skip the page transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+                1. [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
             * If the promise was resolved, then:
 
                 1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
 
-                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
+                    Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
                 1. Set [=document/transition suppressing rendering=] to false.
 
@@ -779,9 +779,9 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
                     Issue: The link for "paint order" doesn't seem right.
                         Is there a more canonical definition?
 
-                    1. Let |transitionTag| be the [=computed value=] of 'page-transition-tag' for |element|.
+                    1. Let |transitionTag| be the [=computed value=] of 'view-transition-name' for |element|.
 
-                    1. If |transitionTag| is ''page-transition-tag/none'',
+                    1. If |transitionTag| is ''view-transition-name/none'',
                         or |element| is [=element-not-rendered|not rendered=],
                         then [=continue=].
 
@@ -795,7 +795,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
                         * |element| is not |element|'s [=tree/root=]
                             and |element| allows [=fragmentation=].
 
-                        Then [=skip the page transition=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
+                        Then [=skip the view transition=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
                             and return.
 
                     1. [=set/Append=] |transitionTag| to |usedTransitionTags|.
@@ -805,11 +805,11 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
                     1. Let |capture| be |taggedElements|[|transitionTag|].
 
-                    1. Let |capture|'s [=incoming element=] item be |element|.
+                    1. Let |capture|'s [=new element=] item be |element|.
 
                 1. [=Create transition pseudo-elements=] for |transition|.
 
-                1. [=Animate a page transition=] |transition|.
+                1. [=Animate a view transition=] |transition|.
 
                     Note: This will require running document lifecycle phases
                         to compute information calculated during style/layout.
@@ -822,15 +822,15 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
                 1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
 
-                    Note: This happens if |transition| was [=skip the page transition|skipped=] before this point.
+                    Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
-                1. [=Skip the page transition=] |transition| with |r|.
+                1. [=skip the view transition=] |transition| with |r|.
 </div>
 
-## Skip the page transition ## {#skip-the-page-transition-algorithm}
+## skip the view transition ## {#skip-the-view-transition-algorithm}
 
 <div algorithm>
-    To <dfn>skip the page transition</dfn> for {{ViewTransition}} |transition| with reason |reason|:
+    To <dfn>skip the view transition</dfn> for {{ViewTransition}} |transition| with reason |reason|:
 
     1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
@@ -844,7 +844,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
     1. If |transition|'s [=ViewTransition/phase=] is equal to or [=phases/after=] "`animating`", then:
 
-        1. Remove all associated [=page-transition pseudo-elements=] from |document|.
+        1. Remove all associated [=view-transition pseudo-elements=] from |document|.
 
             Issue: There needs to be a definition/link for "remove".
 
@@ -875,10 +875,10 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
         * If the referenced element has a transform applied to it (or its ancestors),
             then the transform is ignored.
 
-            Note: This transform is applied to the snapshot using the `transform` property of the associated ''::page-transition-container'' pseudo-element.
+            Note: This transform is applied to the snapshot using the `transform` property of the associated ''::view-transition-group'' pseudo-element.
 
         * [=list/For each=] |descendant| of [=shadow-including descendant=] {{Element}} and [=pseudo-element=] of |element|,
-            if |descendant| has a [=computed value=] of 'page-transition-tag' that is not ''page-transition-tag/none'',
+            if |descendant| has a [=computed value=] of 'view-transition-name' that is not ''view-transition-name/none'',
             then skip painting |descendant|.
 
             Note: This is necessary since the descendant will generate its own snapshot which will be displayed and animated independently.
@@ -904,9 +904,9 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
     1. Let |hasActiveAnimations| be a boolean, initially false.
 
-    1. For each [=page-transition pseudo-elements=] associated with |transition|:
+    1. For each [=view-transition pseudo-elements=] associated with |transition|:
 
-        1. Let |element| be the [=page-transition pseudo-element=].
+        1. Let |element| be the [=view-transition pseudo-element=].
 
         1. For each |animation| whose [=timeline=] is a [=document timeline=] associated with |document|,
             and contains at least one [=animation/associated effect=] whose [=effect target=] is |element|,
@@ -926,7 +926,7 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
         1. Set |transition|'s [=ViewTransition/phase=] to "`done`".
 
-        1. Remove all associated [=page-transition pseudo-elements=] from |document|.
+        1. Remove all associated [=view-transition pseudo-elements=] from |document|.
 
             Issue: There needs to be a definition/link for "remove".
 
@@ -940,14 +940,14 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
     1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=ViewTransition/tagged elements=]:
 
-        1. If |capturedElement| has an "incoming element", run [=capture the image=]
-            on |capturedElement|'s "incoming element" and update the displayed
-            image for ''::page-transition-incoming-image'' with the tag |tag|.
+        1. If |capturedElement| has an "new element", run [=capture the image=]
+            on |capturedElement|'s "new element" and update the displayed
+            image for ''::view-transition-new'' with the tag |tag|.
 
             At the [=user-agent origin=],
-            set |incoming|'s 'object-view-box' property
-            to a value that when applied to |incoming|,
-            will cause the view box to coincide with "incoming element"'s [=border box=]
+            set |new|'s 'object-view-box' property
+            to a value that when applied to |new|,
+            will cause the view box to coincide with "new element"'s [=border box=]
             in the image.
 
         1. ...
@@ -975,25 +975,25 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
         Issue: Define the algorithm used to clip the snapshot when it exceeds max size.
 </div>
 
-## [=Animate a page transition=] ## {#animate-a-page-transition-algorithm}
+## [=Animate a view transition=] ## {#animate-a-view-transition-algorithm}
 
 <div algorithm>
-    To <dfn>animate a page transition</dfn> given a {{ViewTransition}} |transition|:
+    To <dfn>animate a view transition</dfn> given a {{ViewTransition}} |transition|:
 
-    1. Generate a <<keyframe>> named "page-transition-fade-out" in
+    1. Generate a <<keyframe>> named "view-transition-fade-out" in
         [=user-agent origin=] as follows:
 
         <pre><code highlight=css>
-            @keyframes page-transition-fade-out {
+            @keyframes view-transition-fade-out {
                   to { opacity: 0; }
             }
         </code></pre>
 
-    1. Generate a <<keyframe>> named "page-transition-fade-in" in
+    1. Generate a <<keyframe>> named "view-transition-fade-in" in
         [=user-agent origin=] as follows:
 
         <pre><code highlight=css>
-            @keyframes page-transition-fade-in {
+            @keyframes view-transition-fade-in {
                   from { opacity: 0; }
             }
         </code></pre>
@@ -1001,30 +1001,30 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
     1. Apply the following styles in [=user-agent origin=]:
 
         <pre><code highlight=css>
-            html::page-transition-outgoing-image(*) {
-                animation-name: page-transition-fade-out;
+            html::view-transition-old(*) {
+                animation-name: view-transition-fade-out;
             }
 
-            html::page-transition-incoming-image(*) {
-                animation-name: page-transition-fade-in;
+            html::view-transition-new(*) {
+                animation-name: view-transition-fade-in;
             }
         </code></pre>
 
     1. [=map/For each=] |tag| -> |capturedElement| of |transition|'s [=ViewTransition/tagged elements=]:
 
-        1. If neither of |capturedElement|'s [=captured element/outgoing image=] or [=captured element/incoming element=] is null:
+        1. If neither of |capturedElement|'s [=captured element/old image=] or [=captured element/new element=] is null:
 
-            1. Let 'transform' be |capturedElement|'s [=outgoing styles=]'s 'transform' property.
+            1. Let 'transform' be |capturedElement|'s [=old styles=]'s 'transform' property.
 
-            1. Let 'width' be |capturedElement|'s [=outgoing styles=]'s 'width' property.
+            1. Let 'width' be |capturedElement|'s [=old styles=]'s 'width' property.
 
-            1. Let 'height' be |capturedElement|'s [=outgoing styles=]'s 'height' property.
+            1. Let 'height' be |capturedElement|'s [=old styles=]'s 'height' property.
 
-            1. Generate a <<keyframe>> named "page-transition-container-anim-|tag|" in
+            1. Generate a <<keyframe>> named "view-transition-group-anim-|tag|" in
                 [=user-agent origin=] as follows:
 
             <pre><code highlight=css>
-                @keyframes page-transition-container-anim-|tag| {
+                @keyframes view-transition-group-anim-|tag| {
                     from {
                         transform: |transform|;
                         width: |width|;
@@ -1036,8 +1036,8 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
         1. Apply the following styles in [=user-agent origin=]:
 
             <pre><code highlight=css>
-                html::page-transition-container(|tag|) {
-                    animation-name: page-transition-container-anim-|tag|;
+                html::view-transition-group(|tag|) {
+                    animation-name: view-transition-group-anim-|tag|;
                 }
             </code></pre>
 
@@ -1050,11 +1050,11 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 <div algorithm>
     To <dfn>create transition pseudo-elements</dfn> for a {{ViewTransition}} |transition|:
 
-    1. Let |transitionRoot| be the result of creating a new ''::page-transition'' pseudo-element.
+    1. Let |transitionRoot| be the result of creating a new ''::view-transition'' pseudo-element.
 
     1. [=map/For each=] |transitionTag| → |capturedElement| of |transition|'s [=ViewTransition/tagged elements=]:
 
-        1. Let |container| be the result of creating a new ''::page-transition-container'' pseudo-element with the tag |transitionTag|.
+        1. Let |container| be the result of creating a new ''::view-transition-group'' pseudo-element with the tag |transitionTag|.
 
             Issue: "tag" should be defined/linked.
 
@@ -1065,65 +1065,65 @@ The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=Vi
 
         1. Let |width|, |height|, |transform|, |writingMode|, and |direction| be null.
 
-        1. If |capturedElement|'s [=incoming element=] is null, then:
+        1. If |capturedElement|'s [=new element=] is null, then:
 
-            1. Set |width| to |capturedElement|'s [=outgoing styles=] 'width' property.
+            1. Set |width| to |capturedElement|'s [=old styles=] 'width' property.
 
-            1. Set |height| to |capturedElement|'s [=outgoing styles=] 'height' property.
+            1. Set |height| to |capturedElement|'s [=old styles=] 'height' property.
 
-            1. Set |transform| to |capturedElement|'s [=outgoing styles=] 'transform' property.
+            1. Set |transform| to |capturedElement|'s [=old styles=] 'transform' property.
 
-            1. Set |writingMode| to |capturedElement|'s [=outgoing styles=] 'writing-mode' property.
+            1. Set |writingMode| to |capturedElement|'s [=old styles=] 'writing-mode' property.
 
-            1. Set |direction| to |capturedElement|'s [=outgoing styles=] 'direction' property.
+            1. Set |direction| to |capturedElement|'s [=old styles=] 'direction' property.
 
         1. Otherwise:
 
-            1. Set |width| to the current width of |capturedElement|'s [=incoming element=]'s [=border box=].
+            1. Set |width| to the current width of |capturedElement|'s [=new element=]'s [=border box=].
 
-            1. Set |height| to the current height of |capturedElement|'s [=incoming element=]'s [=border box=].
+            1. Set |height| to the current height of |capturedElement|'s [=new element=]'s [=border box=].
 
-            1. Set |transform| to a transform that maps the |capturedElement|'s [=incoming element=]'s [=border box=] from document origin to its quad in layout viewport.
+            1. Set |transform| to a transform that maps the |capturedElement|'s [=new element=]'s [=border box=] from document origin to its quad in layout viewport.
 
-            1. Set |writingMode| to the [=computed value=] of 'writing-mode' on |capturedElement|'s [=incoming element=].
+            1. Set |writingMode| to the [=computed value=] of 'writing-mode' on |capturedElement|'s [=new element=].
 
-            1. Set |direction| to the [=computed value=] of 'direction' on |capturedElement|'s [=incoming element=].
+            1. Set |direction| to the [=computed value=] of 'direction' on |capturedElement|'s [=new element=].
 
         1. At the [=user-agent origin=],
             set |container|'s 'width', 'height', 'transform', 'writing-mode', and 'direction' properties
             to |width|, |height|, |transform|, |writingMode|, and |direction|.
 
-        1. Let |imageWrapper| be a new ''::page-transition-image-wrapper'' pseudo-element with the tag |transitionTag|.
+        1. Let |imagePair| be a new ''::view-transition-image-pair'' pseudo-element with the tag |transitionTag|.
 
-        1. Append |imageWrapper| to |container|.
+        1. Append |imagePair| to |container|.
 
-        1. If |capturedElement|'s [=captured element/outgoing image=] is not null, then:
+        1. If |capturedElement|'s [=captured element/old image=] is not null, then:
 
-            1. Let |outgoing| be a new ''::page-transition-outgoing-image'' [=replaced element=] pseudo-element,
+            1. Let |old| be a new ''::view-transition-old'' [=replaced element=] pseudo-element,
                 with the tag |transitionTag|,
-                displaying |capturedElement|'s [=captured element/outgoing image=].
+                displaying |capturedElement|'s [=captured element/old image=].
 
-            1. Append |outgoing| to |imageWrapper|.
+            1. Append |old| to |imagePair|.
 
             1. At the [=user-agent origin=],
-                set |outgoing|'s 'object-view-box' property to |capturedElement|'s [=outgoing styles=] 'object-view-box' property.
+                set |old|'s 'object-view-box' property to |capturedElement|'s [=old styles=] 'object-view-box' property.
 
                 Issue: Which of ''xywh()''/''rect()''/''inset()'' should we use?
 
-        1. If |capturedElement|'s [=incoming element=] is not null, then:
+        1. If |capturedElement|'s [=new element=] is not null, then:
 
-            1. Let |incoming| be a new ''::page-transition-incoming-image'' [=replaced element=] pseudo-element, with the tag |transitionTag|, displaying the [=capture the image=] of |capturedElement|'s [=incoming element=].
+            1. Let |new| be a new ''::view-transition-new'' [=replaced element=] pseudo-element, with the tag |transitionTag|, displaying the [=capture the image=] of |capturedElement|'s [=new element=].
 
-            1. Append |incoming| to |imageWrapper|.
+            1. Append |new| to |imagePair|.
 
             1. At the [=user-agent origin=],
-                set |incoming|'s 'object-view-box' property to a value that when applied to |incoming|,
-                will cause the view box to coincide with [=incoming element=]'s [=border box=] in the image.
+                set |new|'s 'object-view-box' property to a value that when applied to |new|,
+                will cause the view box to coincide with [=new element=]'s [=border box=] in the image.
 
-            The [=incoming element=] and its contents (the flat tree descendants of the element,
+            The [=new element=] and its contents (the flat tree descendants of the element,
             including both text and elements, or the replaced content of a replaced element), except the
-            [=page-transition pseudo-elements=], are not painted (as if they had visibility: hidden) and
-            do not respond to hit-testing (as if they had pointer-events: none) until |incoming| exists.
+            [=view-transition pseudo-elements=], are not painted (as if they had visibility: hidden) and
+            do not respond to hit-testing (as if they had pointer-events: none) until |new| exists.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Rename everything based on resolution at https://github.com/w3c/csswg-drafts/issues/7960. This also includes a tentative rename for page-transition-image-wrapper to keep the spec consistent.
