### PR TITLE
[css-images-3] remove && from <linear-color-stop> syntax

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -887,7 +887,7 @@ Color Stop Lists</h4>
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
 			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
-		<dfn>&lt;linear-color-stop></dfn> = <<color>> && <<length-percentage>>?
+		<dfn>&lt;linear-color-stop></dfn> = <<color>> <<length-percentage>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 	</pre>
 


### PR DESCRIPTION
w3c/csswg-drafts@c03b2ea changed `<color-stop> = <color> <length-percentage>?` to `<linear-color-stop> = <color> && <length-percentage>?`
I believe the `&&` was a mistake, since `<length-percentage> <color>` doesn't seem to be valid?

Note: This also affects [css-images-4], which uses the same definition.