### PR TITLE
[css-sizing-3] Define min|max-width|height with animation type

### DIFF
--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -393,7 +393,7 @@ Minimum Size Properties: the 'min-width' and 'min-height' properties</h4>
 	Inherited: no
 	Percentages: relative to width/height of <a>containing block</a>
 	Computed Value: as specified, with <<length-percentage>> values computed
-	Animatable: by computed value, recursing into ''min-width/fit-content()''
+	Animation Type: by computed value, recursing into ''min-width/fit-content()''
 	</pre>
 
 	The 'min-width' and 'min-height' properties specify
@@ -415,7 +415,7 @@ Maximum Size Properties: the 'max-width' and 'max-height' properties</h4>
 	Inherited: no
 	Percentages: relative to width/height of <a>containing block</a>
 	Computed Value: as specified, with <<length-percentage>> values computed
-	Animatable: by computed value, recursing into ''max-width/fit-content()''
+	Animation Type: by computed value, recursing into ''max-width/fit-content()''
 	</pre>
 
 	The 'max-width' and 'max-height' properties specify


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.