### PR TITLE
[css-text-4] Fix a grammar issue in line 5934 - https://drafts.csswg.org/css-text-4/#text-wrap

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -5931,7 +5931,7 @@ Text Wrap Settings: the 'text-wrap' property</h3>
 
 	<!-- add a sample prioritization algorithm -->
 
-	Note: The ''text-wrap/wrap'' value is will typically map
+	Note: The ''text-wrap/wrap'' value will typically map
 	to Web browsers’ speedy legacy line breaking,
 	which has so far used first-fit/greedy algorithms
 	that can often give sub-optimal results. 


### PR DESCRIPTION
Remove the unnecessary verb 'is' in line 5934.

https://drafts.csswg.org/css-text-4/#text-wrap:~:text=The%20wrap%20value-,is,-will%20typically%20map