### PR TITLE
[css-values-4][css-images-4][css-fonts-4] URL request modifiers

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -3208,7 +3208,7 @@ downloadable fonts to avoid large page reflows where possible.
 Font fetching requirements</h4>
 
 <div algorithm>
-	To <dfn>fetch a font</dfn> given a selected [=/url=] |url| for ''@font-face'' |rule|,
+	To <dfn>fetch a font</dfn> given a selected <<url>> |url| for ''@font-face'' |rule|,
 	[=fetch a style resource|fetch=] |url|,
 	with stylesheet being |rule|'s <a spec=cssom for=CSSRule>parent CSS style sheet</a>,
 	destination "font",

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -144,7 +144,7 @@ Fetching External Images {#fetching-images}
 -------------------------------------------
 
 	To <dfn>fetch an external image for a stylesheet</dfn>,
-	given a [=/url=] |url| and {{CSSStyleSheet}} sheet,
+	given a <<url>> |url| and {{CSSStyleSheet}} sheet,
 	[=fetch a style resource=] given |url|,
 	with stylesheet {{CSSStyleSheet}},
 	destination "image",

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1050,8 +1050,8 @@ URL Modifiers</h4>
 URL Processing Model</h4>
 
 	<div algorithm>
-		To <dfn export>fetch a style resource</dfn> from [=/url=] |url|,
-		given a {{CSSStyleSheet}} |sheet|,
+		To <dfn export>fetch a style resource</dfn> from [=/url=] or
+		<<url>> |urlValue|, given a {{CSSStyleSheet}} |sheet|,
 		a string |destination| matching a {{RequestDestination}},
 		a "no-cors" or "cors" |corsMode|,
 		and an algorithm |processResponse| accepting a [=/response=] and a null, failure or byte
@@ -1063,33 +1063,69 @@ URL Processing Model</h4>
 
 		4. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
 
-		5. Let |referrer| be |documentBase|.
+		5. If |base| is null, set |base| to |documentBase|.
 
-		6. If |base| is null, set |base| to |documentBase|.
+		6. Let |url| be |urlValue|.
 
-		7. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		7. If |urlValue| is a <<url>>, set |url| to |urlValue|'s [/=url].
+
+		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.
-
-		8. If |corsMode| is "cors", set |referrer| to |sheet|'s
-			<a spec=cssom>location</a>. [[CSSOM]]
 
 		9. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
-			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
-			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
-			set, [=request/client=] is |environmentSettings|, and whose [=request/referrer=] is
-			|referrer|.
+			[=request/origin=] is |environmentSettings|'s
+			[=environment settings object/origin=], [=request/credentials mode=] is
+			"same-origin", [=request/use-url-credentials flag=] is set, [=request/client=] is
+			|environmentSettings|, and whose [=request/referrer=] is |documentBase|.
 
-		10. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |req|'s
+		10. [=Apply request modifiers from URL value=] given |req| and |urlValue|.
+
+		11. If |req|'s [=request/mode] is "cors", set |req|'s [=request/referrer=] to |sheet|'s
+			<a spec=cssom>location</a>. [[CSSOM]]
+
+		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |req|'s
 			[=request/initiator type=] to "css". [[CSSOM]]
 
-		11. [=/Fetch|fetching=] |req|, with [=fetch/processresponseconsumebody=] set to
+		13. [=/Fetch|fetching=] |req|, with [=fetch/processresponseconsumebody=] set to
 			|processResponse|.
 	</div>
 
-	Note: Resources loaded through CSS style sheets
-	are cached and cleared the same as any other resources
-	linked from the document.
+<h4 id='request-url-modifiers'>
+Request URL Modifiers</h4>
+
+	The <dfn><<request-url-modifier>></dfn>s represent <<url-modifier>>s that affect the resource's
+	[=/request=]. Each <<request-url-modifier>> has a <dfn>request modifier steps</dfn> which accepts
+	a [=/requests=].
+
+	<pre class=prod>
+		<<url-request-modifier>> = <<crossorigin-modifier>> | <<integrity-modifier>> | <<referrerpolicy-modifier>>
+		<<crossorigin-modifier>> = crossorigin(anonymous | use-credentials)
+		<<integrity-modifier>> = integrity(<<string>>)
+		<<referrerpolicy-modifier>> = referrerpolicy(no-referrer | no-referrer-when-downgrade | same-origin | origin | strict-origin | origin-when-cross-origin | strict-origin-when-cross-origin | unsafe-url)
+	</pre>
+
+	<dl dfn-for="<<request-url-modifier>>">
+	<dt><dfn><<crossorigin-modifier>></dfn> = <dfn function>crossorigin</dfn>(<dfn value>anonymous</dfn> | <dfn value>use-credentials</dfn>)
+	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are:
+	    1. Set [=/request=]'s [=request/mode=] to "cors".
+
+		2. If the given value is ''use-credentials'', set [=/request=]'s
+		   [=request/credentials mode=] to "include".
+
+	<dt><dfn><<integrity-modifier>></dfn> = <dfn function>integrity</dfn>(<<string>>)
+	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are to set
+	    [=/request=]'s [=request/integrity metadata=] to the given <<string>>.
+
+	<dt><dfn><<referrerpolicy-modifier>></dfn> = <dfn function>referrerpolicy</dfn>(<dfn value>no-referrer</dfn> | <dfn value>no-referrer-when-downgrade</dfn> | <dfn value>same-origin</dfn> | <dfn value>origin</dfn> | <dfn value>strict-origin</dfn> | <dfn value>origin-when-cross-origin</dfn> | <dfn value>strict-origin-when-cross-origin</dfn> | <dfn value>unsafe-url</dfn>)
+	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are to set
+	    [=/request=]'s [=request/referrer policy=] to the [=referrer policy=] that matches the given value.
+
+	<div algorithm>
+	To <dfn>apply request modifiers from URL value</dfn> given a [=/request=] |req| and a <<url>>
+	|urlValue|, call the [=request modifier steps=] for <<url>>'s <<url-request-modifier>>s in sequence
+	given |req|.
+	</div>
 
 <h2 id="numeric-types">
 Numeric Data Types</h2>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1081,8 +1081,8 @@ URL Processing Model</h4>
 
 		10. [=Apply request modifiers from URL value=] given |req| and |urlValue|.
 
-		11. If |req|'s [=request/mode] is "cors", set |req|'s [=request/referrer=] to |sheet|'s
-			<a spec=cssom>location</a>. [[CSSOM]]
+		11. If |req|'s [=request/mode] is "cors", 
+			set |req|'s [=request/referrer=] to |sheet|'s <a spec=cssom>location</a>. [[CSSOM]]
 
 		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |req|'s
 			[=request/initiator type=] to "css". [[CSSOM]]

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1087,8 +1087,8 @@ URL Processing Model</h4>
 		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, 
 			set |req|'s [=request/initiator type=] to "css". [[CSSOM]]
 
-		13. [=/Fetch|fetching=] |req|, with [=fetch/processresponseconsumebody=] set to
-			|processResponse|.
+		13. [=/Fetch|fetching=] |req|,
+			with [=fetch/processresponseconsumebody=] set to |processResponse|.
 	</div>
 
 <h4 id='request-url-modifiers'>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1059,35 +1059,28 @@ URL Processing Model</h4>
 
 		1. Let |environmentSettings| be |sheet|'s [=relevant settings object=].
 
-		3. Let |documentBase| be |environmentSettings|'s [=API base URL=].
+		2. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a> if it is not null, otherwise
+			|environmentSettings|'s [=API base URL=]. [[CSSOM]]
 
-		4. Let |base| be |sheet|'s <a spec=cssom>stylesheet base URL</a>. [[CSSOM]]
-
-		5. If |base| is null, set |base| to |documentBase|.
-
-		6. Let |url| be |urlValue|.
-
-		7. If |urlValue| is a <<url>>, set |url| to |urlValue|'s [=/url=].
-
-		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
+		3. Let |parsedUrl| be the result of the [=URL parser=] steps with |urlValue|'s [=/url=] and |base|.
 			If the algorithm returns an error, return.
 
-		9. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
+		4. Let |req| be a new [=/request=] whose [=request/url=] is |parsedUrl|, whose
 			[=request/destination=] is |destination|, [=request/mode=] is |corsMode|,
-			[=request/origin=] is |environmentSettings|'s
-			[=environment settings object/origin=], [=request/credentials mode=] is
-			"same-origin", [=request/use-url-credentials flag=] is set, [=request/client=] is
-			|environmentSettings|, and whose [=request/referrer=] is |documentBase|.
+			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
+			[=request/credentials mode=] is "same-origin", [=request/use-url-credentials flag=] is
+			set, [=request/client=] is |environmentSettings|, and whose [=request/referrer=] is
+			|environmentSettings|'s [=API base URL=].
 
-		10. [=Apply request modifiers from URL value=] given |req| and |urlValue|.
+		5. [=Apply request modifiers from URL value=] given |req| and |urlValue|.
 
-		11. If |req|'s [=request/mode] is "cors", 
+		6. If |req|'s [=request/mode=] is "cors",
 			set |req|'s [=request/referrer=] to |sheet|'s <a spec=cssom>location</a>. [[CSSOM]]
 
-		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, 
+		7. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
 			set |req|'s [=request/initiator type=] to "css". [[CSSOM]]
 
-		13. [=/Fetch|fetching=] |req|,
+		8. [=/Fetch=] |req|,
 			with [=fetch/processresponseconsumebody=] set to |processResponse|.
 	</div>
 
@@ -1099,31 +1092,32 @@ Request URL Modifiers</h4>
 	a [=/request=].
 
 	<pre class=prod>
-		<<url-request-modifier>> = <<crossorigin-modifier>> | <<integrity-modifier>> | <<referrerpolicy-modifier>>
+		<<request-url-modifier>> = <<crossorigin-modifier>> | <<integrity-modifier>> | <<referrerpolicy-modifier>>
 		<<crossorigin-modifier>> = crossorigin(anonymous | use-credentials)
 		<<integrity-modifier>> = integrity(<<string>>)
 		<<referrerpolicy-modifier>> = referrerpolicy(no-referrer | no-referrer-when-downgrade | same-origin | origin | strict-origin | origin-when-cross-origin | strict-origin-when-cross-origin | unsafe-url)
 	</pre>
 
 	<dl dfn-for="<<request-url-modifier>>">
-	<dt><dfn><<crossorigin-modifier>></dfn> = <dfn function>crossorigin</dfn>(<dfn value>anonymous</dfn> | <dfn value>use-credentials</dfn>)
+	<dt><dfn><<crossorigin-modifier>></dfn> = <dfn function lt="crossorigin()">crossorigin</dfn>(<dfn value>anonymous</dfn> | <dfn value>use-credentials</dfn>)
 	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are:
 		1. Set [=/request=]'s [=request/mode=] to "cors".
 
 		2. If the given value is ''use-credentials'', set [=/request=]'s
-		   [=request/credentials mode=] to "include".
+			[=request/credentials mode=] to "include".
 
-	<dt><dfn><<integrity-modifier>></dfn> = <dfn function>integrity</dfn>(<<string>>)
+	<dt><dfn><<integrity-modifier>></dfn> = <dfn function lt="integrity()">integrity</dfn>(<<string>>)
 	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are to set
-	    [=/request=]'s [=request/integrity metadata=] to the given <<string>>.
+		[=/request=]'s [=request/integrity metadata=] to the given <<string>>.
 
-	<dt><dfn><<referrerpolicy-modifier>></dfn> = <dfn function>referrerpolicy</dfn>(<dfn value>no-referrer</dfn> | <dfn value>no-referrer-when-downgrade</dfn> | <dfn value>same-origin</dfn> | <dfn value>origin</dfn> | <dfn value>strict-origin</dfn> | <dfn value>origin-when-cross-origin</dfn> | <dfn value>strict-origin-when-cross-origin</dfn> | <dfn value>unsafe-url</dfn>)
+	<dt><dfn><<referrerpolicy-modifier>></dfn> = <dfn function lt="referrerpolicy()">referrerpolicy</dfn>(<dfn value>no-referrer</dfn> | <dfn value>no-referrer-when-downgrade</dfn> | <dfn value>same-origin</dfn> | <dfn value>origin</dfn> | <dfn value>strict-origin</dfn> | <dfn value>origin-when-cross-origin</dfn> | <dfn value>strict-origin-when-cross-origin</dfn> | <dfn value>unsafe-url</dfn>)
 	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are to set
-	    [=/request=]'s [=request/referrer policy=] to the [=referrer policy=] that matches the given value.
+		[=/request=]'s [=request/referrer policy=] to the {{ReferrerPolicy}} that matches the given value.
+	</dl>
 
 	<div algorithm>
 	To <dfn>apply request modifiers from URL value</dfn> given a [=/request=] |req| and a <<url>>
-	|urlValue|, call the [=request modifier steps=] for <<url>>'s <<url-request-modifier>>s in sequence
+	|url|, call the [=request modifier steps=] for |url|'s <<request-url-modifier>>s in sequence
 	given |req|.
 	</div>
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1087,9 +1087,10 @@ URL Processing Model</h4>
 <h4 id='request-url-modifiers'>
 Request URL Modifiers</h4>
 
-	The <dfn><<request-url-modifier>></dfn>s represent <<url-modifier>>s that affect the resource's
-	[=/request=]. Each <<request-url-modifier>> has a <dfn>request modifier steps</dfn> which accepts
-	a [=/request=].
+	The <dfn><<request-url-modifier>></dfn>s represent <<url-modifier>>s 
+	that affect the resource's [=/request=]. 
+	Each <<request-url-modifier>> has a <dfn>request modifier steps</dfn> 
+	which accepts a [=/request=].
 
 	<pre class=prod>
 		<<request-url-modifier>> = <<crossorigin-modifier>> | <<integrity-modifier>> | <<referrerpolicy-modifier>>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1108,7 +1108,7 @@ Request URL Modifiers</h4>
 	<dl dfn-for="<<request-url-modifier>>">
 	<dt><dfn><<crossorigin-modifier>></dfn> = <dfn function>crossorigin</dfn>(<dfn value>anonymous</dfn> | <dfn value>use-credentials</dfn>)
 	<dd>The [=request modifier steps=] for this modifier given [=/request=] |req| are:
-	    1. Set [=/request=]'s [=request/mode=] to "cors".
+		1. Set [=/request=]'s [=request/mode=] to "cors".
 
 		2. If the given value is ''use-credentials'', set [=/request=]'s
 		   [=request/credentials mode=] to "include".

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1084,8 +1084,8 @@ URL Processing Model</h4>
 		11. If |req|'s [=request/mode] is "cors", 
 			set |req|'s [=request/referrer=] to |sheet|'s <a spec=cssom>location</a>. [[CSSOM]]
 
-		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, set |req|'s
-			[=request/initiator type=] to "css". [[CSSOM]]
+		12. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set, 
+			set |req|'s [=request/initiator type=] to "css". [[CSSOM]]
 
 		13. [=/Fetch|fetching=] |req|, with [=fetch/processresponseconsumebody=] set to
 			|processResponse|.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1067,7 +1067,7 @@ URL Processing Model</h4>
 
 		6. Let |url| be |urlValue|.
 
-		7. If |urlValue| is a <<url>>, set |url| to |urlValue|'s [/=url].
+		7. If |urlValue| is a <<url>>, set |url| to |urlValue|'s [=/url=].
 
 		8. Let |parsedUrl| be the result of the [=URL parser=] steps with |url| and |base|.
 			If the algorithm returns an error, return.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1096,7 +1096,7 @@ Request URL Modifiers</h4>
 
 	The <dfn><<request-url-modifier>></dfn>s represent <<url-modifier>>s that affect the resource's
 	[=/request=]. Each <<request-url-modifier>> has a <dfn>request modifier steps</dfn> which accepts
-	a [=/requests=].
+	a [=/request=].
 
 	<pre class=prod>
 		<<url-request-modifier>> = <<crossorigin-modifier>> | <<integrity-modifier>> | <<referrerpolicy-modifier>>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1117,9 +1117,11 @@ Request URL Modifiers</h4>
 	</dl>
 
 	<div algorithm>
-	To <dfn>apply request modifiers from URL value</dfn> given a [=/request=] |req| and a <<url>>
-	|url|, call the [=request modifier steps=] for |url|'s <<request-url-modifier>>s in sequence
-	given |req|.
+		To <dfn>apply request modifiers from URL value</dfn>
+		given a [=/request=] |req| 
+		and a <<url>> |url|,
+		call the [=request modifier steps=] for |url|'s <<request-url-modifier>>s in sequence
+		given |req|.
 	</div>
 
 <h2 id="numeric-types">


### PR DESCRIPTION
Added a few URL modifiers to enable request parameters:

3 modifiers that correspond to `link` attributes:
- [`crossorigin`](https://html.spec.whatwg.org/#attr-link-crossorigin)
- [`referrerpolicy`](https://html.spec.whatwg.org/#attr-link-referrerpolicy)
- [`integrity`](https://html.spec.whatwg.org/#attr-link-integrity)

This enables CORS requests for CSS images, credentialed requests for fonts, and fine-tuning using integrity etc.

Example:
`url("https://..." crossorigin(anonymous) integrity("shaX--something") referrerpolicy(same-origin))`

See #1603
