### PR TITLE
[web-animations-2] Don't convert mixed times and proportions to proportional.

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -226,18 +226,12 @@ Append:
 
 > Animation effects associated with a [=progress-based timeline=] require their
 > timing properties to be converted to proportions. The procedure for converting
-> a <dfn lt="time-based animation to a proportional animation"></dfn> is as
+> a <dfn lt="time-based animation to a proportional animation">time-based
+> animation to a proportional animation</dfn> is as
 > follows:
 >
-> 1.  If the [=iteration duration=] is auto, then perform the following steps.
->     *   Set [=start delay=] and [=end delay=] to 0, as it is not
->         possible to mix time and proportions.
->
->         Note: Future versions may allow these properties to be assigned
->         percentages, at which point the delays are only to be ignored if
->         their values are expressed as times and not as percentages.
->
->     Otherwise:
+> 1.  If the [=iteration duration=], [=start delay=], and [=end delay=] are
+>     all <<time>> values, then:
 >          1. Let <var>total time</var> be equal to [=end time=]
 >          1. Set [=start delay=] to be the result of evaluating
 >             <code>|specified start delay| / |total time| *
@@ -248,6 +242,11 @@ Append:
 >          1. Set [=end delay=] to be the result of evaluating
 >             <code>|specified end delay| / |total time| *
 >             |timeline duration|</code>.
+>
+>     Otherwise:
+>     *   If [=start delay=] is a <<time>>, set it to 0%.
+>     *   If [=end delay=] is a <<time>>, set it to 100%.
+>     *   If [=iteration duration=] is a <<time>>, set it to be auto.
 >
 > The procedure to <dfn>normalize specified timing</dfn> is as follows:
 >

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -226,8 +226,7 @@ Append:
 
 > Animation effects associated with a [=progress-based timeline=] require their
 > timing properties to be converted to proportions. The procedure for converting
-> a <dfn lt="time-based animation to a proportional animation">time-based
-> animation to a proportional animation</dfn> is as
+> a <dfn>time-based animation to a proportional animation</dfn> is as
 > follows:
 >
 > 1.  If the [=iteration duration=], [=start delay=], and [=end delay=] are


### PR DESCRIPTION
[web-animations-2] Don't convert mixed times and proportions to proportional #7749

In supporting the timeline range based start and end delays on animations we should only convert time based animations if all values are time based so as not to clobber any developer set proportional values.