### PR TITLE
[resize-observer] Update initial value of lastReportedSizes #3664

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -72,6 +72,8 @@ counterpart to {{Window}}'s {{Window/resize}} event.
 
 ResizeObserver's notifications can be used to respond to changes in {{Element}}'s size. Some interesting facts about these observations:
 
+* Observation will fire when observation starts.
+
 * Observation will fire when watched Element is inserted/removed from DOM.
 
 * Observation will fire when watched Element <a>display</a> gets set to none.
@@ -79,8 +81,6 @@ ResizeObserver's notifications can be used to respond to changes in {{Element}}'
 * Observations do not fire for non-replaced inline Elements.
 
 * Observations will not be triggered by CSS transforms.
-
-* Observation will fire when observation starts if Element is [being rendered](https://html.spec.whatwg.org/#being-rendered), and Element's size is not 0,0.
 
 <div class="example">
   <pre highlight="html">
@@ -331,7 +331,7 @@ interface ResizeObservation {
 
         3. Set |this| internal {{ResizeObservation/observedBox}} slot to |observedBox|.
 
-        4. Set |this| internal {{ResizeObservation/lastReportedSizes}} slot to [(0,0)].
+        4. Set |this| internal {{ResizeObservation/lastReportedSizes}} slot to [(-1,-1)].
 
     : <dfn method lt="isActive()">isActive()</dfn>
     ::


### PR DESCRIPTION
Outcome: https://github.com/w3c/csswg-drafts/issues/3664#issuecomment-1218270926
> When first observing an element with ResizeObserver, lastReportedSize gets initialized with a -1 x -1 size