### PR TITLE
[css-page-floats-3]: editorial: add all clear values to summary

### DIFF
--- a/css-page-floats-3/Overview.bs
+++ b/css-page-floats-3/Overview.bs
@@ -464,7 +464,7 @@ The 'clear' property</h2>
 
   <pre class="propdef">
     Name: clear
-    Value: inline-start | inline-end | block-start | block-end | left | right | top | bottom | none
+    Value: inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none
     Initial: none
     Applies to: block-level elements, floats, regions, pages
     Inherited: no


### PR DESCRIPTION
[css-page-floats-3] 

The page-floats-3 spec does not enumerate all possible clear values in the property summary. The description below the summary details the available properties `both-inline`, `both-block` and `both`, but these aren't in the summary.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
