### PR TITLE
[css-view-transitions-1] Rename domUpdated to updateCallbackDone

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -596,7 +596,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			undefined skipTransition();
 			readonly attribute Promise<undefined> finished;
 			readonly attribute Promise<undefined> ready;
-			readonly attribute Promise<undefined> domUpdated;
+			readonly attribute Promise<undefined> updateCallbackDone;
 		};
 	</xmp>
 
@@ -630,7 +630,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
-		: <dfn>DOM updated promise</dfn>
+		: <dfn>update callback done promise</dfn>
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
@@ -655,7 +655,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	The {{ViewTransition/ready}} [=getter steps=] are to return [=this's=] [=ViewTransition/ready promise=].
 
-	The {{ViewTransition/domUpdated}} [=getter steps=] are to return [=this's=] [=ViewTransition/DOM updated promise=].
+	The {{ViewTransition/updateCallbackDone}} [=getter steps=] are to return [=this's=] [=ViewTransition/update callback done promise=].
 
 	### {{ViewTransition/skipTransition()}} ### {#ViewTransition-skipTransition}
 
@@ -804,7 +804,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			1. [=Call the DOM update callback=] of |transition|.
 
-			1. [=promise/React=] to |transition|'s [=ViewTransition/DOM updated promise=]:
+			1. [=promise/React=] to |transition|'s [=ViewTransition/update callback done promise=]:
 
 				* If the promise does not settle within an implementation-defined timeout, then:
 
@@ -906,12 +906,12 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 			Note: The ready promise would've been resolved if {{ViewTransition/skipTransition()}} is called after we start animating.
 
-		1. [=promise/React=] to |transition|'s [=ViewTransition/DOM updated promise=]:
+		1. [=promise/React=] to |transition|'s [=ViewTransition/update callback done promise=]:
 
-			* If |transition|'s [=ViewTransition/DOM updated promise=] was resolved,
+			* If |transition|'s [=ViewTransition/update callback done promise=] was resolved,
 				then [=resolve=] |transition|'s [=ViewTransition/finished promise=].
 
-			* If |transition|'s [=ViewTransition/DOM updated promise=] was rejected with reason |reason|,
+			* If |transition|'s [=ViewTransition/update callback done promise=] was rejected with reason |reason|,
 				then [=reject=] |transition|'s [=ViewTransition/finished promise=] with |reason|.
 	</div>
 
@@ -1280,9 +1280,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. [=promise/React=] to |callbackPromise|:
 
-			* If |callbackPromise| was resolved, then [=resolve=] |transition|'s [=ViewTransition/DOM updated promise=].
+			* If |callbackPromise| was resolved, then [=resolve=] |transition|'s [=ViewTransition/update callback done promise=].
 
-			* If |callbackPromise| was rejected with reason |r|, then [=reject=] |transition|'s [=ViewTransition/DOM updated promise=] with |r|.
+			* If |callbackPromise| was rejected with reason |r|, then [=reject=] |transition|'s [=ViewTransition/update callback done promise=] with |r|.
 	</div>
 
 ## [=Clear view transition=] ## {#clear-view-transition-algorithm}


### PR DESCRIPTION
[css-view-transitions-1] Rename domUpdated to updateCallbackDone

Fixes #8144 