### PR TITLE
[css-view-transitions-1][css-view-transitions-2] Initial draft for cross-document view transitions

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1048,6 +1048,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Note: This is used to detect changes in the [=snapshot containing block size=],
 			which causes the transition to [=skip the view transition|skip=].
 			[Discussion of this behavior](https://github.com/w3c/csswg-drafts/issues/8045).
+
+		: <dfn>old state captured steps</dfn>
+		:: An algorithm accepting nothing, or null.
+			Initially null.
+
+			Note: this is used for cross-document view transitions.
 	</dl>
 
 	The {{ViewTransition/finished}} [=getter steps=] are to return [=this's=] [=ViewTransition/finished promise=].
@@ -1204,7 +1210,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Capture the old state=] for |transition|.
 
-			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
+
+		1.If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
 
 		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
@@ -1217,7 +1225,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					although the render steps in the HTML spec act as if it's synchronous.
 
 			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
-
+0
 				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 					The [=skip the view transition=] steps [=call the update callback=],
 					ensuring the |transition|'s [=ViewTransition/update callback=] is always called.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1572,6 +1572,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
+		1. If |transition|'s [=ViewTransition/phase=] is "`pending-capture`" and |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
+
 		1. If |transition|'s [=ViewTransition/phase=] is before "`update-callback-called`", then [=queue a global task=] on the [=DOM manipulation task source=],
 			given |transition|'s [=relevant global object=], to [=call the update callback=] of |transition|.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1230,6 +1230,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					although the render steps in the HTML spec act as if it's synchronous.
 
 			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
+
 				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 					The [=skip the view transition=] steps [=call the update callback=],
 					ensuring the |transition|'s [=ViewTransition/update callback=] is always called.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1225,7 +1225,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					although the render steps in the HTML spec act as if it's synchronous.
 
 			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
-0
 				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 					The [=skip the view transition=] steps [=call the update callback=],
 					ensuring the |transition|'s [=ViewTransition/update callback=] is always called.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1056,6 +1056,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Note: this is used for cross-document view transitions.
 	</dl>
 
+	A {{ViewTransition}} must never have both an [=ViewTransition/update callback=] and a [=ViewTransition/old state captured steps=].
+
+	Note: [=ViewTransition/update callback=] is optionally set for same-document view transitions,
+		and [=ViewTransition/old state captured steps=] is set for cross-document view transitions.
+
 	The {{ViewTransition/finished}} [=getter steps=] are to return [=this's=] [=ViewTransition/finished promise=].
 
 	The {{ViewTransition/ready}} [=getter steps=] are to return [=this's=] [=ViewTransition/ready promise=].
@@ -1208,7 +1213,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. [=Capture the old state=] for |transition|.
+		1. [=Capture the old state=] for |transition|. If that fails, set |transition|'s [=ViewTransition/phase=] to "`done`".
 
 		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
 
@@ -1572,8 +1577,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is not "`done`".
 
-		1. If |transition|'s [=ViewTransition/phase=] is "`pending-capture`" and |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
-
 		1. If |transition|'s [=ViewTransition/phase=] is before "`update-callback-called`", then [=queue a global task=] on the [=DOM manipulation task source=],
 			given |transition|'s [=relevant global object=], to [=call the update callback=] of |transition|.
 
@@ -1596,6 +1599,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Note: Since the rejection of |transition|'s [=ViewTransition/update callback done promise=] isn't explicitly handled here,
 			if |transition|'s [=ViewTransition/update callback done promise=] rejects,
 			then |transition|'s [=ViewTransition/finished promise=] will reject with the same reason.
+
+		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call |transition|'s [=ViewTransition/process old state captured=].
 	</div>
 
 ## [=Capture the image=] ## {#capture-the-image-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1213,12 +1213,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
-		1. [=Capture the old state=] for |transition|. If that fails, set |transition|'s [=ViewTransition/phase=] to "`done`".
+		1. [=Capture the old state=] for |transition|.
+
+			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
 
 		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
-
-		1. If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
-			and return.
 
 		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1212,7 +1212,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
 
-		1.If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+		1. If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
 
 		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -106,7 +106,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	A successful cross-document view transition goes through the following phases:
 
 	1. The user navigates, by clicking a link, submitting a form, traversing history using the
-		browser API, etc.
+		browser UI, etc.
 
 	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
 		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -11,7 +11,7 @@ TR: https://www.w3.org/TR/css-view-transitions-2/
 Work Status: exploring
 Editor: Noam Rosenthal, Google, w3cid 121539
 Editor: Khushal Sagar, Google, w3cid 122787
-Editor: Vladimir Levin, Google
+Editor: Vladimir Levin, Google, w3cid 75295
 Editor: Tab Atkins-Bittner, Google, http://xanthir.com/contact/, w3cid 42199
 Abstract: This module defines how the View Transition API works with cross-document navigations.
 Markup Shorthands: css yes, markdown yes
@@ -20,15 +20,16 @@ Markup Shorthands: css yes, markdown yes
 <pre class=link-defaults>
 spec:css-view-transitions-1;
 	text: active view transition; type: dfn;
+	text: activate view transition; type: dfn;
 	text: skip the view transition; type: dfn;
 	text: ViewTransition; type: interface;
 	text: named elements; for: ViewTransition; type: dfn;
 	text: update callback done promise; for: ViewTransition; type: dfn;
 	text: initial snapshot containing block size; for: ViewTransition; type: dfn;
-	text: capture the old state; type: dfn;
 	text: activate view transition; type: dfn;
 	text: captured elements; type: dfn;
 	text: updateCallbackDone; type: property; for: ViewTransition;
+	text: phase; type: property; for: ViewTransition;
 	text: call the update callback; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
@@ -118,7 +119,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Right before the new {{Document}} has the first [=rendering opportunity=], its state is captured as
 		the "new" state.
 
-	1. An event named [[#reveal-event|`reveal`]] is fired on the new {{Document}}, with a `viewTransition` property,
+	1. An event named {{PageRevealEvent|reveal}} is fired on the new {{Document}}, with a `viewTransition` property,
 		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
 		and its [=captured elements=] are populated from the old {{Document}}.
 
@@ -150,7 +151,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		- Opt-in to auto-view-transitions in both pages.
 		- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
-		- Intercept the {{ViewTransition}} object in the new document, using the [[#reveal-event|`reveal` event]].
+		- Intercept the {{ViewTransition}} object in the new document, using the {{PageRevealEvent|reveal event}}.
 
 		In both pages:
 		```css
@@ -208,7 +209,13 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 # CSS rules # {#css-rules}
 
 ## The <dfn id="at-auto-view-transition-rule">''@auto-view-transition''</dfn> rule ## {#auto-view-transition-rule}
-<h3 id="syntax-page-selector">@auto-view-transition rule grammar</h3>
+
+The ''@auto-view-transition'' rule is used by a document to indicate that cross-document navigations
+should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
+when unloading, and in the new document when it is being [=reveal document|revealed=].
+
+
+## @auto-view-transition rule grammar ## {#auto-view-transition-grammer}
 
 ''@auto-view-transition'' rules are [=CSS/parsed=] according to the following grammar,
 plus the additional rules noted below:
@@ -271,9 +278,9 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
 	<div algorithm="monkey patch to unload">
-		Run the following step before <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-documents:update-the-visibility-state">updating the visibility state</a> in the [=unload=] steps:
+		Run the following step at the beginning of the [=unload=] steps:
 
-		1. If |newDocument| is given, then [=setup outbound cross-document view transition=] given |oldDocument| and |newDocument|.
+		1. If |newDocument| is given, then [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the remaining steps.
 	</div>
 
 	<div algorithm="monkey patch to render blocking">
@@ -282,6 +289,13 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. [=reveal document|reveal=] |document|.
 
 		Reword the text in the [=render-blocked=] definition, to call [=reveal document=] |document| if the [=implementation-defined=] timeout value has been exceeded.
+	</div>
+
+	<div algorithm="monkey patch to script processing model">
+		In the <a href="https://html.spec.whatwg.org/#script-processing-model">Script processing model</a> section,
+		move <a href="https://html.spec.whatwg.org/#script-processing-model:unblock-rendering">unblock rendering</a> step to the end.
+
+		Note: this ensures that the [=reveal document=] steps are called after firing script `load` or `error` events.
 	</div>
 
 	<div algorithm="monkey patch to reactivation">
@@ -302,24 +316,22 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
 	</div>
 
-## Setting up and activating the cross-document view transition
+## Setting up and activating the cross-document view transition ##
 
 	<div algorithm>
-		To <dfn>setup outbound cross-document view transition</dfn> given a {{Document}} |oldDocument|
-		and a {{Document}} |newDocument|:
-
-		1. Assert: this is called when |oldDocument| is [=unloading=].
+		To <dfn>setup outbound cross-document view transition</dfn> given a {{Document}} |oldDocument|,
+		a {{Document}} |newDocument|, and |onReady|, which is an algorithm accepting nothing:
 
 		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
-			|newDocument|'s [=environment settings object/origin=] then return.
+			|newDocument|'s [=environment settings object/origin=] then call |onReady| and return.
 
 		1. If |newDocument| [=was created via cross-origin redirects=] is true
-			and |newDocument|'s [=latest entry=] is null, then return.
+			and |newDocument|'s [=latest entry=] is null, then call |onReady| and return.
 
 			Note: A document with a non-null [=latest entry=]
 			is being [=Document/reactivated=], in which case we don't need to check for cross-origin redirects.
 
-		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then return.
+		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then call |onReady| and return.
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when it is [=reveal document|revealed=].
@@ -331,27 +343,28 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 			Note: this means that any running transition would be skipped when the document is ready
 			to unload.
 
-		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
+			whose [=ViewTransition/process old state captured=] is set to the following steps:
+
+			1. |outboundTransition|'s [=ViewTransition/phase=] is not "`pending-capture`", then call |onReady| and return.
+
+			1. If |oldDocument| does not [=opt in to cross-document view transitions|opts in to cross-document view transitions=],
+				then [=queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
+				to perform the following step:
+
+				1. Let |newDocument|'s [=active view transition=] be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
+					whose [=ViewTransition/named elements=] is |outboundTransition|'s [=ViewTransition/named elements=],
+					[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
+					and whose [=ViewTransition/is cross-document=] is true.
+
+				1. [=Call the update callback=] for |newDocument|'s [=active view transition=].
+
+				1. Call |onReady|.
 
 			Note: |outboundTransition| is not exposed to JavaScript, it is used only for capturing
 			the state of the old document.
 
-		1. [=Capture the old state=] for |outboundTransition|. If this fails, return.
-
-			Note: implementations might need to [=queue a task=] in order to [=capture the old state=].
-			However, this should not have web-observable side-effects.
-
-		1. [=Queue a global task=] on the [=DOM manipulation task source=],
-			given |newDocument|'s [=relevant global object=], to perform the following step:
-
-			1. Let |inboundTransition| be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
-				whose [=ViewTransition/named elements=] is |outboundTransition|'s [=ViewTransition/named elements=],
-				[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
-				and whose [=ViewTransition/is cross-document=] is true.
-
-			1. [=Call the update callback=] for |inboundTransition|.
-
-			1. Set |newDocument|'s [=active view transition=] to |inboundTransition|.
+		1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
 	</div>
 
 	<div algorithm>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -363,6 +363,11 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 			1. Assert: |outboundTransition|'s  [=ViewTransition/phase=] is "`pending-capture`".
 
+			1. [=Clear view transition=] |outboundTransition|.
+
+				Note: The ViewTransition object on the old Document should be destroyed after its state has been copied to the new Document below.
+					We explicitly clear it here since the old Document may be cached by the UA.
+
 			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
 				to perform the following step:
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -97,7 +97,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	*This section is non-normative.*
 
-	View Transitions, as specified in [css-view-transitions-1], is a feature that allows developers
+	View Transitions, as specified in [[css-view-transitions-1]], is a feature that allows developers
 	to create animated transitions between visual states of the [=/document=].
 
 	Level 2 extends that specification, by adding the necessary API and lifecycle to enable

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -321,7 +321,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
 	</div>
 
-## Setting up and activating the cross-document view transition ##
+## Setting up and activating the cross-document view transition ## {#setting-up-and-activating-the-cross-document-view-transition}
 
 	<div algorithm>
 		To <dfn>setup outbound cross-document view transition</dfn> given a {{Document}} |oldDocument|,

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -321,7 +321,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then return.
 
-			Note: we don't know yet if |newDocument| has opted in, as it might not be parsed yet.
+			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when it is [=reveal document|revealed=].
 
 		1. Let |transition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -29,8 +29,10 @@ spec:css-view-transitions-1;
 	text: activate view transition; type: dfn;
 	text: captured elements; type: dfn;
 	text: updateCallbackDone; type: property; for: ViewTransition;
-	text: phase; type: property; for: ViewTransition;
+	text: phase; type: dfn; for: ViewTransition;
 	text: call the update callback; type: dfn;
+	text: perform pending transition operations; type: dfn;
+	text: setup view transition; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
 spec:html
@@ -243,6 +245,8 @@ plus the additional rules noted below:
 		: <dfn>enabled</dfn>
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
 			redirects.
+
+			See <a href="https://github.com/w3c/csswg-drafts/issues/8684">Issue #8684</a>.
 	</dl>
 
 # API # {#api}
@@ -271,7 +275,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 	A {{ViewTransition}} additionally has:
 	<dl dfn-for=ViewTransition>
-		: <dfn>is cross-document</dfn>
+		: <dfn>is inbound cross-document transition</dfn>
 		:: a boolean, initially false.
 	</dl>
 
@@ -291,7 +295,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		1. [=reveal document|reveal=] |document|.
 
-		Reword the text in the [=render-blocked=] definition, to call [=reveal document=] |document| if the [=implementation-defined=] timeout value has been exceeded.
+		Issue: Reword the text in the [=render-blocked=] definition, to call [=reveal document=] |document| if the [=implementation-defined=] timeout value has been exceeded.
 	</div>
 
 	<div algorithm="monkey patch to script processing model">
@@ -311,12 +315,14 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	To <dfn>reveal {{Document}}</dfn> |document|:
 		1. Assert: |document|'s [=page showing=] is false.
 
-		1. If |document| is [=render blocked=], return.
+		1. If |document| is [=render-blocked=], then return.
+
+		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
+
+		1. If |document| does not [=opt in to cross-document view transitions=], then [=skip the view transition|skip=] |transition| and set |transition| to null.
 
 		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
 			using {{PageRevealEvent}}.
-
-		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
 
 		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
 	</div>
@@ -351,16 +357,19 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
 			whose [=ViewTransition/process old state captured=] is set to the following steps:
 
-			1. |outboundTransition|'s [=ViewTransition/phase=] is not "`pending-capture`", then call |onReady| and return.
+			Issue: should we check for the opt-in again, in case there was a CSSOM change in a requestAnimationFrame callback?
 
-			1. If |oldDocument| does not [=opt in to cross-document view transitions|opts in to cross-document view transitions=],
-				then [=queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
+			1. If |outboundTransition|'s [=ViewTransition/phase=] is "`done`", then call |onReady| and return.
+
+			1. Assert: |outboundTransition|'s  [=ViewTransition/phase=] is "`pending-capture`".
+
+			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
 				to perform the following step:
 
 				1. Let |newDocument|'s [=active view transition=] be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
 					whose [=ViewTransition/named elements=] is |outboundTransition|'s [=ViewTransition/named elements=],
 					[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
-					and whose [=ViewTransition/is cross-document=] is true.
+					and whose [=ViewTransition/is inbound cross-document transition=] is true.
 
 				1. [=Call the update callback=] for |newDocument|'s [=active view transition=].
 
@@ -370,19 +379,19 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 			the state of the old document.
 
 		1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
+
+			Note: The process continues in [=setup view transition=], via [=perform pending transition operations=], which is called in [[css-view-transitions-1#monkey-patch-to-rendering-algorithm]].
 	</div>
 
 	<div algorithm>
 		To get the <dfn>inbound cross-document view-transition</dfn> for a {{Document}} |document|:
 
-		1. If |document| does not [=opt in to cross-document view transitions=], then return null.
-
 		1. Let |transition| be |document|'s [=active view transition=].
 
-		1. If |transition| is null or |transition|'s [=ViewTransition/is cross-document=] is false,
+		1. If |transition| is null or |transition|'s [=ViewTransition/is inbound cross-document transition=] is false,
 			then return null.
 
-			Note: |transition|'s [=ViewTransition/is cross-document=] would be false if a same-document
+			Note: |transition|'s [=ViewTransition/is inbound cross-document transition=] would be false if a same-document
 			transition was started before the page was revealed.
 
 		1. Return |transition|.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2,7 +2,7 @@
 Title: CSS View Transitions Module Level 2
 Shortname: css-view-transitions
 Level: 2
-Status: WD
+Status: ED
 Group: csswg
 Date: 2023-05-30
 Prepare for TR: yes
@@ -11,6 +11,7 @@ TR: https://www.w3.org/TR/css-view-transitions-2/
 Work Status: exploring
 Editor: Noam Rosenthal, Google, w3cid 121539
 Editor: Khushal Sagar, Google, w3cid 122787
+Editor: Vladimir Levin, Google, w3cid 75295
 Editor: Tab Atkins-Bittner, Google, http://xanthir.com/contact/, w3cid 42199
 Abstract: This module defines how the View Transition API works with cross-document navigations.
 Markup Shorthands: css yes, markdown yes
@@ -28,6 +29,7 @@ spec:css-view-transitions-1;
 	text: activate view transition; type: dfn;
 	text: captured elements; type: dfn;
 	text: updateCallbackDone; type: property; for: ViewTransition;
+	text: call the update callback; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
 spec:html
@@ -102,6 +104,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 
 ## Lifecycle ## {#lifecycle}
+
+	*This section is non-normative.*
 
 	A successful cross-document view transition goes through the following phases:
 
@@ -247,6 +251,8 @@ Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatw
 		};
 </xmp>
 
+Note: this event is fired when [=reveal document|revealing a document=].
+
 The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are to return the
 [=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
 
@@ -281,14 +287,12 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	<div algorithm="monkey patch to reactivation">
 		Run the following step in [=Document/reactivate=], before step 4 (querying for [=page showing=]):
 
-		1. [=reveal document|reveal=] |document|.
+		1. If |document| is not [=render-blocked=], then [=reveal document|reveal=] |document|.
 	</div>
 
 	<div algorithm="page reveal">
 	To <dfn>reveal {{Document}}</dfn> |document|:
 		1. Assert: |document|'s [=page showing=] is false.
-
-		1. If |document| is [=render-blocked=] then return.
 
 		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
 			using {{PageRevealEvent}}.
@@ -306,10 +310,6 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		1. Assert: this is called when |oldDocument| is [=unloading=].
 
-		1. If |oldDocument|'s [=active view transition=] is not null,
-			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
-			with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
-
 		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
 			|newDocument|'s [=environment settings object/origin=] then return.
 
@@ -324,9 +324,19 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when it is [=reveal document|revealed=].
 
-		1. Let |transition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+		1. If |oldDocument|'s [=active view transition=] is not null,
+			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
+			with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
 
-		1. [=Capture the old state=] for |transition|. If this fails, return.
+			Note: this means that any running transition would be skipped when the document is ready
+			to unload.
+
+		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+
+			Note: |outboundTransition| is not exposed to JavaScript, it is used only for capturing
+			the state of the old document.
+
+		1. [=Capture the old state=] for |outboundTransition|. If this fails, return.
 
 			Note: implementations might need to [=queue a task=] in order to [=capture the old state=].
 			However, this should not have web-observable side-effects.
@@ -334,13 +344,14 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. [=Queue a global task=] on the [=DOM manipulation task source=],
 			given |newDocument|'s [=relevant global object=], to perform the following step:
 
-			1. Set |newDocument|'s [=active view transition=] to a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
-				whose [=ViewTransition/named elements=] is |transition|'s [=ViewTransition/named elements=],
-				[=ViewTransition/update callback done promise=] is [=a promise resolved with=] undefined,
-				[=ViewTransition/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=],
+			1. Let |inboundTransition| be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
+				whose [=ViewTransition/named elements=] is |outboundTransition|'s [=ViewTransition/named elements=],
+				[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
 				and whose [=ViewTransition/is cross-document=] is true.
 
-			Note: this task would run before any script on the new {{Document}}.
+			1. [=Call the update callback=] for |inboundTransition|.
+
+			1. Set |newDocument|'s [=active view transition=] to |inboundTransition|.
 	</div>
 
 	<div algorithm>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -45,6 +45,49 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	text: signal; for: NavigateEvent; url: #ref-for-dom-navigateevent-signal①
 </pre>
 
+<style>
+	spec-scaler {
+		display: block;
+	}
+	spec-scaler:not(:defined) > * {
+		display: none;
+	}
+	.spec-slides {
+		width: 100%;
+		height: 100%;
+		border: none;
+		display: block;
+	}
+	.spec-slide-controls {
+		text-align: center;
+	}
+	.main-example-video {
+		display: block;
+		width: 100%;
+		max-width: 702px;
+		height: auto;
+		margin: 0 auto;
+	}
+
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+		padding: .5em;
+		border: thin solid #ddd; border-radius: .5em;
+		margin: .5em calc(-0.5em - 1px);
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+		margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+		margin-bottom: 0;
+	}
+	[data-algorithm] [data-algorithm] {
+		margin: 1em 0;
+	}
+	pre {
+		tab-size: 2;
+	}
+</style>
 <script async type="module" src="diagrams/resources/scaler.js"></script>
 
 # Introduction # {#intro}
@@ -71,11 +114,91 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Right before the new {{Document}} has a new [=rendering opportunity=], its state is captured as
 		the "new" state.
 
-	1. An event named `reveal` is fired on the new {{Document}}, with a `viewTransition` property,
+	1. An event named [[#reveal-event|`reveal`]] is fired on the new {{Document}}, with a `viewTransition` property,
 		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
 		and its [=captured elements=] are populated from the old {{Document}}.
 
 	1. From this point forward, the transition continues as if it was a same-document transition, as per [=activate view transition=].
+
+## Examples ## {#examples}
+
+	<div class=example>
+		To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
+		but across documents, we don't need JavaScript.
+
+		Instead, we opt in to auto-view-transitions in both page 1 and page 2:
+
+		```css
+		// in both documents:
+		@auto-view-transitions {
+			same-origin: enable;
+		}
+		```
+
+		A link from page 1 to or from page 2 would generate a crossfade transition for example 1.
+		To achieve the effect examples 2, 3 & 4, simply put the CSS for the pseudo-elements in both
+		documents.
+	</div>
+
+	<div class="example">
+		To achieve the effect in [[css-view-transitions-1#examples|example 5]], we have to do several
+		things:
+
+		- Opt-in to auto-view-transitions in both pages.
+		- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
+		- Intercept the {{ViewTransition}} object in the new document, using the [[#reveal-event|`reveal` event]].
+
+		In both pages:
+		```css
+		@auto-view-transitions {
+			same-origin: enable;
+		}
+
+		```
+
+		In the old page:
+		```js
+		addEventListener('click', event => {
+			sessionStorage.setItem("lastClickX", event.clientX);
+			sessionStorage.setItem("lastClickY", event.clientY);
+		});
+		```
+
+		In the new page:
+		```js
+		// This would run both on initial load and on reactivation from BFCache.
+		addEventListener("reveal", async event => {
+			if (!event.viewTransition)
+				return;
+
+			const x = sessionStorage.getItem("lastClickX") ?? innerWidth / 2;
+			const y = sessionStorage.getItem("lastClickY") ?? innerHeight / 2;
+
+			const endRadius = Math.hypot(
+				Math.max(x, innerWidth - x),
+				Math.max(y, innerHeight - y)
+			);
+
+			await event.viewTransition.ready;
+
+			// Animate the new document's view
+			document.documentElement.animate(
+				{
+					clipPath: [
+						`circle(0 at ${x}px ${y}px)`,
+						`circle(${endRadius}px at ${x}px ${y}px)`,
+					],
+				},
+				{
+					duration: 500,
+					easing: 'ease-in',
+					pseudoElement: '::view-transition-new(root)'
+				}
+			);
+		})
+		```
+	</div>
+
 
 
 # CSS rules # {#css-rules}
@@ -113,7 +236,7 @@ plus the additional rules noted below:
 
 # API # {#api}
 
-## The `reveal` event ## {#reveal-document-algorithm}
+## The <dfn interface>PageRevealEvent</dfn> ## {#reveal-event}
 
 Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatwg/html/issues/9315).
 
@@ -124,7 +247,7 @@ Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatw
 		};
 </xmp>
 
-The {{PageRevealEvent/viewTransition}} [=getter steps=] are to return the
+The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are to return the
 [=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
 
 
@@ -167,7 +290,8 @@ The {{PageRevealEvent/viewTransition}} [=getter steps=] are to return the
 
 		1. If |document| is [=render-blocked=] then return.
 
-		1. Fire a new {{PageRevealEvent}}.
+		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
+			using {{PageRevealEvent}}.
 
 		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
 
@@ -197,7 +321,8 @@ The {{PageRevealEvent/viewTransition}} [=getter steps=] are to return the
 
 		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then return.
 
-			Note: we don't know yet if |newDocument| has opted in.
+			Note: we don't know yet if |newDocument| has opted in, as it might not be parsed yet.
+			We check the opt-in for |newDocument| when it is [=reveal document|revealed=].
 
 		1. Let |transition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
 
@@ -207,12 +332,13 @@ The {{PageRevealEvent/viewTransition}} [=getter steps=] are to return the
 			However, this should not have web-observable side-effects.
 
 		1. [=Queue a global task=] on the [=DOM manipulation task source=],
-			given |newDocument|'s [=relevant global object=], to set |newDocument|'s
-			[=active view transition=] to a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
-			whose [=ViewTransition/named elements=] is |transition|'s [=ViewTransition/named elements=],
-			[=ViewTransition/update callback done promise=] is [=a promise resolved with=] undefined,
-			[=ViewTransition/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=],
-			and whose [=ViewTransition/is cross-document=] is true.
+			given |newDocument|'s [=relevant global object=], to perform the following step:
+
+			1. Set |newDocument|'s [=active view transition=] to a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
+				whose [=ViewTransition/named elements=] is |transition|'s [=ViewTransition/named elements=],
+				[=ViewTransition/update callback done promise=] is [=a promise resolved with=] undefined,
+				[=ViewTransition/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=],
+				and whose [=ViewTransition/is cross-document=] is true.
 
 			Note: this task would run before any script on the new {{Document}}.
 	</div>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -118,12 +118,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
 		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
 
-	1. Right before the new {{Document}} has the first [=rendering opportunity=], its state is captured as
-		the "new" state.
-
 	1. An event named {{PageRevealEvent|reveal}} is fired on the new {{Document}}, with a `viewTransition` property,
 		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
 		and its [=captured elements=] are populated from the old {{Document}}.
+
+	1. Right before the new {{Document}} has the first [=rendering opportunity=], its state is captured as
+		the "new" state.
 
 	1. From this point forward, the transition continues as if it was a same-document transition, as per [=activate view transition=].
 
@@ -319,7 +319,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
 
-		1. If |document| does not [=opt in to cross-document view transitions=], then [=skip the view transition|skip=] |transition| and set |transition| to null.
+		1. If |transition| is not null and |document| does not [=opt in to cross-document view transitions=], then [=skip the view transition|skip=] |transition| and set |transition| to null.
 
 		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
 			using {{PageRevealEvent}}.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -11,7 +11,7 @@ TR: https://www.w3.org/TR/css-view-transitions-2/
 Work Status: exploring
 Editor: Noam Rosenthal, Google, w3cid 121539
 Editor: Khushal Sagar, Google, w3cid 122787
-Editor: Vladimir Levin, Google, w3cid 75295
+Editor: Vladimir Levin, Google
 Editor: Tab Atkins-Bittner, Google, http://xanthir.com/contact/, w3cid 42199
 Abstract: This module defines how the View Transition API works with cross-document navigations.
 Markup Shorthands: css yes, markdown yes

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -1,0 +1,247 @@
+<pre class='metadata'>
+Title: CSS View Transitions Module Level 2
+Shortname: css-view-transitions
+Level: 2
+Status: WD
+Group: csswg
+Date: 2023-05-30
+Prepare for TR: yes
+ED: https://drafts.csswg.org/css-view-transitions-2/
+TR: https://www.w3.org/TR/css-view-transitions-2/
+Work Status: exploring
+Editor: Noam Rosenthal, Google, w3cid 121539
+Editor: Khushal Sagar, Google, w3cid 122787
+Editor: Tab Atkins-Bittner, Google, http://xanthir.com/contact/, w3cid 42199
+Abstract: This module defines how the View Transition API works with cross-document navigations.
+Markup Shorthands: css yes, markdown yes
+</pre>
+
+<pre class=link-defaults>
+spec:css-view-transitions-1;
+	text: active view transition; type: dfn;
+	text: skip the view transition; type: dfn;
+	text: ViewTransition; type: interface;
+	text: named elements; for: ViewTransition; type: dfn;
+	text: update callback done promise; for: ViewTransition; type: dfn;
+	text: initial snapshot containing block size; for: ViewTransition; type: dfn;
+	text: capture the old state; type: dfn;
+	text: activate view transition; type: dfn;
+	text: captured elements; type: dfn;
+	text: updateCallbackDone; type: property; for: ViewTransition;
+spec:dom; type:dfn; text:document
+spec:css22; type:dfn; text:element
+spec:html
+	text: latest entry; type: dfn;
+	text: was created via cross-origin redirects; type: dfn;
+	text: unload; type: dfn;
+	text: render-blocked; type: dfn;
+	text: unblock rendering; type: dfn;
+	text: page showing; type: dfn;
+</pre>
+
+<pre class=anchors>
+urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
+	text: NavigateEvent
+	text: signal; for: NavigateEvent; url: #ref-for-dom-navigateevent-signal①
+</pre>
+
+<script async type="module" src="diagrams/resources/scaler.js"></script>
+
+# Introduction # {#intro}
+
+	*This section is non-normative.*
+
+	View Transitions, as specified in [css-view-transitions-1], is a feature that allows developers
+	to create animated transitions between visual states of the [=/document=].
+
+	Level 2 extends that specification, by adding the necessary API and lifecycle to enable
+	transitions across a same-origin cross-document navigation.
+
+
+## Lifecycle ## {#lifecycle}
+
+	A successful cross-document view transition goes through the following phases:
+
+	1. The user navigates, by clicking a link, submitting a form, traversing history using the
+		browser API, etc.
+
+	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
+		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
+
+	1. Right before the new {{Document}} has a new [=rendering opportunity=], its state is captured as
+		the "new" state.
+
+	1. An event named `reveal` is fired on the new {{Document}}, with a `viewTransition` property,
+		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
+		and its [=captured elements=] are populated from the old {{Document}}.
+
+	1. From this point forward, the transition continues as if it was a same-document transition, as per [=activate view transition=].
+
+
+# CSS rules # {#css-rules}
+
+## The <dfn id="at-auto-view-transition-rule">''@auto-view-transition''</dfn> rule ## {#auto-view-transition-rule}
+<h3 id="syntax-page-selector">@auto-view-transition rule grammar</h3>
+
+''@auto-view-transition'' rules are [=CSS/parsed=] according to the following grammar,
+plus the additional rules noted below:
+
+<pre class=prod>
+	@auto-view-transition = @auto-view-transition { <<declaration-rule-list>> }
+</pre>
+
+## The [=@auto-view-transition/same-origin=] property ## {#view-transition-name-prop}
+
+	<pre class='descdef'>
+	Name: same-origin
+	For: @auto-view-transition
+	Value: enabled | disabled
+	Initial: disabled
+	</pre>
+
+	The '<dfn for="@auto-view-transition">same-origin</dfn>' property opts in to automatically performing a view transition when performing a [=same origin=] navigation.
+	It needs to be enabled both in the old document (when unloading) and in the new document (when ready to render).
+
+	<dl dfn-type=value dfn-for="same-origin">
+		: <dfn>disabled</dfn>
+		:: There will be no transition.
+
+		: <dfn>enabled</dfn>
+		:: The transition will be enabled if the navigation is same-origin, without cross-origin
+			redirects.
+	</dl>
+
+# API # {#api}
+
+## The `reveal` event ## {#reveal-document-algorithm}
+
+Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatwg/html/issues/9315).
+
+<xmp class=idl>
+		[Exposed=Window]
+		interface PageRevealEvent : Event {
+			readonly attribute ViewTransition? viewTransition;
+		};
+</xmp>
+
+The {{PageRevealEvent/viewTransition}} [=getter steps=] are to return the
+[=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
+
+
+
+# Algorithms # {#algorithms}
+
+## Additions to {{ViewTransition}} ## {#view-transitions-extension}
+
+	A {{ViewTransition}} additionally has:
+	<dl dfn-for=ViewTransition>
+		: <dfn>is cross-document</dfn>
+		:: a boolean, initially false.
+	</dl>
+
+## Monkey patches to HTML ## {#monkey-patch-to-html}
+
+	<div algorithm="monkey patch to unload">
+		Run the following step before <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-documents:update-the-visibility-state">updating the visibility state</a> in the [=unload=] steps:
+
+		1. If |newDocument| is given, then [=setup outbound cross-document view transition=] given |oldDocument| and |newDocument|.
+	</div>
+
+	<div algorithm="monkey patch to render blocking">
+		Run the following step at the end of [=unblock rendering=]:
+
+		1. [=reveal document|reveal=] |document|.
+
+		Reword the text in the [=render-blocked=] definition, to call [=reveal document=] |document| if the [=implementation-defined=] timeout value has been exceeded.
+	</div>
+
+	<div algorithm="monkey patch to reactivation">
+		Run the following step in [=Document/reactivate=], before step 4 (querying for [=page showing=]):
+
+		1. [=reveal document|reveal=] |document|.
+	</div>
+
+	<div algorithm="page reveal">
+	To <dfn>reveal {{Document}}</dfn> |document|:
+		1. Assert: |document|'s [=page showing=] is false.
+
+		1. If |document| is [=render-blocked=] then return.
+
+		1. Fire a new {{PageRevealEvent}}.
+
+		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
+
+		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
+	</div>
+
+## Setting up and activating the cross-document view transition
+
+	<div algorithm>
+		To <dfn>setup outbound cross-document view transition</dfn> given a {{Document}} |oldDocument|
+		and a {{Document}} |newDocument|:
+
+		1. Assert: this is called when |oldDocument| is [=unloading=].
+
+		1. If |oldDocument|'s [=active view transition=] is not null,
+			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
+			with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
+
+		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
+			|newDocument|'s [=environment settings object/origin=] then return.
+
+		1. If |newDocument| [=was created via cross-origin redirects=] is true
+			and |newDocument|'s [=latest entry=] is null, then return.
+
+			Note: A document with a non-null [=latest entry=]
+			is being [=Document/reactivated=], in which case we don't need to check for cross-origin redirects.
+
+		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then return.
+
+			Note: we don't know yet if |newDocument| has opted in.
+
+		1. Let |transition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+
+		1. [=Capture the old state=] for |transition|. If this fails, return.
+
+			Note: implementations might need to [=queue a task=] in order to [=capture the old state=].
+			However, this should not have web-observable side-effects.
+
+		1. [=Queue a global task=] on the [=DOM manipulation task source=],
+			given |newDocument|'s [=relevant global object=], to set |newDocument|'s
+			[=active view transition=] to a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
+			whose [=ViewTransition/named elements=] is |transition|'s [=ViewTransition/named elements=],
+			[=ViewTransition/update callback done promise=] is [=a promise resolved with=] undefined,
+			[=ViewTransition/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=],
+			and whose [=ViewTransition/is cross-document=] is true.
+
+			Note: this task would run before any script on the new {{Document}}.
+	</div>
+
+	<div algorithm>
+		To get the <dfn>inbound cross-document view-transition</dfn> for a {{Document}} |document|:
+
+		1. If |document| does not [=opt in to cross-document view transitions=], then return null.
+
+		1. Let |transition| be |document|'s [=active view transition=].
+
+		1. If |transition| is null or |transition|'s [=ViewTransition/is cross-document=] is false,
+			then return null.
+
+			Note: |transition|'s [=ViewTransition/is cross-document=] would be false if a same-document
+			transition was started before the page was revealed.
+
+		1. Return |transition|.
+	</div>
+
+	<div algorithm>
+		A {{Document}} |document| is said to <dfn>opt in to cross-document view transitions</dfn>
+		if the [=computed value=] of <a data-xref-type="css-descriptor" data-xref-for="@auto-view-transition">same-origin</a>
+		is <code>enabled</code>.
+	</div>
+
+
+<h2 id="priv" class="no-num">Privacy Considerations</h2>
+
+This specification introduces no new privacy considerations.
+
+<h2 id="sec" class="no-num">Security Considerations</h2>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -277,10 +277,16 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
-	<div algorithm="monkey patch to unload">
-		Run the following step at the beginning of the [=unload=] steps:
+	<div algorithm="monkey patch to apply the history step">
+		Change the step that <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:unload-a-document">unloads the old document</a>
+		and <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#activate-history-entry">activates the new one</a>
+		(<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">apply the history step</a> 14.11.1):
 
-		1. If |newDocument| is given, then [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the remaining steps.
+		Replace the line:
+		Instead of If |changingNavigableContinuation|'s update-only is false, then:
+
+		With:
+		If |changingNavigationContinuation| update-only is false, then [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the following steps:
 	</div>
 
 	<div algorithm="monkey patch to render blocking">

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -304,12 +304,14 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	<div algorithm="monkey patch to reactivation">
 		Run the following step in [=Document/reactivate=], before step 4 (querying for [=page showing=]):
 
-		1. If |document| is not [=render-blocked=], then [=reveal document|reveal=] |document|.
+		1. [=Reveal document|reveal=] |document|.
 	</div>
 
 	<div algorithm="page reveal">
 	To <dfn>reveal {{Document}}</dfn> |document|:
 		1. Assert: |document|'s [=page showing=] is false.
+
+		1. If |document| is [=render blocked=], return.
 
 		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
 			using {{PageRevealEvent}}.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -278,15 +278,12 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
 	<div algorithm="monkey patch to apply the history step">
-		Change the step that <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:unload-a-document">unloads the old document</a>
-		and <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#activate-history-entry">activates the new one</a>
-		(<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">apply the history step</a> 14.11.1):
+		Prepend a step at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
+		when <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">applying the history step</a> (14.11.1, <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:queue-a-global-task-3">here</a>):
 
-		Replace the line:
-		Instead of If |changingNavigableContinuation|'s update-only is false, then:
+		If |changingNavigationContinuation| update-only is false, then return from these steps and [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the remaining steps.
 
-		With:
-		If |changingNavigationContinuation| update-only is false, then [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the following steps:
+		Note: This would wait until a transition is captured or skipped before proceeding to unloading the old document and activating the new one.
 	</div>
 
 	<div algorithm="monkey patch to render blocking">

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -111,7 +111,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
 		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
 
-	1. Right before the new {{Document}} has a new [=rendering opportunity=], its state is captured as
+	1. Right before the new {{Document}} has the first [=rendering opportunity=], its state is captured as
 		the "new" state.
 
 	1. An event named [[#reveal-event|`reveal`]] is fired on the new {{Document}}, with a `viewTransition` property,

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -281,7 +281,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		Prepend a step at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
 		when <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">applying the history step</a> (14.11.1, <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:queue-a-global-task-3">here</a>):
 
-		If |changingNavigationContinuation| update-only is false, then return from these steps and [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the remaining steps.
+		If |changingNavigationContinuation| update-only is false, then [=setup outbound cross-document view transition=] given |oldDocument|, |newDocument| and the remaining steps and return from these steps.
 
 		Note: This would wait until a transition is captured or skipped before proceeding to unloading the old document and activating the new one.
 	</div>


### PR DESCRIPTION
This lays the foundations for cross-document view transitions.
Specifically:
- The opt-in
- The reveal event

See https://github.com/WICG/view-transitions/blob/main/cross-doc-explainer.md