### PR TITLE
[css-contain-2] Adds missing attribute values. 

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -100,7 +100,7 @@ Strong Containment: the 'contain' property</h2>
 		Initial: none
 		Inherited: no
 		Applies to: See <a href="#contain-applies">below</a>
-		Computed value: the keyword ''contain/none'' or one or more of ''size'', ''layout'', ''paint''
+		Computed value: the keyword ''contain/none'' or one or more of ''size'', ''layout'', ''style'', ''paint''
 		Animation type: not animatable
 	</pre>
 


### PR DESCRIPTION
maybe? I don't know why it doesn't have this property. 
