### PR TITLE
[css-nav-1] Define properties with animation type

### DIFF
--- a/css-nav-1/Overview.bs
+++ b/css-nav-1/Overview.bs
@@ -1345,6 +1345,7 @@ Name: spatial-navigation-contain
 Value: auto | contain
 Initial: auto
 Inherited: no
+Animation Type: discrete
 </pre>
 
 <dl dfn-for=spatial-navigation-contain dfn-type=value>
@@ -1451,6 +1452,7 @@ Value: auto | focus | scroll
 Initial: auto
 Applies to: <a>scroll containers</a>
 Inherited: no
+Animation Type: discrete
 </pre>
 
 When the focus is inside of a scroll container and the user triggers spatial navigation,
@@ -1565,6 +1567,7 @@ Value: normal | grid
 Initial: normal
 Applies to: <a>spatial navigation containers</a>
 Inherited: no
+Animation Type: discrete
 </pre>
 
 The default algorithm of spatial navigation specified in the [[#processing-model]] may need the fine tune depending on the layout types.


### PR DESCRIPTION
Adds `Animation Type: not animatable` to all property definitions. According to [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties), they would be otherwise considered as animatable:

> Unless otherwise specified, all CSS properties are **animatable**.