### PR TITLE
[css-view-transitions-1] Define pseudo-nesting and naming

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -199,7 +199,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 ## Pseudo-element parents ## {#parent-pseudo}
 
-	A <dfn>pseudo-element parent</dfn> is a mixin that has <dfn for="pseudo-element parent">children</dfn>,
+	A <dfn>pseudo-element parent</dfn> is a mixin for [=tree-abiding pseudo-elements=] that has <dfn for="pseudo-element parent">children</dfn>,
 	a [=/list=] of [=pseudo-elements=].
 	Initially an empty [=/list=].
 
@@ -227,7 +227,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 ## Named view-transition pseudo-elements ## {#named-view-transition-pseudo}
 
-	A <dfn>named view-transition pseudo-element</dfn> is a mixin for [=pseudo-elements=]
+	A <dfn>named view-transition pseudo-element</dfn> is a mixin for [=tree-abiding pseudo-elements=]
 	that also have a <dfn for="named view-transition pseudo-element">view-transition name</dfn>,
 	a string.
 
@@ -249,7 +249,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 ## View transition pseudo-elements ## {#view-transition-pseudos}
 
 	: <dfn>::view-transition</dfn>
-	:: A [=pseudo-element parent=].
+	:: A [=tree-abiding pseudo-element=] that is also
+		a [=pseudo-element parent=].
 		Its [=originating element=] is the document's [=document element=].
 
 		The following is added to the [=HTML user agent style sheet=]:
@@ -270,7 +271,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		</div>
 
 	: <dfn>::view-transition-group( <<pt-name-selector>> )</dfn>
