### PR TITLE
[css-position-3] Move definition of "absolute positioning containing block"

### DIFF
--- a/css-position-3/Overview.bs
+++ b/css-position-3/Overview.bs
@@ -212,7 +212,7 @@ Choosing A Positioning Scheme: 'position' property</h2>
 	The 'position' property determines which of the <dfn export lt="positioning scheme">positioning schemes</dfn>
 	is used to calculate the position of a box.
 	Values other than ''static'' make the box a <dfn export lt="positioned box|positioned">positioned box</dfn>,
-	and cause it to establish an [=absolute positioning containing block=] for its descendants.
+	and cause it to establish an <dfn export>absolute positioning containing block</dfn> for its descendants.
 	Values have the following meanings:
 
 <dl dfn-for="position" dfn-type="value">
@@ -309,7 +309,7 @@ Containing Blocks of Positioned Boxes</h3>
 		<dt id="absolute-cb">If the box has ''position: absolute'':
 		<dd>
 			The [=containing block=] is established
-			by the nearest ancestor box that establishes an <dfn export>absolute positioning containing block</dfn>,
+			by the nearest ancestor box that establishes an [=absolute positioning containing block=],
 			in the following way:
 
 			<dl class=switch>


### PR DESCRIPTION
The term "absolute positioning containing block" (APCB) previously linked to a usage of the term, rather than its definition. Instead, with this change, it now links to the description of when an APCB is established. This should remove some confusion.

This confusion is partially discussed in [#5332](https://github.com/w3c/csswg-drafts/issues/5332), where the term "fixed positioning containing block" (FPCB) is also discussed. Since there is no normative description of anything that establishes an FPCB (only a vague note), an equivalent change cannot be made for FPCB without some larger changes.