### PR TITLE
[view-transitions-1] Remove DOM references

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -113,7 +113,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 	*This section is non-normative.*
 
-	View Transitions is a feature that allows DOM changes to smoothly animate between states.
+	View Transitions is a feature that allows developers to create animated transitions between visual states of the [=/document=].
 
 ## Separating transitions from DOM updates ## {#separating-transitions}
 
@@ -857,7 +857,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	A {{Document}} additionally has:
 
 	<dl dfn-for=document>
-		: <dfn>active DOM transition</dfn>
+		: <dfn>active view transition</dfn>
 		:: a {{ViewTransition}} or null. Initially null.
 
 		: <dfn>transition suppressing rendering</dfn>
@@ -872,7 +872,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 		: <dfn>show view-transition root pseudo-element</dfn>
 		:: A boolean. Initially false.
 
-			When this is true, [=this=]'s [=active DOM transition=]'s [=ViewTransition/transition root pseudo-element=] renders as a child of [=this=]'s [=document element=],
+			When this is true, [=this=]'s [=active view transition=]'s [=ViewTransition/transition root pseudo-element=] renders as a child of [=this=]'s [=document element=],
 			and [=this=]'s [=document element=] is its [=originating element=].
 
 			Note: The position of the [=ViewTransition/transition root pseudo-element=] within the [=document element=] does not matter, as the [=ViewTransition/transition root pseudo-element=]'s [=containing block=] is the [=snapshot root=].
@@ -915,15 +915,15 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
-		1. If |document|'s [=active DOM transition=] is not null,
-			then [=skip the view transition=] |document|'s [=active DOM transition=]
+		1. If |document|'s [=active view transition=] is not null,
+			then [=skip the view transition=] |document|'s [=active view transition=]
 			with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
 
 			Note: This can result in two asynchronous [=ViewTransition/update callbacks=] running concurrently.
-			One for the |document|'s current [=active DOM transition=], and another for this |transition|.
+			One for the |document|'s current [=active view transition=], and another for this |transition|.
 			As per the [design of this feature](#transitions-as-enhancements), it's assumed that the developer is using another feature or framework to correctly schedule these DOM changes.
 
-		1. Set |document|'s [=active DOM transition=] to |transition|.
+		1. Set |document|'s [=active view transition=] to |transition|.
 
 			Note: The process continues in [=setup view transition=], via [=perform pending transition operations=], which is called in [[#monkey-patch-to-rendering-algorithm]].
 
@@ -1084,13 +1084,13 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 	<div algorithm>
 		To <dfn>perform pending transition operations</dfn> given a {{Document}} |document|, perform the following steps:
 
-		1. If |document|'s [=document/active DOM transition=] is not null, then:
+		1. If |document|'s [=document/active view transition=] is not null, then:
 
-			1. If |document|'s [=document/active DOM transition=]'s [=ViewTransition/phase=] is "`pending-capture`",
-				then [=setup view transition=] with |document|'s [=document/active DOM transition=].
+			1. If |document|'s [=document/active view transition=]'s [=ViewTransition/phase=] is "`pending-capture`",
+				then [=setup view transition=] with |document|'s [=document/active view transition=].
 
-			1. Otherwise, if |document|'s [=document/active DOM transition=]'s [=ViewTransition/phase=] is "`animating`",
-				then [=handle transition frame=] for |document|'s [=document/active DOM transition=].
+			1. Otherwise, if |document|'s [=document/active view transition=]'s [=ViewTransition/phase=] is "`animating`",
+				then [=handle transition frame=] for |document|'s [=document/active view transition=].
 	</div>
 
 ## [=Setup view transition=] ## {#setup-view-transition-algorithm}
@@ -1463,7 +1463,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. [=Assert=]: |document|'s [=document/active DOM transition=] is |transition|.
+		1. [=Assert=]: |document|'s [=document/active view transition=] is |transition|.
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
@@ -1722,7 +1722,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. [=Assert=]: |document|'s [=document/active DOM transition=] is |transition|.
+		1. [=Assert=]: |document|'s [=document/active view transition=] is |transition|.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 
@@ -1734,7 +1734,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/rendering.html; type: dfn;
 
 		1. Set |document|'s [=document/show view-transition root pseudo-element=] to false.
 
-		1. Set |document|'s [=document/active DOM transition=] to null.
+		1. Set |document|'s [=document/active view transition=] to null.
 	</div>
 
 <h2 id="priv" class="no-num">Privacy Considerations</h2>


### PR DESCRIPTION
We removed "DOM" from the API, since it isn't usually referenced in API naming, but left it in a couple of non-API places.