### PR TITLE
[css2] Drop duplicated dfn of `@media` at-rule

### DIFF
--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -4949,7 +4949,7 @@ the <a href="#assigning">chapter on the cascade</a>.
 
 <h4 id="at-media-rule">The <dfn id="at-ruledef-media" data-dfn-type="at-rule" data-export="">@media</dfn> rule</h4>
 
-<p>An <dfn data-lt="media">@media</dfn> rule
+<p>An <a>@media</a> rule
 specifies the target <a href="#media-types">media types</a> (separated
 by commas) of a set of <a href="#tokenization">statements</a> (delimited by curly
 braces). Invalid statements must be ignored per <a href="#rule-sets">4.1.7 "Rule sets, declaration blocks,


### PR DESCRIPTION
The `@media` at-rule was defined twice, first time in the heading and second time in the prose without the `@` prefix. Both were flagged as "exported". This update replaces the second one with a reference to the first to avoid the duplication (and avoid the creation of an at-rule without the `@` prefix).
