### PR TITLE
[css-overflow-3] Fix ref to property production

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -450,7 +450,7 @@ Managing Overflow: the 'overflow-x', 'overflow-y', and 'overflow' properties</h3
 
 	<pre class="propdef shorthand">
 		Name: overflow
-		Value: <'overflow-block'>{1,2}
+		Value: <<'overflow-block'>>{1,2}
 		Initial: visible
 		Applies to: block containers [[!CSS2]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
 		Inherited: no


### PR DESCRIPTION
Fixes ref to `<'overflow-block'>`.

https://drafts.csswg.org/css-overflow-3/#propdef-overflow