### PR TITLE
[css-values-4] Section 6.1: Removed the word "unit" to avoid confusion

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1742,7 +1742,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 	</figure>
 
 	<dl export dfn-type=value dfn-for="<length>">
-		<dt><dfn id="em" lt="em">em>
+		<dt><dfn id="em">em</dfn>
 		<dd>
 			Equal to the computed value of the 'font-size' property of the element on which it is used.
 
@@ -1761,7 +1761,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 				will be 20% greater than the computed font size inherited by <code>h1</code> elements.
 			</div>
 
-		<dt><dfn id="rem" lt="rem">rem</dfn>
+		<dt><dfn id="rem" caniuse="rem">rem</dfn>
 		<dd>
 			Equal to the computed value of the ''em'' unit on the root element.
 
@@ -1769,7 +1769,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-rem-lang.html
 			</wpt>
 
-		<dt><dfn id="ex" lt="ex">ex</dfn>
+		<dt><dfn id="ex">ex</dfn>
 		<dd>
 			Equal to the used x-height of the <a href="https://www.w3.org/TR/css3-fonts/#first-available-font">first available font</a> [[!CSS3-FONTS]].
 			The x-height is so called because it is often equal to the height of the lowercase "x".
@@ -1804,11 +1804,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-ch-ex-lang.html
 			</wpt>
 
-		<dt><dfn id="rex" lt="rex">rex</dfn>
+		<dt><dfn id="rex">rex</dfn>
 		<dd>
 			Equal to the value of the ''ex'' unit on the root element.
 
-		<dt><dfn id="cap" lt="cap">cap</dfn>
+		<dt><dfn id="cap">cap</dfn>
 		<dd>
 			Equal to the used cap-height of the <a href="https://www.w3.org/TR/css3-fonts/#first-available-font">first available font</a> [[!CSS3-FONTS]].
 			The cap-height is so called because it is approximately equal to the height of a capital Latin letter.
@@ -1823,11 +1823,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			In the cases where it is impossible or impractical to determine the cap-height,
 			the font's ascent must be used.
 
-		<dt><dfn id="rcap" lt="rcap">rcap</dfn>
+		<dt><dfn id="rcap">rcap</dfn>
 		<dd>
 			Equal to the value of the ''cap'' unit on the root element.
 
-		<dt><dfn id="ch" lt="ch">ch</dfn>
+		<dt><dfn id="ch" caniuse="ch">ch</dfn>
 		<dd>
 			Represents the typical <a>advance measure</a> of European alphanumeric characters,
 			and measured as the used <a>advance measure</a> of the “0” (ZERO, U+0030) glyph
@@ -1866,11 +1866,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-ch-ex-lang.html
 			</wpt>
 
-		<dt><dfn id="rch" lt="rch">rch</dfn>
+		<dt><dfn id="rch">rch</dfn>
 		<dd>
 			Equal to the value of the ''ch'' unit on the root element.
 
-		<dt><dfn id="ic" lt="ic">ic</dfn>
+		<dt><dfn id="ic">ic</dfn>
 		<dd>
 			Represents the typical <a>advance measure</a> of CJK letters,
 			and measured as the used <a>advance measure</a> of the “水” (CJK water ideograph, U+6C34) glyph
@@ -1896,11 +1896,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/ic-unit-012.html
 			</wpt>
 
-		<dt><dfn id="ric" lt="ric">ric</dfn>
+		<dt><dfn id="ric">ric</dfn>
 		<dd>
 			Equal to the value of the ''ic'' unit on the root element.
 
-		<dt><dfn id="lh" lt="lh">lh</dfn>
+		<dt><dfn id="lh">lh</dfn>
 		<dd>
 			Equal to the computed value of the 'line-height' property of the element on which it is used,
 			converting ''line-height/normal'' to an absolute length
@@ -1912,7 +1912,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/lh-unit-002.html
 			</wpt>
 
-		<dt><dfn id="rlh" lt="rlh">rlh</dfn>
+		<dt><dfn id="rlh">rlh</dfn>
 		<dd>
 			Equal to the value of the ''lh'' unit on the root element.
 
@@ -2158,10 +2158,10 @@ The Various Viewport-relative Units</h5>
 	The [=viewport-percentage length=] units are:
 
 	<dl export dfn-type=value dfn-for="<length>">