-	:: A [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=] that is also
+		a [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 
@@ -299,7 +301,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		</div>
 
 	: <dfn>::view-transition-image-pair( <<pt-name-selector>> )</dfn>
-	:: A [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=] that is also
+		a [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 
@@ -318,7 +321,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		Note: This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition-group()''.
 
 	: <dfn>::view-transition-old( <<pt-name-selector>> )</dfn>
-	:: A [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=] that is also
+		a [=named view-transition pseudo-element=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -199,7 +199,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 ## Pseudo-element root ## {#pseudo-root}
 
-	Issue: This definition should be moved to [[css-pseudo-4]].
+	Note: This is a general definition for trees of pseudo-elements. If other features need this behavior, these definitions will be moved to [[css-pseudo-4]].
 
 	A <dfn>pseudo-element root</dfn> is a type of [=tree-abiding pseudo-element=] that is the [=tree/root=] in a [=tree=] of [=tree-abiding pseudo-elements=],
 	known as the <dfn>pseudo-element tree</dfn>.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -259,6 +259,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		a [=pseudo-element parent=].
 		Its [=originating element=] is the document's [=document element=].
 
+		Its [=containing block=] is the [=snapshot viewport=].
+
 		The following is added to the [=HTML user agent style sheet=]:
 
 		```css
@@ -422,8 +424,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	- The [=view-transition layer=] paints after the stacking context for the [=document element=] and [=top layer=].
 
-	- The [=view-transition layer=]'s [=containing block=] is the [=snapshot viewport=].
-
 	Note: The intent of the feature is to be able to capture the contents of the page, which includes the top layer elements.
 	In order to accomplish that, the [=view-transition layer=] cannot be a part of the captured top layer context,
 	since that results in a circular dependency.
@@ -499,6 +499,16 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			Note: This is used to hold dynamic styles relating to transitions.
 	</dl>
+
+## Additions to [=document element=] ## {#additions-to-document-element}
+
+	A [=document element=] additionally has a <dfn for="document element">view-transition root pseudo-element</dfn>.
+	A ''::view-transition'' or null. Initially null.
+
+	When this is a ''::view-transition'', the ''::view-transition'' renders as a child of the [=document element=],
+	and the [=document element=] is its [=originating element=].
+
+	Note: The position of the ''::view-transition'' within the [=document element=] does not matter, as the ''::view-transition'''s [=containing block=] is the [=snapshot viewport=].
 
 # API # {#api}
 
@@ -1054,7 +1064,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-		1. [=list/Append=] |transition|'s [=ViewTransition/transition root pseudo-element=] to this |document|'s [=snapshot viewport=]'s [=pseudo-element parent/children=].
+		1. Set |document|'s [=document element=]'s [=view-transition root pseudo-element=] to |transition|'s [=ViewTransition/transition root pseudo-element=].
 
 		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=]:
 
@@ -1281,8 +1291,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. [=list/Remove=] |transition|'s [=ViewTransition/transition root pseudo-element=]
-			from |document|'s [=snapshot viewport=]'s [=pseudo-element parent/children=].
+		1. Set |document|'s [=document element=]'s [=view-transition root pseudo-element=] to null.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1282,6 +1282,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 					and |style| is in |document|'s [=document/view transition style sheet=],
 					then remove |style| from |document|'s [=document/view transition style sheet=].
 
+		1. Set |document|'s [=document/show view-transition root pseudo-element=] to false.
+
 		1. Set |document|'s [=document/active DOM transition=] to null.
 	</div>
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -212,7 +212,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
 	then |pseudo|'s [=originating pseudo-element=] is |parent|.
 
-	If a [=pseudo-element parent=]'s [=pseudo-element parent/children=]'s [=list/size=] is 1, then '':only-child'' selects [=pseudo-element parent/children=][0].
+	If a [=pseudo-element parent=]'s [=pseudo-element parent/children=]'s [=list/size=] is 1, then '':only-child'' selects [=pseudo-element parent/children=][0]. Otherwise, '':only-child'' selects nothing.
+
+	Note: This means that `::view-transition-new(ident):only-child` will only select `::view-transition-new(ident)` if the parent `::view-transitions-image-pair(ident)` only contains one child. As in, there is no `::view-transition-old(ident)`.
 
 	<div algorithm>
 		To get the <dfn for="pseudo-element parent">descendants</dfn> of a [=pseudo-element parent=] |parent|, perform the following steps.
@@ -498,17 +500,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			Initially a new [=style sheet=] in the [=user-agent origin=], ordered after the [=HTML user agent style sheet=].
 
 			Note: This is used to hold dynamic styles relating to transitions.
+
+		: <dfn>view-transition root pseudo-element</dfn>
+		:: A ''::view-transition'' or null. Initially null.
+			When this is a ''::view-transition'', the ''::view-transition'' renders as a child of the [=document element=],
+			and the [=document element=] is its [=originating element=].
+
+			Note: The position of the ''::view-transition'' within the [=document element=] does not matter, as the ''::view-transition'''s [=containing block=] is the [=snapshot viewport=].
 	</dl>
-
-## Additions to [=document element=] ## {#additions-to-document-element}
-
-	A [=document element=] additionally has a <dfn for="document element">view-transition root pseudo-element</dfn>.
-	A ''::view-transition'' or null. Initially null.
-
-	When this is a ''::view-transition'', the ''::view-transition'' renders as a child of the [=document element=],
-	and the [=document element=] is its [=originating element=].
-
-	Note: The position of the ''::view-transition'' within the [=document element=] does not matter, as the ''::view-transition'''s [=containing block=] is the [=snapshot viewport=].
 
 # API # {#api}
 
@@ -1064,7 +1063,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-		1. Set |document|'s [=document element=]'s [=view-transition root pseudo-element=] to |transition|'s [=ViewTransition/transition root pseudo-element=].
+		1. Set |document|'s [=view-transition root pseudo-element=] to |transition|'s [=ViewTransition/transition root pseudo-element=].
 
 		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=]:
 
@@ -1291,7 +1290,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. Set |document|'s [=document element=]'s [=view-transition root pseudo-element=] to null.
+		1. Set |document|'s [=view-transition root pseudo-element=] to null.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -197,40 +197,23 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 # Pseudo-elements # {#pseudo}
 
-## Pseudo-element parents ## {#parent-pseudo}
+## Pseudo-element root ## {#pseudo-root}
 
 	Issue: This definition should be moved to [[css-pseudo-4]].
 
-	A <dfn>pseudo-element parent</dfn> is a type of [=tree-abiding pseudo-element=].
+	A <dfn>pseudo-element root</dfn> is a type of [=tree-abiding pseudo-element=] that is the [=tree/root=] in a [=tree=] of [=tree-abiding pseudo-elements=],
+	known as the <dfn>pseudo-element tree</dfn>.
 
-	It has <dfn for="pseudo-element parent">children</dfn>,
-	a [=/list=] of [=pseudo-elements=].
-	Initially an empty [=/list=].
+	The [=pseudo-element tree=] defines the document order of its [=tree/descendant=] [=tree-abiding pseudo-elements=].
 
-	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] defines the nested children of the [=pseudo-element parent=] in document order.
+	When a [=pseudo-element=] [=tree/participates=] in a [=pseudo-element tree=],
+	its [=originating pseudo-element=] is its [=tree/parent=].
 
-	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
-	then |pseudo|'s [=originating pseudo-element=] is |parent|.
+	If a [=tree/descendant=] |pseudo| of a [=pseudo-element root=] has no other [=tree/siblings=],
+	then '':only-child'' matches that |pseudo|.
 
-	If a [=pseudo-element parent=]'s [=pseudo-element parent/children=]'s [=list/size=] is 1, then '':only-child'' selects [=pseudo-element parent/children=][0]. Otherwise, '':only-child'' selects nothing.
-
-	Note: This means that `::view-transition-new(ident):only-child` will only select `::view-transition-new(ident)` if the parent `::view-transitions-image-pair(ident)` only contains one child. As in, there is no `::view-transition-old(ident)`.
-
-	<div algorithm>
-		To get the <dfn for="pseudo-element parent">descendants</dfn> of a [=pseudo-element parent=] |parent|, perform the following steps.
-		They return a [=/list=] of [=pseudo-elements=].
-
-		1. Let |descendants| be a new [=/list=].
-
-		1. [=list/For each=] |child| of |parent|'s [=pseudo-element parent/children=]:
-
-			1. [=list/Append=] |child| to |descendants|.
-
-			1. If |child| is a [=pseudo-element parent=],
-				then [=list/append=] each of |child|'s [=pseudo-element parent/descendants=] to |descendants|.
-
-		1. Return |descendants|.
-	</div>
+	Note: This means that `::view-transition-new(ident):only-child` will only select `::view-transition-new(ident)` if the parent `::view-transitions-image-pair(ident)` contains a single [=tree/child=].
+	As in, there is no [=tree/sibling=] `::view-transition-old(ident)`.
 
 ## Named view-transition pseudo-elements ## {#named-view-transition-pseudo}
 
@@ -258,7 +241,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	: <dfn>::view-transition</dfn>
 	:: A [=tree-abiding pseudo-element=] that is also
-		a [=pseudo-element parent=].
+		a [=pseudo-element root=].
 		Its [=originating element=] is the document's [=document element=].
 
 		Its [=containing block=] is the [=snapshot viewport=].
@@ -279,8 +262,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		</div>
 
 	: <dfn>::view-transition-group( <<pt-name-selector>> )</dfn>
-	:: A [=tree-abiding pseudo-element=] that is also
-		a [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=]
+		that is also a [=named view-transition pseudo-element=],
+		and [=tree/participates=] in a [=pseudo-element tree=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 
@@ -305,12 +289,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			Also the element's 'transform' is animated from the old element's screen space transform to the new element's screen space transform.
 			This style is generated dynamically since the values of animated properties are determined at the time that the transition begins.
 
-			This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition''.
+			This is only ever a [=tree/child=] of a ''::view-transition''.
 		</div>
 
 	: <dfn>::view-transition-image-pair( <<pt-name-selector>> )</dfn>
-	:: A [=tree-abiding pseudo-element=] that is also
-		a [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=]
+		that is also a [=named view-transition pseudo-element=],
+		and [=tree/participates=] in a [=pseudo-element tree=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 
@@ -326,11 +311,12 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		}
 		```
 
-		Note: This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition-group()''.
+		Note: This is only ever a [=tree/child=] of a ''::view-transition-group()''.
 
 	: <dfn>::view-transition-old( <<pt-name-selector>> )</dfn>
-	:: A [=tree-abiding pseudo-element=] that is also
-		a [=named view-transition pseudo-element=].
+	:: A [=tree-abiding pseudo-element=]
+		that is also a [=named view-transition pseudo-element=],
+		and [=tree/participates=] in a [=pseudo-element tree=].
 
 		It is selected from its [=ultimate originating element=], the [=document element=].
 
@@ -356,7 +342,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		Note: Additional styles in the [=document/view transition style sheet=] added to animate these pseudo-elements are detailed in [=setup transition pseudo-elements=] and [=update pseudo-element styles=].
 
-		Note: This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition-image-pair()''.
+		Note: This is only ever a [=tree/child=] of a ''::view-transition-image-pair()'', and never has any [=tree/children=].
 
 	: <dfn>::view-transition-new( <<pt-name-selector>> )</dfn>
 	:: Identical to ''::view-transition-old()'',
@@ -957,7 +943,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Otherwise:
 
-			1. Render |element| and its descendants,
+			1. Render |element| and its [=tree/descendants=],
 				at the same size it appears in its [=node document=],
 				over an infinite transparent canvas,
 				following the [=capture rendering characteristics=].
@@ -1004,7 +990,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |hasActiveAnimations| be a boolean, initially false.
 
-		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=] and its [=pseudo-element parent/descendants=]:
+		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=tree/inclusive descendants=]:
 
 			1. For each |animation| whose [=timeline=] is a [=document timeline=] associated with |document|,
 				and contains at least one [=animation/associated effect=] whose [=effect target=] is |element|,
@@ -1070,12 +1056,12 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			1. Let |group| be a new ''::view-transition-group()'',
 				with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|.
 
-			1. [=list/Append=] |group| to |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=pseudo-element parent/children=].
+			1. Append |group| to |transition|'s [=ViewTransition/transition root pseudo-element=].
 
 			1. Let |imagePair| be a new ''::view-transition-image-pair()'',
 				with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|.
 
