### PR TITLE
[css2] Fix reference to border-bottom-width

### DIFF
--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -5664,7 +5664,7 @@ buttons, menus, etc.) differently than for
 defined in this section refer to the <dfn id="value-def-border-width">&lt;border-width&gt;</dfn>
 value type, which may take one of the following values:</p>
 
-<dl data-dfn-for="&lt;border-width&gt;,border-top-width,border-right-width,border-bottom-right,border-left-width,border-width" data-dfn-type="value" >
+<dl data-dfn-for="&lt;border-width&gt;,border-top-width,border-right-width,border-bottom-width,border-left-width,border-width" data-dfn-type="value" >
 <dt><dfn id="valdef-border-width-thin">thin</dfn>
 <dd>A thin border.
 <dt><dfn id="valdef-border-width-medium">medium</dfn>


### PR DESCRIPTION
The `data-dfn-for` attribute incorrectly referenced the non-existing `border-bottom-right` property, instead of `border-bottom-width` (this attribute's value is typically used to generate the index at the end of the spec).
