### PR TITLE
[css-text-4] interscript text-spacing as default

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -7991,7 +7991,7 @@ Character Class Spacing: the 'text-spacing' property</h3>
 		<dt><dfn>normal</dfn>
 		<dd>
 			Specifies the baseline behavior,
-			equivalent to ''space-start trim-end trim-adjacent''.
+			equivalent to ''space-start trim-end trim-adjacent ideograph-alpha ideograph-numeric''.
 
 		<dt><dfn>none</dfn>
 		<dd>
@@ -9291,6 +9291,9 @@ Default UA Stylesheet</h2>
 
 			/* do not allow white space to collapse in textarea */
 			textarea { text-space-collapse: preserve !important; }
+
+			/* preserve character grid in preformatted text */
+			pre, code, kbd, samp, tt { text-spacing: none; }
 		</pre>
 	</div>
 	<!--

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -8107,12 +8107,14 @@ Character Class Spacing: the 'text-spacing' property</h3>
 		<dt><dfn>ideograph-alpha</dfn>
 		<dd>
 			Creates extra spacing between runs of
-			<a>ideographs</a> and <a>non-ideographic letters</a>.
+			<a>ideographs</a> and <a>non-ideographic letters</a>,
+			see [[#inter-script-spacing]].
 
 		<dt><dfn>ideograph-numeric</dfn>
 		<dd>
 			Creates extra spacing between runs of
-			<a>ideographs</a> and <a>non-ideographic numerals</a> glyphs.
+			<a>ideographs</a> and <a>non-ideographic numerals</a>,
+			see [[#inter-script-spacing]].
 
 		<dt><dfn>punctuation</dfn>
 		<dd>
@@ -8127,12 +8129,6 @@ Character Class Spacing: the 'text-spacing' property</h3>
 			ISSUE: Integrate rules for correcting incorrect spaces?
 			<a href="https://github.com/w3c/csswg-drafts/issues/318">Issue 318</a>
 	</dl>
-
-	Note: A commonly used algorithm for ''ideograph-alpha'' and ''ideograph-numeric''
-	is specified in [[JLREQ]].
-	Spacing conventions vary, but values typically range from 1/4em to as low as 1/8em,
-	with 1/4em being particularly common in monospace contexts
-	and 1/6em being more common in proportional typesetting.
 
 	This property is additive with the 'word-spacing' and 'letter-spacing' properties.
 	That is, the amount of spacing contributed by the 'letter-spacing' setting (if any)
@@ -8152,6 +8148,19 @@ Character Class Spacing: the 'text-spacing' property</h3>
 	It is strongly recommended for UAs that wish to support CJK typography.
 
 	Issue: It was requested to add a value for doubling the space after periods.
+
+<h4 id="inter-script-spacing">
+Inter-script Spacing</h4>
+
+	The ''ideograph-alpha'' and ''ideograph-numeric'' values
+	introduce spacing at the boundary between particular classes of characters
+	when they are directly adjoining on a line,
+	i.e. without any intervening non-zero [=margin=], [=border=], or [=padding=]
+	or intervening characters (such as a quotation mark or a space).
+
+	Note: Spacing conventions vary, but values typically range from 1/4ic to as low as 1/8ic,
+	with 1/4ic being more common in historical contexts due to metal type limitations
+	and 1/6ic or thinner being more common in proportional typesetting.
 
 <h4 id="fullwidth-collapsing">
 Fullwidth Punctuation Collapsing</h4>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -8157,10 +8157,17 @@ Inter-script Spacing</h4>
 	when they are directly adjoining on a line,
 	i.e. without any intervening non-zero [=margin=], [=border=], or [=padding=]
 	or intervening characters (such as a quotation mark or a space).
+	The amount of space introduced by these keywords is 1/8 of the CJK advance measure,
+	i.e ''0.125ic''.
 
 	Note: Spacing conventions vary, but values typically range from 1/4ic to as low as 1/8ic,
 	with 1/4ic being more common in historical contexts due to metal type limitations
 	and 1/6ic or thinner being more common in proportional typesetting.
+	Because these spaces are inserted by default
+	(through the initial value, ''text-spacing/normal''),
+	CSS uses 1/8ic in order to be conservative in its interference.
+	A future level of this module may introduce control
+	over the amount of spacing.
 
 <h4 id="fullwidth-collapsing">
 Fullwidth Punctuation Collapsing</h4>


### PR DESCRIPTION
This pull request makes several changes in response to https://github.com/w3c/csswg-drafts/issues/6950:

- Adds `ideograph-alpha` and `ideograph-numeric` to the initial value, `normal`.
- Adds a UA stylesheet rule to disable `text-spacing` in `pre`, `code`, and `tt` to preserve their monospace behavior.
- Specifies that non-zero margin/border/padding inhibits autospacing.
- Clarifies that intervening characters such as spaces also inhibit autospacing.
- Defines the interscript autospace to be 1/8 of the ideographic advance (`0.125ic`), which is the smallest amount in the common-use range. The primary justification for using 1/8 instead of 1/6 or 1/4 is that, since we're trying to make this the default, it minimizes the layout impact on existing pages. (Note that Antenna House uses a 1/4 default.)