-			1. [=list/Append=] |imagePair| to |group|'s [=pseudo-element parent/children=].
+			1. Append |imagePair| to |group|.
 
 			1. If |capturedElement|'s [=captured element/old image=] is not null, then:
 
@@ -1083,7 +1069,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 					with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|,
 					displaying |capturedElement|'s [=captured element/old image=].
 
-				1. [=list/Append=] |old| to |imagePair|'s [=pseudo-element parent/children=].
+				1. Append |old| to |imagePair|.
 
 				1. Let |oldViewBox| be |capturedElement|'s [=captured element/old styles=] 'object-view-box' property.
 
@@ -1105,11 +1091,11 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 					with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|,
 					displaying the [=capture the image=] of |capturedElement|'s [=new element=].
 
-				1. [=list/Append=] |new| to |imagePair|'s [=pseudo-element parent/children=].
+				1. Append |new| to |imagePair|.
 
 				The [=new element=] and its contents
 				(the flat tree descendants of the element, including both text and elements, or the replaced content of a replaced element),
-				except the |transition|'s [=ViewTransition/transition root pseudo-element=] and its [=pseudo-element parent/descendants=],
+				except the |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=tree/inclusive descendants=],
 				are not painted (as if they had visibility: hidden)
 				and do not respond to hit-testing (as if they had pointer-events: none) until |new| exists.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -197,38 +197,59 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 # Pseudo-elements # {#pseudo}
 
