### PR TITLE
[css-overflow-3] Fix typo in example 6 #8190

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -1378,7 +1378,7 @@ Limiting Visible Lines: the 'line-clamp' shorthand property</h3>
 	<div class="example">
 		In this example, the lead paragraph of each article
 		is listed in a shortened menu,
-		truncated to fit within 10 lines
+		truncated to fit within 5 lines
 		that end with “… (continued on next page)”:
 
 		<xmp highlight=css>


### PR DESCRIPTION
Fixes: #8190 