### PR TITLE
[css-contain-2] Elements stay relevant to the user during a view transition

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1681,6 +1681,10 @@ Suppressing An Element's Contents Entirely: the 'content-visibility' property {#
 			content-visibility/content-visibility-with-top-layer-005.html
 			content-visibility/content-visibility-with-top-layer-006.html
 			</wpt>
+
+		* The element or one of its ancestors participates in an ongoing {{ViewTransition}},
+			and the element was [=relevant to the user=] when {{Document/startViewTransition()}} was called.
+
 	</div>
 
 


### PR DESCRIPTION
Closes #8060

See [resolution](https://github.com/w3c/csswg-drafts/issues/8060#issuecomment-1411189366).