### PR TITLE
[css-scrollbars] Fix typos

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -196,7 +196,7 @@ the desired thickness of an element’s scrollbars.
 
 <div class=advisement>
 	The primary purpose of this property is not
-	to allow authors to chose a particular scrollbar aesthetic for their pages,
+	to allow authors to choose a particular scrollbar aesthetic for their pages,
 	but to let them indicate for certain small or cramped elements of their pages
 	that a smaller scrollbar would be desirable.
 
@@ -351,7 +351,7 @@ This appendix is <em>non-normative</em>.
 
 	No specific concerns regarding privacy have been identified for this specification.
 
-<h3 class="no-num" id="security-privacy-self-review">Self-review questionaire</h3>
+<h3 class="no-num" id="security-privacy-self-review">Self-review questionnaire</h3>
 
 Per the <a href="https://www.w3.org/TR/security-privacy-questionnaire/#questions">
 Self-Review Questionnaire: Security and Privacy: Questions to Consider</a>


### PR DESCRIPTION
Fix two basic typos that I spotted while reading the spec.