### PR TITLE
[selectors-4] Added `:blank` to at-risk list and removed `:read-write` and `:has()` from it

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -27,6 +27,7 @@ At Risk: the column combinator
 At Risk: the '':read-write'' pseudo-class
 At Risk: the '':has()'' pseudo-class
 At Risk: [=user action pseudo-classes=] applying to non-[=tree-abiding=] [=pseudo-elements=]
+At Risk: the '':blank'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
 Ignored Vars: identifier, extended filtering, i
 </pre>
@@ -4108,6 +4109,7 @@ Changes since the 7 May 2022 Working Draft</h3>
 
 	Significant changes since the <a href="https://www.w3.org/TR/2022/WD-selectors-4-20220507/">7 May 2022 Working Draft</a>:
 
+	* Marked '':blank'' as at-risk and removed the at-risk status from '':read-write'' and '':has()''
 	* Added '':open'' and '':closed'' pseudo-classes.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/7319">Issue 7319</a>)
 	* Disallowed [=pseudo-elements=] from '':has()'' unless explicitly allowed


### PR DESCRIPTION
What the title says. See #8168 for the reasoning.

Fixes #8168