### PR TITLE
[css-color-6] Fix typo in contrast-color() syntax

### DIFF
--- a/css-color-6/Overview.bs
+++ b/css-color-6/Overview.bs
@@ -65,7 +65,7 @@ Computing a Contrasting Color: the ''contrast-color()'' function {#colorcontrast
 	<pre class='prod'>
 		<<contrast-color()>> = contrast-color(
 		  [ [ <<color>> && [ tbd-fg | tbd-bg ] && <<target-contrast>>? ] |
-		    [ <<color>> && [ tbd-fg | tbd-bg ] && <<target-contrast>>, <<color>># ] )
+		    [ <<color>> && [ tbd-fg | tbd-bg ] && <<target-contrast>>, <<color>># ] ] )
 		<<target-contrast>> = <<wcag2>>
 		<!-- Allow multiple algorithms in the future by using && operator instead of | for <<target-contrast>> additions.
 		See resolution in #7357 -->


### PR DESCRIPTION
One `]` character was missing.