-		<dt><dfn lt="vw">vw</dfn>
-		<dt><dfn lt="svw">svw</dfn>
-		<dt><dfn lt="lvw">lvw</dfn>
-		<dt><dfn lt="dvw">dvw</dfn>
+		<dt><dfn id="vw">vw</dfn>
+		<dt><dfn id="svw">svw</dfn>
+		<dt><dfn id="lvw">lvw</dfn>
+		<dt><dfn id="dvw">dvw</dfn>
 		<dd>
 			Equal to 1% of the width of the
 			[=UA-default viewport size=],
@@ -2178,10 +2178,10 @@ The Various Viewport-relative Units</h5>
 				<pre>h1 { font-size: 8vw }</pre>
 			</div>
 
-		<dt><dfn lt="vh">vh</dfn>
-		<dt><dfn lt="svh">svh</dfn>
-		<dt><dfn lt="lvh">lvh</dfn>
-		<dt><dfn lt="dvh">dvh</dfn>
+		<dt><dfn id="vh">vh</dfn>
+		<dt><dfn id="svh">svh</dfn>
+		<dt><dfn id="lvh">lvh</dfn>
+		<dt><dfn id="dvh">dvh</dfn>
 		<dd>
 			Equal to 1% of the height of the
 			[=UA-default viewport size=],
@@ -2190,10 +2190,10 @@ The Various Viewport-relative Units</h5>
 			and [=dynamic viewport size=],
 			respectively.
 
-		<dt><dfn lt=vi>vi</dfn>
-		<dt><dfn lt=svi>svi</dfn>
-		<dt><dfn lt=lvi>lvi</dfn>
-		<dt><dfn lt=dvi>dvi</dfn>
+		<dt><dfn id=vi>vi</dfn>
+		<dt><dfn id=svi>svi</dfn>
+		<dt><dfn id=lvi>lvi</dfn>
+		<dt><dfn id=dvi>dvi</dfn>
 		<dd>
 			Equal to 1% of the size of the
 			[=large viewport size=],
@@ -2202,10 +2202,10 @@ The Various Viewport-relative Units</h5>
 			(respectively)
 			in the box’s [=inline axis=].
 
-		<dt><dfn lt=vb>vb</dfn>
-		<dt><dfn lt=svb>svb</dfn>
-		<dt><dfn lt=lvb>lvb</dfn>
-		<dt><dfn lt=dvb>dvb</dfn>
+		<dt><dfn id=vb>vb</dfn>
+		<dt><dfn id=svb>svb</dfn>
+		<dt><dfn id=lvb>lvb</dfn>
+		<dt><dfn id=dvb>dvb</dfn>
 		<dd>
 			Equal to 1% of the size of the initial containing block
 			[=UA-default viewport size=],
@@ -2215,17 +2215,17 @@ The Various Viewport-relative Units</h5>
 			(respectively)
 			in the box’s [=block axis=].
 
-		<dt><dfn lt="vmin">vmin</dfn>
-		<dt><dfn lt="svmin">svmin</dfn>
-		<dt><dfn lt="lvmin">lvmin</dfn>
-		<dt><dfn lt="dvmin">dvmin</dfn>
+		<dt><dfn id="vmin">vmin</dfn>
+		<dt><dfn id="svmin">svmin</dfn>
+		<dt><dfn id="lvmin">lvmin</dfn>
+		<dt><dfn id="dvmin">dvmin</dfn>
 		<dd>
 			Equal to the smaller of ''*vw'' or ''*vh''.
 
-		<dt><dfn lt="vmax">vmax</dfn>
-		<dt><dfn lt="svmax">svmax</dfn>
-		<dt><dfn lt="lvmax">lvmax</dfn>
-		<dt><dfn lt="dvmax">dvmax</dfn>
+		<dt><dfn id="vmax">vmax</dfn>
+		<dt><dfn id="svmax">svmax</dfn>
+		<dt><dfn id="lvmax">lvmax</dfn>
+		<dt><dfn id="dvmax">dvmax</dfn>
 		<dd>
 			Equal to the larger of ''*vw'' or ''*vh''.
 	</dl>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1742,7 +1742,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 	</figure>
 
 	<dl export dfn-type=value dfn-for="<length>">
