### PR TITLE
[css-link-params] Renamed index.bs to Overview.bs

### DIFF
--- a/css-link-params/Overview.bs
+++ b/css-link-params/Overview.bs
@@ -79,7 +79,7 @@ In CSS: the 'link-parameters' property {#link-param-prop}
 Name: link-parameters
 Value: none | <<link-param>>+
 Initial: none
-Inherits: no
+Inherited: no
 Applies to: all elements and pseudo-elements
 Computed value: as specified
 Animation type: discrete


### PR DESCRIPTION
In order to get picked up by the spec. processor, the index.bs file was renamed to Overview.bs.

Sebastian