### PR TITLE
[scroll-animations-1] Define `animation-range-start|end` with animation type

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -780,7 +780,7 @@ spec: cssom-view-1; type: dfn;
 		Inherited: no
 		Percentages: relative to the specified [=named timeline range=]
 		Computed value: list, each item either the keyword ''animation-range-start/normal'' or a timeline range and progress percentage
-		Animatable: no
+		Animation type: not animatable
 	</pre>
 
 	Shifts the <a spec="web-animations-1">start time</a> of the animation
@@ -809,7 +809,7 @@ spec: cssom-view-1; type: dfn;
 		Inherited: no
 		Percentages: relative to the specified [=named timeline range=]
 		Computed value: list, each item either the keyword ''animation-range-end/normal'' or a timeline range and progress percentage
-		Animatable: no
+		Animation type: not animatable
 	</pre>
 
 	Shifts the <a spec="web-animations-1">end time</a> of the animation


### PR DESCRIPTION
Replaces `Animatable` by `Animation Type`, as defined in [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table

`w3c/reffy` (spec crawler) does not normalize `Animatable` to `Animation Type` therefore users have to check both `propDef.animationType` and `propDef.animatable`, which is not great.