### PR TITLE
[css-view-transitions-1] Direct pointer events to document element while rendering is suppressed

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -500,6 +500,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 # Layout and rendering changes # {#layout-rendering-changes}
 
+## Named and transitioning elements ## {#named-and-transitioning}
+
 	[=/Elements=] have an <dfn>involved in a view transition</dfn> boolean, initially false.
 
 	[=/Elements=] that either have a 'view-transition-name' [=computed value=] that is not ''view-transition-name/none'',
@@ -512,6 +514,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	- a [=backdrop root=].
 
 	Note: This spec uses CSS's definition of [=element=], which includes [=pseudo-elements=].
+
+## Interactions during suppressed rendering ## {#interactions-during-suppressed}
+
+	While a {{Document}} |document|'s [=document/transition suppressing rendering=] is true,
+	pointer hit testing must target |document|'s [=document element=],
+	ignoring all other [=elements=].
+
+	Note: This does not effect pointers that are [=pointer capture|captured=].
 
 # User-agent styles # {#ua-styles}
 


### PR DESCRIPTION
Fixes #7797

Reviewed in https://github.com/jakearchibald/csswg-drafts/pull/4