### PR TITLE
[css-anchor-position-1] Hide `anchor-scroll` as an internal detail

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -457,7 +457,7 @@ assuming that all [=scroll containers=]
 between the [=target anchor element=]
 and the positioned element's [=containing block=]
 are scrolled to their initial scroll position
-(but see 'anchor-scroll').
+(but see [[#scroll]]).
 
 If the [=target anchor element=] is [=fragmented=],
 the axis-aligned bounding rectangle
@@ -642,17 +642,8 @@ This has two effects:
 ██     ██          ██████   ██████  ██     ██  ███████  ████████ ████████
 -->
 
-Taking Scroll Into Account: the 'anchor-scroll' property {#scroll}
+Taking Scroll Into Account {#scroll}
 ------------------------------------------------------------------
-
-<pre class=propdef>
-Name: anchor-scroll
-Value: none | default | <<anchor-element>>
-Initial: default
-Inherited: no
-Applies to: [=absolutely-positioned=] elements
-Animation Type: discrete
-</pre>
 
 Because scrolling is often done in a separate thread from layout in implementations for performance reasons,
 but ''anchor()'' can result in both positioning changes
@@ -667,37 +658,16 @@ This means a positioned element
 will <em>not</em> be aligned with its anchor
 if any of the scrollers are <em>not</em> at their initial positions.
 
-The 'anchor-scroll' property allows an author to compensate for this,
-without losing the performance benefits of the separate scrolling thread,
+To compensate for this without losing
+the performance benefits of the separate scrolling thread,
 so long as the positioned element
-is only anchoring to a single anchor element.
-Its values are:
-
-<dl dfn-type=value dfn-for=anchor-scroll>
-	: <dfn>none</dfn>
-	:: No effect.
-
-	: <dfn>default</dfn>
-	:: Behaves identically to <<anchor-element>>,
-		but draws its value from 'anchor-default' on the element.
-
-	: <dfn><<anchor-element>></dfn>
-	::
-		Selects a [=target anchor element=]
-		the same as ''anchor()'',
-		which will be compensated for in positioning and fallback.
-</dl>
-
-Note: When the element uses 'anchor-default'
-or has an [=implicit anchor element=],
-authors can often avoid explicitly setting an 'anchor-scroll' value
-because the initial value is ''anchor-scroll/default''.
+is only anchoring to elements in the same scroll container,
+we define:
 
 <div algorithm="compensate for scroll">
-	If 'anchor-scroll' is not ''anchor-scroll/none''
-	on an [=absolutely-positioned=] element |query el|,
-	and there is a [=target anchor element=] for |query el|
-	given the 'anchor-scroll' value,
+	For any [=absolutely-positioned=] element |query el|,
+	if there is a [=target anchor element=]
+	given the [=default anchor specifier=] of |query el|,
 	and at least one ''anchor()'' function on |query el|
 	refers to the same [=target anchor element=],
 	then |query el| has a <dfn>snapshotted scroll offset</dfn>,

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -660,8 +660,6 @@ if any of the scrollers are <em>not</em> at their initial positions.
 
 To compensate for this without losing
 the performance benefits of the separate scrolling thread,
-so long as the positioned element
-is only anchoring to elements in the same [=scroll container=],
 we define:
 
 <div algorithm="compensate for scroll">

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -661,7 +661,7 @@ if any of the scrollers are <em>not</em> at their initial positions.
 To compensate for this without losing
 the performance benefits of the separate scrolling thread,
 so long as the positioned element
-is only anchoring to elements in the same scroll container,
+is only anchoring to elements in the same [=scroll container=],
 we define:
 
 <div algorithm="compensate for scroll">


### PR DESCRIPTION
Fixes #8675

As discussed, there's no need to expose `anchor-scroll` as a separate property and provide opt-out. So we turn it into a internal detail of computing the snapshotted scroll offset.