### PR TITLE
Temporary fix for w3c.github.io redirect breakage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
+<body onload='(function() {
+  const path = location.path ? location.path : "";
+  const hash = location.hash ? location.hash : "";
+  location.href = `https://drafts.csswg.org/${path}${hash}`;
+})()'>


### PR DESCRIPTION
See https://github.com/mdn/content/issues/26613. The change made in https://github.com/w3c/csswg-drafts/commit/52077ef broke all links to CSS specs in all MDN CSS articles. This is an attempt to get all those links unbroken temporarily until we can find a better fix.