### PR TITLE
[css-contain-3] Tweak the spec for style() queries #8127

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -621,7 +621,8 @@ Container Queries: the ''@container'' rule</h3>
 	each [=container feature=] in the <<container-query>>
 	is evaluated against that [=query container=].
 	If no ancestor is an eligible [=query container=],
-	then the [=container query=] is ''unknown'' for that element.
+	then the [=container query=] is ''unknown'' for that element. As for media queries,
+	<<general-enclosed>> evaluates to ''unknown''.
 
 	<div class=example>
 		As with [=media queries=],
@@ -902,17 +903,15 @@ Style Container Features</h3>
 	It is a boolean combination of
 	individual <dfn>style features</dfn> (<<style-feature>>)
 	that each query a single, specific property of the [=query container=].
-	The syntax of a <dfn><<style-feature>></dfn> is the same as for a valid [=declaration=]
-	[[!CSS-SYNTAX-3]],
-	and its query is true if
-	the [=computed value=] of the given property on the [=query container=]
-	matches the given value
-	(which is also [=computed value|computed=] with respect to the [=query container=]),
-	and false otherwise.
+	The syntax of a <dfn><<style-feature>></dfn> is either the same as for a valid [=declaration=]
+	[[!CSS-SYNTAX-3]], a [=supported CSS property=], or a <<custom-property-name>>.
 
-	A [=style feature=] can also be a supported property name without a value. Such
-	features evaluate to true if the [=computed value=] is different from the [=initial=]
-	value for the given [=property=].
+	Its query evaluates to true if the [=computed value=] of the given property on the
+	[=query container=] matches the given value (which is also [=computed value|computed=]
+	with respect to the [=query container=]), and false otherwise.
+
+	A [=style feature=] without a value evaluates to true if the [=computed value=]
+	is different from the [=initial=] value for the given [=property=].
 
 	The boolean syntax and logic combining [=style features=] into a [=container style query|style query=]
 	is the same as for [=CSS feature queries=].

--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -602,7 +602,6 @@ Container Queries: the ''@container'' rule</h3>
 	<dfn><<style-in-parens>></dfn>     = ( <<style-query>> )
 	                      | ( <<style-feature>> )
 	                      | <<general-enclosed>>
-	<dfn><<style-feature>></dfn>			 = <<ident>> : <<declaration-value>> | <<ident>>
 	</pre>
 
 	The keywords ''container-name/none'', ''and'', ''not'', and ''or''
@@ -903,16 +902,15 @@ Style Container Features</h3>
 	It is a boolean combination of
 	individual <dfn>style features</dfn> (<<style-feature>>)
 	that each query a single, specific property of the [=query container=].
-	The syntax of a <dfn><<style-feature>></dfn> is the same as for a [=declaration=]
+	The syntax of a <dfn><<style-feature>></dfn> is the same as for a valid [=declaration=]
 	[[!CSS-SYNTAX-3]],
 	and its query is true if
 	the [=computed value=] of the given property on the [=query container=]
 	matches the given value
 	(which is also [=computed value|computed=] with respect to the [=query container=]),
-	unknown if the property or its value is invalid or unsupported,
 	and false otherwise.
 
-	A [=style feature=] can also be a property name without a value. Such
+	A [=style feature=] can also be a supported property name without a value. Such
 	features evaluate to true if the [=computed value=] is different from the [=initial=]
 	value for the given [=property=].
 


### PR DESCRIPTION
Remove the recently added grammar part for style-feature that was inaccurate.

Do not accept invalid declarations or unsupported property names as a style-feature. The effect of that is that we do not need to store invalid declarations, but merely fall back to parse the style() query with the invalid declaration as a general-enclosed, which will evaluate to unknown.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
