### PR TITLE
[web-animations-1] Animations are current if associated with non-increasing timelines.

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2396,8 +2396,9 @@ of the following conditions are true:
 *   the [=animation effect=] is [=associated with an animation=] with
     a [=playback rate=] &lt; 0 and
     the [=animation effect=] is in the [=animation effect/after phase=].
-*   the [=animation effect=] is [=associated with an animation=] with an
-    associated [=timeline=] that is not [=monotonically increasing=].
+*   the [=animation effect=] is [=associated with an animation=] not in the
+    [=play state/idle=] [=play state=] with a non-null associated
+    [=timeline=] that is not [=monotonically increasing=].
 
 An animation effect is <dfn>in effect</dfn> if its <a>active time</a>, as
 calculated according to the procedure in [[#calculating-the-active-time]],

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2395,7 +2395,7 @@ of the following conditions are true:
     the [=animation effect=] is in the [=animation effect/before phase=], or
 *   the [=animation effect=] is [=associated with an animation=] with
     a [=playback rate=] &lt; 0 and
-    the [=animation effect=] is in the [=animation effect/after phase=].
+    the [=animation effect=] is in the [=animation effect/after phase=], or
 *   the [=animation effect=] is [=associated with an animation=] not in the
     [=play state/idle=] [=play state=] with a non-null associated
     [=timeline=] that is not [=monotonically increasing=].

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2396,6 +2396,8 @@ of the following conditions are true:
 *   the [=animation effect=] is [=associated with an animation=] with
     a [=playback rate=] &lt; 0 and
     the [=animation effect=] is in the [=animation effect/after phase=].
+*   the [=animation effect=] is [=associated with an animation=] with an
+    associated [=timeline=] that is not [=monotonically increasing=].
 
 An animation effect is <dfn>in effect</dfn> if its <a>active time</a>, as
 calculated according to the procedure in [[#calculating-the-active-time]],


### PR DESCRIPTION
[web-animations-1] Animations are current if associated with non-increasing timelines.

If an animation is associated with a non-monotically increasing timeline it may become active in the future. As such it should still be considered current (the same as an animation which may play in the future). This fixes #8053.