### PR TITLE
[css-exclusions-1] Define properties with animation type

### DIFF
--- a/css-exclusions-1/Overview.bs
+++ b/css-exclusions-1/Overview.bs
@@ -146,6 +146,7 @@ The 'wrap-flow' property</h4>
   Inherited: no
   Percentages: N/A
   Computed value: as specified except for element's whose 'float' computed value is not ''float/none'', in which case the computed value is ''auto''.
+  Animation Type: not animatable
   </pre>
 
   The values of this property have the following meanings:
@@ -364,6 +365,7 @@ Applies to: block-level elements
 Inherited: no
 Percentages: N/A
 Computed value: as specified
+Animation Type: not animatable
 </pre>
 
 The values of this property have the following meanings:


### PR DESCRIPTION
Adds `Animation Type: not animatable` to all property definitions. According to [Web Animations 1](https://drafts.csswg.org/web-animations-1/#animating-properties), they would be otherwise considered as animatable:

> Unless otherwise specified, all CSS properties are **animatable**.