### PR TITLE
[css-view-transitions-1] Add manual spec link for CSS-Viewport

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -36,6 +36,26 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	text: HTML user agent style sheet; url: #the-css-user-agent-style-sheet-and-presentational-hints
 </pre>
 
+<!-- CSS-Viewport appears not to be in specref as it's not published on a W3C TR. Once it is this manual entry can be removed. -->
+<pre class=biblio>
+{
+	"css-viewport": {
+		"authors": [
+			"Emilio Cobos Álvarez",
+			"Matt Rakow",
+			"Florian Rivoal"
+		],
+		"href": "https://drafts.csswg.org/css-viewport/",
+		"title": "CSS Viewport Module Level 1",
+		"status": "ED",
+		"publisher": "W3C",
+		"deliveredBy": [
+			"https://www.w3.org/Style/CSS/"
+		]
+	}
+}
+</pre>
+
 <style>
 	/* Put nice boxes around each algorithm. */
 	[data-algorithm]:not(.heading) {


### PR DESCRIPTION
[css-view-transitions-1] Add manual spec link for CSS-Viewport

It appears CSS-Viewport isn't being exported to SpecRef due to not having a published TR. Add a manual link to css-view-transitions for now to fix linking errors. 
