### PR TITLE
[scroll-animations-1] Define `view-timeline` and `animation-range-*` as not animatable

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -762,6 +762,7 @@ spec: cssom-view-1; type: dfn;
 	<pre class="propdef shorthand">
 		Name: animation-range
 		Value: [ <<'animation-range-start'>> <<'animation-range-end'>>? | <<timeline-range-name>> ]#
+		Animation type: not animatable
 	</pre>
 
 	The 'animation-range' property is a [=shorthand property|shorthand=]
@@ -781,7 +782,7 @@ spec: cssom-view-1; type: dfn;
 		Inherited: no
 		Percentages: relative to the specified [=named timeline range=]
 		Computed value: list, each item either the keyword ''animation-range-start/normal'' or a timeline range and progress percentage
-		Animatable: no
+		Animation type: not animatable
 	</pre>
 
 	Shifts the <a spec="web-animations-1">start time</a> of the animation
@@ -810,7 +811,7 @@ spec: cssom-view-1; type: dfn;
 		Inherited: no
 		Percentages: relative to the specified [=named timeline range=]
 		Computed value: list, each item either the keyword ''animation-range-end/normal'' or a timeline range and progress percentage
-		Animatable: no
+		Animation type: not animatable
 	</pre>
 
 	Shifts the <a spec="web-animations-1">end time</a> of the animation

--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -609,6 +609,7 @@ spec: cssom-view-1; type: dfn;
 	Name: view-timeline
 	Value: [ <<'view-timeline-name'>> <<'view-timeline-axis'>>? ]#
 	Applies to: all elements
+	Animation type: not animatable
 	</pre>
 
 	This property is a [=shorthand=] for setting


### PR DESCRIPTION
This PR replaces the default `Animation Type: see individual properties` by an explicit `Animation Type: not animatable` for the `view-timeline` and `animation-range` shorthands.

The `Animation type` of `animation`, `transition`, `scroll-timeline`, which are shorthands whose sub-properties are all `not animatable`, is explicitly defined as `not animatable` instead of `see individual properties`, like `view-timeline` and `animation-range`.

In my opinion, `see individual properties` should be used only when some/all sub-properties are animatable.

This PR also replaces `Animatable` with `Animation type` for `animation-range-*`, as required by [Web Animations](https://drafts.csswg.org/web-animations-1/#animating-properties):

> How property values combine is defined by the ***Animation type*** line in each property’s property definition table