### PR TITLE
[css-conditional-3] Remove procedure to set readonly CSSMediaRule.con…

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -812,10 +812,6 @@ js/CSSConditionRule.html
   <dd>The <code>conditionText</code> attribute (defined on the <code>CSSConditionRule</code> parent rule),
     on getting, must return the value of <code>media.mediaText</code> on the rule.
     <wpt title="Value of CSSMediaRule.conditionText matches value of media.mediaText."></wpt>
-
-    Setting the <code>conditionText</code> attribute
-      must set the <code>media.mediaText</code> attribute on the rule.
-    <wpt title="Setting CSSMediaRule.conditionText also sets .media.mediaText."></wpt>
 </dl>
 
 


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/6c659d6e6b8675a80d4face3a904985605c643e0 changed [`CSSConditionalRule.conditionText`](https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext) to readonly, as resolved in #6819.

This PR removes the procedure to set `CSSMediaRule.conditionText`, which I think is an oversight:

  > <TabAtkins> I suppose the fact that `@media` *does* have the `.media` mutable means it's okay for the `.conditionText` to be a readonly version that covers everyone