### PR TITLE
[css-align-3] When assuming orthogonal writing mode for baseline alignment, choose based on 'direction'. #7775

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2272,9 +2272,12 @@ Determining the Baselines of a Box</h2>
 	* If the box establishing the <a>alignment context</a>
 		has a <a>block flow direction</a> that is orthogonal to the axis of the <a>alignment context</a>,
 		use its <a>writing mode</a>.
-	* Otherwise, assume either ''horizontal-tb'' or ''vertical-lr'' 'writing-mode',
-		whichever is orthogonal to the box’s own 'writing-mode'.
-		<!-- This pairing is chosen because the most likely case for this situation is CJK. -->
+	* Otherwise:
+		* If the box’s own [=writing mode=] is vertical,
+			assume ''horizontal-tb''.
+		* If the box’s own [=writing mode=] is horizontal,
+			assume ''vertical-lr'' if 'direction' is ''ltr''
+			and ''vertical-rl'' if 'direction' is ''rtl''.
 
 	For the purposes of finding the baselines of a box,
 	it and all its in-flow descendants with a scrolling mechanism (see the 'overflow' property)


### PR DESCRIPTION
Needs i18n review.