### PR TITLE
[css-page-3][editorial] Replaced `border-short-style` by `border-style`

### DIFF
--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -2269,7 +2269,7 @@ Appendix A: Applicable CSS2.1 Properties</h2>
 			<tr><td>border-right-style
 			<tr><td>border-bottom-style
 			<tr><td>border-left-style
-			<tr><td>border-short-style
+			<tr><td>border-style
 			<tr><td>border-top
 			<tr><td>border-right
 			<tr><td>border-bottom
@@ -2383,7 +2383,7 @@ CSS 2.1 properties that apply within the margin contexts</h3>
 			<tr><td>border-right-style
 			<tr><td>border-bottom-style
 			<tr><td>border-left-style
-			<tr><td>border-short-style
+			<tr><td>border-style
 			<tr><td>border-top
 			<tr><td>border-right
 			<tr><td>border-bottom


### PR DESCRIPTION
There is no `border-short-style` in CSS 2.1. Replaced it with the `border-style` shorthand.

Fixes #3156

Sebastian