### PR TITLE
Revert "Temporary fix for w3c.github.io redirect breakage"

### DIFF
--- a/css-align/index.html
+++ b/css-align/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-anchor-position/index.html
+++ b/css-anchor-position/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-animations/index.html
+++ b/css-animations/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-backgrounds/index.html
+++ b/css-backgrounds/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-block/index.html
+++ b/css-block/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-box/index.html
+++ b/css-box/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-break/index.html
+++ b/css-break/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-cascade/index.html
+++ b/css-cascade/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-color-adjust/index.html
+++ b/css-color-adjust/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-color/index.html
+++ b/css-color/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-conditional-values/index.html
+++ b/css-conditional-values/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-conditional/index.html
+++ b/css-conditional/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-contain/index.html
+++ b/css-contain/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-content/index.html
+++ b/css-content/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-counter-styles/index.html
+++ b/css-counter-styles/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-display/index.html
+++ b/css-display/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-easing/index.html
+++ b/css-easing/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-egg/index.html
+++ b/css-egg/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-env/index.html
+++ b/css-env/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-exclusions/index.html
+++ b/css-exclusions/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-extensions/index.html
+++ b/css-extensions/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-flexbox/index.html
+++ b/css-flexbox/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-floats/index.html
+++ b/css-floats/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-font-loading/index.html
+++ b/css-font-loading/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-fonts/index.html
+++ b/css-fonts/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-forms/index.html
+++ b/css-forms/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-gcpm/index.html
+++ b/css-gcpm/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-grid/index.html
+++ b/css-grid/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-highlight-api/index.html
+++ b/css-highlight-api/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-images/index.html
+++ b/css-images/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-inline/index.html
+++ b/css-inline/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-line-grid/index.html
+++ b/css-line-grid/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-link-params/index.html
+++ b/css-link-params/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-lists/index.html
+++ b/css-lists/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-logical/index.html
+++ b/css-logical/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-multicol/index.html
+++ b/css-multicol/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-namespaces/index.html
+++ b/css-namespaces/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-nav/index.html
+++ b/css-nav/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-nesting/index.html
+++ b/css-nesting/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-overflow/index.html
+++ b/css-overflow/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-overscroll/index.html
+++ b/css-overscroll/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-page-floats/index.html
+++ b/css-page-floats/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-page-template/index.html
+++ b/css-page-template/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-page/index.html
+++ b/css-page/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-position/index.html
+++ b/css-position/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-preslev/index.html
+++ b/css-preslev/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-pseudo/index.html
+++ b/css-pseudo/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-regions/index.html
+++ b/css-regions/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-rhythm/index.html
+++ b/css-rhythm/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-round-display/index.html
+++ b/css-round-display/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-ruby/index.html
+++ b/css-ruby/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-scoping/index.html
+++ b/css-scoping/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-scroll-anchoring/index.html
+++ b/css-scroll-anchoring/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-scroll-snap/index.html
+++ b/css-scroll-snap/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-scrollbars/index.html
+++ b/css-scrollbars/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-shadow-parts/index.html
+++ b/css-shadow-parts/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-shapes/index.html
+++ b/css-shapes/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-size-adjust/index.html
+++ b/css-size-adjust/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-sizing/index.html
+++ b/css-sizing/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-speech/index.html
+++ b/css-speech/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-style-attr/index.html
+++ b/css-style-attr/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-syntax/index.html
+++ b/css-syntax/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-tables/index.html
+++ b/css-tables/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-template/index.html
+++ b/css-template/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-text-decor/index.html
+++ b/css-text-decor/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-text/index.html
+++ b/css-text/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-transforms/index.html
+++ b/css-transforms/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-transitions/index.html
+++ b/css-transitions/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-ui/index.html
+++ b/css-ui/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-values/index.html
+++ b/css-values/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-variables/index.html
+++ b/css-variables/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-view-transitions/index.html
+++ b/css-view-transitions/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-will-change/index.html
+++ b/css-will-change/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/css-writing-modes/index.html
+++ b/css-writing-modes/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/cssom-view/index.html
+++ b/cssom-view/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/cssom/index.html
+++ b/cssom/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/mediaqueries/index.html
+++ b/mediaqueries/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/resize-observer/index.html
+++ b/resize-observer/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/scroll-animations/index.html
+++ b/scroll-animations/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/selectors-nonelement/index.html
+++ b/selectors-nonelement/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/selectors/index.html
+++ b/selectors/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>

--- a/web-animations/index.html
+++ b/web-animations/index.html
@@ -1,6 +1,0 @@
-<!doctype html><html lang=en><title>Moved…</title><meta charset="utf-8">
-<body onload='(function() {
-  const path = location.pathname ? location.pathname.replace("csswg-drafts/", "") : "";
-  const hash = location.hash ? location.hash : "";
-  location.href = `https://drafts.csswg.org${path}${hash}`;
-})()'>


### PR DESCRIPTION
This reverts the series of commits made to attempt to cause the unversioned spec URLs to work again. Given that drafts.csswg.org is now simply proxying w3c.github.io/csswg-drafts, the approach of setting up the redirects in the way that series of commits did won’t work.