### PR TITLE
[scroll-animations-1] Time-based delays get convered to their respective proportions #7749

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -757,8 +757,8 @@ spec: cssom-view-1; type: dfn;
 	(see [[#named-range-animation-declaration]]).
 
 	Time-based delays ('animation-delay')
-	do not apply to [=scroll-driven animations=],
-	which are distance-based.
+	get converted to their respective proportions
+	as described in [[web-animations-2#animations]]
 
 ## Finite Timeline Calculations ## {#finite-attachment}
 


### PR DESCRIPTION
There still was a leftover paragraph from an earlier version of the spec that mentioned time-based `animation-delay`s do not apply. This is not the case, as per https://github.com/w3c/csswg-drafts/issues/7749#issuecomment-1505563335 resolution.