### PR TITLE
[css-contain-3] Support boolean context style() queries #8127

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -602,6 +602,7 @@ Container Queries: the ''@container'' rule</h3>
 	<dfn><<style-in-parens>></dfn>     = ( <<style-query>> )
 	                      | ( <<style-feature>> )
 	                      | <<general-enclosed>>
+	<dfn><<style-feature>></dfn>			 = <<ident>> : <<declaration-value>> | <<ident>>
 	</pre>
 
 	The keywords ''container-name/none'', ''and'', ''not'', and ''or''
@@ -910,6 +911,11 @@ Style Container Features</h3>
 	(which is also [=computed value|computed=] with respect to the [=query container=]),
 	unknown if the property or its value is invalid or unsupported,
 	and false otherwise.
+
+	A [=style feature=] can also be a property name without a value. Such
+	features evaluate to true if the [=computed value=] is different from the [=initial=]
+	value for the given [=property=].
+
 	The boolean syntax and logic combining [=style features=] into a [=container style query|style query=]
 	is the same as for [=CSS feature queries=].
 	(See ''@supports''. [[!CSS-CONDITIONAL-3]])


### PR DESCRIPTION
Per resolution in #8127, style() queries can query properties without a value which evaluates to true if the computed value is different from the initial value for that property.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
