### PR TITLE
[cssom-1] Fix typo

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1679,7 +1679,7 @@ To <dfn export>parse a CSS rule</dfn> from a string <var>string</var>, run the f
  <li>Let <var>rule</var> be the return value of invoking <a>parse a rule</a> with <var>string</var>.
  <li>If <var>rule</var> is a syntax error, return <var>rule</var>.
  <li>Let <var>parsed rule</var> be the result of parsing <var>rule</var> according to the appropriate CSS specifications, dropping parts that are said to be
- ignored. If the whole style rule is dropped, return a syntax error.
+ ignored. If the whole <var>rule</var> is dropped, return a syntax error.
  <li>Return <var>parsed rule</var>.
 </ol>
 


### PR DESCRIPTION
Removes the false assumption that *parse a CSS rule* only receives style rules, which is an oversight in this [commit](https://github.com/w3c/csswg-drafts/commit/19dabdbdcae66319b023e570ba587e951981a603#diff-d3a2dbe000640f0fa11122e261954d2d3eb276f97f2540b1e94afb883d050854L1741), I guess.