### PR TITLE
[scroll-animations-1] Fix `<keyframe-selector>`

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -719,7 +719,7 @@ spec: cssom-view-1; type: dfn;
 	The CSS ''@keyframes'' rule is extended thus:
 
 	<pre class="prod">
-		<<keyframe-selector>> = from | to | <<percentage>> | <<timeline-range-name>> <<percentage>>
+		<<keyframe-selector>> = from | to | <<timeline-range-name>>? <<percentage [0,100]>>
 	</pre>
 
 	where <<timeline-range-name>> is the [=CSS identifier=]


### PR DESCRIPTION
This PR adds a range restriction [0, 100] on `<percentage>` of `<keyframe-selector>`, [as defined in CSS Animations 1](https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector), with a minor simplification of its syntax.