### PR TITLE
[web-animations-1] fix code example by handling `Animation.finished` with `.then()`

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -2479,7 +2479,7 @@ the style as illustrated below:
 // In the first frame after the following animation finishes, the callback for
 // the \`finished\` promise will run BEFORE style is updated and hence will NOT
 // flicker.
-elem.animate({ transform: 'translateY(100px)' }, 200).finished(() => {
+elem.animate({ transform: 'translateY(100px)' }, 200).finished.then(() => {
   elem.style.transform = 'translateY(100px)';
 });
 </pre></div>


### PR DESCRIPTION
[A code example](https://w3c.github.io/csswg-drafts/web-animations-1/#example-515a2006) calls `Animation.finished()` with a callback function. [`Animation.finished`](https://w3c.github.io/csswg-drafts/web-animations-1/#dom-animation-finished) is a promise and not callable. This PR changes the code example to use `Animation.finished.then()`, not `Animation.finished()`.