### PR TITLE
Remove duplicate script-blocking style sheet requirement

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1549,7 +1549,6 @@ must be run:
      </ol>
    </ol>
  </ol>
-
 </div>
 
 ### Requirements on user agents Implementing the HTTP Link Header ### {#requirements-on-user-agents-implementing-the-http-link-header}

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -71,6 +71,9 @@ urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: semantics.html
         type: dfn
             text: a style sheet that is blocking scripts
+            text: contributes a script-blocking style sheet
+            for: Document
+                text: script-blocking style sheet set
 urlPrefix: https://dom.spec.whatwg.org/#concept-
     type: dfn
         text: dispatch; url: event-dispatch
@@ -1541,6 +1544,11 @@ must be run:
      </ol>
    </ol>
  </ol>
+
+If <var>node</var> <a>contributes a script-blocking style sheet</a>, then user agents must <a
+for=list>append</a> <var>node</var> to its <a>node document</a>'s <a for=Document>script-blocking
+style sheet set</a>.
+
 </div>
 
 ### Requirements on user agents Implementing the HTTP Link Header ### {#requirements-on-user-agents-implementing-the-http-link-header}

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1543,15 +1543,6 @@ must be run:
  </ol>
 </div>
 
-A style sheet referenced by an <a>xml-stylesheet processing instruction</a> using the rules in this section, in the context of
-the {{Document}} of an <a>XML parser</a> is said to be
-<a>a style sheet that is blocking scripts</a> if the <code>ProcessingInstruction</code>
-<a>node</a> was created by that {{Document}}'s parser, and the style sheet was
-enabled when the node was created by the parser, the last time the
-<a>event loop</a> reached step 1, the node was in that Document,
-and the user agent hasn't given up on loading that particular style sheet
-yet. A user agent may give up on such a style sheet at any time.
-
 ### Requirements on user agents Implementing the HTTP Link Header ### {#requirements-on-user-agents-implementing-the-http-link-header}
 
 <!-- XXX ref, one day -->

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1158,9 +1158,14 @@ steps:
 
 <ol>
  <li>Add the <a>CSS style sheet</a> to the list of
- <a>document or shadow root CSS style sheets</a> at the appropriate location. The
- remainder of these steps deal with the
- <a>disabled flag</a>.
+ <a>document or shadow root CSS style sheets</a> at the appropriate location.
+
+ <li>
+  <p>If the <a>CSS style sheet</a>'s <a for=CSSStyleSheet>owner node</a> <a>contributes a
+ script-blocking style sheet</a>, then user agents must <a for=list>append</a> the <a
+ for=CSSStyleSheet>owner node</a> to its <a>node document</a>'s <a for=Document>script-blocking
+ style sheet set</a>.</p>
+ <p class="note">The remainder of these steps deal with the <a>disabled flag</a>.</p>
 
  <li>If the <a>disabled flag</a> is set, then return.
 
@@ -1544,10 +1549,6 @@ must be run:
      </ol>
    </ol>
  </ol>
-
-If <var>node</var> <a>contributes a script-blocking style sheet</a>, then user agents must <a
-for=list>append</a> <var>node</var> to its <a>node document</a>'s <a for=Document>script-blocking
-style sheet set</a>.
 
 </div>
 


### PR DESCRIPTION
Per https://github.com/w3c/csswg-drafts/issues/3103#issuecomment-421261334, this PR removes a reference to HTML's "script-blocking style sheet" concept from https://drafts.csswg.org/cssom/#requirements-on-user-agents-implementing-the-xml-stylesheet-processing-instruction.

PTAL @annevk. Btw do you have any opinions on what we should do about the same reference to the same term at the bottom of https://drafts.csswg.org/cssom/#requirements-on-user-agents-implementing-the-http-link-header? These days HTML defines the `Link` header processing model, and as per https://html.spec.whatwg.org/#table-link-relations we only support `preconnect` and `preload`, not what CSSOM-1 defines here (and this is noted by the section's "Note yet widely implemented" call-out). IMO it seems best to expand this PR to also remove (at the very least, scoped to this PR) that reference from that section and let HTML work it out if it chooses to.