### PR TITLE
[scroll-snap-2] Add scroll-start-target longhand details

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -196,7 +196,7 @@ The 'scroll-start-target' property {#scroll-start-target}
 
   <pre class="propdef shorthand">
   Name: scroll-start-target
-  Value: [ none | auto ]
+  Value: [ none | auto ]{1,2}
   </pre>
 
   This property is a shorthand property that sets all of the scroll-start-target-* longhands in one declaration.
@@ -331,6 +331,37 @@ Flow-relative Longhands for 'scroll-start'  {#scroll-start-longhands-logical}
 	Percentages: relative to the corresponding axis of the scroll container’s scrollport
 	Computed value: the keyword ''scroll-start/auto'' or a computed <<length-percentage>> value
 	Animation type: by computed value type
+	</pre>
+
+	...
+Flow-relative Longhands for 'scroll-start-target'  {#scroll-start-target-longhands-logical}
+--------------------------------------------------------------------------
+
+	<pre class="propdef">
+	Name: scroll-start-target-block, scroll-start-target-inline
+	Value: auto | none
+	Initial: none
+	Applies to: all elements
+	Inherited: no
+	Percentages: n/a
+	Computed Value: either of the keywords "none" or "auto"
+	Animation type: not animatable
+	</pre>
+
+	...
+
+Physical Longhands for 'scroll-start' {#scroll-start-target-longhands-physical}
+----------------------------------------------------------------------
+
+	<pre class="propdef">
+	Name: scroll-start-target-x, scroll-start-target-y
+	Value: none | auto
+	Initial: none
+	Applies to: all elements
+	Inherited: no
+	Percentages: n/a
+	Computed value: either of the keywords "none" or "auto"
+	Animation type: not animatable
 	</pre>
 
 	...


### PR DESCRIPTION
scroll-start-target is a shorthand. This change specifies its related shorthands.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
