### PR TITLE
[css-color-5] fix typo

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2943,7 +2943,7 @@ No new privacy considerations have been reported on this specification.
 	<li>Clarified which of CIE Lightness and Oklab lightness are being used</li>
 	<li>Clarified serialization of the result of a ''color-mix()'' function if ''currentColor'' is used. Added an example of this.</li>
 	<li>Fixed typo's in some color-mix examples </li>
-	<li>Fixed an example whichused 0 instead on none for powerless components</li>
+	<li>Fixed an example which used 0 instead of none for powerless components</li>
 	<li>Defined serialization of specified value of color-mix and clarified that it serializes with specified, not normalized, percentages</li>
 	<li>Removed the unchanged alpha-value definition, link to Color 4 instead</li>
 	<li>Used separate grammar productions for modern and legacy rgb, rgba, hsl, and hsla</li>


### PR DESCRIPTION
Fixed two typo's in the list of changes of `css-color-5`