### PR TITLE
[cssom-1] Add CSSImportRule supportsText attribute

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2046,6 +2046,7 @@ interface CSSImportRule : CSSRule {
   [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
   [SameObject] readonly attribute CSSStyleSheet styleSheet;
   readonly attribute CSSOMString? layerName;
+  readonly attribute CSSOMString? supportsText;
 };
 </pre>
 
@@ -2063,6 +2064,9 @@ The <dfn attribute for=CSSImportRule>styleSheet</dfn> attribute must return the 
 The <dfn attribute for=CSSImportRule>layerName</dfn> attribute must return the [=layer name=] declared in the at-rule itself,
 or an empty string if the layer is anonymous,
 or null if the at-rule does not declare a layer.
+
+The <dfn attribute for=CSSImportRule>supportsText</dfn> attribute must return the <<supports-condition>> declared in the at-rule itself,
+or null if the at-rule does not declare a supports condition.
 
 Note: An <code>@import</code> at-rule always has an associated <a>CSS style sheet</a>.
 


### PR DESCRIPTION
Added a `supportsText` attribute to `CSSImportRule` to allow access to supports conditions declared in `@import` rules. Closes #8710.