-	The following <dfn export>view-transition pseudo-elements</dfn> represent the various items being animated.
+## Pseudo-element parents ## {#parent-pseudo}
 
-	The ''::view-transition'' pseudo-element acts as a grouping element for other [=view-transition pseudo-elements=]
-	and has the document's [=document element=] as its [=originating element=].
+	A <dfn>pseudo-element parent</dfn> is a mixin that has <dfn for="pseudo-element parent">children</dfn>,
+	a [=/list=] of [=pseudo-elements=].
+	Initially an empty [=/list=].
 
-	Note: For example, '':root::view-transition'' selector matches this pseudo-element,
-	but ''div::view-transition'' does not.
+	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] should be laid out in the order they appear in the [=/list=], according to their styles.
 
-	Other [=view-transition pseudo-elements=] take a <<pt-name-selector>> argument
-	to specify which elements named with 'view-transition-name' are affected.
+	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
+	and |parent| is a [=pseudo-element=],
+	then |pseudo|'s [=originating pseudo-element=] is |parent|.
 
-	There can be multiple pseudo-elements of the same type,
-	one for each 'view-transition-name' participating in a transition.
+	<div algorithm>
+		To get the <dfn for="pseudo-element parent">descendants</dfn> of a [=pseudo-element parent=] |parent|, perform the following steps.
+		They return a [=/list=] of [=pseudo-elements=].
 
-	The <<pt-name-selector>> is defined as follows:
+		1. Let |descendants| be a new [=/list=].
+
+		1. [=list/For each=] |child| of |parent|'s [=pseudo-element parent/children=]:
+
+			1. [=list/Append=] |child| to |descendants|.
+
+			1. If |child| is a [=pseudo-element parent=],
+				then [=list/append=] |child|'s [=pseudo-element parent/descendants=] to |descendants|.
+
+		1. Return |descendants|.
+	</div>
+
+## Named view-transition pseudo-elements ## {#named-view-transition-pseudo}
+
+	A <dfn>named view-transition pseudo-element</dfn> is a mixin for [=pseudo-elements=]
+	that also have a <dfn for="named view-transition pseudo-element">view-transition name</dfn>,
+	a string.
+
+	Their selector takes a <<pt-name-selector>> argument.
 
 	<pre class=prod>
 		<dfn>&lt;pt-name-selector></dfn> = '*' | <<custom-ident>>
 	</pre>
 
-	A value of ''*'' makes the corresponding selector apply to all pseudo elements of the specified type.
-	The specificity of a view-transition selector with a ''*'' argument is zero.
+	The selector matches if the <<pt-name-selector>> is `*` or matches the [=named view-transition pseudo-element=]'s [=named view-transition pseudo-element/view-transition name=].
 
-	The <<custom-ident>> value makes the corresponding selector apply to exactly one pseudo element of the specified type,
-	namely the pseudo-element that is created as a result of the 'view-transition-name' property on an element with the same <<custom-ident>> value.
 	The specificity of a view-transition selector with a <<custom-ident>> argument is the same as for other pseudo-elements,
 	and is equivalent to a [=type selector=].
 
