### PR TITLE
[css-backgrounds-4] Defined `box-shadow-*` as coordinating list property group

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -771,16 +771,24 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either 'none' or a list,
-	each item a pair of offsets (horizontal and vertical) from the element‘s box
+Computed value: list, each item either 'none' or a pair of offsets
+  (horizontal and vertical) from the element‘s box
 Animatable: by computed value
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
-The property accepts a comma-separated list of horizontal and vertical offset pairs,
+The property accepts a comma-separated list.
+Each item in that list can either accept the ''box-shadow-offset/none'' value,
+which indicates no shadow, or a pair of horizontal and vertical offsets,
 where both values are described as <<length>> values.
 
 <dl>
+  <dt><dfn id="shadow-offset-none">none</dfn>
+  <dd>
+    No box shadow will be created.
+	Any other box shadow properties specified for this box shadow have no
+	effect.
+
   <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
   <dd>
     Specifies the <dfn>horizontal offset</dfn> of the shadow.

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -774,6 +774,11 @@ Percentages: N/A
 Computed value: list, each item either 'none' or a pair of offsets
   (horizontal and vertical) from the element‘s box
 Animatable: by computed value
+	letting ''box-shadow-offset/none'' create a blank shadow
+	(''transparent 0 0 0 0'') when interpolated with non-'none' values
+	and appending blank shadows with a corresponding
+	''box-shadow-position/inset'' keyword as needed to match the longer list
+	if the shorter list is otherwise compatible with the longer one
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
@@ -904,11 +909,7 @@ Applies to: all elements
 Inherited: no
 Percentages: N/A
 Computed value: see individual properties
-Animatable: by computed value,
-    appending blank shadows (''transparent 0 0 0 0'')
-    with a corresponding ''box-shadow-position/inset'' keyword as needed
-    to match the longer list
-    if the shorter list is otherwise compatible with the longer one
+Animatable: see individual properties
 </pre>
 
   <p>The 'box-shadow' property attaches one or more drop-shadows to the box.

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -922,6 +922,37 @@ Animatable: by computed value,
   <pre class=prod>
   <dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ <<'box-shadow-offset'>> [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
 
+<h4 id="shadow-layers">
+Layering, Layout, and Other Details</h4>
+
+  Drop shadows are declared in the [=coordinated value list=]
+  constructed from the 'box-shadow-*' properties,
+  which form a [=coordinating list property group=]
+  with 'box-shadow-offset' as the [=coordinating list base property=].
+  See [[css-values-4#linked-properties]].
+
+  <p>The shadow effects are applied front-to-back:
+  the first shadow is on top and the others are layered behind.
+  Shadows do not influence layout and may overlap (or be overlapped by)
+  other boxes and text or their shadows.
+  In terms of stacking contexts and the painting order,
+  the <i>outer box-shadows</i> of an element are drawn immediately below the background of that element,
+  and the <i>inner shadows</i> of an element are drawn immediately above the background of that element
+  (below the borders and border image, if any).
+
+  <p>If an element has multiple boxes, all of them get drop shadows,
+  but shadows are only drawn where borders would also be drawn;
+  see 'box-decoration-break'.
+
+  <p>Shadows do not trigger scrolling or increase the size of the scrollable area.
+
+  <p>Outer shadows have no effect on internal table elements in the collapsing border model.
+  If a shadow is defined for single border edge in the collapsing border model
+  that has multiple border thicknesses
+  (e.g. an outer shadow on a table where one row has thicker borders than the others,
+  or an inner shadow on a rowspanning table cell that adjoins cells with different border thicknesses),
+  the exact position and rendering of its shadows are undefined
+
 <h2 id="changes">
 Changes</h2>
 

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -778,7 +778,7 @@ Animatable: by computed value
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
 The property accepts a comma-separated list.
-Each item in that list can either accept the ''box-shadow-offset/none'' value,
+Each item in that list can either be the ''box-shadow-offset/none'' value,
 which indicates no shadow, or a pair of horizontal and vertical offsets,
 where both values are described as <<length>> values.
 
@@ -903,12 +903,9 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either the keyword ''box-shadow-offset/none'' or
-    a list, each item consisting of four absolute lengths
-    plus a computed color and optionally also a ''box-shadow-position/inset'' keyword
+Computed value: see individual properties
 Animatable: by computed value,
-    treating ''box-shadow-offset/none'' as a zero-item list
-    and appending blank shadows (''transparent 0 0 0 0'')
+    appending blank shadows (''transparent 0 0 0 0'')
     with a corresponding ''box-shadow-position/inset'' keyword as needed
     to match the longer list
     if the shorter list is otherwise compatible with the longer one

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -739,7 +739,7 @@ The 'border-clip' properties</h3>
 		<p>The fragments are shown in red for illustrative purposes; they should be black in compliant UAs.
 	</div>
 
-<h2 id="misc">Drop Shadows</h2>
+<h2 id="drop-shadows">Drop Shadows</h2>
 
 <h3 id="box-shadow-color">Coloring shadows: the 'box-shadow-color' property</h3>
 

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -766,7 +766,7 @@ layer.
 
 <pre class="propdef">
 Name: box-shadow-offset
-Value: none | <<length>>{2}#
+Value: [ none | <<length>>{2} ]#
 Initial: none
 Applies to: all elements
 Inherited: no


### PR DESCRIPTION
Copied over the section from Level 3 about "Layering, Layout, and Other Details" of box shadows and defined the longhands as coordinating list property group with `box-shadow-offset` being the coordinating list base property.

I've also move the "Animatable" definition to `box-shadow-offset`. Though I have to admit, I am not completely sure whether it fits there.
Maybe there should be a new section "Animation of Drop Shadows" explaining this in more detail?

This patch is based on the changes of #8605 to avoid any merge conflicts. So the other one should be merged first.

This is meant to fix #8592.

Sebastian