### PR TITLE
[css-backgrounds-4] Fixed and added definitions for box-shadow-offset: none

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -902,10 +902,11 @@ Inherited: no
 Percentages: N/A
 Computed value: see individual properties
 Animation type: by computed value,
-    appending blank shadows (''transparent 0 0 0 0'')
-    with a corresponding ''box-shadow-position/inset'' keyword as needed
-    to match the longer list
-    if the shorter list is otherwise compatible with the longer one
+	letting ''box-shadow-offset/none'' create a blank shadow
+	(''transparent 0 0 0 0'') when interpolated with non-'none' values
+	and appending blank shadows with a corresponding
+	''box-shadow-position/inset'' keyword as needed to match the longer list
+	if the shorter list is otherwise compatible with the longer one
 </pre>
 
   <p>The 'box-shadow' property attaches one or more drop-shadows to the box.

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -768,16 +768,24 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either 'none' or a list,
-	each item a pair of offsets (horizontal and vertical) from the element‘s box
+Computed value: list, each item either 'none' or a pair of offsets
+  (horizontal and vertical) from the element‘s box
 Animation type: by computed value
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
-The property accepts a comma-separated list of horizontal and vertical offset pairs,
+The property accepts a comma-separated list.
+Each item in that list can either accept the ''box-shadow-offset/none'' value,
+which indicates no shadow, or a pair of horizontal and vertical offsets,
 where both values are described as <<length>> values.
 
 <dl>
+  <dt><dfn id="shadow-offset-none">none</dfn>
+  <dd>
+    No box shadow will be created.
+	Any other box shadow properties specified for this box shadow have no
+	effect.
+
   <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
   <dd>
     Specifies the <dfn>horizontal offset</dfn> of the shadow.

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -775,7 +775,7 @@ Animation type: by computed value
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
 The property accepts a comma-separated list.
-Each item in that list can either accept the ''box-shadow-offset/none'' value,
+Each item in that list can either be the ''box-shadow-offset/none'' value,
 which indicates no shadow, or a pair of horizontal and vertical offsets,
 where both values are described as <<length>> values.
 
@@ -900,12 +900,9 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either the keyword ''box-shadow-offset/none'' or
-    a list, each item consisting of four absolute lengths
-    plus a computed color and optionally also a ''box-shadow-position/inset'' keyword
+Computed value: see individual properties
 Animation type: by computed value,
-    treating ''box-shadow-offset/none'' as a zero-item list
-    and appending blank shadows (''transparent 0 0 0 0'')
+    appending blank shadows (''transparent 0 0 0 0'')
     with a corresponding ''box-shadow-position/inset'' keyword as needed
     to match the longer list
     if the shorter list is otherwise compatible with the longer one


### PR DESCRIPTION
I've added the definition for the `none` value of `box-shadow-offset` and corrected the computed value of that property to account for the `none` value now being part of the shadow list.

This is meant to fix #8567.

Sebastian