### PR TITLE
[css-animations-1] Export 'pending animation event queue'

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2069,9 +2069,9 @@ this specification as well as the <a>events from CSS transitions</a>
 Future specifications may extend this set with further types of [=animation
 events=].
 
-Each {{Document}} maintains a <dfn>pending animation event queue</dfn> that
-stores [=animation events=] along with their corresponding event targets and
-<dfn>scheduled event time</dfn>.
+Each {{Document}} maintains a <dfn export>pending animation event queue</dfn>
+that stores [=animation events=] along with their corresponding event targets
+and <dfn>scheduled event time</dfn>.
 The [=scheduled event time=] is a [=time value=] relative to the [=time origin=]
 representing when the event would ideally have been dispatched were animations
 updated at an infinitely high frequency.


### PR DESCRIPTION
[css-animations-1] Export 'pending animation event queue'

Export this definition for [use in css-view-transitions-1](https://www.w3.org/TR/css-view-transitions-1/#:~:text=pending%20animation%20event%20queue)
