### PR TITLE
[css-borders-4] Fixed and added definitions for box-shadow-offset: none

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -633,9 +633,8 @@ where both values are described as <<length>> values.
 <dl>
   <dt><dfn id="shadow-offset-none">none</dfn>
   <dd>
-    No box shadow will be created.
-    Any other box shadow properties specified for that shadow in the list
-    of box shadows have no effect.
+    The shadow will not be rendered.
+    The values of other box shadow properties corresponding to this shadow have no effect.
 
   <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
   <dd>
@@ -762,8 +761,10 @@ Animation type: see individual properties
   <p>Each shadow is given as a <<spread-shadow>>,
   outlining the 'box-shadow-offset', and optional values for the 'box-shadow-blur',
   'box-shadow-spread', 'box-shadow-color', and 'box-shadow-position'.
-  If the offset is ''box-shadow-offset/none'',
-  ''box-shadow-color'' is treated as ''transparent''.
+  Omitted lengths are '0';
+  omitted colors default to ''transparent'' when the specified offset is ''box-shadow-offset/none''
+  and to ''currentcolor'' otherwise.
+
   <pre class=prod>
   <dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ <<'box-shadow-offset'>> [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -617,16 +617,24 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either 'none' or a list,
-	each item a pair of offsets (horizontal and vertical) from the element‘s box
+Computed value: list, each item either 'none' or a pair of offsets
+  (horizontal and vertical) from the element‘s box
 Animation type: by computed value
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
-The property accepts a comma-separated list of horizontal and vertical offset pairs,
+The property accepts a comma-separated list.
+Each item in that list can either be the ''box-shadow-offset/none'' value,
+which indicates no shadow, or a pair of horizontal and vertical offsets,
 where both values are described as <<length>> values.
 
 <dl>
+  <dt><dfn id="shadow-offset-none">none</dfn>
+  <dd>
+    No box shadow will be created.
+    Any other box shadow properties specified for this box shadow have no
+    effect.
+
   <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
   <dd>
     Specifies the <dfn>horizontal offset</dfn> of the shadow.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -749,14 +749,12 @@ Initial: none
 Applies to: all elements
 Inherited: no
 Percentages: N/A
-Computed value: either the keyword ''box-shadow-offset/none'' or
-    a list, each item consisting of four absolute lengths
-    plus a computed color and optionally also a ''box-shadow-position/inset'' keyword
+Computed value: see individual properties
 Animation type: by computed value,
-    treating ''box-shadow-offset/none'' as a zero-item list
-    and appending blank shadows (''transparent 0 0 0 0'')
-    with a corresponding ''box-shadow-position/inset'' keyword as needed
-    to match the longer list
+    letting ''box-shadow-offset/none'' create a blank shadow
+    (''transparent 0 0 0 0'') when interpolated with non-'none' values
+    and appending blank shadows with a corresponding
+    ''box-shadow-position/inset'' keyword as needed to match the longer list
     if the shorter list is otherwise compatible with the longer one
 </pre>
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -619,7 +619,12 @@ Inherited: no
 Percentages: N/A
 Computed value: list, each item either 'none' or a pair of offsets
   (horizontal and vertical) from the element‘s box
-Animation type: by computed value
+Animation type: by computed value,
+    letting ''box-shadow-offset/none'' create a blank shadow
+    (''transparent 0 0 0 0'') when interpolated with non-'none' values
+    and appending blank shadows with a corresponding
+    ''box-shadow-position/inset'' keyword as needed to match the longer list
+    if the shorter list is otherwise compatible with the longer one
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
@@ -750,12 +755,7 @@ Applies to: all elements
 Inherited: no
 Percentages: N/A
 Computed value: see individual properties
-Animation type: by computed value,
-    letting ''box-shadow-offset/none'' create a blank shadow
-    (''transparent 0 0 0 0'') when interpolated with non-'none' values
-    and appending blank shadows with a corresponding
-    ''box-shadow-position/inset'' keyword as needed to match the longer list
-    if the shorter list is otherwise compatible with the longer one
+Animation type: see individual properties
 </pre>
 
   <p>The 'box-shadow' property attaches one or more drop-shadows to the box.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -620,11 +620,8 @@ Percentages: N/A
 Computed value: list, each item either 'none' or a pair of offsets
   (horizontal and vertical) from the element‘s box
 Animation type: by computed value,
-    letting ''box-shadow-offset/none'' create a blank shadow
-    (''transparent 0 0 0 0'') when interpolated with non-'none' values
-    and appending blank shadows with a corresponding
-    ''box-shadow-position/inset'' keyword as needed to match the longer list
-    if the shorter list is otherwise compatible with the longer one
+  treating ''box-shadow-offset/none'' as ''0 0''
+  when interpolated with non-'none' values.
 </pre>
 
 <p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
@@ -759,13 +756,14 @@ Animation type: see individual properties
 </pre>
 
   <p>The 'box-shadow' property attaches one or more drop-shadows to the box.
-  The property accepts either the ''box-shadow-offset/none'' value, which indicates no shadows,
-  or a comma-separated list of shadows, ordered front to back.
+  The property accepts a comma-separated list of shadows,
+  ordered front to back.
 
   <p>Each shadow is given as a <<spread-shadow>>,
   outlining the 'box-shadow-offset', and optional values for the 'box-shadow-blur',
   'box-shadow-spread', 'box-shadow-color', and 'box-shadow-position'.
-  Omitted lengths are 0; omitted colors default to the ''currentcolor'' value.
+  If the offset is ''box-shadow-offset/none'',
+  ''box-shadow-color'' is treated as ''transparent''.
   <pre class=prod>
   <dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ <<'box-shadow-offset'>> [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -634,8 +634,8 @@ where both values are described as <<length>> values.
   <dt><dfn id="shadow-offset-none">none</dfn>
   <dd>
     No box shadow will be created.
-    Any other box shadow properties specified for this box shadow have no
-    effect.
+    Any other box shadow properties specified for that shadow in the list
+    of box shadows have no effect.
 
   <dt><dfn id="shadow-offset-x">1st <<length>></dfn>
   <dd>


### PR DESCRIPTION
I've added the definition for the `none` value of `box-shadow-offset` and corrected the computed value of that property to account for the `none` value now being part of the shadow list.
The `box-shadow` shorthand was adjusted accordingly.

Fixes #8567

Sebastian