-		<dt><dfn id="em" lt="em">em unit</dfn>
+		<dt><dfn id="em" lt="em">em>
 		<dd>
 			Equal to the computed value of the 'font-size' property of the element on which it is used.
 
@@ -1761,7 +1761,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 				will be 20% greater than the computed font size inherited by <code>h1</code> elements.
 			</div>
 
-		<dt><dfn id="rem" lt="rem" caniuse="rem">rem unit</dfn>
+		<dt><dfn id="rem" lt="rem">rem</dfn>
 		<dd>
 			Equal to the computed value of the ''em'' unit on the root element.
 
@@ -1769,7 +1769,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-rem-lang.html
 			</wpt>
 
-		<dt><dfn id="ex" lt="ex">ex unit</dfn>
+		<dt><dfn id="ex" lt="ex">ex</dfn>
 		<dd>
 			Equal to the used x-height of the <a href="https://www.w3.org/TR/css3-fonts/#first-available-font">first available font</a> [[!CSS3-FONTS]].
 			The x-height is so called because it is often equal to the height of the lowercase "x".
@@ -1804,11 +1804,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-ch-ex-lang.html
 			</wpt>
 
-		<dt><dfn id="rex" lt="rex">rex unit</dfn>
+		<dt><dfn id="rex" lt="rex">rex</dfn>
 		<dd>
 			Equal to the value of the ''ex'' unit on the root element.
 
-		<dt><dfn id="cap" lt="cap">cap unit</dfn>
+		<dt><dfn id="cap" lt="cap">cap</dfn>
 		<dd>
 			Equal to the used cap-height of the <a href="https://www.w3.org/TR/css3-fonts/#first-available-font">first available font</a> [[!CSS3-FONTS]].
 			The cap-height is so called because it is approximately equal to the height of a capital Latin letter.
@@ -1823,11 +1823,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			In the cases where it is impossible or impractical to determine the cap-height,
 			the font's ascent must be used.
 
-		<dt><dfn id="rcap" lt="rcap">rcap unit</dfn>
+		<dt><dfn id="rcap" lt="rcap">rcap</dfn>
 		<dd>
 			Equal to the value of the ''cap'' unit on the root element.
 
-		<dt><dfn id="ch" lt="ch" caniuse="ch-unit">ch unit</dfn>
+		<dt><dfn id="ch" lt="ch">ch</dfn>
 		<dd>
 			Represents the typical <a>advance measure</a> of European alphanumeric characters,
 			and measured as the used <a>advance measure</a> of the “0” (ZERO, U+0030) glyph
@@ -1866,11 +1866,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/calc-ch-ex-lang.html
 			</wpt>
 
-		<dt><dfn id="rch" lt="rch">rch unit</dfn>
+		<dt><dfn id="rch" lt="rch">rch</dfn>
 		<dd>
 			Equal to the value of the ''ch'' unit on the root element.
 
-		<dt><dfn id="ic" lt="ic">ic unit</dfn>
+		<dt><dfn id="ic" lt="ic">ic</dfn>
 		<dd>
 			Represents the typical <a>advance measure</a> of CJK letters,
 			and measured as the used <a>advance measure</a> of the “水” (CJK water ideograph, U+6C34) glyph
@@ -1896,11 +1896,11 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/ic-unit-012.html
 			</wpt>
 
-		<dt><dfn id="ric" lt="ric">ric unit</dfn>
+		<dt><dfn id="ric" lt="ric">ric</dfn>
 		<dd>
 			Equal to the value of the ''ic'' unit on the root element.
 
-		<dt><dfn id="lh" lt="lh">lh unit</dfn>
+		<dt><dfn id="lh" lt="lh">lh</dfn>
 		<dd>
 			Equal to the computed value of the 'line-height' property of the element on which it is used,
 			converting ''line-height/normal'' to an absolute length
@@ -1912,7 +1912,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 			css/css-values/lh-unit-002.html
 			</wpt>
 
-		<dt><dfn id="rlh" lt="rlh">rlh unit</dfn>
+		<dt><dfn id="rlh" lt="rlh">rlh</dfn>
 		<dd>
 			Equal to the value of the ''lh'' unit on the root element.
 
@@ -2158,10 +2158,10 @@ The Various Viewport-relative Units</h5>
 	The [=viewport-percentage length=] units are:
 
 	<dl export dfn-type=value dfn-for="<length>">
