### PR TITLE
[css-animations-2] Define animation-timeline with animation type

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -532,7 +532,7 @@ Computed value: list, each item either a case-sensitive [=css identifier=] or
     the keywords ''single-animation-timeline/none'',
     ''single-animation-timeline/auto''.
 Canonical order: per grammar
-Animatable: no
+Animation Type: not animatable
 </pre>
 
 <pre class=prod>


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.