### PR TITLE
[css-display-3] Typo: fix reference to "<display-listitem>"

### DIFF
--- a/css-display-3/Overview.bs
+++ b/css-display-3/Overview.bs
@@ -541,7 +541,7 @@ Inner Display Layout Models: the ''flow'', ''flow-root'', ''table'', ''flex'', '
 <h3 id="list-items">
 Generating Marker Boxes: the ''list-item'' keyword</h3>
 
-	The <dfn value for="display, <display-list-item>">list-item</dfn> keyword
+	The <dfn value for="display, <display-listitem>">list-item</dfn> keyword
 	causes the element to generate a ''::marker'' pseudo-element [[!CSS-PSEUDO-4]]
 	with the content specified by its <l spec=css2>'list-style'</l> properties
 	(<a href="https://www.w3.org/TR/CSS2/generate.html#lists">CSS 2.1§12.5 Lists</a>) [[!CSS2]]


### PR DESCRIPTION
Only one hyphen in `display-listitem`.
