### PR TITLE
[css-images] Add basic syntax of repeating gradient types

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -331,10 +331,10 @@ Linear Gradients: the ''linear-gradient()'' notation {#linear-gradients}
 	Its syntax is as follows:
 
 	<pre class=prod>
-		<<linear-gradient()>> = linear-gradient(
-			[ <<angle>> | to <<side-or-corner>> ]? ,
-			<<color-stop-list>>
-		)
+		<<linear-gradient()>> = linear-gradient( [ <<linear-gradient-syntax>> ] )
+
+		<dfn>&lt;linear-gradient-syntax></dfn> = [ <<angle>> | to <<side-or-corner>> ]? , <<color-stop-list>>
+
 		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]
 	</pre>
 
@@ -506,10 +506,11 @@ Radial Gradients: the ''radial-gradient()'' notation {#radial-gradients}
 	The radial gradient syntax is:
 
 	<pre class=prod>
-		<<radial-gradient()>> = radial-gradient(
-		  [ <<rg-ending-shape>> || <<rg-size>> ]? [ at <<position>> ]? ,
-		  <<color-stop-list>>
-		)
+		<<radial-gradient()>> = radial-gradient( [ <radial-gradient-syntax> ] )
+
+		<dfn>&lt;radial-gradient-syntax></dfn> =
+			<<rg-ending-shape>> || <<rg-size>> ]? [ at <<position>> ]? ,
+			<<color-stop-list>>
 
 		<dfn>&lt;rg-size></dfn> = <<rg-extent-keyword>> | <<length [0,∞]>> | <<length-percentage [0,∞]>>{2}
 
@@ -769,6 +770,11 @@ Repeating Gradients: the ''repeating-linear-gradient()'' and ''repeating-radial-
 	These notations take the same values
 	and are interpreted the same
 	as their respective non-repeating siblings defined previously.
+
+	<pre class=prod>
+		<dfn>&lt;repeating-linear-gradient()></dfn> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
+		<dfn>&lt;repeating-radial-gradient()></dfn> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
+	</pre>
 
 	When rendered, however, the color-stops are repeated infinitely in both directions,
 	with their positions shifted by multiples of the difference between

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1197,10 +1197,9 @@ Linear Gradients: the ''linear-gradient()'' notation {#linear-gradients}
 	See [[css-color-4#interpolation]].
 
 	<pre class=prod>
-		<dfn>linear-gradient()</dfn> = linear-gradient(
+		<dfn>&lt;linear-gradient-syntax></dfn> =
 			[ [ <<angle>> | to <<side-or-corner>> ] || <<color-interpolation-method>> ]? ,
 			<<color-stop-list>>
-		)
 		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]
 	</pre>
 
@@ -1343,10 +1342,9 @@ Radial Gradients: the ''radial-gradient()'' notation {#radial-gradients}
 	See [[css-color-4#interpolation]].
 
 	<pre class=prod>
-		<dfn>radial-gradient()</dfn> = radial-gradient(
-		  [ [ [ <<rg-ending-shape>> || <<rg-size>> ]? [ at <<position>> ]? ] || <<color-interpolation-method>>]? ,
-		  <<color-stop-list>>
-		)
+		<dfn>&lt;radial-gradient-syntax></dfn> =
+			[ [ [ <<rg-ending-shape>> || <<rg-size>> ]? [ at <<position>> ]? ] || <<color-interpolation-method>>]? ,
+		  	<<color-stop-list>>
 	</pre>
 
 <div class="example">
@@ -1422,10 +1420,10 @@ Conic Gradients: the ''conic-gradient()'' notation</h3>
 	The syntax for a conic gradient is:
 
 	<pre class='prod'>
-		<dfn>conic-gradient()</dfn> = conic-gradient(
+		<dfn>conic-gradient()</dfn> = conic-gradient( [ <<conic-gradient-syntax>> ] )
+		<dfn>&lt;conic-gradient-syntax></dfn> =
 			[ [ [ from <<angle>> ]? [ at <<position>> ]? ] || <<color-interpolation-method>> ]? ,
 			<<angular-color-stop-list>>
-		)
 	</pre>
 
 	The arguments are defined as follows:
@@ -1582,6 +1580,12 @@ Repeating Gradients: the ''repeating-linear-gradient()'', ''repeating-radial-gra
 	These notations take the same values
 	and are interpreted the same
 	as their respective non-repeating siblings defined previously.
+
+	<pre class=prod>
+		<dfn>&lt;repeating-conic-gradient()></dfn> = repeating-conic-gradient( [ <<conic-gradient-syntax>> ] )
+		<dfn>&lt;repeating-linear-gradient()></dfn> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
+		<dfn>&lt;repeating-radial-gradient()></dfn> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
+	</pre>
 
 	<div class=example>
 		Basic repeating conic gradient:


### PR DESCRIPTION
This PR adds an explicit value definition of `<repeating-*-gradient>`, similarly as in https://github.com/w3c/csswg-drafts/commit/8a7728f0fd26cd4c849a18f1e000a85e975f2adf for `hsla()` and `rgba()` (#8231).