### PR TITLE
[css-anchor-position-1] Add implicit anchors to pseudo elements

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -166,6 +166,12 @@ for a given positioned element.
 with the ''implicit'' keyword,
 rather than referring to some 'anchor-name' value.
 
+A ''::before'', ''::after'' or ''::backdrop'' [=pseudo-element=]
+has the same [=implicit anchor element=]
+as its [=originating element=].
+
+Note: Without this, these [=pseudo-elements=], which are often inaccessible
+by other specifications, cannot be positioned with [=implicit anchor elements=].
 
 Finding An Anchor {#target}
 -----------------


### PR DESCRIPTION
For #8913

Allows `::before`, `::after` and `::backdrop` to use originating element's implicit anchor element

@tabatkins  PTAL