### PR TITLE
[css-color-5] Fix "custom-color-space" grammar, add autolinks

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2374,12 +2374,12 @@ or any other color or monochrome output device which has been characterized.
 	<a href="#custom-color">custom color spaces</a>:
 
 	<pre class='prod'>
-		<dfn export>&lt;color-space></dfn> = &lt;rectangular-color-space> | &lt;polar-color-space> | &lt; custom-color-space>
+		<dfn export>&lt;color-space></dfn> = <<rectangular-color-space>> | <<polar-color-space>> | <<custom-color-space>>
 		<dfn export>&lt;rectangular-color-space></dfn> = ''srgb'' | ''srgb-linear'' | ''lab'' | ''oklab'' | ''xyz'' | ''xyz-d50'' | ''xyz-d65''
 		<dfn export>&lt;polar-color-space></dfn> = ''hsl'' | ''hwb'' | ''lch'' | ''oklch''
 		<dfn export>&lt;custom-color-space></dfn> = <<dashed-ident>>
 		<dfn export>&lt;hue-interpolation-method></dfn> = [ shorter | longer | increasing | decreasing ] hue
-		<dfn export id="color-interpolation-method">&lt;color-interpolation-method></dfn> = in [ <<rectangular-color-space>> | <<polar-color-space>> <<hue-interpolation-method>>? | &lt; custom-color-space> ]
+		<dfn export id="color-interpolation-method">&lt;color-interpolation-method></dfn> = in [ <<rectangular-color-space>> | <<polar-color-space>> <<hue-interpolation-method>>? | <<custom-color-space>> ]
 	</pre>
 
 	The <<dashed-ident>> must have been declared 


### PR DESCRIPTION
CSS grammar parsers do not like it when there is a space after the opening `<`.

This update also uses the autolink wrapper syntax to create links between the references `<custom-color-space>` references and its definition. That is also more consistent with the rest of the production rules in that block.
