### PR TITLE
[css-contain-3] Make content-visibility animatable.

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -1119,6 +1119,8 @@ Changes since the 18 August 2022 Working Draft</h3>
 	* Correct typo in 'container-type' syntax, to clarify that ''normal'' cannot
 		be combined with other values.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/7669">Issue 7669</a>)
+	* Make the 'content-visibility' property animatable.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/8627">Issue 8627</a>)
 
 <h3 id="changes-2021-12">
 Changes since the 21 December 2021 First Public Working Draft</h3>


### PR DESCRIPTION
Allow animating content-visibility as animation type discrete with special interpolation to avoid hidden values similar to visibility. Fixes #8627