### PR TITLE
[css-overflow-3] Fix typo

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -677,7 +677,7 @@ Smooth Scrolling: the 'scroll-behavior' Property</h3>
 	Applies to: [=scroll containers=]
 	Inherited: no
 	Computed value:    specified value
-	Animatation Type: not animatable
+	Animation Type: not animatable
 	Canonical Order: per grammar
 	</pre>
 


### PR DESCRIPTION
I apologize for this typo: Animatation -> Animation.