### PR TITLE
[mediaqueries-5] Add `prefers-shapes` media query

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -157,8 +157,9 @@ Prefers-* Media Features Security and Privacy</h3>
 	User agents and developers implementing this
 	specification need to be aware of this vector and take it
 	into consideration when deciding whether to use the feature.
-	Specifically `prefers-reduced-motion`, `prefers-color-scheme` and
-	`prefers-reduced-data` are currently of concern for exploitation.
+	Specifically `prefers-reduced-motion`, `prefers-color-scheme`,
+	`prefers-reduced-data`, `prefers-reduced-transparency` and `prefers-shapes` are currently of concern for
+	exploitation.
 	</div>
 
 <!--
@@ -3140,6 +3141,36 @@ Detecting the desire for reduced data usage when loading a page: the 'prefers-re
 		}
 		</pre>
 	</div>
+
+<h3 id="prefers-shapes">
+Detecting the desire for conveying information through shapes instead of using color alone: the 'prefers-shapes' feature</h3>
+
+	<pre class='descdef mq'>
+	Name: prefers-shapes
+	Value: no-preference | active
+	For: @media
+	Type: discrete
+	</pre>
+
+	The 'prefers-shapes' media feature is used to detect if the user
+	has a preference for information to be conveyed using shapes instead
+	of color alone.
+
+	<dl dfn-type=value dfn-for="@media/prefers-shapes">
+		<dt><dfn>no-preference</dfn>
+		<dd>
+			Indicates that the user has made no preference known
+			to the system. This keyword value evaluates as false
+			in the <a>boolean context</a>.
+
+		<dt><dfn>active</dfn>
+		<dd>
+			Indicates that user has expressed a preference.
+	</dl>
+
+	The method by which the user expresses their preference can vary.
+	It might be a system-wide setting exposed by the Operating System,
+	or a setting controlled by the user agent.
 
 <h3 id=auto-pref>
 Automatic handling of User Preferences</h3>


### PR DESCRIPTION
Fixes  #7406

This is used to indicate that a user has a preference for conveying information through more than just colors alone.
