### PR TITLE
[various] Replace optional group with implicitly optional comma

### DIFF
--- a/css-conditional-values-1/Overview.bs
+++ b/css-conditional-values-1/Overview.bs
@@ -180,7 +180,7 @@ to different values based on certain conditions.
 
 <pre class="prod def">
 
-<<if()>> = if( <<condition>>, <<consequent>> [, <<antecedent>>]?)
+<<if()>> = if( <<condition>>, <<consequent>>, <<antecedent>>? )
 <dfn>&lt;consequent></dfn> = <<declaration-value>>
 <dfn>&lt;antecedent></dfn> = <<declaration-value>>
 </pre>

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -274,7 +274,7 @@ The meaning of each value is as follows:
       </figcaption>
     </figure>
 
-:   <dfn function lt="steps()">steps(&lt;integer&gt;[, &lt;step-position&gt; ]?)</dfn>
+:   <dfn function lt="steps()">steps(&lt;integer&gt;, &lt;step-position&gt;?)</dfn>
 ::  The first parameter specifies the number of intervals in the function.
     It must be a positive integer greater than 0
     unless the second parameter is <a value for="steps()">jump-none</a>

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -588,7 +588,7 @@ The meaning of each value is as follows:
       </figcaption>
     </figure>
 
-:   <dfn function lt="steps()">steps(&lt;integer&gt;[, &lt;step-position&gt; ]?)</dfn>
+:   <dfn function lt="steps()">steps(&lt;integer&gt;, &lt;step-position&gt;?)</dfn>
 ::  The first parameter specifies the number of intervals in the function.
     It must be a positive integer greater than 0
     unless the second parameter is <a value for="steps()">jump-none</a>

--- a/css-egg-1/Overview.bs
+++ b/css-egg-1/Overview.bs
@@ -445,7 +445,7 @@ The <<gradient>> syntax is extended to accept <<double-rainbow()>> in addition t
 
 <pre>
 	<dfn>double-rainbow()</dfn> = double-rainbow(
-		 <<position>> [, [ <<extent>> | <<length-percentage [0,∞]>>]]?
+		 <<position>> , [ <<extent>> | <<length-percentage [0,∞]>> ]?
 	)
 	<dfn noexport><<extent>></dfn> = ''closest-corner'' | ''closest-side'' | ''farthest-corner'' | ''farthest-side''
 </pre>


### PR DESCRIPTION
Editorial change replacing explicit optional groups with implicitly optional commas, ie. `... [ , ... ]?` with `... , ...?`.

I would appreciate this change because parsing against these two syntaxes with the CSS parser I am using, produces two different results (ie. `List(..., optionalList(comma, ...))` vs. `List(..., comma, ...)`), and the second is easier to handle.

I searched for all occurrences with `/\[\s*,.+\]\s*\?/`. I did not replace the result found in the value definition of [`copy-into`](https://drafts.csswg.org/css-gcpm-4/#propdef-copy-into) (CSS GCPM 4, not ready for implementation): the whole alternation can be omitted, which seems to be a bug.

  > **Name:** `copy-into`
  > **Value**: `none | [ [ <custom-ident> <content-level>] [, <custom-ident> <content-level>]* ]?`

It should probably be `none | [ <custom-ident> <content-level> ]#`.