### PR TITLE
[css-anchor-1] Change Popup references to Popover

### DIFF
--- a/css-anchor-1/Overview.bs
+++ b/css-anchor-1/Overview.bs
@@ -507,9 +507,9 @@ might not be capable of anchoring the positioned element.
 An element can also have an <dfn export>implicit anchor element</dfn>,
 used when an [=anchor function=] doesn't specify an explicit [=anchor name=].
 
-Note: The Popup API, for example,
-defines an [=implicit anchor element=] for a popup--
-the element that the popup is attached to.
+Note: The Popover API, for example,
+defines an [=implicit anchor element=] for a popover--
+the element that the popover is attached to.
 
 Note: An element can have only one implicit anchor element.
 If we end up with multiple features defining
@@ -696,7 +696,7 @@ In any case, not worth the cost in spec or impl.
 Issue: This implies that the values can't be transitioned in the usual fashion,
 since transitions key off of computed values
 and we're past that point.
-However, popups sliding between positions is a common effect in UI libs.
+However, popovers sliding between positions is a common effect in UI libs.
 Probably should introduce a <css>smooth</css> keyword
 to 'position-fallback'
 to trigger automatic "animation" of the fallback'd properties.
@@ -755,48 +755,48 @@ This limit must be <em>at least</em> five.
 
 <div class=example>
 	For example,
-	the following CSS will first attempt to position a "popup"
+	the following CSS will first attempt to position a "popover"
 	below the [=element=],
 	but if it doesn't fit on-screen will switch to being above;
 	it defaults to left-aligning,
 	but will switch to right-aligning if that doesn't fit.
 
 	<pre highlight=css>
-	#myPopup {
+	#myPopover {
 		position: fixed;
-		position-fallback: --button-popup;
+		position-fallback: --button-popover;
 		overflow: auto;
 
-		/* The popup is at least as wide as the button */
+		/* The popover is at least as wide as the button */
 		min-width: anchor-size(--button width);
 
-		/* The popup is at least as tall as 2 menu items */
+		/* The popover is at least as tall as 2 menu items */
 		min-height: 6em;
 	}
 
-	@position-fallback --button-popup {
-		/* First try to align the top, left edge of the popup
+	@position-fallback --button-popover {
+		/* First try to align the top, left edge of the popover
 		with the bottom, left edge of the button. */
 		@try {
 			top: anchor(--button bottom);
 			left: anchor(--button left);
 		}
 
-		/* Next try to align the bottom, left edge of the popup
+		/* Next try to align the bottom, left edge of the popover
 		with the top, left edge of the button. */
 		@try {
 			bottom: anchor(--button top);
 			left: anchor(--button left);
 		}
 
-		/* Next try to align the top, right edge of the popup
+		/* Next try to align the top, right edge of the popover
 		with the bottom, right edge of the button. */
 		@try {
 			top: anchor(--button bottom);
 			right: anchor(--button right);
 		}
 
-		/* Finally, try to align the bottom, right edge of the popup
+		/* Finally, try to align the bottom, right edge of the popover
 		with the top, right edge of the button. Other positions are possible,
 		but this is the final option the author would like the rendering
 		engine to try. */


### PR DESCRIPTION
Spec update to change `popup` references to `popover` to align with the renaming of the Popover API.


