### PR TITLE
[css-view-transitions-1] Remove HTML monkey patches

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1166,27 +1166,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	Note: These are used to update, and later remove styles
 	from a [=/document=]'s [=document/dynamic view transition style sheet=].
 
-## Monkey patches to rendering ## {#monkey-patch-to-rendering-algorithm}
-
-	<div algorithm="monkey patch to rendering">
-		Run the following steps before <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:run-the-update-intersection-observations-steps">intersection observer steps</a> in the [=update the rendering=] steps:
-
-		1. For each [=fully active=] {{Document}} in <var ignore>docs</var>,
-			[=perform pending transition operations=] for that {{Document}}.
-
-		Note: These steps will be added to the [=update the rendering=] in the HTML spec.
-			As such, the prose style is written to match other steps in that algorithm.
-	</div>
-
-	<div algorithm="suppress rendering">
-		In the definition for [=rendering opportunity=], add the following condition:
-
-		A navigable has no rendering opportunities if active document has [=document/rendering suppression for view transitions=] set to true.
-
-		Note: These steps will be added to the [=update the rendering=] in the HTML spec.
-		See <a href="https://github.com/w3c/csswg-drafts/issues/7784">#7884</a> for more context.
-	</div>
-
 ## [=Perform pending transition operations=] ## {#perform-pending-transition-operations-algorithm}
 
 	<div algorithm>


### PR DESCRIPTION
The monkey patches have been integrated into the HTML spec.
See e.g. https://html.spec.whatwg.org/#perform-pending-transition-operations