### PR TITLE
[scroll-animations-1] Use options dictionary for getCurrentTime() #8201

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1328,42 +1328,58 @@ spec: cssom-view-1; type: dfn;
 	by the {{AnimationTimeline/getCurrentTime()}} method:
 
 	<pre class="idl">
+		dictionary AnimationTimeOptions {
+		  DOMString? range;
+		};
+
 		[Exposed=Window]
 		partial interface AnimationTimeline {
-		  CSSNumericValue? getCurrentTime(optional CSSOMString rangeName);
+		  CSSNumericValue? getCurrentTime(optional AnimationTimeOptions options = {});
 		};
 	</pre>
 
-	<div algorithm="AnimationTimeline.getCurrentTime()">
-		The <code><dfn method for=AnimationTimeline>getCurrentTime(optional |rangeName|)</dfn></code> [=method steps=] are:
+	<div class='methods'>
 
-		1. If [=this=] is an [=inactive timeline=],
-			return null.
+		<dt><dfn method for=AnimationTimeline lt='getCurrentTime()'>CSSNumericValue? getCurrentTime(optional AnimationCurrentTimeOptions = {})</dfn>
+		<dd>
+			Returns a representation of the [=timeline/current time=]
+			as follows:
 
-		1. If |rangeName| is provided:
+			<dl class="switch">
+				<dt>If {{AnimationTimeOptions/range}} is not provided:
+				<dd>
+					Returns the value of {{AnimationTimeline/currentTime}} on [=this=],
+					but representing millisecond values
+					as a new {{CSSUnitValue}} in ''ms'' units
+					rather than as a double.
 
-			1. If |rangeName| is a valid [=named timeline range=] on [=this=],
-				let |progress| be the current progress through that range,
-				expressed as a percentage value.
+				<dt>If {{AnimationTimeOptions/range}} is provided
+					and is a valid [=named timeline range=] on [=this=]:
+				<dd>
+					Let |progress| be the current progress through that range,
+					expressed as a percentage value.
 
-				Create a [=new unit value=] from (|progress|, "percent")
-				and return it.
+					Create a [=new unit value=] from (|progress|, "percent")
+					and return it.
 
-				If the start and end points of the [=named timeline range=] coincide,
-				return negative infinity for time values before it,
-				positive infinity for time values after it,
-				and zero for time values coinciding with that point.
+					If the start and end points of the [=named timeline range=] coincide,
+					return negative infinity for time values before it,
+					positive infinity for time values after it,
+					and zero for time values coinciding with that point.
 
-			2. Otherwise, return null.
-
-		2. Let |current time|
-			be the value of [=this's=] {{AnimationTimeline/currentTime}} internal slot.
-
-			If [=this=] is a {{ScrollTimeline}},
-			create a [=new unit value=] from (|current time|, "percent")
-			and return it.
-
-			Otherwise,
-			create a [=new unit value=] from (|current time|, "ms")
-			and return it.
+				<dt>
+					If {{AnimationTimeOptions/range}} is provided
+					but is not a valid [=named timeline range=] on [=this=]:
+				<dd>
+					Returns null.
+			</dl>
 	</div>
+
+	ISSUE(8201): This method is related to {{AnimationTimeline/currentTime}}
+	but not quite the same; should it have a different name?
+
+	ISSUE: This method returns percentages relative to a ScrollTimeline’s range
+	when a range name is provided.
+	But for time-based timelines, if a range name is provided,
+	should it return percentage progress through that range,
+	or time progress through that range?


### PR DESCRIPTION
I think there's more to consider here, but this at least aligns us with the most recent resolution in #8201.