### PR TITLE
[css-view-transitions-1] When skipping transitions, call the DOM-update callback from a task

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1468,7 +1468,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		even if the transition is [=Skip the view transition|skipped=].
 		The reasons for this are discussed in [[#transitions-as-enhancements]].
 
-		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`".
+		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is "`done`", or [=phases/before=] "`update-callback-called`".
 
 		1. Let |callbackPromise| be null.
 
@@ -1478,7 +1478,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Otherwise, set |callbackPromise| to the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
 
-		1. Set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
+		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
 
 		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=]
 			with the result of [=reacting=] to |callbackPromise|:
@@ -1500,7 +1500,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
-		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=call the update callback=] of |transition|.
+		1. If |transition|'s [=ViewTransition/phase=] is [=phases/before=] "`update-callback-called`", then [=queue a global task=] on the [=DOM manipulation task source=],
+			given |transition|'s [=relevant global object=], to [=call the update callback=] of |transition|.
 
 		1. Set [=document/transition suppressing rendering=] to false.
 


### PR DESCRIPTION
Amend assert to allow calling the callback from a "done" state

The "finished" promise is bound to the update callback promise, so it doesn't need to change (the update callback is async anyway).

See [resolution](https://github.com/w3c/csswg-drafts/issues/7904#issuecomment-1468794641).

Closes #7904

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
