### PR TITLE
[css-color-6] Fix typo in wcag2 keyword

### DIFF
--- a/css-color-6/Overview.bs
+++ b/css-color-6/Overview.bs
@@ -240,7 +240,7 @@ If no target contrast is specified</h4>
 	Their syntax is:
 
 	<pre class="prod">
-	  <dfn><<wcag2>></dfn> =  wcag | wcag2([<<number>> | [ aa | aaa ] && large? ])
+	  <dfn><<wcag2>></dfn> =  wcag2 | wcag2([<<number>> | [ aa | aaa ] && large? ])
 	</pre>
 
 	Its [=target contrast level=] keywords map as follows:


### PR DESCRIPTION
Prose says keyword is `wcag2`, not `wcag`.
