### PR TITLE
[css-color-5] fix mention of powerless components

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -413,8 +413,8 @@ The choice of mixing color space can have a large effect on the end result.
 	The calcuation is as follows:
 	* <span class="swatch" style="--color: white"></span> white
 		is rgb(100% 100% 100%)
-		which is lch(100% 0 none)
-		which is oklch(100% 0 none)
+		which is lch(100% none none)
+		which is oklch(100% none none)
 	* <span class="swatch" style="--color: blue"></span> blue
 		is rgb(0% 0% 100%)
 		which is lch(29.5683% 131.201 301.364)


### PR DESCRIPTION
see : https://github.com/w3c/csswg-drafts/issues/8609

https://drafts.csswg.org/css-color-4/#specifying-lab-lch

> If the chroma of an LCH color is 0%, the hue component is [powerless](https://drafts.csswg.org/css-color-4/#powerless-color-component). If the lightness of an LCH color (after clamping) is 0%, or 100%, both the hue and chroma components are powerless.

https://drafts.csswg.org/css-color-4/#specifying-oklab-oklch

> If the chroma of an Oklch color is 0% or 0, the hue component is [powerless](https://drafts.csswg.org/css-color-4/#powerless-color-component). If the lightness of an Oklch color is 0% or 0, or 100% or 1.0, both the hue and chroma components are powerless.