### PR TITLE
[css-view-transitions-1] Clarify that ink overflow is outside the image content box #8819

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1674,9 +1674,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				following the [=capture rendering characteristics=].
 
 			1. Return the portion of the canvas that includes |element|'s [=ink overflow rectangle=] as an image.
-				The [=natural size=] of the image must be |element|'s [=border box=]'s [=/size=],
-				and its origin corresponds to the |element|'s [=border box=]'s origin.
+				The [=natural dimensions=] of this image must be those of its [=principal box|principal=] [=border box=],
+				and its origin must correspond to that [=border box=]'s origin,
+				such that the image represents the contents of this [=border box=]
+				and any captured [=ink overflow=] is represented outside these bounds.
 
+				Note: When this image is rendered as a [=replaced element=] at its [=natural size=],
+				it will display with the size and contents of element’s [=principal box=],
+				with any captured [=ink overflow=] overflowing its [=content box=].
 	</div>
 
 ### [=Capture rendering characteristics=] ### {#capture-rendering-characteristics-algorithm}


### PR DESCRIPTION
And not e.g. squashed into it.

See https://github.com/w3c/csswg-drafts/pull/8819 for discussions