### PR TITLE
[scroll-animations-1] Fixed `view()` grammar related to view timeline inset

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -446,7 +446,7 @@ spec: cssom-view-1; type: dfn;
 	Its syntax is
 
 	<pre class="prod">
-		<<view()>> = view( [ <<axis>> || <<'view-timeline-inset'>> ]? )
+		<<view()>> = view( [ <<axis>> || <<single-view-timeline-inset>> ]? )
 	</pre>
 
 	By default,
@@ -454,7 +454,7 @@ spec: cssom-view-1; type: dfn;
 	as for ''scroll()'',
 	this can be changed by providing an explicit <<axis>> value.
 
-	The optional <<'view-timeline-inset'>> value provides an adjustment
+	The optional <<single-view-timeline-inset>> value provides an adjustment
 	of the [=view progress visibility range=],
 	as defined for 'view-timeline-inset'.
 
@@ -594,7 +594,7 @@ spec: cssom-view-1; type: dfn;
 
 	<pre class='propdef'>
 	Name: view-timeline-inset
-	Value: [ [ auto | <<length-percentage>> ]{1,2} ]#
+	Value: <<single-view-timeline-inset>>#
 	Initial: 0
 	Applies to: all elements
 	Inherited: no
@@ -602,6 +602,8 @@ spec: cssom-view-1; type: dfn;
 	Computed value: a list consisting of two-value pairs representing the start and end insets each as either the keyword ''view-timeline-inset/auto'' or a computed <<length-percentage>> value
 	Animation type: by computed value type
 	</pre>
+
+	<span class=prod><dfn>&lt;single-view-timeline-inset></dfn> = [ auto | <<length-percentage>> ]{1,2}</span>
 
 	Specifies an inset (positive) or outset (negative) adjustment of the [=scrollport=]
 	when determining whether the box is in view


### PR DESCRIPTION
`view()` only refers to a single view timeline inset, so its grammar was changed to reflect that.

Fixes #8519