### PR TITLE
[cssom-view-1] Restore `scrollTo({ behavior: "instant" }`

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -359,11 +359,13 @@ the following steps must be run:
   </ul>
   ...then perform a <a>smooth scroll</a> of <var>box</var> to <var>position</var>. Once the position has finished updating, emit the <a event>scrollend</a> event.
   Otherwise, perform an <a>instant scroll</a> of <var>box</var> to <var>position</var>. After an <a>instant scroll</a> emit the <a event>scrollend</a> event.
-  
+
+  Note: <code>behavior: "instant"</code> always performs an <a>instant scroll</a> by this algorithm.
+
   Note: If the scroll position did not change as a result of the user interaction or programmatic invocation, where no translations were applied as a result, then no <a event>scrollend</a> event fires because no scrolling occured.
 </ol>
 
-Scroll is <dfn lt="scroll completed">completed</dfn> when the scroll position has no more pending updates or translations and the user has completed their gesture. Scroll position updates include smooth or instant mouse wheel scrolling, keyboard scrolling, scroll-snap events, or other APIs and gestures which cause the scroll position to update and possibly interpolate. User gestures like touch panning or trackpad scrolling aren't complete until pointers or keys have released. 
+Scroll is <dfn lt="scroll completed">completed</dfn> when the scroll position has no more pending updates or translations and the user has completed their gesture. Scroll position updates include smooth or instant mouse wheel scrolling, keyboard scrolling, scroll-snap events, or other APIs and gestures which cause the scroll position to update and possibly interpolate. User gestures like touch panning or trackpad scrolling aren't complete until pointers or keys have released.
 
 When a user agent is to perform a <dfn export id=concept-smooth-scroll>smooth scroll</dfn> of a <a>scrolling box</a> <var>box</var> to <var>position</var>,
 it must update the scroll position of <var>box</var> in a user-agent-defined fashion over a user-agent-defined amount of time. When the scroll is
@@ -400,7 +402,7 @@ then <var>x</var> must be changed to the value <code>0</code>. [[!WEBIDL]]
 <h2 id=extensions-to-the-window-interface>Extensions to the {{Window}} Interface</h2>
 
 <pre class=idl>
-enum ScrollBehavior { "auto", "smooth" };
+enum ScrollBehavior { "auto", "instant", "smooth" };
 
 dictionary ScrollOptions {
     ScrollBehavior behavior = "auto";


### PR DESCRIPTION
This reverts commit b270d9091a211f67aec9e7740dde1de845181e8e.

Also clarifies that the algorithm covers `behavior: "instant"` so that no one will retry removing it.

Closes #7773 