### PR TITLE
[css-easing-2] Typo: Fix reference to "<easing-function>"

### DIFF
--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -427,7 +427,7 @@ It returns an [=output progress value=].
 
 <h3 id=the-linear-easing-keyword oldids=linear-timing-function-section>The linear easing keyword: ''linear''</h3>
 
-The <dfn dfn-type=value for=easing-function>linear</dfn> keyword
+The <dfn dfn-type=value for="<easing-function>">linear</dfn> keyword
 produces a [=linear easing function=]
 with two [=linear easing function/points=]:
 


### PR DESCRIPTION
Enclosing `<` and `>` characters cannot be omitted when referencing a `type` definition.

