### PR TITLE
[css-view-transitions-1] Fragmented elements don't participate in view transitions.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1612,8 +1612,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |hasActiveAnimations| be a boolean, initially false.
 
-		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=tree/inclusive descendants=]:
+		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=],
+			if |capturedElement| has more than one [=box-fragment=],
+			then [=skip the view transition=] for |transition|, and return.
 
+		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=tree/inclusive descendants=]:
 			1. For each |animation| whose [=timeline=] is a [=document timeline=] associated with |document|,
 				and contains at least one [=animation/associated effect=] whose [=effect target=] is |element|,
 				set |hasActiveAnimations| to true if any of the following conditions is true:

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1612,10 +1612,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |hasActiveAnimations| be a boolean, initially false.
 
-		1. [=map/For each=] |transitionName| → |capturedElement| of |transition|'s [=ViewTransition/named elements=],
-			if |capturedElement| has more than one [=box-fragment=],
-			then [=skip the view transition=] for |transition|, and return.
-
 		1. [=list/For each=] |element| of |transition|'s [=ViewTransition/transition root pseudo-element=]'s [=tree/inclusive descendants=]:
 			1. For each |animation| whose [=timeline=] is a [=document timeline=] associated with |document|,
 				and contains at least one [=animation/associated effect=] whose [=effect target=] is |element|,
@@ -1676,9 +1672,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Otherwise:
 
-				1. If any [=flat tree=] ancestor of |capturedElement|'s [=new element=] [=skips its contents=],
-					or |capturedElement|'s [=new element=] is [=element-not-rendered|not rendered=],
-					then return failure.
+				1. Return failure if any of the following conditions is true:
+					- |capturedElement|'s [=new element=] has a [=flat tree=] ancestor that [=skips its contents=].
+
+					- |capturedElement|'s [=new element=] is [=element-not-rendered|not rendered=].
+
+					- |capturedElement| has more than one [=box-fragment=].
 
 					Note: Other rendering constraints are enforced via |capturedElement|'s [=new element=] being [=involved in a view transition=].
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1243,7 +1243,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. If any [=flat tree=] ancestor of this |element| [=skips its contents=], then [=continue=].
 
-			1. If |element| is not |element|'s [=tree/root=] and |element| allows [=fragmentation=], then [=continue=].
+			1. If |element| has more than one [=box-fragment=], then [=continue=].
 
 				Issue: We might want to enable transitions for fragmented elements in future versions.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1243,19 +1243,17 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. If any [=flat tree=] ancestor of this |element| [=skips its contents=], then [=continue=].
 
+			1. If |element| is not |element|'s [=tree/root=] and |element| allows [=fragmentation=], then [=continue=].
+
+				Issue: We might want to enable transitions for fragmented elements in future versions.
+
 			1. Let |transitionName| be the [=computed value=] of 'view-transition-name' for |element|.
 
 			1. If |transitionName| is ''view-transition-name/none'',
 				or |element| is [=element-not-rendered|not rendered=],
 				then [=continue=].
 
-			1. If any of the following is true:
-
-				* |usedTransitionNames| [=list/contains=] |transitionName|.
-
-				* |element| is not |element|'s [=tree/root=] and |element| allows [=fragmentation=].
-
-				Then return failure.
+			1. If |usedTransitionNames| [=list/contains=] |transitionName|, then return failure.
 
 			1. [=set/Append=] |transitionName| to |usedTransitionNames|.
 
@@ -1794,6 +1792,7 @@ Changes from <a href="https://www.w3.org/TR/2022/WD-css-view-transitions-1-20221
 * When skipping a transition, the {{UpdateCallback}} is called in own task rather than synchronosly. See <a href="https://github.com/w3c/csswg-drafts/issues/7904">issue 7904</a>
 * When capturing images, at least the in-viewport part of the image should be captured, downscale if needed. See <a href="https://github.com/w3c/csswg-drafts/issues/8561">issue 8561</a>.
 * Applying the [=ink overflow=] to the captured image is implementation defined, and doesn't affect the image's [=natural size=]. See <a href="https://github.com/w3c/csswg-drafts/issues/8597">issue 8597</a>.
+* Fragmented elements don't participate in view transitions. See <a href="https://github.com/w3c/csswg-drafts/issues/8339">issue 8339</a>.
 
 <h3 id="changes-since-2022-10-25">
 Changes from <a href="https://www.w3.org/TR/2022/WD-css-view-transitions-1-20221025/">2022-10-25 Working Draft (FPWD)</a>


### PR DESCRIPTION
Skip fragmented elements when preparing transition, and add note about looking at this again in the future.

See [resolution](https://github.com/w3c/csswg-drafts/issues/8339#issuecomment-1470268830).
Closes #8339

