### PR TITLE
[css-backgrounds-4] Added `background-layer` property

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -186,10 +186,10 @@ Painting Area: the 'background-clip' property</h3>
 	</dl>
 
 <h3 id='background-layers'>
-Background Image Layers: the 'background-layer' shorthand property</h3>
+Background Image Layers: the 'background-tbd' shorthand property</h3>
 
 	<pre class="propdef">
-		Name: background-layer
+		Name: background-tbd
 		Value: <<bg-layer>>#
 		Initial: see individual properties
 		Applies to: all elements
@@ -199,11 +199,15 @@ Background Image Layers: the 'background-layer' shorthand property</h3>
 		Animation type: see individual properties
 	</pre>
 
-	<p>The 'background-layer' property is a
-	shorthand property for setting most background properties at the same
-	place in the style sheet. It covers basically the same as 'background',
-	i.e. it allows to define all the background layers. The only difference
-	is that it doesn't set the 'background-color'.
+	<p>The 'background-tbd' property is a [=shorthand property=]
+	that sets all the same properties as the 'background' shorthand
+	except for 'background-color',
+	allowing authors to easily declare and position background images
+	while letting 'background-color' cascade through independently.
+
+	Issue:
+		The name of this property is discussed in
+		<a href="https://github.com/w3c/csswg-drafts/issues/9083">issue 9083</a>.
 
 	<div class="example" id="background-layer-example">
 		This example sets three background layers,
@@ -213,7 +217,7 @@ Background Image Layers: the 'background-layer' shorthand property</h3>
 
 		<pre class="lang-css">
 		p {
-			background-layer:
+			background-tbd:
 				url(a.png) top left no-repeat,
 				url(b.png) center / 100% 100% no-repeat,
 				url(c.png);
@@ -224,11 +228,11 @@ Background Image Layers: the 'background-layer' shorthand property</h3>
 	<div class="invalid example" id="invalid-background-layer-example">
 		This example tries to set the background color in addition to
 		the background image. For that to work, 'background' needs
-		to be used instead of 'background-layer'.
+		to be used instead of 'background-tbd'.
 
 		<pre class="lang-css">
 		p {
-			background-layer: url(c.png) white;
+			background-tbd: url(c.png) white;
 		}
 		</pre>
 	</div>
@@ -244,7 +248,7 @@ Additions since [[CSS3BG]]</h3>
 	* turned 'background-position' into a shorthand and added physical and logical longhands
 	* added logical keywords to <<bg-position>>
 	* added 'background-clip'
-	* added 'background-layer'
+	* added 'background-tbd'
 
 <h2 id="acknowledgments">Acknowledgments</h2>
 

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -210,29 +210,33 @@ Background Image Layers: the 'background-tbd' shorthand property</h3>
 		<a href="https://github.com/w3c/csswg-drafts/issues/9083">issue 9083</a>.
 
 	<div class="example" id="background-layer-example">
-		This example sets three background layers,
-		the first one including the image, position and repetition,
-		the second including the image, position, and size,
-		and the third one only consisting of the image.
+		This example sets two background layers later in the cascade.
+		By using 'background-tbd', the previously set 'background-color'
+		won't be overridden.
 
 		<pre class="lang-css">
 		p {
+			background-color: green;
+		}
+
+		p {
 			background-tbd:
-				url(a.png) top left no-repeat,
-				url(b.png) center / 100% 100% no-repeat,
-				url(c.png);
+				url(a.png) top left,
+				url(b.png) top left no-repeat;
 		}
 		</pre>
 	</div>
 
 	<div class="invalid example" id="invalid-background-layer-example">
 		This example tries to set the background color in addition to
-		the background image. For that to work, 'background' needs
-		to be used instead of 'background-tbd'.
+		the background image. But for that to work,
+		'background' needs to be used instead of 'background-tbd'.
+		So the 'background-tbd' declaration will be dropped.
 
 		<pre class="lang-css">
 		p {
-			background-tbd: url(c.png) white;
+			background: url(pass.png) green;   /* valid */
+			background-tbd: url(fail.png) red; /* invalid */
 		}
 		</pre>
 	</div>

--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -185,6 +185,54 @@ Painting Area: the 'background-clip' property</h3>
 		</dd>
 	</dl>
 
+<h3 id='background-layers'>
+Background Image Layers: the 'background-layer' shorthand property</h3>
+
+	<pre class="propdef">
+		Name: background-layer
+		Value: <<bg-layer>>#
+		Initial: see individual properties
+		Applies to: all elements
+		Inherited: no
+		Percentages: see individual properties
+		Computed value: see individual properties
+		Animation type: see individual properties
+	</pre>
+
+	<p>The 'background-layer' property is a
+	shorthand property for setting most background properties at the same
+	place in the style sheet. It covers basically the same as 'background',
+	i.e. it allows to define all the background layers. The only difference
+	is that it doesn't set the 'background-color'.
+
+	<div class="example" id="background-layer-example">
+		This example sets three background layers,
+		the first one including the image, position and repetition,
+		the second including the image, position, and size,
+		and the third one only consisting of the image.
+
+		<pre class="lang-css">
+		p {
+			background-layer:
+				url(a.png) top left no-repeat,
+				url(b.png) center / 100% 100% no-repeat,
+				url(c.png);
+		}
+		</pre>
+	</div>
+
+	<div class="invalid example" id="invalid-background-layer-example">
+		This example tries to set the background color in addition to
+		the background image. For that to work, 'background' needs
+		to be used instead of 'background-layer'.
+
+		<pre class="lang-css">
+		p {
+			background-layer: url(c.png) white;
+		}
+		</pre>
+	</div>
+
 Issue: Should a <a href="https://lists.w3.org/Archives/Public/www-style/2011Sep/0331.html">'background-repeat: extend'</a> be added?
 
 <h2 id="changes">
@@ -196,6 +244,7 @@ Additions since [[CSS3BG]]</h3>
 	* turned 'background-position' into a shorthand and added physical and logical longhands
 	* added logical keywords to <<bg-position>>
 	* added 'background-clip'
+	* added 'background-layer'
 
 <h2 id="acknowledgments">Acknowledgments</h2>
 


### PR DESCRIPTION
This adds a `background-layer` property as a shorthand for everything related to background layers excluding `background-color`.

It follows the resolution of https://github.com/w3c/csswg-drafts/issues/8726#issuecomment-1611761835.

Note that I went with `background-layer` for now. The name might still change, which is discussed in #9083.

Fixes #8726

Sebastian