### PR TITLE
[css-syntax-3] Fix typos in parser entry points section

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2126,7 +2126,7 @@ Parser Entry Points</h3>
 	from lists of CSS tokens.
 
 	<div algorithm="normalize into a list of tokens">
-		The algorithms here are operate on a token stream as input,
+		The algorithms here operate on a token stream as input,
 		but for convenience
 		can also be invoked with a number of other value types.
 
@@ -2182,7 +2182,7 @@ Parser Entry Points</h3>
 
 			<li>
 				"<a>Parse a block's contents</a>" is intended for parsing the contents of any block in CSS
-				(including things like the style attribute},
+				(including things like the style attribute),
 				and APIs such as {{CSSStyleDeclaration/cssText|the CSSStyleDeclaration cssText attribute}}.
 
 			<li>


### PR DESCRIPTION
Spotted some typos while reading the spec so here's a fix.
