### PR TITLE
[css-view-transitions-1] Clarify stacking context model #8917

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -770,25 +770,22 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 ## View Transition Painting Order ## {#view-transition-stacking-layer}
 
 	This specification introduces a new stacking layer, the [=view transition layer=],
-	to the <a href="https://www.w3.org/TR/CSS22/zindex.html">Elaborate Description of Stacking Contexts</a>.
+	to the end of the painting order established in
+	<a href="https://www.w3.org/TR/CSS22/zindex.html">CSS2&sect;E Elaborate Description of Stacking Contexts</a>. [[!CSS2]]
 
-	The ''::view-transition'' pseudo-element generates a new stacking context
-	called the <dfn>view transition layer</dfn>
-	with the following characteristics:
-
-	- Its parent [=stacking context=] is the root stacking context.
-
-	- If the ''::view-transition'' pseudo-element exists,
-		a new [=stacking context=] is created for the [=document element=] and the [=Document/top layer=].
-		The [=view transition layer=] is a sibling of this stacking context.
-
-	- The [=view transition layer=] paints after the stacking context for the [=document element=] and [=Document/top layer=].
-		This includes the filters and effects that are applied to the [=document element=].
+	The ''::view-transition'' pseudo-element generates a new stacking context,
+	called the <dfn>view transition layer</dfn>,
+	which paints after all other content of the document
+	(including any content rendered in the [=top layer=] [[!FULLSCREEN]]),
+	after any filters and effects that are applied to such content.
+	(It is not subject to such filters or effects,
+	except insofar as they affect the rendered contents
+	of the ''::view-transition-old()'' and ''::view-transition-new()'' pseudo-elements.)
 
 	Note: The intent of the feature is to be able to capture the contents of the page, which includes the top layer elements.
-	In order to accomplish that, the [=view transition layer=] cannot be a part of the captured top layer context,
+	In order to accomplish that, the [=view transition layer=] cannot be a part of the captured stacking contexts,
 	since that results in a circular dependency.
-	Instead, this stacking context is a sibling of other page contents.
+	Therefore, the [=view transition layer=] is a sibling of all other content.
 
 # User Agent Stylesheet # {#ua-styles}
 


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/8917 The revised definition looks less formal, but afaict it actually hooks up more properly.

THIS PATCH BUILDS ON https://github.com/w3c/csswg-drafts/pull/8918 in order to avoid merge conflicts, and therefore incorporates that entire PR. See last commit for this change.