### PR TITLE
[css-text-4] Fix refs to property productions

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1734,7 +1734,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 
 	<pre class="propdef">
 	Name: white-space
-	Value: normal | pre | nowrap | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap'> || <'text-space-trim'>
+	Value: normal | pre | nowrap | pre-wrap | pre-line | <<'white-space-collapse'>> || <<'text-wrap'>> || <<'text-space-trim'>>
 	Initial: normal
 	Applies to: text
 	Inherited: yes


### PR DESCRIPTION
Fixes `<'white-space-collapse'> || <'text-wrap'> || <'text-space-trim'>` generated without enclosing quotes:

https://drafts.csswg.org/css-text-4/#propdef-white-space