### PR TITLE
[css-mediaqueries-4] Remove "at-risk" for the '@media/update' media feature

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -32,7 +32,6 @@ Ignore Can I Use URL Failure: http://drafts.csswg.org/mediaqueries-4/
 Ignore Can I Use URL Failure: https://drafts.csswg.org/mediaqueries/
 Ignore Can I Use URL Failure: http://drafts.csswg.org/mediaqueries/
 Ignore Can I Use URL Failure: http://www.w3.org/TR/mediaqueries-4/
-At Risk: The '@media/update' media feature
 </pre>
 
 <pre class=link-defaults>


### PR DESCRIPTION
As Firefox has shipped it and Chromium is about to ship, I propose to remove "at-risk" for the '@media/update' media feature.