### PR TITLE
[css-view-transitions-1] Clarify how unhandled rejections should work

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -936,8 +936,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		[Exposed=Window]
 		interface ViewTransition {
 			readonly attribute Promise<undefined> updateCallbackDone;
-			readonly attribute Promise<undefined> ready;
-			readonly attribute Promise<undefined> finished;
+			[SameObject] readonly attribute Promise<undefined> ready;
+			[SameObject] readonly attribute Promise<undefined> finished;
 			undefined skipTransition();
 		};
 	</xmp>
@@ -1009,15 +1009,23 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		: <dfn>ready promise</dfn>
 		:: a {{Promise}}.
-			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
+			Initially [=a new promise=] in [=this's=] [=relevant Realm=], [=marked as handled=].
+
+			Note: This is [=marked as handled=] to avoid {{unhandledrejection}}s prior to the {{ViewTransition/ready}} property being accessed.
 
 		: <dfn>update callback done promise</dfn>
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
+			Note: This promise is not initially [=marked as handled=],
+			so rejections will be {{unhandledrejection}}s,
+			even if the {{ViewTransition/updateCallbackDone}} property is not accessed.
+
 		: <dfn>finished promise</dfn>
 		:: a {{Promise}}.
-			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
+			Initially [=a new promise=] in [=this's=] [=relevant Realm=], [=marked as handled=].
+
+			Note: This is [=marked as handled=] to avoid {{unhandledrejection}}s prior to the {{ViewTransition/finished}} property being accessed.
 
 		: <dfn>transition root pseudo-element</dfn>
 		:: a ''::view-transition''.
@@ -1032,9 +1040,12 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			[Discussion of this behavior](https://github.com/w3c/csswg-drafts/issues/8045).
 	</dl>
 
-	The {{ViewTransition/finished}} [=getter steps=] are to return [=this's=] [=ViewTransition/finished promise=].
+	The {{ViewTransition/finished}} [=getter steps=] are to return [=a promise resolved with=] [=this's=] [=ViewTransition/finished promise=].
 
-	The {{ViewTransition/ready}} [=getter steps=] are to return [=this's=] [=ViewTransition/ready promise=].
+	The {{ViewTransition/ready}} [=getter steps=] are to return [=a promise resolved with=] [=this's=] [=ViewTransition/ready promise=].
+
+	Note: These properties return a new promise that is not [=marked as handled=].
+	They always return the same promise due to {{SameObject}}.
 
 	The {{ViewTransition/updateCallbackDone}} [=getter steps=] are to return [=this's=] [=ViewTransition/update callback done promise=].
 


### PR DESCRIPTION
@domenic I'd like your feedback on this, as I'm not sure if this is the correct way to spec this.

Right now, in Chrome, this is a silent failure:

```js
const transition = document.startViewTransition(() => {
  doesNotExist();
});
```

…which is bad. Whereas:

```js
const transition = document.startViewTransition(() => {
  doesNotExist();
});

transition.updateCallbackDone;
transition.ready;
transition.finished;
```

…causes three unhandled rejections. That seems correct, since all three promises reject.

I want to spec it so, in the first example, there's one unhandled rejection, but without creating four unhandled rejections in the second example.

I've tried to do this by creating only one unhandled promise when the `ViewTransition` instance is created (`transition.updateCallbackDone`). The other promises are handled, and only create unhandled promises when their properties are accessed.

Am I doing this right?