### PR TITLE
[CSSOM-VIEW] Export 'scrolling box','layout viewport' dfns

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -99,7 +99,7 @@ An element <var>body</var> (which will be <a>the <code>body</code> element</a>) 
 Note: A <{body}> element that is <a>potentially scrollable</a> might not have a <a>scrolling box</a>.
 For instance, it could have a used value of 'overflow' being ''overflow/auto'' but not have its content overflowing its content area.
 
-A <dfn>scrolling box</dfn> of a <a>viewport</a> or element has two <dfn>overflow directions</dfn>, which are the <a>block-end</a> and <a>inline-end</a> directions for that viewport or element.
+A <dfn export>scrolling box</dfn> of a <a>viewport</a> or element has two <dfn>overflow directions</dfn>, which are the <a>block-end</a> and <a>inline-end</a> directions for that viewport or element.
 Note that the initial scroll position might not be aligned with the [=scrolling area origin=]
 depending on the [=content-distribution properties=], see [[css-align-3#overflow-scroll-position]].
 
@@ -267,7 +267,7 @@ The <dfn>ending edges</dfn> of a particular set of edges of a box or element are
 </dl>
 
 The <dfn>visual viewport</dfn> is a kind of <a>viewport</a> whose <a>scrolling area</a> is another <a>viewport</a>,
-called the <dfn>layout viewport</dfn>.
+called the <dfn export>layout viewport</dfn>.
 
 In addition to scrolling, the <a>visual viewport</a> may also apply a scale transform to its <a>layout viewport</a>.
 This transform is applied to the <a>canvas</a> of the <a>layout viewport</a> and does not affect its internal coordinate space.


### PR DESCRIPTION
[CSSOM-VIEW] Export 'scrolling box','layout viewport' dfns

This would allow other specs to refer to these useful concepts. Example: https://www.w3.org/TR/css-view-transitions-1/#:~:text=without%20moving%20or%20resizing%20the%20layout%20viewport
