### PR TITLE
[css-grid-1][css-grid-2][editorial] Fix 'auto' sizing function link in layout-algorithm

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -3799,7 +3799,7 @@ Grid Sizing</h2>
 
 	<ul>
 		<li>A <dfn>fixed sizing function</dfn> (<<length>> or resolvable <<percentage>>).
-		<li>An <dfn>intrinsic sizing function</dfn> (''min-content'', ''max-content'', ''auto'', ''fit-content()'').
+		<li>An <dfn>intrinsic sizing function</dfn> (''min-content'', ''max-content'', ''grid-template-rows/auto'', ''fit-content()'').
 		<li>A <dfn>flexible sizing function</dfn> (<<flex>>).
 	</ul>
 

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -4345,7 +4345,7 @@ Grid Sizing</h2>
 
 	<ul>
 		<li>A <dfn>fixed sizing function</dfn> (<<length>> or resolvable <<percentage>>).
-		<li>An <dfn>intrinsic sizing function</dfn> (''min-content'', ''max-content'', ''auto'', ''fit-content()'').
+		<li>An <dfn>intrinsic sizing function</dfn> (''min-content'', ''max-content'', ''grid-template-rows/auto'', ''fit-content()'').
 		<li>A <dfn>flexible sizing function</dfn> (<<flex>>).
 	</ul>
 


### PR DESCRIPTION
Without the 'grid-template-rows' prefix this link points at 'auto' in the context of the grid item placement properties, but like its neighbors it is actually meant to refer to the track sizing function.