### PR TITLE
[web-animations-1] Maintain start time when changing playback rate for non-monotonic animations

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1846,7 +1846,8 @@ is as follows:
 
 1.  Set the [=playback rate=] to <var>new playback rate</var>.
 
-1.  If <var>previous time</var> is <a lt="unresolved">resolved</a>,
+1.  If the <var>animation</var> is associated with a [=monotonically increasing=]
+    [=timeline=] and <var>previous time</var> is <a lt="unresolved">resolved</a>,
     <a>set the current time</a> of <var>animation</var> to
     <var>previous time</var>
 


### PR DESCRIPTION
[web-animations-1] Maintain start time when changing playback rate for non-monotonic animations

Animations associated with non-monotonic timelines typically anchor to the start of their associated timeline. Setting the playback rate currently would change that by explicitly setting the current time after changing the playback rate which implicitly changes the start time. This would result in the animation getting out of sync with the timeline range. This fixes #2075.