### PR TITLE
[css-pseudo-4][editorial] Fixed formatting in example 2

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -93,9 +93,9 @@ First-Line Text: the ''::first-line'' pseudo-element</h3>
 
     <pre class="figure">
       THIS IS A SOMEWHAT LONG HTML PARAGRAPH THAT
-      will be broken into several lines. The
-      first line will be styled by the ‘::first-line’
-      pseudo-element. The other lines will be
+      will be broken into several lines. The first
+      line will be styled by the ‘::first-line’
+      pseudo-element. The other lines will be 
       treated as ordinary lines in the paragraph.
     </pre>
 
@@ -106,11 +106,11 @@ First-Line Text: the ''::first-line'' pseudo-element</h3>
       HTML paragraph that will
       be broken into several
       lines. The first line will
-      be styled by the ‘::first-line’
-      pseudo-element. The other
-      lines will be treated as
-      ordinary lines in the
-      paragraph.
+      be styled by the
+      ‘::first-line’ pseudo-
+      element. The other lines
+      will be treated as ordinary
+      lines in the paragraph.
     </pre>
   </div>
 


### PR DESCRIPTION
After #9024, the line breaks were a bit off, which this change corrects.