### PR TITLE
[css-scroll-snap-2] Mark as ED

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -3,8 +3,7 @@ Title: CSS Scroll Snap Module Level 2
 Group: csswg
 Shortname: css-scroll-snap
 Level: 2
-Status: UD
-Warning: Not Ready
+Status: ED
 Implementation Report: https://wpt.fyi/results/css/css-scroll-snap
 Work Status: Testing
 ED: https://drafts.csswg.org/css-scroll-snap-2/


### PR DESCRIPTION
This was marked as UD, however, all of the features have been discussed. Previous resolutions:
`scroll-start` and `scroll-start-target`: https://github.com/w3c/csswg-drafts/issues/6986#issuecomment-1028503857
`:snapped`, `snapChanged` and `snapChanging` and creation of css-scroll-snap-2 ED: https://github.com/w3c/csswg-drafts/issues/6985#issuecomment-1049029573

Discussion of original PR in #8766.