### PR TITLE
[css-anchor-position-1] Edits from proofreading.

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -198,12 +198,12 @@ or nothing (a missing specifier).
 		for |query el|
 		given the |query el|'s [=default anchor specifier=].
 
-	2. If |anchor spec| is ''implicit'',
-		and the Popover API defines an [=implicit anchor element=] for |query el|
-		which is an [=acceptable anchor element=] for |query el|,
-		return that element.
+	2. If |anchor spec| is ''implicit'':
+		1. If the Popover API defines an [=implicit anchor element=] for |query el|
+			which is an [=acceptable anchor element=] for |query el|,
+			return that element.
 
-		Otherwise, return nothing.
+		2. Otherwise, return nothing.
 
 		Note: Future APIs might also define implicit anchor elements.
 		When they do, they'll be explicitly handled in this algorithm,
@@ -312,7 +312,7 @@ in ''anchor()'' and ''anchor-size()''.
 
 	@position-fallback --under-then-over {
 		@try {
-			// No <anchor-element> specified,
+			// No <<anchor-element>> specified,
 			// so it takes from 'anchor-default'.
 			top: calc(.5em + anchor(auto));
 			bottom: auto;
@@ -703,9 +703,10 @@ only if all the following conditions are true:
 	it's being used in an [=inset property=] in that axis.
 	(For example, ''left'' can only be used in 'left', 'right',
 	or a logical [=inset property=] in the horizontal axis.)
-* There is a [=target anchor element=]
-	for the element it's used on,
-	and the <<anchor-element>> value specified in the function.
+* The result of determining the [=target anchor element=] is not nothing when
+	given the querying element as the element it's used on,
+	and the anchor specifier as
+	the <<anchor-element>> value specified in the function.
 
 If any of these conditions are false,
 the ''anchor()'' function resolves to its specified fallback value.
@@ -969,7 +970,7 @@ Animation type: discrete
 
 		The [=additional fallback-bounds rect=]
 		is the [=padding box=]
-		of the [=target anchor element=]
+		of the result of determining the [=target anchor element=]
 		given this element and the specified <<dashed-ident>>.
 		If there is no such [=target anchor element=],
 		there is no [=additional fallback-bounds rect=].


### PR DESCRIPTION
This makes a few edits from proofreading the document.  In particular:

* add a sub-list to make it clearer what condition an "Otherwise" is referring to,
* use correct bikeshed shorthand for a syntax item in a comment in an example so that it shows up, and
* change two places that invoke a defined algorithm to use wording that makes it clearer that they're invoking an algorithm.