### PR TITLE
[cssom-1] Merge CSSImportRule layer extensions from cascade-5

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1956,22 +1956,6 @@ Rolling Back Cascade Layers: the ''revert-layer'' keyword</h4>
 
 <h2 id="layer-apis">Layer APIs</h2>
 
-<h3 id='extensions-to-cssimportrule-interface'>
-Extensions to the <code>CSSImportRule</code> interface</h3>
-
-	The <code>CSSImportRule</code> interface is extended as follows:
-
-	<pre class='idl'>
-	partial interface CSSImportRule {
-	  readonly attribute CSSOMString? layerName;
-	};
-	</pre>
-
-	Its <dfn attribute for=CSSImportRule>layerName</dfn> attribute represents
-	the [=layer name=] declared in the at-rule itself,
-	and is an empty string if the layer is anonymous,
-	or null if the at-rule does not declare a layer.
-
 <h3 id="the-csslayerblockrule-interface">
 The <code>CSSLayerBlockRule</code> interface</h3>
 

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2045,6 +2045,7 @@ interface CSSImportRule : CSSRule {
   readonly attribute USVString href;
   [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
   [SameObject] readonly attribute CSSStyleSheet styleSheet;
+  readonly attribute CSSOMString? layerName;
 };
 </pre>
 
@@ -2058,6 +2059,10 @@ The <dfn attribute for=CSSImportRule>media</dfn> attribute must return the value
 attribute of the associated <a>CSS style sheet</a>.
 
 The <dfn attribute for=CSSImportRule>styleSheet</dfn> attribute must return the associated <a>CSS style sheet</a>.
+
+The <dfn attribute for=CSSImportRule>layerName</dfn> attribute may return the layer name declared in the at-rule itself,
+or an empty string if the layer is anonymous,
+or null if the at-rule does not declare a layer.
 
 Note: An <code>@import</code> at-rule always has an associated <a>CSS style sheet</a>.
 


### PR DESCRIPTION
Merged the CSSImportRule extension for `layerName` into cssom-1 from cascade-5, as recommended by @emilio.