### PR TITLE
[css-pseudo-4][editorial] Fixed typo in example

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -94,7 +94,7 @@ First-Line Text: the ''::first-line'' pseudo-element</h3>
     <pre class="figure">
       THIS IS A SOMEWHAT LONG HTML PARAGRAPH THAT
       will be broken into several lines. The
-      first line will be by the ‘::first-line’
+      first line will be styled by the ‘::first-line’
       pseudo-element. The other lines will be
       treated as ordinary lines in the paragraph.
     </pre>
@@ -106,7 +106,7 @@ First-Line Text: the ''::first-line'' pseudo-element</h3>
       HTML paragraph that will
       be broken into several
       lines. The first line will
-      be by the ‘::first-line’
+      be styled by the ‘::first-line’
       pseudo-element. The other
       lines will be treated as
       ordinary lines in the


### PR DESCRIPTION
This adds the missin word "styled" to the examples.

Fixes #9023