### PR TITLE
[css-anchor-1] Fix syntax of a few anchor-* properties

### DIFF
--- a/css-anchor-1/Overview.bs
+++ b/css-anchor-1/Overview.bs
@@ -666,7 +666,7 @@ Values are defined as follows:
 	:: The property has no effect.
 
 	: <dfn><<dashed-ident>></dfn>
-	:: This <<dashed-ident> is the [=default anchor specifier=] for all
+	:: This <<dashed-ident>> is the [=default anchor specifier=] for all
 	   [=anchor functions=] on the element.
 </dl>
 

--- a/css-anchor-1/Overview.bs
+++ b/css-anchor-1/Overview.bs
@@ -417,7 +417,7 @@ Taking Scroll Into Account: the 'anchor-scroll' property {#scroll}
 
 <pre class=propdef>
 Name: anchor-scroll
-Value: none | <<dashed-ident>>
+Value: none | implicit | <<dashed-ident>>
 Initial: none
 Inherited: no
 Applies to: [=absolutely-positioned=] elements
@@ -646,8 +646,8 @@ Default Anchors: the 'anchor-default' property</h3>
 
 <pre class=propdef>
 Name: anchor-default
-Value: <<anchor-element>>
-Initial: implicit
+Value: none | <<dashed-ident>>
+Initial: none
 Applies to: [=absolutely positioned=] elements
 Inherited: no
 Animation type: discrete
@@ -658,6 +658,17 @@ for all [=anchor functions=] on the element,
 allowing multiple elements to use the same set of [=anchor functions=]
 (and [=position fallback lists=]!)
 while changing which [=anchor element=] each is referring to.
+
+Values are defined as follows:
+
+<dl dfn-type=value dfn-for=anchor-default>
+	: <dfn>none</dfn>
+	:: The property has no effect.
+
+	: <dfn><<dashed-ident>></dfn>
+	:: This <<dashed-ident> is the [=default anchor specifier=] for all
+	   [=anchor functions=] on the element.
+</dl>
 
 Its values are identical to the <<anchor-element>> term in ''anchor()'' and ''anchor-size()''.
 


### PR DESCRIPTION
- Fix the missing keyword `implicit` in `anchor-scroll`'s syntax
- Change the syntax of `anchor-default` from `<<anchor-element>>` to `none | <<dashed-ident>>`, since the `implicit` keyword doesn't make sense here