-	The following describes all of the [=view-transition pseudo-elements=] and their function:
+	The specificity of a view-transition selector with a `*` argument is zero.
+
+	Note: The [=named view-transition pseudo-element/view-transition name=] is set to the 'view-transition-name' that triggered its creation.
+
+## View transition pseudo-elements ## {#view-transition-pseudos}
 
 	: <dfn>::view-transition</dfn>
-	:: This pseudo-element is the grouping container of all the other [=view-transition pseudo-elements=].
+	:: A [=pseudo-element parent=].
 		Its [=originating element=] is the document's [=document element=].
 
 		The following is added to the [=HTML user agent style sheet=]:
@@ -240,15 +261,18 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		}
 		```
 
-		Note: This pseudo-element provides a containing block for all ''::view-transition-group()'' pseudo-elements.
-		The aim of the style is to size the pseudo-element to cover the [=snapshot viewport=]
-		and position all ''::view-transition-group()'' pseudo-elements relative to the [=snapshot viewport origin=].
+		<div class="note">
+			This pseudo-element provides a containing block for all ''::view-transition-group()'' pseudo-elements.
+			The aim of the style is to size the pseudo-element to cover the [=snapshot viewport=]
+			and position all ''::view-transition-group()'' pseudo-elements relative to the [=snapshot viewport origin=].
+
+			This is only ever the [=pseudo-element parent/children|child=] of the [=snapshot viewport=].
+		</div>
 
 	: <dfn>::view-transition-group( <<pt-name-selector>> )</dfn>
-	:: One of these pseudo-elements exists for each 'view-transition-name' in a view transition,
-		and holds the rest of the pseudo-elements corresponding to this 'view-transition-name'.
+	:: A [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
 
-		Its [=originating element=] is the ''::view-transition'' pseudo-element.
+		It is selected from its [=ultimate originating element=], the [=document element=].
 
 		The following is added to the [=HTML user agent style sheet=]:
 
@@ -270,15 +294,14 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			from the size of the old element's [=border box=] to that of the new element's [=border box=].
 			Also the element's 'transform' is animated from the old element's screen space transform to the new element's screen space transform.
 			This style is generated dynamically since the values of animated properties are determined at the time that the transition begins.
+
+			This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition''.
 		</div>
 
-		Issue: The selector for this and subsequently defined pseudo-elements is likely to change to indicate position in the pseudo-tree hierarchy.
-
 	: <dfn>::view-transition-image-pair( <<pt-name-selector>> )</dfn>
-	::  One of these pseudo-elements exists for each view-transition-name being in a view transition,
-		and holds the images of the old and new elements.
+	:: A [=pseudo-element parent=], and a [=named view-transition pseudo-element=].
 
-		Its [=originating element=] is the ''::view-transition-group()'' pseudo-element with the same transition-name.
+		It is selected from its [=ultimate originating element=], the [=document element=].
 
 		The following is added to the [=HTML user agent style sheet=]:
 
@@ -292,14 +315,15 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		}
 		```
 
-		Note: The aim of the style is to position the element to occupy the same space as its ''::view-transition-group()'' element.
+		Note: This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition-group()''.
 
 	: <dfn>::view-transition-old( <<pt-name-selector>> )</dfn>
-	::  One of these pseudo-elements exists for each element in the old DOM being animated by the view transition,
-		and is a [=replaced element=] displaying the old element's snapshot image.
-		It has [=natural dimensions=] equal to the snapshot's size.
+	:: A [=named view-transition pseudo-element=].
 
-		Its [=originating element=] is the ''::view-transition-image-pair()'' pseudo-element with the same transition-name.
+		It is selected from its [=ultimate originating element=], the [=document element=].
+
+		It is a [=replaced element=] displaying the old element's snapshot image.
+		It has [=natural dimensions=] equal to the snapshot's size.
 
 		The following is added to the [=HTML user agent style sheet=]:
 
@@ -320,11 +344,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		Note: Additional styles in the [=document/view transition style sheet=] added to animate these pseudo-elements are detailed in [=setup transition pseudo-elements=] and [=update pseudo-element styles=].
 
+		Note: This is only ever a [=pseudo-element parent/children|child=] of a ''::view-transition-image-pair()''.
+
 	: <dfn>::view-transition-new( <<pt-name-selector>> )</dfn>
 	:: Identical to ''::view-transition-old()'',
 		except it deals with the new element instead.
 
-	The precise tree structure, and in particular the order of sibling pseudo-elements,
+	Note: The precise tree structure, and in particular the order of sibling pseudo-elements,
 	is defined in the [=setup transition pseudo-elements=] algorithm.
 
 # Concepts # {#concepts}
