### PR TITLE
[css-module] Replace "Animatable" by "Animation Type"

### DIFF
--- a/css-module/Overview.bs
+++ b/css-module/Overview.bs
@@ -125,7 +125,7 @@ Internal display model: the 'foo' property {#the-foo-property}
 		Inherited: no
 		Percentages: n/a
 		Computed value: specified value
-		Animatable: no
+		Animation Type: not animatable
 		Canonical order: per grammar
 	</pre>
 


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table