### PR TITLE
[css-view-transitions-1] Clarify that observable image size refers to the border-box, and observed natural size is not affected by hw constraints

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1500,7 +1500,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
-		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=call the update callback=] of |transition|.
+		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=queue a global task=] on the [=DOM manipulation task source=],
+			given |transition|'s [=relevant global object=], to [=call the update callback=] of |transition|.
 
 		1. Set [=document/transition suppressing rendering=] to false.
 
@@ -1591,7 +1592,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		* Implementations may clip the rendered contents if the [=ink overflow rectangle=] exceeds some [=implementation-defined=] maximum.
 			However, the captured image should include, at the very least, the contents of |element| that intersect with the [=snapshot root=].
-			Implementations may adjust the rasterization quality to account for elements with a large [=border box=] that are transformed into view.
+			Implementations may adjust the rasterization quality to account for elements with a large [=ink overflow area=] that are transformed into view.
 
 		* [=list/For each=] |descendant| of [=shadow-including descendant=] {{Element}} and [=pseudo-element=] of |element|,
 			if |descendant| has a [=computed value=] of 'view-transition-name' that is not ''view-transition-name/none'',

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1790,6 +1790,8 @@ Changes from <a href="https://www.w3.org/TR/2022/WD-css-view-transitions-1-20221
 * Add support for :only-child. See <a href="https://github.com/w3c/csswg-drafts/issues/8057">issue 8057</a>.
 * Add concept of a tree of pseudo-elements under [=pseudo-element root=]. See <a href="https://github.com/w3c/csswg-drafts/issues/8113">issue 8113</a>.
 * When skipping a transition, the {{UpdateCallback}} is called in own task rather than synchronosly. See <a href="https://github.com/w3c/csswg-drafts/issues/7904">issue 7904</a>
+* When capturing images, at least the in-viewport part of the image should be captured, downscale if needed. See <a href="https://github.com/w3c/csswg-drafts/issues/8561">issue 8561</a>.
+* Applying the [=ink overflow=] to the captured image is implementation defined, and doesn't affect the image's [=natural size=]. See <a href="https://github.com/w3c/csswg-drafts/issues/8597">issue 8597</a>.
 
 <h3 id="changes-since-2022-10-25">
 Changes from <a href="https://www.w3.org/TR/2022/WD-css-view-transitions-1-20221025/">2022-10-25 Working Draft (FPWD)</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1570,7 +1570,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				following the [=capture rendering characteristics=].
 
 			1. Return the portion of the canvas that includes |element|'s [=ink overflow rectangle=] as an image.
-				The [=natural size=] of the image must be |element|'s [=border box=]'s [=size=].
+				The [=natural size=] of the image must be |element|'s [=border box=]'s [=size=],
+				and its origin corresponds to the |element|'s [=border box=]'s origin.
 
 	</div>
 
@@ -1589,7 +1590,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		* Effects on the element, such as 'opacity' and 'filter' are applied to the capture.
 
 		* Implementations may clip the rendered contents if the [=ink overflow rectangle=] exceeds some [=implementation-defined=] maximum.
