### PR TITLE
[css-images-4] Apply #8021 to gradient definitions in CSS Images 4

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1672,13 +1672,13 @@ Color Stop Lists</h4>
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
 			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
-		<dfn>&lt;linear-color-stop></dfn> = <<color>> && <<color-stop-length>>?
+		<dfn>&lt;linear-color-stop></dfn> = <<color>> <<color-stop-length>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 		<dfn>&lt;color-stop-length></dfn> = <<length-percentage>>{1,2}
 
 		<dfn>&lt;angular-color-stop-list></dfn> =
 			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
-		<dfn>&lt;angular-color-stop></dfn> = <<color>> && <<color-stop-angle>>?
+		<dfn>&lt;angular-color-stop></dfn> = <<color>> <<color-stop-angle>>?
 		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>>
 		<dfn>&lt;color-stop-angle></dfn> = <<angle-percentage>>{1,2}
 


### PR DESCRIPTION
It prevents switching positions of a color and its position in a gradient color stop.

This change was already applied in CSS Images 3 via #8021.