### PR TITLE
[css-speech-1] Define all properties as not animatable

### DIFF
--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -203,6 +203,7 @@ The 'voice-volume' property</h3>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: ''silent'', or a keyword value and optionally also a decibel offset (if not zero)
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-volume' property allows authors to control
@@ -308,6 +309,7 @@ The 'voice-balance' property</h3>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: the specified value resolved to a &lt;number&gt; between ''-100'' and ''100'' (inclusive)
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-balance' property controls the spatial distribution
@@ -452,6 +454,7 @@ The 'speak' property</h3>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'speak' property determines whether or not to render text aurally.
@@ -508,6 +511,7 @@ The 'speak-as' property</h3>
 		Inherited: yes
 		Percentages: N/A
 		Computed value: specified value
+		Animation Type: not animatable
 	</pre>
 
 	The 'speak-as' property determines in what manner text gets rendered aurally,
@@ -574,6 +578,7 @@ The 'pause-before' and 'pause-after' properties</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'pause-before' and 'pause-after' properties specify a prosodic boundary
@@ -633,6 +638,7 @@ The 'pause' shorthand property</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: N/A (see individual properties)
+	Animation Type: not animatable
 	</pre>
 
 	The 'pause' property is a shorthand property for 'pause-before' and 'pause-after'.
@@ -693,6 +699,7 @@ The 'rest-before' and 'rest-after' properties</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'rest-before' and 'rest-after' properties specify a prosodic boundary
@@ -740,6 +747,7 @@ The 'rest' shorthand property</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: N/A (see individual properties)
+	Animation Type: not animatable
 	</pre>
 
 	The 'rest' property is a shorthand for 'rest-before' and 'rest-after'.
@@ -760,6 +768,7 @@ The 'cue-before' and 'cue-after' properties</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'cue-before' and 'cue-after' properties specify auditory icons
@@ -897,6 +906,7 @@ The 'cue' shorthand property</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: N/A (see individual properties)
+	Animation Type: not animatable
 	</pre>
 
 	The 'cue' property is a shorthand for 'cue-before' and 'cue-after'.
@@ -934,6 +944,7 @@ The 'voice-family' property</h3>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-family' property specifies a prioritized list of component values
@@ -1117,6 +1128,7 @@ The 'voice-rate' property</h3>
 	Inherited: yes
 	Percentages: refer to default value
 	Computed value: a keyword value, and optionally also a percentage relative to the keyword (if not 100%)
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-rate' property manipulates the rate of generated synthetic speech
@@ -1206,6 +1218,7 @@ The 'voice-pitch' property</h3>
 		otherwise an absolute frequency calculated by converting the keyword value (if any) to a
 		fixed frequency based on the current voice-family and by applying the specified relative
 		offset (if any)
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-pitch' property specifies the "baseline" pitch of the generated speech output,
@@ -1318,6 +1331,7 @@ The 'voice-range' property</h3>
 		otherwise an absolute frequency calculated by converting the keyword value (if any) to a
 		fixed frequency based on the current voice-family and by applying the specified relative
 		offset (if any)
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-range' property specifies the variability in the "baseline" pitch,
@@ -1469,6 +1483,7 @@ The 'voice-stress' property</h3>
 	Inherited: yes
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-stress' property manipulates the strength of emphasis,
@@ -1541,6 +1556,7 @@ The 'voice-duration' property</h3>
 	Inherited: no
 	Percentages: N/A
 	Computed value: specified value
+	Animation Type: not animatable
 	</pre>
 
 	The 'voice-duration' property specifies how long it should take to render


### PR DESCRIPTION
Adds `Animation Type: not animatable` to all property definitions. According to [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties), they would be otherwise considered as animatable:

> Unless otherwise specified, all CSS properties are **animatable**.