### PR TITLE
[css-images] Fix duplicate repeating gradient definitions

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -772,8 +772,8 @@ Repeating Gradients: the ''repeating-linear-gradient()'' and ''repeating-radial-
 	as their respective non-repeating siblings defined previously.
 
 	<pre class=prod>
-		<dfn>&lt;repeating-linear-gradient()></dfn> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
-		<dfn>&lt;repeating-radial-gradient()></dfn> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
+		<<repeating-linear-gradient()>> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
+		<<repeating-radial-gradient()>> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
 	</pre>
 
 	When rendered, however, the color-stops are repeated infinitely in both directions,

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1582,9 +1582,9 @@ Repeating Gradients: the ''repeating-linear-gradient()'', ''repeating-radial-gra
 	as their respective non-repeating siblings defined previously.
 
 	<pre class=prod>
-		<dfn>&lt;repeating-conic-gradient()></dfn> = repeating-conic-gradient( [ <<conic-gradient-syntax>> ] )
-		<dfn>&lt;repeating-linear-gradient()></dfn> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
-		<dfn>&lt;repeating-radial-gradient()></dfn> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
+		<<repeating-conic-gradient()>> = repeating-conic-gradient( [ <<conic-gradient-syntax>> ] )
+		<<repeating-linear-gradient()>> = repeating-linear-gradient( [ <<linear-gradient-syntax>> ] )
+		<<repeating-radial-gradient()>> = repeating-radial-gradient( [ <<radial-gradient-syntax>> ] )
 	</pre>
 
 	<div class=example>


### PR DESCRIPTION
`<repeating-*-gradient>` are both defined as types and functions. Hopefully they are correctly defined (as functions) now.

https://github.com/w3c/webref/blob/main/ed/css/css-images-4.json#L191
https://github.com/w3c/webref/blob/main/ed/css/css-images-4.json#L224