### PR TITLE
[selectors-4] Make empty language strings match untagged elements. #6915

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1915,9 +1915,16 @@ The Language Pseudo-class: '':lang()''</h3>
 	when represented in BCP 47 syntax [[BCP47]],
 	it matches that <a>language range</a> in an <var>extended filtering</var>
 	operation per [[RFC4647]] <cite>Matching of Language Tags</cite> (section 3.3.2).
+	For this purpose, a wildcard [=language range=] (<code>"*"</code>) does not match
+	elements whose language is not tagged (e.g. <code>lang=""</code>),
+	but does match elements whose language is tagged as undetermined (<code>lang=und</code>).
 	The matching is performed [=ASCII case-insensitively=].
 	The <a>language range</a> does not need to be a valid language code to
 	perform this comparison.
+
+	A [=language range=] consisting of an empty string
+	('':lang("")'')
+	matches (only) elements whose language is not tagged.
 
 	Note: It is recommended that documents and protocols
 	indicate language using codes from [[BCP47]] or its successor,


### PR DESCRIPTION
Wasn't clear whether the resolution mapped both `:lang()` and `:lang("")` or just `:lang("")` ...