### PR TITLE
[css-nesting-1] Improve example for appearance order

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -755,8 +755,8 @@ Mixing Nesting Rules and Declarations {#mixing}
 
 		<xmp class=lang-css>
 			article {
-				color: blue;
 				& { color: red; }
+				color: blue;
 			}
 		</xmp>
 


### PR DESCRIPTION
I think this change better demonstrates the point: *nested style rules and nested conditional group rules are considered to come after their parent rule*.