### PR TITLE
[css-anchor-position-1] Change implicit anchor element example

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -160,9 +160,11 @@ a particular element is an <dfn>implicit anchor element</dfn>
 for a given positioned element.
 
 <p class=example>
-	For example, the HTML spec defines an "anchor" attribute which allows an
-	element to declare what element it is anchored to. This makes the declared
-	element the [=implicit anchor element=] for the element with the attribute.
+	For example, the HTML spec <a
+	href="https://whatpr.org/html/9144/dom.html#the-anchor-attribute">defines an
+	"anchor" attribute</a> which allows an element to declare what element it is
+	anchored to. This makes the declared element the [=implicit anchor element=]
+	for the element with the attribute.
 
 [=Implicit anchor elements=] can be referenced
 with the ''implicit'' keyword,

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -160,9 +160,9 @@ a particular element is an <dfn>implicit anchor element</dfn>
 for a given positioned element.
 
 <p class=example>
-	For example, the HTML spec defines an attribute which allows an element to
-	declare what element it is anchored to. This makes the declared element the
-	[=implicit anchor element=] for the element with the attribute.
+	For example, the HTML spec defines an "anchor" attribute which allows an
+	element to declare what element it is anchored to. This makes the declared
+	element the [=implicit anchor element=] for the element with the attribute.
 
 [=Implicit anchor elements=] can be referenced
 with the ''implicit'' keyword,

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -160,10 +160,9 @@ a particular element is an <dfn>implicit anchor element</dfn>
 for a given positioned element.
 
 <p class=example>
-	For example, the HTML spec <a
-	href="https://whatpr.org/html/9144/dom.html#the-anchor-attribute">defines an
-	"anchor" attribute</a> which allows an element to declare what element it is
-	anchored to. This makes the declared element the [=implicit anchor element=]
+	For example, the HTML spec defines an <{html-global/anchor}> attribute
+	which allows an element to declare what element it is anchored to. 
+	This makes the declared element the [=implicit anchor element=]
 	for the element with the attribute.
 
 [=Implicit anchor elements=] can be referenced

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -160,10 +160,9 @@ a particular element is an <dfn>implicit anchor element</dfn>
 for a given positioned element.
 
 <p class=example>
-	For example, the Popover API allows a popover
-	to declare what element is anchoring it.
-	This makes the declared element the [=implicit anchor element=]
-	for the popover.
+	For example, the HTML spec defines an attribute which allows an element to
+	declare what element it is anchored to. This makes the declared element the
+	[=implicit anchor element=] for the element with the attribute.
 
 [=Implicit anchor elements=] can be referenced
 with the ''implicit'' keyword,


### PR DESCRIPTION
I am writing an HTML spec PR to define the anchor attribute, which sets the implicit anchor element. That PR doesn't have any references to or integrations with the popover attribute, and I got feedback that the implicit anchor element seems popover-specific due to the example: https://github.com/whatwg/html/pull/9144#discussion_r1244592176

This PR changes the example to talk about the anchor attribute rather than the popover API. I'm not sure if the popover API is supposed to set an implicit anchor element... maybe @xiaochengh knows?