@@ -370,6 +396,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	</figure>
 
 	This means the snapshot canvas size is likely to be consistent for the [=document element=]'s [=captured element/old image=] and [=captured element/new element=].
+
+	The [=snapshot viewport=] is also a [=pseudo-element parent=].
 
 	The <dfn>snapshot viewport origin</dfn> refers to the start of the block and inline axes of the [=snapshot viewport=].
 
@@ -605,6 +633,10 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		: <dfn>finished promise</dfn>
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
+
+		: <dfn>transition root pseudo-element</dfn>
+		:: a ''::view-transition''.
+			Initially a new ''::view-transition''.
 	</dl>
 
 	The {{ViewTransition/finished}} [=getter steps=] are to return [=this's=] [=ViewTransition/finished promise=].
@@ -959,9 +991,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |hasActiveAnimations| be a boolean, initially false.
 
-		1. For each [=view-transition pseudo-elements=] associated with |transition|:
-
-			1. Let |element| be the [=view-transition pseudo-element=].
+		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=] and its [=pseudo-element parent/descendants=]:
 
 			1. For each |animation| whose [=timeline=] is a [=document timeline=] associated with |document|,
 				and contains at least one [=animation/associated effect=] whose [=effect target=] is |element|,
@@ -1020,30 +1050,27 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-		1. Let |transitionRoot| be the result of creating a new ''::view-transition'' pseudo-element in |document|'s [=snapshot viewport=].
+		1. [=list/Append=] |transition|'s [=ViewTransition/transition root pseudo-element=] to this |document|'s [=snapshot viewport=]'s [=pseudo-element parent/children=].
 
 		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=]:
 
-			1. Let |group| be the result of creating a new ''::view-transition-group()'' pseudo-element with the name |transitionName|.
+			1. Let |group| be a new ''::view-transition-group()'',
+				with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|.
 
-				Issue: "name" should be defined/linked.
+			1. [=list/Append=] |group| to |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=pseudo-element parent/children=].
 
-			1. Append |group| to |transitionRoot|.
+			1. Let |imagePair| be a new ''::view-transition-image-pair()'',
+				with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|.
 
-				Issue: This should be better defined.
-					I'm not sure if pseudo-elements have defined ways to modify their DOM.
-
-			1. Let |imagePair| be a new ''::view-transition-image-pair()'' pseudo-element with the name |transitionName|.
-
-			1. Append |imagePair| to |group|.
+			1. [=list/Append=] |imagePair| to |group|'s [=pseudo-element parent/children=].
 
 			1. If |capturedElement|'s [=captured element/old image=] is not null, then:
 
-				1. Let |old| be a new ''::view-transition-old()'' [=replaced element=] pseudo-element,
-					with the name |transitionName|,
+				1. Let |old| be a new ''::view-transition-old()'',
+					with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|,
 					displaying |capturedElement|'s [=captured element/old image=].
 
-				1. Append |old| to |imagePair|.
+				1. [=list/Append=] |old| to |imagePair|'s [=pseudo-element parent/children=].
 
 				1. Let |oldViewBox| be |capturedElement|'s [=captured element/old styles=] 'object-view-box' property.
 
@@ -1061,15 +1088,15 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			1. If |capturedElement|'s [=new element=] is not null, then:
 
-				1. Let |new| be a new ''::view-transition-new()'' [=replaced element=] pseudo-element,
-					with the name |transitionName|,
+				1. Let |new| be a new ''::view-transition-new()'',
+					with its [=named view-transition pseudo-element/view-transition name=] set to |transitionName|,
 					displaying the [=capture the image=] of |capturedElement|'s [=new element=].
 
-				1. Append |new| to |imagePair|.
+				1. [=list/Append=] |new| to |imagePair|'s [=pseudo-element parent/children=].
 
 				The [=new element=] and its contents
 				(the flat tree descendants of the element, including both text and elements, or the replaced content of a replaced element),
-				except the [=view-transition pseudo-elements=],
+				except the |transition|'s [=ViewTransition/transition root pseudo-element=] and its [=pseudo-element parent/descendants=],
 				are not painted (as if they had visibility: hidden)
 				and do not respond to hit-testing (as if they had pointer-events: none) until |new| exists.
 
@@ -1250,11 +1277,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. Remove all associated [=view-transition pseudo-elements=] from |document|.
-
-				Issue: There needs to be a definition/link for "remove".
-
-				Issue: There needs to be a definition/link for "associated".
+		1. [=list/Remove=] |transition|'s [=ViewTransition/transition root pseudo-element=]
+			from |document|'s [=snapshot viewport=]'s [=pseudo-element parent/children=].
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -356,14 +356,10 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 ## Phases ## {#phases-concept}
 
 	<dfn>Phases</dfn> represent an ordered sequence of states.
