### PR TITLE
[css-anchor-position-1] Update the anchor() math example

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -239,17 +239,17 @@ as if by an additional ''translate()'' transform.
 	<pre highlight=css>
 	.centered-message {
 		position: fixed;
-		max-width: max-content;
-		justify-content: center;
-
-		--center: anchor(--x 50%);
+		anchor-default: --x;
+		max-inline-size: max-content;
+		margin-inline: auto;
+		--center: anchor(50%);
 		--half-distance: min(
 			abs(0% - var(--center)),
 			abs(100% - var(--center))
 		);
-		left: calc(var(--center) - var(--half-distance));
-		right: calc(var(--center) - var(--half-distance));
-		bottom: anchor(--x top);
+		inset-inline-start: calc(var(--center) - var(--half-distance));
+		inset-inline-end: calc(var(--center) - var(--half-distance));
+		inset-block-end: anchor(start);
 	}
 	</pre>
 


### PR DESCRIPTION
[css-anchor-1] Update the anchor() math example

I was re-reading the specs, and noticed that one of the examples seemed to promise a fix for one of the use-cases I was wondering what could be the best fix for — the one where we can use an extensive calculation to get a centered message.

When trying it in the Canary, I noticed that the code for the example is not optimal, so I did update the example.

Here is a CodePen demonstrating the example with my changes (using the calculations instead off the missing `abs()`): https://codepen.io/kizu/pen/wvYYLGr?editors=1100

The changes:

1. Because the example does not contain `display: flex` or similar, the `justify-content` does not do anything. So, in order to make things work — to center the element properly — we can use `auto` margin.
2. We can also demonstrate the `anchor-default` instead of using the explicit anchor name in the calculation. Potentially, this can make it easier to later reuse this as a part of a position-fallback.
3. I did recently read the https://github.com/w3c/csswg-drafts/issues/8727 issue, and I mostly agree with it, so I took this chance to replace the physical keywords with logical (I like how when used inside `anchor()` there is no need to think of which axis we're thinking about, and this potentially could be used to also separate these parts and reuse for different axis easier).