### PR TITLE
[css-cascade-6] Support limits for implicit scopes

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -385,8 +385,10 @@ Scoping Styles: the ''@scope'' rule</h4>
 		of the stylesheet where the ''@scope'' rule is defined.
 		If no such element exist,
 		then the [=scoping root=] is the [=root=] of the containing [=node tree=].
-	* The [=scoping limits=] are unset;
-		[=implicit scopes=] do not have lower bounds.
+	* Collect all elements that are [=in scope=]
+		and that match <<scope-end>>,
+		using the [=scoping root=] as the '':scope'' element, then
+	* Set those elements as the [=scoping limits=].
 
 	The ''@scope'' [=at-rule=] has three primary effects
 	on the [=style rules=] in its <<stylesheet>>:


### PR DESCRIPTION
The grammar allowed this, but the prose did not.
