### PR TITLE
[css-scroll-snap-1] Default 2nd to 1st value in scroll-*-block and scroll-*-inline

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -1162,6 +1162,8 @@ Flow-relative Longhands for 'scroll-padding'  {#padding-longhands-logical}
     If two values are specified, the first gives the start value
     and the second gives the end value.
 
+    If only one value is specified, the second value defaults to the same value.
+
 Physical Longhands for 'scroll-margin'  {#margin-longhands-physical}
 --------------------------------------------------------------------
 
@@ -1218,6 +1220,8 @@ Flow-relative Longhands for 'scroll-margin'  {#margin-longhands-logical}
 
     If two values are specified, the first gives the start value
     and the second gives the end value.
+
+    If only one value is specified, the second value defaults to the same value.
 
 Privacy and Security Considerations {#priv-sec}
 ===============================================


### PR DESCRIPTION
For [`scroll-padding`](https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding) and `scroll-margin`:

  > [...] assigning values to the longhands representing each side exactly as the padding property does for its longhands

Therefore I assume (and propose that) an omitted second value should default to the first specified value in logical shorthands (instead of the initial value), like in Chrome/FF:

```js
style.scrollPaddingBlock = '1px'
style.scrollPaddingBlockStart; // 1px
style.scrollPaddingBlockEnd; // 1px
```
