### PR TITLE
[css-color-5] move `color()` parameters description out of `<xyz-params>` bullet point

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1533,87 +1533,87 @@ the allowed [=channel keywords=] are:
 	after <a href="#required-conversion">conversion, if required</a> to relative CIE XYZ color space
 	adapted to the relevant white point.
 
-	The parameters have the following form:
+The parameters have the following form:
 
-	* An <<ident>>  or <<dashed-ident>> denoting the color space.
-		If this is an <<ident>> it denotes one of the
-			predefined color spaces
-			[[css-color-4#predefined]]
-		(such as ''display-p3'');
-		if it is a <<dashed-ident>> it denotes a custom
-		color space, defined by a ''@color-profile'' rule.
-		Individual predefined color spaces
-		may further restrict whether <<number>>s or <<percentage>>s
-		or both, may be used.
+* An <<ident>>  or <<dashed-ident>> denoting the color space.
+	If this is an <<ident>> it denotes one of the
+		predefined color spaces
+		[[css-color-4#predefined]]
+	(such as ''display-p3'');
+	if it is a <<dashed-ident>> it denotes a custom
+	color space, defined by a ''@color-profile'' rule.
+	Individual predefined color spaces
+	may further restrict whether <<number>>s or <<percentage>>s
+	or both, may be used.
 
-		If the <<ident>> names a non-existent color space
-		(a name that does not match one of the
-		predefined color spaces),
-		or a predefined but unsupported color space,
-		this argument represents an <a>invalid color</a>.
+	If the <<ident>> names a non-existent color space
+	(a name that does not match one of the
+	predefined color spaces),
+	or a predefined but unsupported color space,
+	this argument represents an <a>invalid color</a>.
 
-		If the <<dashed-ident>> names a non-existent color space
-		( a name that does not match an <a>color profile's</a> name,
-		  or which matches but the corresponding profile has not loaded,
-		  or does not represent a valid profile),
-		this argument represents an <a>invalid color</a>.
+	If the <<dashed-ident>> names a non-existent color space
+	( a name that does not match an <a>color profile's</a> name,
+		or which matches but the corresponding profile has not loaded,
+		or does not represent a valid profile),
+	this argument represents an <a>invalid color</a>.
 
+* One or more <<number>>s or <<percentage>>s providing the parameter values that the color space takes.
 
-	* One or more <<number>>s or <<percentage>>s providing the parameter values that the color space takes.
+	For custom color spaces,
+	specified component values
+	less than 0 or 0%, or greater than 1 or 100%
+	are not invalid;
+	they are clamped to the valid range at computed value time.
+	This is because ICC profiles typically do not accept
+	out of range input values.
 
-		For custom color spaces,
-		specified component values
-		less than 0 or 0%, or greater than 1 or 100%
-		are not invalid;
-		they are clamped to the valid range at computed value time.
-		This is because ICC profiles typically do not accept
-		out of range input values.
+	For custom color spaces, if more <<number>>s or <<percentage>>s are provided than parameters that the color space takes,
+	the excess <<number>>s at the end are ignored.
+	The color is still a [=valid color=].
 
-		For custom color spaces, if more <<number>>s or <<percentage>>s are provided than parameters that the color space takes,
-		the excess <<number>>s at the end are ignored.
-		The color is still a [=valid color=].
+	For custom color spaces, if more <<number>>s or <<percentage>>s are provided than components listed in the optional components descriptor,
+	the additional values at the end are still valid,
+	but cannot be used in Relative Color Syntax.
+	The color is still a [=valid color=].
 
-		For custom color spaces, if more <<number>>s or <<percentage>>s are provided than components listed in the optional components descriptor,
-		the additional values at the end are still valid,
-		but cannot be used in Relative Color Syntax.
-		The color is still a [=valid color=].
+	For custom color spaces, if fewer <<number>>s or <<percentage>>s are provided than parameters that the color space takes,
+	the missing parameters default to ''0''.
+	(This is particularly convenient for multichannel printers
+	where the additional inks are spot colors or varnishes
+	that most colors on the page won't use.)
+	The color is still a [=valid color=].
 
-		For custom color spaces, if fewer <<number>>s or <<percentage>>s are provided than parameters that the color space takes,
-		the missing parameters default to ''0''.
-		(This is particularly convenient for multichannel printers
-		where the additional inks are spot colors or varnishes
-		that most colors on the page won't use.)
-		The color is still a [=valid color=].
+	For predefined color spaces,
+	specified component values
+	less than 0 or 0%, or greater than 1 or 100%
+	are not invalid;
+	these out of gamut colors
+	are gamut mapped to the valid range at computed value time,
+	with a relative colorimetric intent.
 
-		For predefined color spaces,
-		specified component values
-		less than 0 or 0%, or greater than 1 or 100%
-		are not invalid;
-		these out of gamut colors
-		are gamut mapped to the valid range at computed value time,
-		with a relative colorimetric intent.
+* An optional slash-separated <<alpha-value>>.
+	This is interpreted the same way as the <<alpha-value>> in ''rgb()'',
+	and if omitted it defaults to ''100%''.
 
-	* An optional slash-separated <<alpha-value>>.
-		This is interpreted the same way as the <<alpha-value>> in ''rgb()'',
-		and if omitted it defaults to ''100%''.
+<wpt>
+	parsing/color-computed-relative-color.html
+</wpt>
 
-	<wpt>
-		parsing/color-computed-relative-color.html
-	</wpt>
+<div class="example" id="ex-RCS-XYZ">
+	For example, Relative Color Syntax in the CIE XYZ D65 colorspace
+	is used to generate a color which has exactly half the luminance
+	of the base color:
 
-	<div class="example" id="ex-RCS-XYZ">
-		For example, Relative Color Syntax in the CIE XYZ D65 colorspace
-		is used to generate a color which has exactly half the luminance
-		of the base color:
+	<pre class="lang-css">
+		--base: <span class="swatch" style="--color: rgb(73.58% 48.92% 10.45%)"></span> color(display-p3 0.7 0.5 0.1);
+		--dark: <span class="swatch" style="--color: rgb(53.617% 35.186% 6.4237%)"></span> color(from var(--base) xyz-d65 calc(x/2) calc(y/2) calc(z/2));
+	</pre>
 
-		<pre class="lang-css">
-			--base: <span class="swatch" style="--color: rgb(73.58% 48.92% 10.45%)"></span> color(display-p3 0.7 0.5 0.1);
-			--dark: <span class="swatch" style="--color: rgb(53.617% 35.186% 6.4237%)"></span> color(from var(--base) xyz-d65 calc(x/2) calc(y/2) calc(z/2));
-		</pre>
+	The origin color is color(xyz-d65 0.281 0.253 0.044)
+	and so the relative color is color(xyz-d65 0.14 0.126 0.022).
+</div>
 
-		The origin color is color(xyz-d65 0.281 0.253 0.044)
-		and so the relative color is color(xyz-d65 0.14 0.126 0.022).
-	</div>
 
 <h3 id="custom-color">
 	Custom Color Spaces


### PR DESCRIPTION
https://drafts.csswg.org/css-color-5/#relative-color-function

`<ident>`, `<dashed-ident>`, `<number>`, `<percentage>`, and `<alpha-value>` should not be tied to `<xyz-params>` but are in the current draft.