-	Since [=phases=] are ordered, prose can refer to phases <dfn for="phases">before</dfn> a particular phase, meaning they appear earlier in the sequence,
-	or <dfn for="phases">after</dfn> a particular phase, meaning they appear later in the sequence.
+	Since [=phases=] are ordered, prose can refer to phases <dfn for="phases">before</dfn> a particular phase, meaning they appear earlier in the sequence.
+	<!-- or <dfn for="phases">after</dfn> a particular phase, meaning they appear later in the sequence. -->
 
 	The initial phase is the first item in the sequence.
-
-	Note: For the most part, a developer using this API does not need to worry about the different phases, since they progress automatically.
-	It is, however, important to understand what steps happen in each of the phases: when the snapshots are captured, when pseudo-element DOM is created, etc.
-	The description of the phases below tries to be as precise as possible, with an intent to provide an unambiguous set of steps for implementors to follow in order to produce a spec-compliant implementation.
 
 ## The snapshot viewport ## {#snapshot-viewport-concept}
 
@@ -487,12 +483,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			Note: This is used to hold dynamic styles relating to transitions.
 
-		: <dfn>view-transition root pseudo-element</dfn>
-		:: A ''::view-transition'' or null. Initially null.
-			When this is a ''::view-transition'', the ''::view-transition'' renders as a child of the [=document element=],
-			and the [=document element=] is its [=originating element=].
+		: <dfn>show view-transition root pseudo-element</dfn>
+		:: A boolean. Initially false.
 