-			However, the captured image should include, at the very least, the contents of |element| that intersect with the [=viewport=].
+			However, the captured image should include, at the very least, the contents of |element| that intersect with the [=snapshot root=].
 			Implementations may adjust the rasterization quality to account for elements with a large [=border box=] that are transformed into view.
 
 		* [=list/For each=] |descendant| of [=shadow-including descendant=] {{Element}} and [=pseudo-element=] of |element|,

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1500,10 +1500,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
-		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`",
-			then [=queue a global task=] on the [=DOM manipulation task source=],
-			given |transition|'s [=relevant global object=],
-			to [=call the update callback=] of |transition|.
+		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=call the update callback=] of |transition|.
 
 		1. Set [=document/transition suppressing rendering=] to false.
 
@@ -1572,10 +1569,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				over an infinite transparent canvas,
 				following the [=capture rendering characteristics=].
 
-			1. Let |interestRectangle| be the result of [=computing the interest rectangle=] for |element|.
+			1. Return the portion of the canvas that includes |element|'s [=ink overflow rectangle=] as an image.
+				The [=natural size=] of the image must be |element|'s [=border box=]'s [=size=].
 
-			1. Return the portion of the canvas within |interestRectangle| as an image.
-				The natural size of the image is equal to the |interestRectangle| bounds.
 	</div>
 
 ### [=Capture rendering characteristics=] ### {#capture-rendering-characteristics-algorithm}
@@ -1583,14 +1579,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<div algorithm>
 		The <dfn>capture rendering characteristics</dfn> are as follows:
 
-		* The origin of |element|'s [=border box=] is anchored to canvas origin.
-
-		* Expand the canvas to include |element|'s [=ink overflow rectangle=]. The captured image
-		  should include the [=ink overflow region=], however the size of that region is
-		  [=implementation-defined=] and is not web-observable.
-
-		  Note: This means that ''object-view-box'' applies to |element|'s [=border box=], and UAs
-		  have to apply the [=ink overflow region=] to the canvas internally.
+		* The origin of |element|'s [=ink overflow rectangle=] is anchored to canvas origin.
 
 		* If the referenced element has a transform applied to it (or its ancestors),
 			then the transform is ignored.
@@ -1598,6 +1587,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Note: This transform is applied to the snapshot using the `transform` property of the associated ''::view-transition-group'' pseudo-element.
 
 		* Effects on the element, such as 'opacity' and 'filter' are applied to the capture.
+
+		* Implementations may clip the rendered contents if the [=ink overflow rectangle=] exceeds some [=implementation-defined=] maximum.
+			However, the captured image should include, at the very least, the contents of |element| that intersect with the [=viewport=].
+			Implementations may adjust the rasterization quality to account for elements with a large [=border box=] that are transformed into view.
 
 		* [=list/For each=] |descendant| of [=shadow-including descendant=] {{Element}} and [=pseudo-element=] of |element|,
 			if |descendant| has a [=computed value=] of 'view-transition-name' that is not ''view-transition-name/none'',
@@ -1608,28 +1601,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Issue: Refactor this so the algorithm takes a set of elements that will be captured. This centralizes the logic for deciding if an element should be included or not.
 
 			Issue: Specify what happens with 'mix-blend-mode'.
-	</div>
-
-### [=Compute the interest rectangle=] ### {#compute-the-interest-rectangle-algorithm}
-
-	<div algorithm>
-		To <dfn lt="computing the interest rectangle|compute the interest rectangle">compute the interest rectangle</dfn> of an {{Element}} |element|, perform the following steps.
-		They return a rectangle.
-
-		Note: The interest rectangle is the subset of |element|'s [=border box=] that should be captured.
-			This is required for cases where an element's border box needs to be clipped because of hardware constraints.
-			For example, if it exceeds the maximum texture size.
-
-		1. Assert: |element| is not |element|'s [=node document=]'s [=document element=].
-
-			Note: The [=document element=] is captured differently, as specified in [=capture the image=].
-
-		1. If |element|'s [=border area=] does not exceed an implementation-defined maximum size,
-			then return a rectangle that is equal to |element|'s [=border box=].
-
-		1. Otherwise:
-
-			Issue: Define the algorithm used to clip the snapshot when it exceeds max size.
 	</div>
 
 ## [=Handle transition frame=] ## {#handle-transition-frame-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1500,8 +1500,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
-		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=queue a global task=] on the [=DOM manipulation task source=],
-			given |transition|'s [=relevant global object=], to [=call the update callback=] of |transition|.
+		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`",
+			then [=queue a global task=] on the [=DOM manipulation task source=],
+			given |transition|'s [=relevant global object=],
+			to [=call the update callback=] of |transition|.
 
 		1. Set [=document/transition suppressing rendering=] to false.
 
@@ -1581,7 +1583,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<div algorithm>
 		The <dfn>capture rendering characteristics</dfn> are as follows:
 
-		* The origin of |element|'s [=ink overflow rectangle=] is anchored to canvas origin.
+		* The origin of |element|'s [=border box=] is anchored to canvas origin.
+
+		* Expand the canvas to include |element|'s [=ink overflow rectangle=]. The captured image
+		  should include the [=ink overflow region=], however the size of that region is
+		  [=implementation-defined=] and is not web-observable.
+
+		  Note: This means that ''object-view-box'' applies to |element|'s [=border box=], and UAs
+		  have to apply the [=ink overflow region=] to the canvas internally.
 
 		* If the referenced element has a transform applied to it (or its ancestors),
 			then the transform is ignored.
@@ -1607,16 +1616,16 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		To <dfn lt="computing the interest rectangle|compute the interest rectangle">compute the interest rectangle</dfn> of an {{Element}} |element|, perform the following steps.
 		They return a rectangle.
 
-		Note: The interest rectangle is the subset of |element|'s [=ink overflow rectangle=] that should be captured.
-			This is required for cases where an element's ink overflow rectangle needs to be clipped because of hardware constraints.
+		Note: The interest rectangle is the subset of |element|'s [=border box=] that should be captured.
+			This is required for cases where an element's border box needs to be clipped because of hardware constraints.
 			For example, if it exceeds the maximum texture size.
 
 		1. Assert: |element| is not |element|'s [=node document=]'s [=document element=].
 
 			Note: The [=document element=] is captured differently, as specified in [=capture the image=].
 
-		1. If |element|'s [=ink overflow area=] does not exceed an implementation-defined maximum size,
-			then return a rectangle that is equal to |element|'s [=ink overflow rectangle=].
+		1. If |element|'s [=border area=] does not exceed an implementation-defined maximum size,
+			then return a rectangle that is equal to |element|'s [=border box=].
 
 		1. Otherwise:
 


### PR DESCRIPTION
Ink-overflow is an implementation detail, and up to the UA to apply. object-view-box doesn't directly affect the ink-overflow rect. Replaced mentioned of `ink-overflow rect` with `border box`, and added note about how ink-overflow plays into this.

Also, texture size constraints should not affect the observed natural size of the captured image. Instead, implementations
should capture at least the visible part of the element (downscaled if they must).

See [resolution 1](https://github.com/w3c/csswg-drafts/issues/8597#issuecomment-1488952275) and [resolution 2](https://github.com/w3c/csswg-drafts/issues/8561#issuecomment-1470414852).

Closes #8561 
Closes #8597
