### PR TITLE
[css-overflow-4] Added limits to `line-clamp` and `-webkit-line-clamp` syntax

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -809,7 +809,7 @@ Limiting Visible Lines: the 'line-clamp' shorthand property</h3>
 
 	<pre class="propdef shorthand">
 		Name: line-clamp
-		Value: none | <<integer>> <<'block-ellipsis'>>?
+		Value: none | <<integer [1,∞]>> <<'block-ellipsis'>>?
 		Initial: none
 		Percentages: N/A
 	</pre>
@@ -840,7 +840,7 @@ Limiting Visible Lines: the 'line-clamp' shorthand property</h3>
 			'continue' to ''continue/auto'',
 			and 'block-ellipsis' to ''block-ellipsis/none''.
 
-		<dt><dfn><<integer>></dfn>
+		<dt><dfn><<integer [1,∞]>> <'block-ellipsis'>?</dfn>
 		<dd>Sets 'max-lines' to the specified <<integer>>,
 			'continue' to ''discard'',
 			and the 'block-ellipsis' property to second component of the value
@@ -899,7 +899,7 @@ Legacy compatibility</h4>
 
 	<pre class="propdef shorthand">
 		Name: -webkit-line-clamp
-		Value: none | <<integer>>
+		Value: none | <<integer [1,∞]>>
 		Initial: none
 		Percentages: N/A
 	</pre>
@@ -912,7 +912,7 @@ Legacy compatibility</h4>
 	Like 'line-clamp', '-webkit-line-clamp' is a shorthand of 'max-lines', 'continue', and 'block-ellipsis',
 	except that:
 
-	* its syntax is ''line-clamp/none'' | <<integer>>
+	* its syntax is ''line-clamp/none'' | <<integer [1,∞]>>
 	* it sets 'continue' to ''-webkit-discard'' instead of ''discard''
 	* it unconditionally sets 'block-ellipsis' to ''block-ellipsis/auto''
 


### PR DESCRIPTION
Restricted the syntaxes of `line-clamp` and `-webkit-line-clamp` to positive integers.

Fixes #8409.