### PR TITLE
[web-animations-2] Fix IDL definition of KeyframeAnimationOptions

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -3076,7 +3076,7 @@ dictionary TimelineRangeOffset {
   CSSNumericValue offset;
 };
 
-partial dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
+partial dictionary KeyframeAnimationOptions {
     (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart = "normal";
     (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd = "normal";
 };


### PR DESCRIPTION
A partial dictionary definition cannot inherit from anything. "Inheritance is to be specified on the original interface definition": https://webidl.spec.whatwg.org/#dfn-partial-interface

(Inheritance from `KeyframeEffectOptions` is already captured in the original dictionary definition in Web Animations 1)

