### PR TITLE
[css-align-3][css-flexbox-1][css-grid-1] Improve container baseline finding algo #7655 #7641

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2218,7 +2218,8 @@ Determining the Baselines of a Box</h2>
 		<dt>tables
 		<dd>
 			The first/last [=baseline set=] of a table box
-			is the first/last [=baseline set=] of its first/last row.
+			is the first/last [=baseline set=] of its first/last row
+			(after any reordering of [=table row groups=]).
 
 			When finding the first/last baseline set of an inline-block,
 			any baselines contributed by table boxes must be skipped.
@@ -2239,14 +2240,21 @@ Determining the Baselines of a Box</h2>
 				last [=baseline alignment=] along the table’s [=inline axis=],
 				[=generate=] from <em>that</em> [=alignment baseline=].
 
+			<!-- Other layout models have this step, but for compat reasons tables can't.
 			3.  Otherwise, if any cells in the row have an [=inline-axis=] [=baseline set=] at all,
 				take the [=baseline set=] from the cell
 				with the <em>highest</em> ([=block-start=]&ndash;most) baseline
 				corresponding to the table's [=alignment baseline=].
+			-->
 
-			4.  Otherwise, [=synthesize=] from the lowest and highest [=content edges=]
+			4.  Otherwise, if the row is not empty,
+				[=synthesize=] from the lowest and highest [=content edges=]
 				of all the cells in the row.
