### PR TITLE
[css-color-5] fix typo's in `color-mix` examples

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -392,7 +392,7 @@ The choice of mixing color space can have a large effect on the end result.
 	  * mixed result X=(0.3214 * 0.7523) + (0.2070 * (1 - 0.7523)) = 0.29306.
 	  * mixed result Y=(0.2014 * 0.7523) + (0.2391 * (1 - 0.7523)) = 0.21074.
 	  * mixed result Z=(0.0879 * 0.7523) + (0.5249 * (1 - 0.7523)) = 0.19614.
-	  * mix result is <span class="swatch" style="--color: rgb(72.300% 38.639% 53.557%)"></span> lch(53.0304% 38.9346, 352.8138) which is rgb(72.300% 38.639% 53.557%)
+	  * mix result is <span class="swatch" style="--color: rgb(72.300% 38.639% 53.557%)"></span> lch(53.0304% 38.9346 352.8138) which is rgb(72.300% 38.639% 53.557%)
 </div>
 
 <div class="example" id="ex-mix-blue-white">
@@ -422,7 +422,7 @@ The choice of mixing color space can have a large effect on the end result.
 	* <span class="swatch" style="--color: rgb(68.594% 53.794% 100%)"></span> mix
 		in lch is lch(64.7841% 65.6008 301.364) which is quite purple
 	* <span class="swatch" style="--color: rgb(45.304% 63.808% 100%)"></span> mix
-		in oklch is oklch(72.601 0.15661 264.052)
+		in oklch is oklch(72.601% 0.15661 264.052)
 	* <span class="swatch" style="--color: rgb(50% 50% 100%)"></span> mix
 		in srgb is rgb(50% 50% 100%) which is also a bit purple
 </div>


### PR DESCRIPTION
I noticed some typo's in the examples for `color-mix()`.
Doesn't include any substantive changes.