### PR TITLE
[css-view-transitions-1] Fix refs

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -24,6 +24,8 @@ spec:css-position-3; type:property
 spec:css-shapes-3; type:function; text:rect()
 spec:webidl; type:interface; text:Promise
 spec:css-images-4; type:function; text:element()
+spec:dom; type:dfn; text:document
+spec:css-2022; type:dfn; text:style sheet
 </pre>
 
 <pre class=anchors>
@@ -466,7 +468,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	</dl>
 
 	Note: These are used to update, and later remove styles
-	from a [=document=]'s [=document/view transition style sheet=].
+	from a [=/document=]'s [=document/view transition style sheet=].
 
 ## Additions to {{Document}} ## {#additions-to-document}
 
@@ -480,8 +482,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		:: a boolean. Initially false.
 
 		: <dfn>view transition style sheet</dfn>
-		:: a [=style sheet=].
-			Initially a new [=style sheet=] in the [=user-agent origin=], ordered after the [=HTML user agent style sheet=].
+		:: a [=/style sheet=].
+			Initially a new [=/style sheet=] in the [=user-agent origin=], ordered after the [=HTML user agent style sheet=].
 
 			Note: This is used to hold dynamic styles relating to transitions.
 


### PR DESCRIPTION
Bikeshed changed databases, and we ended up with a couple of new warnings/errors.

There's still one remaining new error:

```
LINE ~371: Spec-section autolink tried to link to non-existent 'css-viewport' spec:
[[css-viewport#interactive-widget-section]]
```

I don't think this is our fault, I think it's something missing from the database (cc @tabatkins)