### PR TITLE
[css-view-transitions-1] Remove fixed issue about linking to unexported terms

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -687,7 +687,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		A navigable has no rendering opportunities if active document has [=document/transition suppressing rendering=] set to true.
 
 		Note: These steps will be added to the [=update the rendering=] in the HTML spec.
-		      See <a href="https://github.com/w3c/csswg-drafts/issues/7784">#7884</a> for more context.
+		See <a href="https://github.com/w3c/csswg-drafts/issues/7784">#7884</a> for more context.
 	</div>
 
 ## [=Perform pending transition operations=] ## {#perform-pending-transition-operations-algorithm}
@@ -920,8 +920,6 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 				- Areas outside |element|'s [=scrolling box=] should be rendered as if they were scrolled to, without moving or resizing the [=layout viewport=].
 					This must not trigger events related to scrolling or resizing, such as {{IntersectionObserver}}s.
-
-					Issue: "scrolling box" and "layout viewport" are not exported. They either need exporting, or replaced with better references.
 
 					<figure>
 						<img src="diagrams/phone-browser-with-url.svg" width="202" height="297" alt="A phone browser window, showing a URL bar, a fixed-position element directly beneath it, and some page content beneath that. A scroll bar indicates the page has been scrolled significantly.">


### PR DESCRIPTION
[css-view-transitions-1] Remove fixed issue about linking to unexported terms

These terms were exported in #8325 so we can remove the issue now.
