### PR TITLE
[css-text-4] 'white-space' and longhand integration

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1800,8 +1800,10 @@ White Space and Wrapping: the 'white-space' property</h2>
 	It specifies two things:
 
 	<ul>
-		<li>whether and how [=white space=] is collapsed
-		<li>whether lines may [=wrap=] at unforced [=soft wrap opportunities=]
+		<li>whether and how [=white space=] is collapsed;
+			see [[#white-space-processing|White Space Processing]]
+		<li>whether lines may [=wrap=] at unforced [=soft wrap opportunities=];
+			see [[#line-breaking|Line Breaking]]
 	</ul>
 
 	Note: This shorthand combines both inheritable and non-inheritable properties.
@@ -2056,9 +2058,6 @@ White Space and Wrapping: the 'white-space' property</h2>
 				</wpt>
 	</dl>
 
-	[=White space=] that was not removed or collapsed due to white space processing
-	is called <dfn export local-lt="preserved">preserved white space</dfn>.
-
 	Note: In some cases,
 	[=preserved white space=] and [=other space separators=]
 	can [=hang=] when at the end of the line;
@@ -2129,9 +2128,6 @@ White Space and Wrapping: the 'white-space' property</h2>
 				<td>Hang
 	</table>
 
-	See [[#white-space-processing|White Space Processing Rules]]
-	for details on how [=white space=] collapses.
-
 <!-- This is part of segment break transformation
 	An informative summary of collapsing (''white-space/normal'' and ''white-space/nowrap'') is presented below:
 	<ul class=non-normative>
@@ -2152,8 +2148,6 @@ White Space and Wrapping: the 'white-space' property</h2>
 	</ul>
 -->
 
-	See [[#line-breaking|Line Breaking]]
-	for details on wrapping behavior.
 
 <h2 id="white-space-processing">
 White Space Processing &amp; Control Characters</h2>
@@ -2556,6 +2550,9 @@ White Space Collapsing: the 'white-space-collapse' property</h3>
 			If it preserves line break opportunities,
 			maybe it should be replaced with a 'word-boundary-expansion' value?
 	</dl>
+
+	[=White space=] that was not removed or collapsed due to white space processing
+	is called <dfn export local-lt="preserved">preserved white space</dfn>.
 
 	<div class="example">
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1807,7 +1807,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 	Note: This shorthand combines both inheritable and non-inheritable properties.
 	If this is a problem, please inform the CSSWG.
 
-	The following table gives the mapping of the values of the shorthand to its longhands.
+	The following table gives the normative mapping of the values of the shorthand to its longhands.
 
 	<table class="data">
 		<colgroup class="header"></colgroup>
@@ -1853,15 +1853,9 @@ White Space and Wrapping: the 'white-space' property</h2>
 		</tbody>
 	</table>
 
-	ISSUE: The following is the normative definition from Level 3;
-	once [[#white-space-rules]] is updated
-	(assumming we still want to go in this direction),
-	this text should be merged into its longhands’ definitions.
+	Values have the following informative definitions:
 
-	Values have the following meanings,
-	which must be interpreted according to
-	the [[#white-space-rules|White Space Processing]] and
-	[[#line-breaking|Line Breaking]] rules:
+	ISSUE: Remove these definitions once the tests annotations have been redistributed.
 
 	<dl dfn-for=white-space dfn-type=value>
 		<dt><dfn>normal</dfn>
@@ -2189,7 +2183,7 @@ White Space Processing &amp; Control Characters</h2>
 	to control interpretation of such formatting:
 	to preserve or collapse it away when rendering the document.
 	White space processing in CSS
-	(which is controlled with the 'white-space' property)
+	(which is controlled with the 'white-space-collapse' and 'text-space-trim' properties)
 	interprets [=white space characters=] only for rendering:
 	it has no effect on the underlying document data.
 
@@ -2369,7 +2363,6 @@ White Space Processing &amp; Control Characters</h2>
 White Space Collapsing: the 'white-space-collapse' property</h3>
 
 	ISSUE: This section is still under discussion and may change in future drafts.
-	It also hasn't been integrated into the white space processing rules (below).
 
 	<pre class="propdef">
 	Name: white-space-collapse
@@ -2382,36 +2375,38 @@ White Space Collapsing: the 'white-space-collapse' property</h3>
 	Animation type: discrete
 	</pre>
 
-	This property declares whether and how
+	This property specifies whether and how
 	<a href="#white-space-processing">white space</a>
 	is collapsed.
 	Values have the following meanings,
-	which must be interpreted according to the white space processing rules:
+	which must be interpreted according to
+	the [[#white-space-rules|White Space Processing Rules]]:
 
 	<dl dfn-for=white-space-collapse dfn-type=value>
 		<dt><dfn>collapse</dfn>
 		<dd>
-			This value directs user agents to collapse sequences of white space
+			This value directs user agents to collapse sequences of [=white space=]
 			into a single character
-			(or <a href="https://www.w3.org/TR/css-text/#line-break-transform">in some cases</a>, no character).
+			(or <a href="#line-break-transform">in some cases</a>, no character).
 
 		<dt><dfn>preserve</dfn>
 		<dd>
-			This value prevents user agents
-			from collapsing sequences of white space.
-			<a>Segment breaks</a> are preserved as forced line breaks.
+			This value prevents user agents from collapsing sequences of [=white space=].
+			<a>Segment breaks</a> such as line feeds
+			are preserved as [=forced line breaks=].
 
 		<dt><dfn>preserve-breaks</dfn>
 		<dd>
-			This value collapses white space as for ''collapse'', but preserves
-			<a>segment breaks</a> as forced line breaks.
+			Like ''white-space-collapse/collapse'',
+			this value collapses consecutive [=white space characters=],
+			but preserves [=segment breaks=] in the source as [=forced line breaks=].
 
 		<dt><dfn>preserve-spaces</dfn>
 		<dd>
 			This value prevents user agents
-			from collapsing sequences of white space,
-			and converts tabs and <a>segment breaks</a> to spaces.
-			(This value is intended to match the behavior
+			from collapsing sequences of [=white space=],
+			and converts [=tabs=] and [=segment breaks=] to [=spaces=].
+			(This value is intended to represent the behavior
 			of <code>xml:space="preserve"</code> in SVG.)
 
 		<dt><dfn>break-spaces</dfn>
@@ -2601,8 +2596,7 @@ White Space Trimming: the 'text-space-trim' property</h3>
 
 	This property allows authors to specify trimming behavior
 	at the beginning and end of a box.
-	Values have the following meanings,
-	which must be interpreted according to the white space processing rules:
+	Values have the following meanings:
 
 	<dl dfn-for=text-space-trim dfn-type=value>
 		<dt><dfn>discard-inner</dfn>
@@ -2734,7 +2728,7 @@ Phase I: Collapsing and Transformation</h4>
 
 	<ul>
 		<li id="collapse">
-			If 'white-space' is set to ''white-space/normal'', ''white-space/nowrap'', or ''pre-line'',
+			If 'white-space-collapse' is set to ''white-space-collapse/collapse'' or ''preserve-breaks'',
 			[=white space characters=] are considered <dfn export lt="collapsible white space" local-lt="collapsible">collapsible</dfn>
 			and are processed by performing the following steps:
 
@@ -2834,11 +2828,15 @@ Phase I: Collapsing and Transformation</h4>
 			</ol>
 
 		<li>
-			If 'white-space' is set to ''pre'', ''pre-wrap'', or ''break-spaces'',
-			any sequence of spaces is treated as a sequence of non-breaking spaces.
-			However, for ''pre-wrap'',
-			a [=soft wrap opportunity=] exists at the end of a sequence of [=spaces=] and/or [=tabs=],
-			while for ''break-spaces'',
+			If 'white-space-collapse' is set to ''preserve-spaces'',
+			each [=tab=] and [=segment break=] is converted to a [=space=].
+
+		<li>
+			If 'white-space-collapse' is set to ''preserve'' or ''preserve-spaces'',
+			any sequence of spaces is treated as a sequence of non-breaking spaces
+			except that
+			a [=soft wrap opportunity=] exists at the end of each maximal sequence of [=spaces=] and/or [=tabs=].
+			For ''break-spaces'',
 			a [=soft wrap opportunity=] exists after every [=space=] and every [=tab=].
 
 			<wpt>
@@ -2974,7 +2972,7 @@ Phase II: Trimming and Positioning</h4>
 	Then, the entire block is rendered.
 	Inlines are laid out,
 	taking [[css-writing-modes-4#text-direction|bidi reordering]] into account,
-	and [=wrapping=] as specified by the 'white-space' property.
+	and [=wrapping=] as specified by the 'text-wrap' property.
 	As each line is laid out,
 
 	<ol>
@@ -3015,7 +3013,7 @@ Phase II: Trimming and Positioning</h4>
 			Otherwise, each [=preserved=] [=tab=] is rendered
 			as a horizontal shift that lines up
 			the start edge of the next glyph with the next [=tab stop=].
-			If this distance is less than 0.5<a value class=no-quote>ch</a>,
+			If this distance is less than ''0.5ch'',
 			then the subsequent [=tab stop=] is used instead.
 			<dfn lt="tab stop">Tab stops</dfn> occur at points
 			that are multiples of the [=tab size=]
@@ -3051,7 +3049,7 @@ Phase II: Trimming and Positioning</h4>
 			A sequence of [=collapsible=] [=spaces=]
 			at the end of a line is removed,
 			as well as any trailing U+1680 &#x1680; OGHAM SPACE MARK
-			whose 'white-space' property is ''white-space/normal'', ''white-space/nowrap'', or ''pre-line''.
+			whose 'white-space-collapse' property is ''white-space-collapse/collapse'' or ''white-space-collapse/preserve-breaks''.
 
 			<wpt>
 			white-space/line-edge-white-space-collapse-001.html
@@ -3099,9 +3097,7 @@ Phase II: Trimming and Positioning</h4>
 
 			<ul>
 				<li>
-					If 'white-space' is set to ''white-space/normal'',
-					''white-space/nowrap'',
-					or ''white-space/pre-line'',
+					If 'white-space-collapse' is ''white-space-collapse/collapse'' or ''white-space-collapse/preserve-breaks'',
 					the UA must [=hang=] this sequence (unconditionally).
 
 					<wpt>
@@ -3137,7 +3133,8 @@ Phase II: Trimming and Positioning</h4>
 					</wpt>
 
 				<li>
-					If 'white-space' is set to ''pre-wrap'',
+					If 'white-space-collapse' is ''white-space-collapse/preserve''
+					and 'text-wrap' is not ''text-wrap/nowrap'',
 					the UA must (unconditionally) [=hang=] this sequence,
 					unless the sequence is followed by a [=forced line break=],
 					in which case it must [=conditionally hang=] the sequence instead.
@@ -3207,7 +3204,7 @@ Phase II: Trimming and Positioning</h4>
 					allows users to see the space when selecting or editing text.
 
 				<li>
-					If 'white-space' is set to ''break-spaces'',
+					If 'white-space-collapse' is set to ''break-spaces'',
 					[=spaces=], [=tabs=], and [=other space separators=]
 					are treated the same as other visible characters:
 					they cannot [=hang=] nor have their advance width collapsed.
@@ -3258,6 +3255,7 @@ Phase II: Trimming and Positioning</h4>
 					will either overflow or cause the line to wrap.
 			</ul>
 
+			ISSUE: What should happen here for ''white-space-collapse: preserve-spaces''?
 	</ol>
 
 	<div class=example>
@@ -3369,9 +3367,12 @@ Segment Break Transformation Rules</h4>
 		test for other features that rely on this,
 		rather than by dedicated tests."></wpt>
 
-	When 'white-space' is ''pre'', ''pre-wrap'', ''break-spaces'', or ''pre-line'',
-	[=segment breaks=] are not [=collapsible=]
-	and are instead transformed into a preserved line feed (U+000A).
+	When 'white-space-collapse' is not ''white-space-collapse/collapse'',
+	[=segment breaks=] are not [=collapsible=].
+	For values other than ''white-space-collapse/collapse''
+	or ''white-space-collapse/preserve-spaces''
+	(which transforms them into [=spaces=]),
+	[=segment breaks=] are instead transformed into a preserved line feed (U+000A).
 
 	<wpt pathprefix="/css/CSS2/text/">
 	white-space-008.xht
@@ -3380,7 +3381,7 @@ Segment Break Transformation Rules</h4>
 	white-space-processing-018.xht
 	</wpt>
 
-	For other values of 'white-space',
+	When 'white-space-collapse' is ''white-space-collapse/collapse'',
 	[=segment breaks=] are [=collapsible=],
 	and are collapsed as follows:
 
@@ -3396,6 +3397,8 @@ Segment Break Transformation Rules</h4>
 			or removed
 			depending on the context before and after the break.
 			The rules for this operation are UA-defined in this level.
+
+			ISSUE: Should we define this for Level 4?
 
 <!-- CUT SEGMENT BREAK TRANSFORM
 			<wpt pathprefix="/css/css-text/line-breaking/">

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -2565,7 +2565,9 @@ White Space Collapsing: the 'white-space-collapse' property</h3>
 			This value directs user agents to “discard”
 			all white space in the element.
 
-			Issue: Does this preserve line break opportunities or no? Do we need a "hide" value?
+			Issue: Does this preserve line break opportunities or no? Do we need a distinct "hide" value?
+			If it preserves line break opportunities,
+			maybe it should be replaced with a 'word-boundary-expansion' value?
 	</dl>
 
 	<div class="example">

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1734,7 +1734,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 
 	<pre class="propdef">
 	Name: white-space
-	Value: normal | pre | nowrap | pre-wrap | break-spaces | pre-line
+	Value: normal | pre | nowrap | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap'> || <'text-space-trim'>
 	Initial: normal
 	Applies to: text
 	Inherited: yes
@@ -1807,9 +1807,11 @@ White Space and Wrapping: the 'white-space' property</h2>
 	Note: This shorthand combines both inheritable and non-inheritable properties.
 	If this is a problem, please inform the CSSWG.
 
-	The following table gives the normative mapping of the values of the shorthand to its longhands.
+	The following table gives the normative mapping
+	of the values of the [=shorthand=]’s special keywords
+	to their equivalent [=longhand=] values.
 
-	<table class="data">
+	<table class="data" dfn-for="white-space" dfn-type="value">
 		<colgroup class="header"></colgroup>
 		<colgroup span=3></colgroup>
 		<thead>
@@ -1821,33 +1823,23 @@ White Space and Wrapping: the 'white-space' property</h2>
 		</thead>
 		<tbody>
 		<tr>
-			<th>''white-space/normal''
+			<th><dfn>normal</dfn>
 			<td>''white-space-collapse/collapse''
 			<td>''text-wrap/wrap''
 			<td>''text-space-trim/none''
 		<tr>
-			<th>''pre''
+			<th><dfn>pre</dfn>
 			<td>''white-space-collapse/preserve''
 			<td>''text-wrap/nowrap''
 			<td>''text-space-trim/none''
 		<tr>
-			<th>''white-space/nowrap''
-			<td>''white-space-collapse/collapse''
-			<td>''text-wrap/nowrap''
-			<td>''text-space-trim/none''
-		<tr>
-			<th>''pre-wrap''
+			<th><dfn>pre-wrap</dfn>
 			<td>''white-space-collapse/preserve''
 			<td>''text-wrap/wrap''
 			<td>''text-space-trim/none''
 		<tr>
-			<th>''pre-line''
+			<th><dfn>pre-line</dfn>
 			<td>''white-space-collapse/preserve-breaks''
-			<td>''text-wrap/wrap''
-			<td>''text-space-trim/none''
-		<tr>
-			<th>''break-spaces''
-			<td>''white-space-collapse/break-spaces''
 			<td>''text-wrap/wrap''
 			<td>''text-space-trim/none''
 		</tbody>
@@ -1857,8 +1849,8 @@ White Space and Wrapping: the 'white-space' property</h2>
 
 	ISSUE: Remove these definitions once the tests annotations have been redistributed.
 
-	<dl dfn-for=white-space dfn-type=value>
-		<dt><dfn>normal</dfn>
+	<dl>
+		<dt>''white-space/normal''
 		<dd>
 			This value directs user agents to collapse sequences of [=white space=]
 			into a single character
@@ -1888,7 +1880,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 			white-space-p-element-001.xht
 			</wpt>
 
-		<dt><dfn>pre</dfn>
+		<dt>''white-space/pre''
 		<dd>
 			This value prevents user agents from collapsing sequences of [=white space=].
 			[=Segment breaks=] such as line feeds
@@ -1924,7 +1916,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 			word-break/break-boundary-2-chars-002.html
 			</wpt>
 
-		<dt><dfn>nowrap</dfn>
+		<dt>''white-space/nowrap''
 		<dd>
 			Like ''white-space/normal'',
 			this value collapses [=white space=];
@@ -1949,7 +1941,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 			white-space-processing-006.xht
 			</wpt>
 
-		<dt><dfn>pre-wrap</dfn>
+		<dt>''white-space/pre-wrap''
 		<dd>
 			Like ''pre'',
 			this value preserves [=white space=];
@@ -2025,7 +2017,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 			white-space/white-space-intrinsic-size-017.html
 			</wpt>
 
-			<dt><dfn>pre-line</dfn>
+			<dt>''white-space/pre-line''
 			<dd>
 				Like ''white-space/normal'',
 				this value collapses consecutive [=white space characters=]

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1845,14 +1845,16 @@ White Space and Wrapping: the 'white-space' property</h2>
 			<td>''white-space-collapse/preserve-breaks''
 			<td>''text-wrap/wrap''
 			<td>''text-space-trim/none''
+		<tr>
+			<th>''break-spaces''
+			<td>''white-space-collapse/break-spaces''
+			<td>''text-wrap/wrap''
+			<td>''text-space-trim/none''
 		</tbody>
 	</table>
 
-	ISSUE: Need a way to express ''break-spaces''.
-
 	ISSUE: The following is the normative definition from Level 3;
-	once 'white-space-collapse' can accommodate ''break-spaces''
-	and [[#white-space-rules]] is updated
+	once [[#white-space-rules]] is updated
 	(assumming we still want to go in this direction),
 	this text should be merged into its longhands’ definitions.
 
@@ -2028,152 +2030,6 @@ White Space and Wrapping: the 'white-space' property</h2>
 			white-space/white-space-intrinsic-size-014.html
 			white-space/white-space-intrinsic-size-017.html
 			</wpt>
-
-		<dt><dfn>break-spaces</dfn>
-		<dd>
-			The behavior is identical to that of ''white-space/pre-wrap'',
-			except that:
-
-			<ul>
-				<li>
-					Any sequence of [=preserved=] [=white space=]
-					or [=other space separators=]
-					always takes up space,
-					including at the end of the line.
-
-					<wpt>
-					white-space/white-space-intrinsic-size-001.html
-					white-space/white-space-intrinsic-size-002.html
-					</wpt>
-
-				<li>
-					A line breaking opportunity exists
-					after every [=preserved=] [=white space=] character
-					and after every [=other space separator=]
-					(including between adjacent spaces).
-
-					<wpt>
-					overflow-wrap/overflow-wrap-break-word-002.html
-					overflow-wrap/overflow-wrap-anywhere-002.html
-					white-space/break-spaces-001.html
-					white-space/break-spaces-002.html
-					white-space/break-spaces-003.html
-					white-space/break-spaces-004.html
-					white-space/break-spaces-005.html
-					white-space/break-spaces-006.html
-					white-space/break-spaces-007.html
-					white-space/break-spaces-008.html
-					white-space/break-spaces-009.html
-					white-space/break-spaces-010.html
-					white-space/break-spaces-051.html
-					white-space/break-spaces-052.html
-					white-space/white-space-pre-034.html
-					white-space/textarea-break-spaces-001.html
-					white-space/textarea-break-spaces-002.html
-					white-space/break-spaces-before-first-char-001.html
-					white-space/break-spaces-before-first-char-002.html
-					white-space/break-spaces-before-first-char-003.html
-					white-space/break-spaces-before-first-char-004.html
-					white-space/break-spaces-before-first-char-005.html
-					white-space/break-spaces-before-first-char-006.html
-					white-space/break-spaces-before-first-char-007.html
-					white-space/break-spaces-before-first-char-008.html
-					white-space/break-spaces-before-first-char-009.html
-					white-space/break-spaces-before-first-char-010.html
-					white-space/break-spaces-before-first-char-011.html
-					white-space/break-spaces-before-first-char-012.html
-					white-space/break-spaces-before-first-char-013.html
-					white-space/break-spaces-before-first-char-014.html
-					white-space/break-spaces-before-first-char-015.html
-					white-space/break-spaces-before-first-char-016.html
-					white-space/break-spaces-before-first-char-017.html
-					white-space/break-spaces-before-first-char-018.html
-					white-space/break-spaces-before-first-ideographic-char-001.html
-					white-space/break-spaces-before-first-ideographic-char-002.html
-					white-space/break-spaces-before-first-ideographic-char-003.html
-					white-space/break-spaces-before-first-ideographic-char-004.html
-					white-space/break-spaces-before-first-ideographic-char-005.html
-					white-space/break-spaces-before-first-ideographic-char-006.html
-					white-space/break-spaces-before-first-ideographic-char-007.html
-					white-space/break-spaces-before-first-ideographic-char-008.html
-					white-space/break-spaces-before-first-ideographic-char-009.html
-					white-space/break-spaces-before-first-ideographic-char-010.html
-					white-space/break-spaces-before-first-ideographic-char-011.html
-					white-space/break-spaces-before-first-ideographic-char-012.html
-					white-space/break-spaces-before-first-ideographic-char-013.html
-					white-space/break-spaces-before-first-ideographic-char-014.html
-					white-space/break-spaces-before-first-ideographic-char-015.html
-					white-space/break-spaces-before-first-ideographic-char-016.html
-					white-space/break-spaces-before-first-ideographic-char-017.html
-					white-space/break-spaces-before-first-ideographic-char-018.html
-					white-space/tab-stop-threshold-005.html
-					white-space/tab-stop-threshold-006.html
-					word-break/word-break-break-all-017.html
-					white-space/break-spaces-tab-001.html
-					white-space/break-spaces-tab-002.html
-					white-space/break-spaces-tab-003.html
-					white-space/break-spaces-tab-004.html
-					white-space/break-spaces-tab-005.html
-					white-space/break-spaces-tab-006.html
-					white-space/break-spaces-with-overflow-wrap-001.html
-					white-space/break-spaces-with-overflow-wrap-002.html
-					white-space/break-spaces-with-overflow-wrap-003.html
-					white-space/break-spaces-with-overflow-wrap-004.html
-					white-space/break-spaces-with-overflow-wrap-005.html
-					white-space/break-spaces-with-overflow-wrap-006.html
-					white-space/break-spaces-with-overflow-wrap-007.html
-					white-space/break-spaces-with-overflow-wrap-008.html
-					white-space/break-spaces-with-overflow-wrap-009.html
-					white-space/break-spaces-with-overflow-wrap-010.html
-					white-space/break-spaces-with-ideographic-space-001.html
-					white-space/break-spaces-with-ideographic-space-002.html
-					white-space/break-spaces-with-ideographic-space-003.html
-					white-space/break-spaces-with-ideographic-space-004.html
-					white-space/break-spaces-with-ideographic-space-005.html
-					white-space/break-spaces-with-ideographic-space-006.html
-					white-space/break-spaces-with-ideographic-space-007.html
-					white-space/break-spaces-with-ideographic-space-008.html
-					white-space/break-spaces-with-ideographic-space-009.html
-					white-space/break-spaces-with-ideographic-space-010.html
-					line-break/line-break-anywhere-and-white-space-008.html
-					line-break/line-break-anywhere-and-white-space-009.html
-					white-space/ws-break-spaces-applies-to-001.html
-					white-space/ws-break-spaces-applies-to-002.html
-					white-space/ws-break-spaces-applies-to-003.html
-					white-space/ws-break-spaces-applies-to-005.html
-					white-space/ws-break-spaces-applies-to-006.html
-					white-space/ws-break-spaces-applies-to-007.html
-					white-space/ws-break-spaces-applies-to-008.html
-					white-space/ws-break-spaces-applies-to-009.html
-					white-space/ws-break-spaces-applies-to-010.html
-					white-space/ws-break-spaces-applies-to-011.html
-					white-space/ws-break-spaces-applies-to-012.html
-					white-space/ws-break-spaces-applies-to-013.html
-					white-space/ws-break-spaces-applies-to-014.html
-					white-space/ws-break-spaces-applies-to-015.html
-					white-space/break-spaces-newline-011.html
-					white-space/break-spaces-newline-012.html
-					white-space/break-spaces-newline-013.html
-					white-space/break-spaces-newline-014.html
-					white-space/break-spaces-newline-015.html
-					white-space/break-spaces-newline-016.html
-					white-space/trailing-ideographic-space-break-spaces-001.html
-					white-space/trailing-ideographic-space-break-spaces-002.html
-					white-space/trailing-ideographic-space-break-spaces-003.html
-					white-space/trailing-ideographic-space-break-spaces-004.html
-					white-space/trailing-ideographic-space-break-spaces-005.html
-					white-space/trailing-ideographic-space-break-spaces-006.html
-					white-space/trailing-ideographic-space-break-spaces-007.html
-					white-space/trailing-ideographic-space-break-spaces-008.html
-					</wpt>
-
-			</ul>
-
-			Note: This value does not guarantee
-			that there will never be any overflow due to white space:
-			for example, if the line length is so short
-			that even a single white space character does not fit,
-			overflow is unavoidable.
 
 			<dt><dfn>pre-line</dfn>
 			<dd>
@@ -2513,12 +2369,11 @@ White Space Processing &amp; Control Characters</h2>
 White Space Collapsing: the 'white-space-collapse' property</h3>
 
 	ISSUE: This section is still under discussion and may change in future drafts.
-	It also hasn't been properly updated to account for the newer values of 'white-space',
-	and has not been integrated into the white space processing rules (below).
+	It also hasn't been integrated into the white space processing rules (below).
 
 	<pre class="propdef">
 	Name: white-space-collapse
-	Value: collapse | discard | preserve | preserve-breaks | preserve-spaces
+	Value: collapse | discard | preserve | preserve-breaks | preserve-spaces | break-spaces
 	Initial: collapse
 	Applies to: text
 	Inherited: yes
@@ -2558,6 +2413,152 @@ White Space Collapsing: the 'white-space-collapse' property</h3>
 			and converts tabs and <a>segment breaks</a> to spaces.
 			(This value is intended to match the behavior
 			of <code>xml:space="preserve"</code> in SVG.)
+
+		<dt><dfn>break-spaces</dfn>
+		<dd>
+			The behavior is identical to that of ''preserve'',
+			except that:
+
+			<ul>
+				<li>
+					Any sequence of [=preserved=] [=white space=]
+					or [=other space separators=]
+					always takes up space,
+					including at the end of the line.
+
+					<wpt>
+					white-space/white-space-intrinsic-size-001.html
+					white-space/white-space-intrinsic-size-002.html
+					</wpt>
+
+				<li>
+					A line breaking opportunity exists
+					after every [=preserved=] [=white space=] character
+					and after every [=other space separator=]
+					(including between adjacent spaces).
+
+					<wpt>
+					overflow-wrap/overflow-wrap-break-word-002.html
+					overflow-wrap/overflow-wrap-anywhere-002.html
+					white-space/break-spaces-001.html
+					white-space/break-spaces-002.html
+					white-space/break-spaces-003.html
+					white-space/break-spaces-004.html
+					white-space/break-spaces-005.html
+					white-space/break-spaces-006.html
+					white-space/break-spaces-007.html
+					white-space/break-spaces-008.html
+					white-space/break-spaces-009.html
+					white-space/break-spaces-010.html
+					white-space/break-spaces-051.html
+					white-space/break-spaces-052.html
+					white-space/white-space-pre-034.html
+					white-space/textarea-break-spaces-001.html
+					white-space/textarea-break-spaces-002.html
+					white-space/break-spaces-before-first-char-001.html
+					white-space/break-spaces-before-first-char-002.html
+					white-space/break-spaces-before-first-char-003.html
+					white-space/break-spaces-before-first-char-004.html
+					white-space/break-spaces-before-first-char-005.html
+					white-space/break-spaces-before-first-char-006.html
+					white-space/break-spaces-before-first-char-007.html
+					white-space/break-spaces-before-first-char-008.html
+					white-space/break-spaces-before-first-char-009.html
+					white-space/break-spaces-before-first-char-010.html
+					white-space/break-spaces-before-first-char-011.html
+					white-space/break-spaces-before-first-char-012.html
+					white-space/break-spaces-before-first-char-013.html
+					white-space/break-spaces-before-first-char-014.html
+					white-space/break-spaces-before-first-char-015.html
+					white-space/break-spaces-before-first-char-016.html
+					white-space/break-spaces-before-first-char-017.html
+					white-space/break-spaces-before-first-char-018.html
+					white-space/break-spaces-before-first-ideographic-char-001.html
+					white-space/break-spaces-before-first-ideographic-char-002.html
+					white-space/break-spaces-before-first-ideographic-char-003.html
+					white-space/break-spaces-before-first-ideographic-char-004.html
+					white-space/break-spaces-before-first-ideographic-char-005.html
+					white-space/break-spaces-before-first-ideographic-char-006.html
+					white-space/break-spaces-before-first-ideographic-char-007.html
+					white-space/break-spaces-before-first-ideographic-char-008.html
+					white-space/break-spaces-before-first-ideographic-char-009.html
+					white-space/break-spaces-before-first-ideographic-char-010.html
+					white-space/break-spaces-before-first-ideographic-char-011.html
+					white-space/break-spaces-before-first-ideographic-char-012.html
+					white-space/break-spaces-before-first-ideographic-char-013.html
+					white-space/break-spaces-before-first-ideographic-char-014.html
+					white-space/break-spaces-before-first-ideographic-char-015.html
+					white-space/break-spaces-before-first-ideographic-char-016.html
+					white-space/break-spaces-before-first-ideographic-char-017.html
+					white-space/break-spaces-before-first-ideographic-char-018.html
+					white-space/tab-stop-threshold-005.html
+					white-space/tab-stop-threshold-006.html
+					word-break/word-break-break-all-017.html
+					white-space/break-spaces-tab-001.html
+					white-space/break-spaces-tab-002.html
+					white-space/break-spaces-tab-003.html
+					white-space/break-spaces-tab-004.html
+					white-space/break-spaces-tab-005.html
+					white-space/break-spaces-tab-006.html
+					white-space/break-spaces-with-overflow-wrap-001.html
+					white-space/break-spaces-with-overflow-wrap-002.html
+					white-space/break-spaces-with-overflow-wrap-003.html
+					white-space/break-spaces-with-overflow-wrap-004.html
+					white-space/break-spaces-with-overflow-wrap-005.html
+					white-space/break-spaces-with-overflow-wrap-006.html
+					white-space/break-spaces-with-overflow-wrap-007.html
+					white-space/break-spaces-with-overflow-wrap-008.html
+					white-space/break-spaces-with-overflow-wrap-009.html
+					white-space/break-spaces-with-overflow-wrap-010.html
+					white-space/break-spaces-with-ideographic-space-001.html
+					white-space/break-spaces-with-ideographic-space-002.html
+					white-space/break-spaces-with-ideographic-space-003.html
+					white-space/break-spaces-with-ideographic-space-004.html
+					white-space/break-spaces-with-ideographic-space-005.html
+					white-space/break-spaces-with-ideographic-space-006.html
+					white-space/break-spaces-with-ideographic-space-007.html
+					white-space/break-spaces-with-ideographic-space-008.html
+					white-space/break-spaces-with-ideographic-space-009.html
+					white-space/break-spaces-with-ideographic-space-010.html
+					line-break/line-break-anywhere-and-white-space-008.html
+					line-break/line-break-anywhere-and-white-space-009.html
+					white-space/ws-break-spaces-applies-to-001.html
+					white-space/ws-break-spaces-applies-to-002.html
+					white-space/ws-break-spaces-applies-to-003.html
+					white-space/ws-break-spaces-applies-to-005.html
+					white-space/ws-break-spaces-applies-to-006.html
+					white-space/ws-break-spaces-applies-to-007.html
+					white-space/ws-break-spaces-applies-to-008.html
+					white-space/ws-break-spaces-applies-to-009.html
+					white-space/ws-break-spaces-applies-to-010.html
+					white-space/ws-break-spaces-applies-to-011.html
+					white-space/ws-break-spaces-applies-to-012.html
+					white-space/ws-break-spaces-applies-to-013.html
+					white-space/ws-break-spaces-applies-to-014.html
+					white-space/ws-break-spaces-applies-to-015.html
+					white-space/break-spaces-newline-011.html
+					white-space/break-spaces-newline-012.html
+					white-space/break-spaces-newline-013.html
+					white-space/break-spaces-newline-014.html
+					white-space/break-spaces-newline-015.html
+					white-space/break-spaces-newline-016.html
+					white-space/trailing-ideographic-space-break-spaces-001.html
+					white-space/trailing-ideographic-space-break-spaces-002.html
+					white-space/trailing-ideographic-space-break-spaces-003.html
+					white-space/trailing-ideographic-space-break-spaces-004.html
+					white-space/trailing-ideographic-space-break-spaces-005.html
+					white-space/trailing-ideographic-space-break-spaces-006.html
+					white-space/trailing-ideographic-space-break-spaces-007.html
+					white-space/trailing-ideographic-space-break-spaces-008.html
+					</wpt>
+
+			</ul>
+
+			Note: This value does not guarantee
+			that there will never be any overflow due to white space:
+			for example, if the line length is so short
+			that even a single white space character does not fit,
+			overflow is unavoidable.
 
 		<dt><dfn>discard</dfn>
 		<dd>


### PR DESCRIPTION
Series of commits for properly integrating the L3 'white-space' shorthand and L4 longhand definitions in CSS Text Level 4.