### PR TITLE
[css-overflow-3] Define `scroll-behavior` with animation type

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -677,7 +677,7 @@ Smooth Scrolling: the 'scroll-behavior' Property</h3>
 	Applies to: [=scroll containers=]
 	Inherited: no
 	Computed value:    specified value
-	Animatable: no
+	Animatation Type: not animatable
 	Canonical Order: per grammar
 	</pre>
 


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.