### PR TITLE
[css-anchor-position-1] Apply only allowed properties when applying fallback style

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1040,9 +1040,8 @@ to trigger automatic "animation" of the fallback'd properties.
 
 	2. [=list/For each=] |fallback styles| in the [=position fallback list=]:
 
-		1. Apply the values of
-		        <a lt=try-accepted-properties>properties accepted by <code>@try</code> rule</a>
-		        in |fallback styles| to |el|,
+		1. Apply the values of the [=accepted @try properties=]
+			in |fallback styles| to |el|,
 			overriding the corresponding properties in |base styles|.
 
 			Perform any specified/computed/used-value time normalizations

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -910,7 +910,8 @@ is the rule's name.
 If multiple ''@position-fallback'' rules are declared with the same name,
 the last one in document order "wins".
 
-The ''@try'' rule only accepts the following [=properties=]:
+The ''@try'' rule only <dfn lt=try-accepted-properties>accepts</dfn>
+the following [=properties=]:
 
 * [=inset properties=]
 * [=sizing properties=]
@@ -1039,7 +1040,9 @@ to trigger automatic "animation" of the fallback'd properties.
 
 	2. [=list/For each=] |fallback styles| in the [=position fallback list=]:
 
-		1. Apply the styles in |fallback styles| to |el|,
+		1. Apply the values of
+		        <a lt=try-accepted-properties>properties accepted by <code>@try</code> rule</a>
+		        in |fallback styles| to |el|,
 			overriding the corresponding properties in |base styles|.
 
 			Perform any specified/computed/used-value time normalizations

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -910,7 +910,7 @@ is the rule's name.
 If multiple ''@position-fallback'' rules are declared with the same name,
 the last one in document order "wins".
 
-The ''@try'' rule only <dfn lt=try-accepted-properties>accepts</dfn>
+The ''@try'' rule only <dfn lt="accepted @try properties">accepts</dfn>
 the following [=properties=]:
 
 * [=inset properties=]


### PR DESCRIPTION
Fixes #9042 

@tabatkins PTAL