-			Note: The position of the ''::view-transition'' within the [=document element=] does not matter, as the ''::view-transition'''s [=containing block=] is the [=snapshot viewport=].
+			When this is true, [=this=]'s [=active DOM transition=]'s [=ViewTransition/transition root pseudo-element=] renders as a child of [=this=]'s [=document element=],
+			and [=this=]'s [=document element=] is its [=originating element=].
+
+			Note: The position of the [=ViewTransition/transition root pseudo-element=] within the [=document element=] does not matter, as the [=ViewTransition/transition root pseudo-element=]'s [=containing block=] is the [=snapshot viewport=].
 	</dl>
 
 # API # {#api}
@@ -617,6 +614,10 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			1. "`dom-update-callback-called`".
 			1. "`animating`".
 			1. "`done`".
+
+			Note: For the most part, a developer using this API does not need to worry about the different phases, since they progress automatically.
+			It is, however, important to understand what steps happen in each of the phases: when the snapshots are captured, when pseudo-element DOM is created, etc.
+			The description of the phases below tries to be as precise as possible, with an intent to provide an unambiguous set of steps for implementors to follow in order to produce a spec-compliant implementation.
 
 		: <dfn>DOM update callback</dfn>
 		:: an {{UpdateDOMCallback}} or null. Initially null.
@@ -880,12 +881,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Set [=document/transition suppressing rendering=] to false.
 
-		1. If |transition|'s [=ViewTransition/phase=] is equal to or [=phases/after=] "`animating`",
-			then [=clear view transition=] |transition|.
+		1. [=Clear view transition=] |transition|.
 
 		1. Set |transition|'s [=ViewTransition/phase=] to "`done`".
-
-		1. Set |document|'s [=document/active DOM transition=] to null.
 
 		1. If |transition|'s [=ViewTransition/ready promise=] has not yet been resolved, [=reject=] it with |reason|.
 
@@ -1010,8 +1008,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			1. [=Clear view transition=] |transition|.
 
-			1. Set |document|'s [=document/active DOM transition=] to null.
-
 			1. [=Resolve=] |transition|'s [=ViewTransition/finished promise=].
 
 			1. Return.
@@ -1049,7 +1045,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-		1. Set |document|'s [=view-transition root pseudo-element=] to |transition|'s [=ViewTransition/transition root pseudo-element=].
+		1. Set |document|'s [=show view-transition root pseudo-element=] to true.
 
 		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=]:
 
@@ -1276,14 +1272,17 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. Set |document|'s [=view-transition root pseudo-element=] to null.
+		1. [=Assert=]: |document|'s [=document/active DOM transition=] is |transition|.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 
 			1. [=list/For each=] |style| of |capturedElement|'s [=captured element/style definitions=]:
 
 				1. If |style| is not null,
+					and |style| is in |document|'s [=document/view transition style sheet=],
 					then remove |style| from |document|'s [=document/view transition style sheet=].
+
+		1. Set |document|'s [=document/active DOM transition=] to null.
 	</div>
 
 <h2 id="priv" class="no-num">Privacy Considerations</h2>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -225,7 +225,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			1. [=list/Append=] |child| to |descendants|.
 
 			1. If |child| is a [=pseudo-element parent=],
-				then [=list/append=] |child|'s [=pseudo-element parent/descendants=] to |descendants|.
+				then [=list/append=] each of |child|'s [=pseudo-element parent/descendants=] to |descendants|.
 
 		1. Return |descendants|.
 	</div>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -212,6 +212,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
 	then |pseudo|'s [=originating pseudo-element=] is |parent|.
 
+	If a [=pseudo-element parent=]'s [=pseudo-element parent/children=]'s [=list/size=] is 1, then '':only-child'' selects [=pseudo-element parent/children=][0].
+
 	<div algorithm>
 		To get the <dfn for="pseudo-element parent">descendants</dfn> of a [=pseudo-element parent=] |parent|, perform the following steps.
 		They return a [=/list=] of [=pseudo-elements=].

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -199,14 +199,17 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 ## Pseudo-element parents ## {#parent-pseudo}
 
-	A <dfn>pseudo-element parent</dfn> is a mixin for [=tree-abiding pseudo-elements=] that has <dfn for="pseudo-element parent">children</dfn>,
+	Issue: This definition should be moved to [[css-pseudo-4]].
+
+	A <dfn>pseudo-element parent</dfn> is a type of [=tree-abiding pseudo-element=].
+
+	It has <dfn for="pseudo-element parent">children</dfn>,
 	a [=/list=] of [=pseudo-elements=].
 	Initially an empty [=/list=].
 
-	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] are laid out in the order they appear in the [=/list=], according to their styles.
+	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] defines the nested children of the [=pseudo-element parent=] in document order.
 
 	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
-	and |parent| is a [=pseudo-element=],
 	then |pseudo|'s [=originating pseudo-element=] is |parent|.
 
 	<div algorithm>
@@ -227,8 +230,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 ## Named view-transition pseudo-elements ## {#named-view-transition-pseudo}
 
-	A <dfn>named view-transition pseudo-element</dfn> is a mixin for [=tree-abiding pseudo-elements=]
-	that also have a <dfn for="named view-transition pseudo-element">view-transition name</dfn>,
+	A <dfn>named view-transition pseudo-element</dfn> is a type of [=tree-abiding pseudo-elements=].
+
+	It has a <dfn for="named view-transition pseudo-element">view-transition name</dfn>,
 	a string.
 
 	Their selector takes a <<pt-name-selector>> argument.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -272,8 +272,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			This pseudo-element provides a containing block for all ''::view-transition-group()'' pseudo-elements.
 			The aim of the style is to size the pseudo-element to cover the [=snapshot viewport=]
 			and position all ''::view-transition-group()'' pseudo-elements relative to the [=snapshot viewport origin=].
-
-			This is only ever the [=pseudo-element parent/children|child=] of the [=snapshot viewport=].
 		</div>
 
 	: <dfn>::view-transition-group( <<pt-name-selector>> )</dfn>
@@ -407,8 +405,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	This means the snapshot canvas size is likely to be consistent for the [=document element=]'s [=captured element/old image=] and [=captured element/new element=].
 
-	The [=snapshot viewport=] is also a [=pseudo-element parent=].
-
 	The <dfn>snapshot viewport origin</dfn> refers to the start of the block and inline axes of the [=snapshot viewport=].
 
 ## The [=view-transition layer=] stacking layer ## {#view-transition-stacking-layer}
@@ -426,9 +422,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	- The [=view-transition layer=] paints after the stacking context for the [=document element=] and [=top layer=].
 
-	- The [=view-transition layer=] is positioned at the [=snapshot viewport origin=],
-		and is the same size as the [=snapshot viewport=].
-		As in, it covers the [=snapshot viewport=].
+	- The [=view-transition layer=]'s [=containing block=] is the [=snapshot viewport=].
 
 	Note: The intent of the feature is to be able to capture the contents of the page, which includes the top layer elements.
 	In order to accomplish that, the [=view-transition layer=] cannot be a part of the captured top layer context,

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -203,7 +203,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	a [=/list=] of [=pseudo-elements=].
 	Initially an empty [=/list=].
 
-	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] should be laid out in the order they appear in the [=/list=], according to their styles.
+	A [=pseudo-element parent=]'s [=pseudo-element parent/children=] are laid out in the order they appear in the [=/list=], according to their styles.
 
 	When a [=pseudo-element=] |pseudo| is part of a [=pseudo-element parent=] |parent|'s [=pseudo-element parent/children=],
 	and |parent| is a [=pseudo-element=],


### PR DESCRIPTION
This attempts to define how pseudos are built and ordered. It also defines the view-transition-name of the pseudos.

Fixes #8113.