### PR TITLE
[css-images-4] Fixed interpolation of `stripes()` with different types

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -2420,7 +2420,8 @@ Interpolating ''stripes()'' {#interpolating-stripes}
 
 	1. Both the starting and ending image must have the same number of <<color-stripe>>s.
 
-	2. Neither image uses a combination of <<length>>, <<percentage>>, and <<flex>> stripes.
+	2. Each pair of interpolated thicknesses must be of the same type,
+		i.e. both must either be of type <<length-percentage>>, or <<flex>>.
 
 	If the two images satisfy both constraints,
 	they must be interpolated as described below.


### PR DESCRIPTION
This changes the interpolation of `stripes()` values to look at each pair of thicknesses instead of disallowing mixing values completely.

This fixes #8163.

Sebastian