-				(See [[!CSS2]].)
+				See [[css2#height-layout]].
+
+			5.  Otherwise,
+				use the [=block-start=] [=content edge=] of the [=table row box=] itself
+				as the [=alignment baseline=].
 
 			For this purpose,
 			any [=table cell=] that spans multiple rows
@@ -2254,8 +2262,8 @@ Determining the Baselines of a Box</h2>
 			except that for step 2,
 			it's ignored if its span does not <em>end</em> in this row.
 
-			Last baselines are analogous
-			(with “first”/“last” and “start”/“end” inverted).
+			<em>Last baselines are analogous
+			(with “first”/“last” and “start”/“end” inverted).</em>
 
 		<dt>flex containers
 		<dd>

--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2226,16 +2226,36 @@ Determining the Baselines of a Box</h2>
 
 		<dt>table rows
 		<dd>
-			If any cells in the row participate in
-			''first baseline''/''last baseline'' alignment
-			along the [=inline axis=],
-			the first/last [=baseline set=] of the row
-			is <a>generated</a> from their shared <a>alignment baseline</a>
-			and the row's <a>first available font</a>,
-			after alignment has been performed.
-			Otherwise, the first/last [=baseline set=] of the row
-			is <a>synthesized</a> from the lowest and highest content edges of the cells in the row.
-			[[!CSS2]]
+			The first [=baseline set=] of a [=table row box=]
+			is taken from the first available of:
+
+			1.  If any cells in the row participate in
+				first [=baseline alignment=] along the table’s [=inline axis=],
+				[=generate=] a [=baseline set=] from their shared [=alignment baseline=]
+				and the row’s [=first available font=],
+				after alignment has been performed.
+
+			2.  Otherwise, if any cells in the row participate in
+				last [=baseline alignment=] along the table’s [=inline axis=],
+				[=generate=] from <em>that</em> [=alignment baseline=].
+
+			3.  Otherwise, if any cells in the row have an [=inline-axis=] [=baseline set=] at all,
+				take the [=baseline set=] from the cell
+				with the <em>highest</em> ([=block-start=]&ndash;most) baseline
+				corresponding to the table's [=alignment baseline=].
+
+			4.  Otherwise, [=synthesize=] from the lowest and highest [=content edges=]
+				of all the cells in the row.
+				(See [[!CSS2]].)
+
+			For this purpose,
+			any [=table cell=] that spans multiple rows
+			is ignored if it’s span does not start in this row;
+			except that for step 2,
+			it's ignored if its span does not <em>end</em> in this row.
+
+			Last baselines are analogous
+			(with “first”/“last” and “start”/“end” inverted).
 
 		<dt>flex containers
 		<dd>

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -2280,24 +2280,35 @@ Flex Container Baselines</h3>
 			matches its <a>main axis</a>,
 			its baselines are determined as follows:
 
-			1. If any of the <a>flex items</a> on the flex container's [=startmost=]/[=endmost=] <a>flex line</a>
-				<a href="#baseline-participation">participate in baseline alignment</a>,
-				the flex container's first/last <a>main-axis baseline set</a>
-				is <a lt="generate baselines">generated</a> from
-				the shared <a>alignment baseline</a> of those <a>flex items</a>.
+			1. If any of the [=flex items=] on the flex container's [=startmost=] [=flex line=]
+				participate in first [=baseline alignment=] along the [=main axis=],
+				<a lt="generate baselines">generate</a> a [=baseline set=] from their shared [=alignment baseline=]
+				and the [=flex container's=] [=first available font=].
 
-			2. Otherwise, if the flex container has at least one <a>flex item</a>,
-				the flex container's first/last <a>main-axis baseline set</a>
-				is <a lt="generate baselines">generated</a> from
-				the <a>alignment baseline</a> of the [=startmost=]/[=endmost=] <a>flex item</a>.
-				(If that item has no <a>alignment baseline</a>
-				parallel to the flex container's <a>main axis</a>,
-				then one is first <a lt="synthesized baseline">synthesized</a>
-				from its border edges.)
+			2. Otherwise, if any of the [=flex items=] on the flex container's [=startmost=] [=flex line=]
+				participate in last [=baseline alignment=] along the [=main axis=],
+				<a lt="generate baselines">generate</a> a [=baseline set=] from their shared [=alignment baseline=]
+				and the [=flex container's=] [=first available font=].
 
-			3. Otherwise, the flex container has no first/last main-axis <a>baseline set</a>,
-				and one is <a lt="synthesize baselines">synthesized</a> if needed
-				according to the rules of its <a>alignment context</a>.
+			3. Otherwise, if any [=flex items=] in the [=startmost=] [=flex line=]
+				have a [=baseline set=] along the [=main axis=],
+				take the [=baseline set=] from the [=flex item=]
+				with the <em>highest</em> ([=block-start=]&ndash;most) baseline
+				corresponding to the [=flex container's=]'s [=alignment baseline=],
+				preferring the first in [=order-modified document order=]
+				if multiple items are tied.
+
+			4. Otherwise, if there are any [=flex items=] at all,
+				<a lt="synthesize baselines">synthesize</a> a [=baseline set=]
+				from the [=startmost=] [=flex item=] on the [=startmost=] line.
+
+			5. Otherwise, the [=flex container=] has no first [=main-axis=] <a>baseline set</a>.
+				(One is <a lt="synthesize baselines">synthesized</a>
+				from the [=flex container=] itself if needed,
+				according to the rules of its <a>alignment context</a>.)
+
+			Last baselines are analogous
+			(with “first”/“last” and “start”/“end” inverted).
 
 		<dt>first/last <dfn export id="cross-axis-baseline"
 			lt="cross-axis baseline set|first cross-axis baseline set|last cross-axis baseline set">

--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -2292,11 +2292,8 @@ Flex Container Baselines</h3>
 
 			3. Otherwise, if any [=flex items=] in the [=startmost=] [=flex line=]
 				have a [=baseline set=] along the [=main axis=],
-				take the [=baseline set=] from the [=flex item=]
-				with the <em>highest</em> ([=block-start=]&ndash;most) baseline
-				corresponding to the [=flex container's=]'s [=alignment baseline=],
-				preferring the first in [=order-modified document order=]
-				if multiple items are tied.
+				take the [=baseline set=] from the first such [=flex item=]
+				in [=order-modified document order=].
 
 			4. Otherwise, if there are any [=flex items=] at all,
 				<a lt="synthesize baselines">synthesize</a> a [=baseline set=]

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -3714,36 +3714,44 @@ Aligning the Grid: the 'justify-content' and 'align-content' properties</h3>
 <h3 id='grid-baselines'>
 Grid Container Baselines</h3>
 
-	The first (last) baselines of a <a>grid container</a>
-	are determined as follows:
+	The first [=baseline set=] of a [=grid container=]
+	is taken from the first available of:
 
-	<ol>
-		<li>
-			Find the first (last) row of the [=grid container=]
-			containing at least one [=grid item=].
+	1.  If any [=grid items=] intersecting the first ([=block-start=]&ndash;most) non-empty [=track=]
+		participate in first [=baseline alignment=] along the relevant axis,
+		<a lt="generate baselines">generate</a> a [=baseline set=] from their shared [=alignment baseline=]
+		and the [=grid container=]’s [=first available font=],
+		after alignment has been performed.
 
-			If any of the [=grid items=] intersecting this row
-			participate in [=baseline alignment=] in that row,
-			the grid container's <a>baseline set</a>
-			is <a lt="generate baselines">generated</a> from
-			the shared <a>alignment baseline</a> of those <a>grid items</a>.
+	2.  Otherwise, if any [=grid items=] intersecting that track participate in
+		last [=baseline alignment=] along the relevant axis,
+		<a lt="generate baselines">generate</a> from <em>that</em> [=alignment baseline=].
 
-			Otherwise,
-			the grid container's first (last) baseline set
-			is <a lt="generate baselines">generated</a> from
-			the <a>alignment baseline</a> of the first (last) <a>grid item</a>
-			in row-major <a>grid order</a> (according to the <a>writing mode</a> of the <a>grid container</a>).
-			If the [=grid item=] has no <a>alignment baseline</a> in the grid's inline axis,
-			then one is first <a lt="synthesize baselines">synthesized</a>
-			from its border edges.
+	3.  Otherwise, if any [=grid items=] intersecting that track
+		have a [=baseline set=] in the relevant axis at all,
+		take the [=baseline set=] from the [=grid item=]
+		with the <em>highest</em> ([=block-start=]&ndash;most) baseline
+		corresponding to the [=grid container=]'s [=alignment baseline=],
+		preferring the first in [=grid order=]
+		if multiple items are tied.
 
-		<li>
-			If the [=grid container=] does not contain any [=grid items=],
-			the grid container has no first (last) <a>baseline set</a>,
-			and one is <a lt="synthesize baselines">synthesized</a> if needed
-			according to the rules of its <a>alignment context</a>.
-			Exit from this algorithm.
-	</ol>
+	4. Otherwise, if there are any [=grid items=] at all,
+		<a lt="synthesize baselines">synthesize</a> a [=baseline set=]
+		from the first [=grid item=] in [=grid order=].
+
+	5. Otherwise, the [=grid container=] has no first <a>baseline set</a> in the relevant axis.
+		(One is <a lt="synthesize baselines">synthesized</a>
+		from the [=grid container=] itself if needed,
+		according to the rules of its <a>alignment context</a>.)
+
+	For this purpose,
+	any [=grid item=] that spans multiple tracks
+	is ignored if it’s span does not start in the indicated track;
+	except that for step 2,
+	it's ignored if its span does not <em>end</em> in the track.
+
+	Last baselines are analogous
+	(with “first”/“last” and “start”/“end” inverted).
 
 	<dfn export lt="grid order|grid-modified document order">Grid-modified document order (grid order)</dfn>
 	is the order in which <a>grid items</a> are encountered

--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -3729,11 +3729,8 @@ Grid Container Baselines</h3>
 
 	3.  Otherwise, if any [=grid items=] intersecting that track
 		have a [=baseline set=] in the relevant axis at all,
-		take the [=baseline set=] from the [=grid item=]
-		with the <em>highest</em> ([=block-start=]&ndash;most) baseline
-		corresponding to the [=grid container=]'s [=alignment baseline=],
-		preferring the first in [=grid order=]
-		if multiple items are tied.
+		take the [=baseline set=] from the first such [=grid item=]
+		in [=grid order=].
 
 	4. Otherwise, if there are any [=grid items=] at all,
 		<a lt="synthesize baselines">synthesize</a> a [=baseline set=]

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -4266,36 +4266,44 @@ Aligning the Grid: the 'justify-content' and 'align-content' properties</h3>
 <h3 id='grid-baselines'>
 Grid Container Baselines</h3>
 
-	The first (last) baselines of a <a>grid container</a>
-	are determined as follows:
+	The first [=baseline set=] of a [=grid container=]
+	is taken from the first available of:
 
-	<ol>
-		<li>
-			Find the first (last) row of the [=grid container=]
-			containing at least one [=grid item=].
+	1.  If any [=grid items=] intersecting the first ([=block-start=]&ndash;most) non-empty [=track=]
+		participate in first [=baseline alignment=] along the relevant axis,
+		<a lt="generate baselines">generate</a> a [=baseline set=] from their shared [=alignment baseline=]
+		and the [=grid container=]’s [=first available font=],
+		after alignment has been performed.
 
-			If any of the [=grid items=] intersecting this row
-			participate in [=baseline alignment=] in that row,
-			the grid container's <a>baseline set</a>
-			is <a lt="generate baselines">generated</a> from
-			the shared <a>alignment baseline</a> of those <a>grid items</a>.
+	2.  Otherwise, if any [=grid items=] intersecting that track participate in
+		last [=baseline alignment=] along the relevant axis,
+		<a lt="generate baselines">generate</a> from <em>that</em> [=alignment baseline=].
 
-			Otherwise,
-			the grid container's first (last) baseline set
-			is <a lt="generate baselines">generated</a> from
-			the <a>alignment baseline</a> of the first (last) <a>grid item</a>
-			in row-major <a>grid order</a> (according to the <a>writing mode</a> of the <a>grid container</a>).
-			If the [=grid item=] has no <a>alignment baseline</a> in the grid's inline axis,
-			then one is first <a lt="synthesize baselines">synthesized</a>
-			from its border edges.
+	3.  Otherwise, if any [=grid items=] intersecting that track
+		have a [=baseline set=] in the relevant axis at all,
+		take the [=baseline set=] from the [=grid item=]
+		with the <em>highest</em> ([=block-start=]&ndash;most) baseline
+		corresponding to the [=grid container=]'s [=alignment baseline=],
+		preferring the first in [=grid order=]
+		if multiple items are tied.
 
-		<li>
-			If the [=grid container=] does not contain any [=grid items=],
-			the grid container has no first (last) <a>baseline set</a>,
-			and one is <a lt="synthesize baselines">synthesized</a> if needed
-			according to the rules of its <a>alignment context</a>.
-			Exit from this algorithm.
-	</ol>
+	4. Otherwise, if there are any [=grid items=] at all,
+		<a lt="synthesize baselines">synthesize</a> a [=baseline set=]
+		from the first [=grid item=] in [=grid order=].
+
+	5. Otherwise, the [=grid container=] has no first <a>baseline set</a> in the relevant axis.
+		(One is <a lt="synthesize baselines">synthesized</a>
+		from the [=grid container=] itself if needed,
+		according to the rules of its <a>alignment context</a>.)
+
+	For this purpose,
+	any [=grid item=] that spans multiple tracks
+	is ignored if it’s span does not start in the indicated track;
+	except that for step 2,
+	it's ignored if its span does not <em>end</em> in the track.
+
+	Last baselines are analogous
+	(with “first”/“last” and “start”/“end” inverted).
 
 	<dfn export lt="grid order|grid-modified document order">Grid-modified document order (grid order)</dfn>
 	is the order in which <a>grid items</a> are encountered

--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -4281,11 +4281,7 @@ Grid Container Baselines</h3>
 
 	3.  Otherwise, if any [=grid items=] intersecting that track
 		have a [=baseline set=] in the relevant axis at all,
-		take the [=baseline set=] from the [=grid item=]
-		with the <em>highest</em> ([=block-start=]&ndash;most) baseline
-		corresponding to the [=grid container=]'s [=alignment baseline=],
-		preferring the first in [=grid order=]
-		if multiple items are tied.
+		take the [=baseline set=] from the first such [=grid item=] in [=grid order=].
 
 	4. Otherwise, if there are any [=grid items=] at all,
 		<a lt="synthesize baselines">synthesize</a> a [=baseline set=]


### PR DESCRIPTION
This pull request covers the issues #7655 #7641 including the following resolutions (see [minutes](https://lists.w3.org/Archives/Public/www-style/2022Oct/0013.html)):

* RESOLVED: When taking the baseline of a row of items, we check a shared first baseline, then a shared last baseline, then the first baseline of the first item. (And vice versa for last baselines.)

* RESOLVED: Rowspanning cells participate only in first baseline alignment of their first row, and last baseline alignment in the last row.

* RESOLVED: Table baselines match grid, per details above.

**OPEN ISSUES**
* There was some confusion over whether we resolved to take the baseline from the first item or the highest item, see [comments](https://github.com/w3c/csswg-drafts/issues/7641#issuecomment-1288415323). Firefox and WebKit use the first, Chrome NG uses the highest.
* If we are indeed using the highest, what happens if there's a tie? (Unclear if there are cases where this matters, but maybe someday there will be?) We wrote in to use order-modified document order for Flex and grid placement order for Grid.
