### PR TITLE
[css-nesting] fix `@layer` example

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -450,7 +450,7 @@ Syntax {#syntax}
 		  html {
 				block-size: 100%;
 
-				@layer base.support {
+				@layer support {
 					& body {
 						min-block-size: 100%;
 					}


### PR DESCRIPTION
@tabatkins @argyleink 

`@layer` already defines how nesting multiple `@layer` rules works.
In that case sub layers are created.

```css
@layer foo {
  @layer bar {

  }
}

/* equivalent to */

@layer foo.bar {}
```