### PR TITLE
[css-contain-3] Explicitly define `container` as not animatable

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -541,6 +541,7 @@ Creating Named Containers: the 'container' shorthand</h3>
 	<pre class='propdef shorthand'>
 		Name: container
 		Value: <<'container-name'>> [ / <<'container-type'>> ]?
+		Animation type: not animatable
 	</pre>
 
 	The 'container' [=shorthand property=] sets


### PR DESCRIPTION
The `Animation type` of `animation`, `transition`, `scroll-timeline`, which are shorthands whose sub-properties are all `not animatable`, is explicitly defined as `not animatable` instead of `see individual properties`, like `container`.

In my opinion, `see individual properties` should be used only when some/all sub-properties are animatable.