### PR TITLE
[css-cascade-4] Replace @import supports() example

### DIFF
--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -221,14 +221,11 @@ Conditional ''@import'' Rules</h3>
 	(even if it is loaded through some other link).
 
 	<div class="example">
-		The following rule illustrates how an author can provide fallback rules for legacy user agents
-		without impacting network performance on newer user agents:
+		The following rule illustrates how an author can provide rules for modern user agents
+		which support newer web features, for example, COLRv1 fonts:
 
 		<pre class='lang-css'>
-		@import url("fallback-layout.css") supports(not (display: flex));
-		@supports (display: flex) {
-		  ...
-		}
+		@import url("COLRv1_fonts.css") supports(font-tech(color-COLRv1));
 		</pre>
 	</div>
 


### PR DESCRIPTION
Current example does not work (legacy UAs do not support @import supports(), so will never be imported), replaced with one based on font-tech(color-COLRv1) instead (open to other suggestions).