### PR TITLE
[css-transitions-1] Define `transition` with animation type

### DIFF
--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -387,7 +387,6 @@ Value Definitions {#values}
         Value: <<single-transition>>#
         Applies to: all elements
         Inherited: no
-        Animatable: no
         Percentages: N/A
         Animation type: not animatable
       </pre>


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.