### PR TITLE
[css-multicol-1] Define `column-count` with animation type

### DIFF
--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -532,7 +532,7 @@ The Number and Width of Columns</h2>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
-	Animatable: by computed value
+	Animation Type: by computed value
 	</pre>
 
 	This property describes the number of columns of a [=multicol container=].


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.