### PR TITLE
[css-backgrounds-3] Define properties with animation type

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -106,18 +106,6 @@ Value Definitions</h3>
   also accept the <a>CSS-wide keywords</a> as their property value.
   For readability they have not been repeated explicitly.
 
-<h3 id=animations>Animated Values</h3>
-
-<p><!-- <a href="http://www.w3.org/Style/CSS/Tracker/issues/210">ISSUE-210.]</a> -->
-It is expected that CSS will include ways to
-animate transitions between styles. (The
-section <a href="https://www.w3.org/TR/css-transitions-1/#animatable-types">“Animation of property types”</a>
-of the <cite>CSS Transitions
-module</cite> [[CSS3-TRANSITIONS]] is expected to define how different
-kinds of values are interpolated during a transition.) In anticipation
-of that, this module includes a line “Animatable” for each property,
-which specifies whether and how values of the property can be animated.
-
 <h2 id="backgrounds">
 Backgrounds</h2>
 
@@ -1223,7 +1211,7 @@ Applies to: all elements except [=ruby base containers=] and [=ruby annotation c
 Inherited: no
 Percentages: N/A
 Computed value: see individual properties
-Animatable: see individual properties
+Animation Type: see individual properties
 </pre>
 
 <p>These properties set the foreground color of the border specified
@@ -1385,7 +1373,7 @@ Applies to: all elements except [=ruby base containers=] and [=ruby annotation c
 Inherited: no
 Percentages: N/A
 Computed value: absolute length; zero if the border style is ''border-style/none'' or ''hidden''
-Animatable: by computed value
+Animation Type: by computed value
 </pre>
 
 <pre class="propdef">
@@ -1396,7 +1384,7 @@ Applies to: all elements except [=ruby base containers=] and [=ruby annotation c
 Inherited: no
 Percentages: see individual properties
 Computed value: see individual properties
-Animatable: see individual properties
+Animation Type: see individual properties
 </pre>
 
 <p>These properties set the thickness of the border.
@@ -1438,7 +1426,7 @@ Applies to: all elements except [=ruby base containers=] and [=ruby annotation c
 Inherited: no
 Percentages: N/A
 Computed value: see individual properties
-Animatable: see individual properties
+Animation Type: see individual properties
 </pre>
 
 <p>This is a shorthand property for setting the width, style, and
@@ -1453,7 +1441,7 @@ Applies to: all elements except [=ruby base containers=] and [=ruby annotation c
 Inherited: no
 Percentages: N/A
 Computed value: see individual properties
-Animatable: see individual properties
+Animation Type: see individual properties
 </pre>
 
 <p>The 'border' property is a shorthand property for setting the same width,
@@ -1528,7 +1516,7 @@ Applies to: all elements (but see prose)
 Inherited: no
 Percentages: Refer to corresponding dimension of the <a>border box</a>.
 Computed value: pair of computed <<length-percentage>> values
-Animatable: by computed value
+Animation Type: by computed value
 </pre>
 
 <pre class=propdef>
@@ -1539,7 +1527,7 @@ Applies to: all elements (but see prose)
 Inherited: no
 Percentages: Refer to corresponding dimension of the <a>border box</a>.
 Computed value: see individual properties
-Animatable: see individual properties
+Animation Type: see individual properties
 </pre>
 
 <p>The two <<length-percentage>> values of the 'border-*-radius'
@@ -2228,7 +2216,7 @@ Applies to: See individual properties
 Inherited: no
 Percentages: N/A
 Computed value: See individual properties
-Animatable: See individual properties
+Animation Type: See individual properties
 </pre>
 
 <p>This is a shorthand property for setting 'border-image-source',
@@ -2713,7 +2701,7 @@ Changes since the 24 July 2012 Candidate Recommendation</h3>
   <li>Clarified how ''background-attachment: local'' is affected by scrolling.
   <li>Simplified computed value of 'background-position'
     to clarify that all 'background-position' values are interpolable.
-  <li>Added “Animatable” values to each property definition table.
+  <li>Added “Animation Type” values to each property definition table.
 </ul>
 
 <h3 id="changes-2012-04">
@@ -2843,7 +2831,7 @@ Candidate Recommendation</a>:
     definition of keywords.
   <li><a href="#animations">Section 2.3</a> (and all property definitions):
     Added a section about expected an expected animations module.
-    Added "Animatable" line to property definition tables.
+    Added "Animation Type" line to property definition tables.
   <li><a href="#the-background-position">Section 3.6</a>:
     Renamed &lt;bg-position&gt; production to <i>&lt;position&gt;</i> for
     easier re-use in other specifications and recast the grammar to be more


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.

Also removes the *Animated Values* section, which links to CSS Transitions 3 as a future reference defining how values interpolate, but this is now defined in Web Animations 1.