### PR TITLE
[css-view-transitions-1] Fix play state tracking for animations

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -969,7 +969,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 				Issue: The prose around "effect target" is incorrect, but [#8001](https://github.com/w3c/csswg-drafts/issues/8001) needs to land before it can be fixed.
 
-				- |animation|'s [=animation/play state=] is [=play state/idle=] or [=play state/running=].
+				- |animation|'s [=animation/play state=] is [=play state/paused=] or [=play state/running=].
 
 				- |document|'s [=pending animation event queue=] has any events associated with |animation|.
 


### PR DESCRIPTION
Animations targeting pseudo-elements are considered active, for the purpose of finishing the transition, if they are in running or paused state. See resolution here for details: https://github.com/w3c/csswg-drafts/issues/7785#issuecomment-1269115123.

"paused" was incorrectly changed to idle in the following commit: https://github.com/w3c/csswg-drafts/commit/5151ae80775a862c0edb5ebb35653bc47a55f906.

This change fixes that.
