### PR TITLE
[css-view-transitions-1] Fix some promise timing, and avoid duplicate unhandled rejections

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1451,6 +1451,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			with the result of [=reacting=] to |callbackPromise|:
 
 			- If the promise was fulfilled, then return undefined.
+
+			Note: Since the rejection of |callbackPromise| isn't explicitly handled here,
+			if |callbackPromise| rejects, then |transition|'s [=ViewTransition/update callback done promise=] will reject with the same reason.
 	</div>
 
 ## [=Skip the view transition=] ## {#skip-the-view-transition-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1015,9 +1015,17 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
+			Note: These promises are immediately created,
+			so rejections will cause {{unhandledrejection}}s unless they're [=mark as handled|handled=],
+			even if the getters such as {{updateCallbackDone}} are not accessed.
+
 		: <dfn>finished promise</dfn>
 		:: a {{Promise}}.
-			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
+			Initially [=a new promise=] in [=this's=] [=relevant Realm=],
+				[=marked as handled=].
+
+			Note: This is [=marked as handled=] to prevent duplicate {{unhandledrejection}}s,
+			as this promise only ever rejects along with the [=update callback done promise=].
 
 		: <dfn>transition root pseudo-element</dfn>
 		:: a ''::view-transition''.
@@ -1134,6 +1142,11 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
 
 						Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
+
+					1. [=Mark as handled=] |transition|'s [=ViewTransition/ready promise=].
+
+						Note: |transition|'s [=ViewTransition/update callback done promise=] will provide the {{unhandledrejection}}.
+						This step avoids a duplicate.
 
 					1. [=Skip the view transition=] |transition| with |reason|.
 
@@ -1424,19 +1437,20 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`".
 
-		1. Let |callbackPromise| be [=a new promise=] in |transition|'s [=relevant Realm=].
+		1. Let |callbackPromise| be null.
 
-			* If |transition|'s [=ViewTransition/update callback=] is null, then resolve |callbackPromise|.
+		1. If |transition|'s [=ViewTransition/update callback=] is null,
+			then set |callbackPromise| to [=a promise resolved with=] undefined,
+			in |transition|'s [=relevant Realm=].
 
-			* Otherwise, let |callbackPromise| be the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
+		1. Otherwise, set |callbackPromise| to the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
 
 		1. Set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
 
-		1. [=promise/React=] to |callbackPromise|:
+		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=]
+			with the result of [=reacting=] to |callbackPromise|:
 
-			* If |callbackPromise| was resolved, then [=resolve=] |transition|'s [=ViewTransition/update callback done promise=].
-
-			* If |callbackPromise| was rejected with reason |r|, then [=reject=] |transition|'s [=ViewTransition/update callback done promise=] with |r|.
+			- If |callbackPromise| was resolved, then return undefined.
 	</div>
 
 ## [=Skip the view transition=] ## {#skip-the-view-transition-algorithm}
@@ -1458,17 +1472,16 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Set |transition|'s [=ViewTransition/phase=] to "`done`".
 
-		1. If |transition|'s [=ViewTransition/ready promise=] has not yet been resolved, [=reject=] it with |reason|.
+		1. [=Reject=] |transition|'s [=ViewTransition/ready promise=] with |reason|.
 
-			Note: The ready promise would've been resolved if {{ViewTransition/skipTransition()}} is called after we start animating.
+			Note: The [=ViewTransition/ready promise=] may already be resolved at this point,
+			if {{ViewTransition/skipTransition()}} is called after we start animating.
+			In that case, this step is a no-op.
 
-		1. [=promise/React=] to |transition|'s [=ViewTransition/update callback done promise=]:
+		1. [=Resolve=] |transition|'s [=ViewTransition/finished promise=] with the result of [=reacting=] to |transition|'s [=ViewTransition/update callback done promise=]:
 
-			* If |transition|'s [=ViewTransition/update callback done promise=] was resolved,
-				then [=resolve=] |transition|'s [=ViewTransition/finished promise=].
-
-			* If |transition|'s [=ViewTransition/update callback done promise=] was rejected with reason |reason|,
-				then [=reject=] |transition|'s [=ViewTransition/finished promise=] with |reason|.
+			- If |transition|'s [=ViewTransition/update callback done promise=] was resolved,
+				then return undefined.
 	</div>
 
 ## [=Capture the image=] ## {#capture-the-image-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1015,7 +1015,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		:: a {{Promise}}.
 			Initially [=a new promise=] in [=this's=] [=relevant Realm=].
 
-			Note: These promises are immediately created,
+			Note: The [=ready promise=] and [=update callback done promise=] are immediately created,
 			so rejections will cause {{unhandledrejection}}s unless they're [=mark as handled|handled=],
 			even if the getters such as {{updateCallbackDone}} are not accessed.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -897,7 +897,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 			{{UpdateCallback|updateCallback}} is called asynchronously, once the current state of the document is captured.
 			Then, when the promise returned by {{UpdateCallback|updateCallback}} fulfills, the new state of the document is captured.
 
-			{{UpdateCallback|updateCallback}} is _always_ called, even if the transition cannot happen (e.g. due to duplicate `view-transition-name` values).
+			{{UpdateCallback|updateCallback}} is *always* called, even if the transition cannot happen (e.g. due to duplicate `view-transition-name` values).
 			The transition is an enhancement around the state change, so a failure to create a transition never prevents the state change.
 			See [[#transitions-as-enhancements]] for more details on this principle.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1150,7 +1150,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 					1. [=Skip the view transition=] |transition| with |reason|.
 
-				* If the promise was resolved, then:
+				* If the promise was fulfilled, then:
 
 					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
 
@@ -1450,7 +1450,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=]
 			with the result of [=reacting=] to |callbackPromise|:
 
-			- If |callbackPromise| was resolved, then return undefined.
+			- If the promise was fulfilled, then return undefined.
 	</div>
 
 ## [=Skip the view transition=] ## {#skip-the-view-transition-algorithm}
@@ -1480,8 +1480,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. [=Resolve=] |transition|'s [=ViewTransition/finished promise=] with the result of [=reacting=] to |transition|'s [=ViewTransition/update callback done promise=]:
 
-			- If |transition|'s [=ViewTransition/update callback done promise=] was resolved,
-				then return undefined.
+			- If the promise was fulfilled, then return undefined.
 	</div>
 
 ## [=Capture the image=] ## {#capture-the-image-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1484,6 +1484,10 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		1. [=Resolve=] |transition|'s [=ViewTransition/finished promise=] with the result of [=reacting=] to |transition|'s [=ViewTransition/update callback done promise=]:
 
 			- If the promise was fulfilled, then return undefined.
+
+			Note: Since the rejection of |transition|'s [=ViewTransition/update callback done promise=] isn't explicitly handled here,
+			if |transition|'s [=ViewTransition/update callback done promise=] rejects,
+			then |transition|'s [=ViewTransition/finished promise=] will reject with the same reason.
 	</div>
 
 ## [=Capture the image=] ## {#capture-the-image-algorithm}


### PR DESCRIPTION
In the current spec, this will cause three unhandled rejections:

```js
const transition = document.startViewTransition(() => {
  doesNotExist();
});
```

As it will cause `transition.updateCallbackDone`, `transition.ready`, and `transition.finished` to reject with the same error.

This PR _always_ marks `transition.finished` as handled, as it only ever rejects for the same reason as  `transition.updateCallbackDone`. It marks `transition.ready` as handled if it's rejected with the same reason as `transition.updateCallbackDone`.