### PR TITLE
[css-animations] Add missing numeric range

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -828,7 +828,7 @@ The 'animation' shorthand property</h3>
 	Canonical order: per grammar
 	</pre>
 
-	<span class=prod><dfn>&lt;single-animation></dfn> = <<time>> || <<easing-function>> || <<time>> || <<single-animation-iteration-count>> || <<single-animation-direction>> || <<single-animation-fill-mode>> || <<single-animation-play-state>> || [ none | <<keyframes-name>> ]</span>
+	<span class=prod><dfn>&lt;single-animation></dfn> = <<time [0s,∞]>> || <<easing-function>> || <<time>> || <<single-animation-iteration-count>> || <<single-animation-direction>> || <<single-animation-fill-mode>> || <<single-animation-play-state>> || [ none | <<keyframes-name>> ]</span>
 
 	Note that order is important within each animation definition: the first value in each
 	<<single-animation>> that can be parsed as a <<time>> is assigned to the 'animation-duration',

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -638,7 +638,7 @@ select keyframes and timeline if necessary.
 
 The 'animation' shorthand property syntax is as follows:
 
-<span class=prod><dfn>&lt;single-animation></dfn> = <<time>> || <<easing-function>> || <<time>> || <<single-animation-iteration-count>> || <<single-animation-direction>> || <<single-animation-fill-mode>> || <<single-animation-play-state>> || [ none | <<keyframes-name>> ] || <<single-animation-timeline>></span>
+<span class=prod><dfn>&lt;single-animation></dfn> = <<time [0s,∞]>> || <<easing-function>> || <<time>> || <<single-animation-iteration-count>> || <<single-animation-direction>> || <<single-animation-fill-mode>> || <<single-animation-play-state>> || [ none | <<keyframes-name>> ] || <<single-animation-timeline>></span>
 
 
 


### PR DESCRIPTION
`<time>` in the value definition of `animation-duration` has a numeric range but `animation` is defined with its own `<time>` production that is missing the same range.