### PR TITLE
[css-contain-2] Reference the HTML spec in the content-visibility clarification

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1994,9 +1994,8 @@ Restrictions and Clarifications {#cv-notes}
 	must determine their proximity to the viewport
 	in the next [=update the rendering=] cycle.
 	The effect of this determination must be reflected in the visual update which results from this [=update the rendering=] cycle.
+	See <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model:content-visibility-auto">the event loop process model</a> for the concrete algorithm description.
 	
-	ISSUE: Reference the HTML spec algorithm here, when it's available.
-
 	<div class=note>
 		When an element first gains ''content-visibility: auto'', it may or may not
 		be positioned on screen. The determination of this state and thus
@@ -2303,6 +2302,7 @@ This appendix is <em>informative</em>.
 Changes from <a href="https://www.w3.org/TR/2022/WD-css-contain-2-20220917/">2022-09-17 Working Draft</a>
 </h3>
 
+* Referenced the HTML event loop process model in the [[#cv-notes]], clarification 4.
 * defined [=proximity to the viewport=] and used it in the [[#cv-notes]], clarification 4.
 * 'content-visibility' applies to the same properties as [=size containment=] rather than [=layout containment=]
 * clarified that 'content-visibility' affects the used value, not computed value, of the 'contain' property


### PR DESCRIPTION
[css-contain-2] Reference the HTML spec in the content-visibility clarification

Fixes #8542 