### PR TITLE
[css-animations-2] Fix value references to "<single-animation-timeline>"

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -548,11 +548,11 @@ with the timelines matched up with animations as described
 Each value has type <<single-animation-timeline>>, whose possible values have
 the following effects:
 
-:   <dfn for="single-animation-timeline" dfn-type=value>auto</dfn>
+:   <dfn for="<single-animation-timeline>" dfn-type=value>auto</dfn>
 ::  The animation's [=timeline=] is a {{DocumentTimeline}}, more specifically
     the <a>default document timeline</a>.
 
-:   <dfn for="single-animation-timeline" dfn-type=value>none</dfn>
+:   <dfn for="<single-animation-timeline>" dfn-type=value>none</dfn>
 ::  The animation is not associated with a [=timeline=].
 
 :   <dfn>&lt;timeline-name></dfn>


### PR DESCRIPTION
Enclosing `<` and `>` characters cannot be omitted when referencing a `type` definition.
