### PR TITLE
[css-backgrounds-4] Made `none` in `box-shadow-offset` repeatable

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -766,7 +766,7 @@ layer.
 
 <pre class="propdef">
 Name: box-shadow-offset
-Value: none | <<length>>{2}#
+Value: [ none | <<length>>{2} ]#
 Initial: none
 Applies to: all elements
 Inherited: no


### PR DESCRIPTION
Made the `none` keyword repeatable to avoid author confusion and be coherent with other list-valued properties.

Fixes #8567