-		<dt><dfn lt="vw">vw unit</dfn>
-		<dt><dfn lt="svw">svw unit</dfn>
-		<dt><dfn lt="lvw">lvw unit</dfn>
-		<dt><dfn lt="dvw">dvw unit</dfn>
+		<dt><dfn lt="vw">vw</dfn>
+		<dt><dfn lt="svw">svw</dfn>
+		<dt><dfn lt="lvw">lvw</dfn>
+		<dt><dfn lt="dvw">dvw</dfn>
 		<dd>
 			Equal to 1% of the width of the
 			[=UA-default viewport size=],
@@ -2178,10 +2178,10 @@ The Various Viewport-relative Units</h5>
 				<pre>h1 { font-size: 8vw }</pre>
 			</div>
 
-		<dt><dfn lt="vh">vh unit</dfn>
-		<dt><dfn lt="svh">svh unit</dfn>
-		<dt><dfn lt="lvh">lvh unit</dfn>
-		<dt><dfn lt="dvh">dvh unit</dfn>
+		<dt><dfn lt="vh">vh</dfn>
+		<dt><dfn lt="svh">svh</dfn>
+		<dt><dfn lt="lvh">lvh</dfn>
+		<dt><dfn lt="dvh">dvh</dfn>
 		<dd>
 			Equal to 1% of the height of the
 			[=UA-default viewport size=],
@@ -2190,10 +2190,10 @@ The Various Viewport-relative Units</h5>
 			and [=dynamic viewport size=],
 			respectively.
 
-		<dt><dfn lt=vi>vi unit</dfn>
-		<dt><dfn lt=svi>svi unit</dfn>
-		<dt><dfn lt=lvi>lvi unit</dfn>
-		<dt><dfn lt=dvi>dvi unit</dfn>
+		<dt><dfn lt=vi>vi</dfn>
+		<dt><dfn lt=svi>svi</dfn>
+		<dt><dfn lt=lvi>lvi</dfn>
+		<dt><dfn lt=dvi>dvi</dfn>
 		<dd>
 			Equal to 1% of the size of the
 			[=large viewport size=],
@@ -2202,10 +2202,10 @@ The Various Viewport-relative Units</h5>
 			(respectively)
 			in the box’s [=inline axis=].
 
-		<dt><dfn lt=vb>vb unit</dfn>
-		<dt><dfn lt=svb>svb unit</dfn>
-		<dt><dfn lt=lvb>lvb unit</dfn>
-		<dt><dfn lt=dvb>dvb unit</dfn>
+		<dt><dfn lt=vb>vb</dfn>
+		<dt><dfn lt=svb>svb</dfn>
+		<dt><dfn lt=lvb>lvb</dfn>
+		<dt><dfn lt=dvb>dvb</dfn>
 		<dd>
 			Equal to 1% of the size of the initial containing block
 			[=UA-default viewport size=],
@@ -2215,17 +2215,17 @@ The Various Viewport-relative Units</h5>
 			(respectively)
 			in the box’s [=block axis=].
 
-		<dt><dfn lt="vmin">vmin unit</dfn>
-		<dt><dfn lt="svmin">svmin unit</dfn>
-		<dt><dfn lt="lvmin">lvmin unit</dfn>
-		<dt><dfn lt="dvmin">dvmin unit</dfn>
+		<dt><dfn lt="vmin">vmin</dfn>
+		<dt><dfn lt="svmin">svmin</dfn>
+		<dt><dfn lt="lvmin">lvmin</dfn>
+		<dt><dfn lt="dvmin">dvmin</dfn>
 		<dd>
 			Equal to the smaller of ''*vw'' or ''*vh''.
 
-		<dt><dfn lt="vmax">vmax unit</dfn>
-		<dt><dfn lt="svmax">svmax unit</dfn>
-		<dt><dfn lt="lvmax">lvmax unit</dfn>
-		<dt><dfn lt="dvmax">dvmax unit</dfn>
+		<dt><dfn lt="vmax">vmax</dfn>
+		<dt><dfn lt="svmax">svmax</dfn>
+		<dt><dfn lt="lvmax">lvmax</dfn>
+		<dt><dfn lt="dvmax">dvmax</dfn>
 		<dd>
 			Equal to the larger of ''*vw'' or ''*vh''.
 	</dl>


### PR DESCRIPTION
Non-substantive contribution for grammar