### PR TITLE
[css-round-display-1] Define `shape-inside` with animation type

### DIFF
--- a/css-round-display-1/Overview.bs
+++ b/css-round-display-1/Overview.bs
@@ -345,7 +345,7 @@ spec:css2; type:type; text:<uri>
     Initial: auto
     Inherited: no
     Computed value: computed lengths for <<basic-shape>>, the absolute URI for <<uri>>, otherwise as specified
-    Animatable: as defined for <<basic-shape>>, otherwise discrete
+    Animation Type: as defined for <<basic-shape>>, otherwise discrete
 </pre>
 
 The example below shows how the 'shape-inside' property works when it is set to '<code>display</code>'.


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.