### PR TITLE
[css-animations-2] Integrate scroll animations into animation-timeline #7579

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -536,7 +536,7 @@ Animatable: no
 </pre>
 
 <pre class=prod>
-<dfn>&lt;single-animation-timeline></dfn> = auto | none | <<timeline-name>>
+<dfn>&lt;single-animation-timeline></dfn> = auto | none | <<timeline-name>> | <<scroll()>> | <<view()>>
 </pre>
 
 The 'animation-timeline' property is similar to properties like 'animation-name'
@@ -557,13 +557,20 @@ the following effects:
 ::  The animation is not associated with a [=timeline=].
 
 :   <dfn><<timeline-name>></dfn>
-::  Find the last timeline at-rule in document order with its name matching
-    <<timeline-name>>. If such a timeline at-rule exists, then the animation's
-    [=timeline=] is a timeline as defined by that rule. Otherwise the animation
-    is not associated with a [=timeline=].
-    <pre class=prod>
-      <<timeline-name>> = <<custom-ident>> | <<string>>
-    </pre>
+::  If a named [=scroll progress timeline=] or [=view progress timeline=]
+    is in scope on this element,
+    use the referenced timeline
+    as defined in [[scroll-animations-1#timeline-scope]].
+
+    Otherwise the animation is not associated with a [=timeline=].
+
+:   <dfn><<scroll()>></dfn>
+::  Use the [=scroll progress timeline=] indicated by the given ''scroll()'' function.
+    See [[scroll-animations-1#scroll-notation]].
+
+:   <dfn><<view()>></dfn>
+::  Use the [=view progress timeline=] indicated by the given ''view()'' function.
+    See [[scroll-animations-1#view-notation]].
 </dl>
 
 


### PR DESCRIPTION
This syntactically integrates the scroll() and view() functions into animation-timeline.

It also defines the named timeline search to look for scroll and view progress timelines before searching at-rule timelines. (This seemed the most reasonable way to integrate the search, but open to other ideas...)