### PR TITLE
[scroll-animations-1] Add inset option to ViewTimeline constructor #7748

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -534,6 +534,7 @@ spec: cssom-view-1; type: dfn;
 		dictionary ViewTimelineOptions {
 		  Element subject;
 		  ScrollAxis axis = "block";
+		  (DOMString or sequence&lt;(CSSNumericValue or CSSKeywordValue)>) inset = "auto";
 		};
 
 		[Exposed=Window]
@@ -608,14 +609,25 @@ spec: cssom-view-1; type: dfn;
 			1. Set the {{ScrollTimeline/source}} of |timeline|
 				to the {{ViewTimeline/subject}}’s
 				nearest ancestor [=scroll container=] element.
+
+			1.  If a {{DOMString}} value is provided as an |inset|,
+				parse it as a <<'view-timeline-inset'>> value;
+				if a sequence is provided,
+				the first value represents the start inset
+				and the second value represents the end inset.
+				If the sequence has only one value,
+				it is duplicated.
+				If it has zero values or more than two values,
+				or if it contains a {{CSSKeywordValue}} whose {{CSSKeywordValue/value}} is not "auto",
+				throw a <span class="exceptionname">TypeError</span>.
+
+				These insets define the {{ViewTimeline}}’s [=view progress visibility range=].
 	</dl>
 
 	If the {{ScrollTimeline/source}} or {{ViewTimeline/subject}} of a {{ViewTimeline}}
 	is an element whose [=principal box=] does not exist,
 	or if its nearest ancestor [=scroll container=] has no [=scrollable overflow=],
 	then the {{ViewTimeline}} is [=inactive timeline|inactive=].
-
-	ISSUE: Figure out how to incorporate fit/inset abilities.
 
 	The values of {{ViewTimeline/subject}}, {{ScrollTimeline/source}}, and {{AnimationTimeline/currentTime}}
 	are all computed when any of them is requested or updated.


### PR DESCRIPTION
See [proposal](https://github.com/w3c/csswg-drafts/issues/7748#issuecomment-1306097703), [WebIDL draft](https://github.com/w3c/csswg-drafts/issues/7748#issuecomment-1307381553), and [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/7748#issuecomment-1325424372).

Note that with the given syntax, it's not possible to ask for `auto` via the TypedOM version of the API. We could do that also, but we'd have to add some validation steps to make sure the keyword is in fact `auto`. (That said, this _is_ the initial value; it could just be omitted.)