### PR TITLE
[css-scroll-snap-2] Define logical property group of scroll-start-*

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -312,6 +312,7 @@ Physical Longhands for 'scroll-start' {#scroll-start-longhands-physical}
 	Initial: auto
 	Applies to: <a>scroll containers</a>
 	Inherited: no
+	Logical property group: scroll-start
 	Percentages: relative to the corresponding axis of the scroll container’s scrollport
 	Computed value: the keyword ''scroll-start/auto'' or a computed <<length-percentage>> value
 	Animation type: by computed value type
@@ -328,6 +329,7 @@ Flow-relative Longhands for 'scroll-start'  {#scroll-start-longhands-logical}
 	Initial: auto
 	Applies to: <a>scroll containers</a>
 	Inherited: no
+	Logical property group: scroll-start
 	Percentages: relative to the corresponding axis of the scroll container’s scrollport
 	Computed value: the keyword ''scroll-start/auto'' or a computed <<length-percentage>> value
 	Animation type: by computed value type
@@ -343,6 +345,7 @@ Flow-relative Longhands for 'scroll-start-target'  {#scroll-start-target-longhan
 	Initial: none
 	Applies to: all elements
 	Inherited: no
+	Logical property group: scroll-start-target
 	Percentages: n/a
 	Computed Value: either of the keywords "none" or "auto"
 	Animation type: not animatable
@@ -350,7 +353,7 @@ Flow-relative Longhands for 'scroll-start-target'  {#scroll-start-target-longhan
 
 	...
 
-Physical Longhands for 'scroll-start' {#scroll-start-target-longhands-physical}
+Physical Longhands for 'scroll-start-target' {#scroll-start-target-longhands-physical}
 ----------------------------------------------------------------------
 
 	<pre class="propdef">
@@ -359,6 +362,7 @@ Physical Longhands for 'scroll-start' {#scroll-start-target-longhands-physical}
 	Initial: none
 	Applies to: all elements
 	Inherited: no
+	Logical property group: scroll-start-target
 	Percentages: n/a
 	Computed value: either of the keywords "none" or "auto"
 	Animation type: not animatable


### PR DESCRIPTION
This PR adds a `Logical property group` field to physical/logical `scroll-start-*` longhands, as required by [this resolution](https://github.com/w3c/csswg-drafts/issues/2822#issuecomment-722050788).

I know CSS Scroll Snap 2 is unofficial and this change is not important at this point, but it seems listed in `w3c/browser-specs`, which means it is deemed relevant for the Web Platform, and `w3c/reffy` extracts its definitions, which means some implementations/tools may start implementing it.