### PR TITLE
[web-animations-2][scroll-animations-1] Fix links

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -1,3 +1,9 @@
+<style>
+	/* crbug.com/1471465 */
+	dl.switch > dt {
+		counter-increment: list-item 0;
+	}
+</style>
 <pre class='metadata'>
 Title: Scroll-driven Animations
 Group: CSSWG
@@ -39,12 +45,21 @@ spec:web-animations-1;
 		text:iteration count
 		text:iteration duration
 		text:finished play state
+		text:play state
+		text:start time
+		text:effective playback rate
+		text:effect value
 spec:html;
 	type:dfn; for:/; text:browsing context
 	type:method; text:requestAnimationFrame()
 spec: cssom-view-1; type: dfn;
 	text: overflow direction;
 	text: css layout box
+spec:css-writing-modes-4; type: dfn;
+	text:start
+	text:end
+spec:infra; type:dfn; text:user agent
+spec:selectors-4; type:dfn; text:selector
 </pre>
 
 # Introduction # {#intro}
@@ -145,9 +160,9 @@ spec: cssom-view-1; type: dfn;
 
 	Progress (the [=timeline/current time=]) for a [=scroll progress timeline=]
 	is calculated as:
-	<var>[=scroll offset=]</var> &div;
-	(<var>[=scrollable overflow=] size</var> &minus;
-		<var>[=scroll container=] size</var>)
+	<var ignore=''>[=scroll offset=]</var> &div;
+	(<var ignore=''>[=scrollable overflow=] size</var> &minus;
+		<var ignore=''>[=scroll container=] size</var>)
 
 	If the 0% position and 100% position coincide
 	(i.e. the denominator in the [=timeline/current time=] formula is zero),
@@ -630,7 +645,7 @@ spec: cssom-view-1; type: dfn;
 				to the {{ViewTimeline/subject}}’s
 				nearest ancestor [=scroll container=] element.
 
-			1.  If a {{DOMString}} value is provided as an |inset|,
+			1.  If a {{DOMString}} value is provided as an inset,
 				parse it as a <<'view-timeline-inset'>> value;
 				if a sequence is provided,
 				the first value represents the start inset
@@ -768,8 +783,8 @@ spec: cssom-view-1; type: dfn;
 	to a finite [=attachment range=]--
 	which may be further limited by 'animation-range'
 	(see [[#timeline-ranges]]).
-	The animation’s <!-- delays ('animation-delay')
-	and --> iterations ('animation-iteration-count')
+	The animation’s <!-- delays ('animation-delay') and -->
+	iterations ('animation-iteration-count')
 	are set within the limits of this finite range.
 	If the specified duration is ''animation-duration/auto'',
 	then <!-- once any delays are subtracted, -->
@@ -874,12 +889,12 @@ spec: cssom-view-1; type: dfn;
 	and the <code>animationend</code> event will fire
 	at the start of the [=active interval=].
 	However, since the <code>finish</code> event
-	is about entering the [=finished play state=],
+	is about entering the [=play state/finished|finished play state=],
 	it only fires when scrolling forwards.
 
 # Frame Calculation Details # {#frames}
 
-## HTML Processing Model: Event loop
+## HTML Processing Model: Event loop ## {#event-loop}
 
 	The ability for scrolling to drive the progress of an animation,
 	gives rise to the possibility of <dfn>layout cycles</dfn>,
@@ -897,7 +912,7 @@ spec: cssom-view-1; type: dfn;
 	these timelines are added to the [=stale timelines=] set.
 	If there are any [=stale timelines=], they now update their current time and associated ranges,
 	the set of [=stale timelines=] is cleared and
-	we run and we run an additional step to recalculate styles and update layout.
+	we run an additional step to recalculate styles and update layout.
 
 	Note: We check for layout changes after dispatching any {{ResizeObserver}}s intentionally
 	to take programmatically sized elements into account.
@@ -908,7 +923,7 @@ spec: cssom-view-1; type: dfn;
 	and be updated at the same time.
 
 	Note: Without this additional round of style and layout,
-	[=initially stale=] timelines would remain stale
+	[=stale timelines|initially stale=] timelines would remain stale
 	(i.e. they would not have a current time)
 	for the remainder of the frame where the timeline was created.
 	This means that animations linked to such a timeline
@@ -918,7 +933,7 @@ spec: cssom-view-1; type: dfn;
 
 	Note: This section has no effect on forced style and layout
 	calculations triggered by {{Window/getComputedStyle()|getComputedStyle()}} or similar.
-	In other words, [=initially stale=] timelines are visible as such
+	In other words, [=stale timelines|initially stale=] timelines are visible as such
 	through those APIs.
 
 	If the final style and layout update
@@ -938,13 +953,13 @@ spec: cssom-view-1; type: dfn;
 	and the state of a scroll-driven animation
 	may be inconsistent in the composited frame.
 
-# Privacy Considerations
+# Privacy Considerations # {#privacy-considerations}
 
-  There are no known privacy impacts of the features in this specification.
+	There are no known privacy impacts of the features in this specification.
 
-# Security Considerations
+# Security Considerations # {#security-considerations}
 
-  There are no known security impacts of the features in this specification.
+	There are no known security impacts of the features in this specification.
 
 # Appendix A: Timeline Ranges # {#timeline-ranges}
 

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -26,6 +26,11 @@ div.informative-bg h4 {
   background: none;
 }
 
+/* crbug.com/1471465 */
+dl.switch > dt {
+  counter-increment: list-item 0;
+}
+
 .attributes::before, .methods::before,
 .parameters::before, .exceptions::before,
 .constructors::before, .members::before {
@@ -59,11 +64,11 @@ Work Status: Exploring
 Shortname: web-animations
 ED: https://drafts.csswg.org/web-animations-2/
 TR: https://www.w3.org/TR/web-animations-2/
-Version history: https://github.com/w3c/csswg-drafts/commits/master/web-animations-2
+Version history: https://github.com/w3c/csswg-drafts/commits/main/web-animations-2
 Level: 2
 
 Group: csswg
-!Participate: <a href="https://github.com/w3c/csswg-drafts/tree/master/web-animations-2">Fix the text through GitHub</a>
+!Participate: <a href="https://github.com/w3c/csswg-drafts/tree/main/web-animations-2">Fix the text through GitHub</a>
 !Participate: Join the &lsquo;waapi&rsquo; channel on the <a href="https://damp-lake-50659.herokuapp.com/">Animation at Work</a> slack
 !Participate: IRC: <a href="ircs://irc.w3.org:6667/webanimations">#webanimations</a> on W3C's IRC
 Repository: w3c/csswg-drafts
@@ -833,8 +838,8 @@ Add the following sentence:
 
 Adds the following text:
 
->     The <a>associated effect</a> of an <a>animation</a> is said to be <dfn
->     lt="directly associated with an animation">directly associated</dfn>
+>     The <a>associated effect</a> of an <a>animation</a> is said to be
+>     <dfn lt="directly associated with an animation">directly associated</dfn>
 >     with that animation.
 >
 >     <a>Animation effects</a> can be combined together into a hierarchy using
@@ -908,11 +913,10 @@ The normative description is updated as follows:
 >     is determined by the <a>parent group</a>, the <a>start
 >     delay</a> is a property of the <a>animation effect</a> itself.
 >
->     The lower bound of the <a>active interval</a> of an <a>animation
->     effect</a>, expressed in <a lt="inherited time">inherited time
->     space</a>, is the sum of the <a
->     lt="animation effect start time">start time</a> and the <a>start
->     delay</a>.
+>     The lower bound of the <a>active interval</a> of an <a>animation effect</a>,
+>     expressed in <a lt="inherited time">inherited time space</a>,
+>     is the sum of the <a lt="animation effect start time">start time</a>
+>     and the <a>start delay</a>.
 >
 >     These definitions are incorporated in the calculation of the <a>local
 >     time</a> (see [[#local-time-and-inherited-time]]) and <a>active time</a>.
@@ -3105,7 +3109,7 @@ partial dictionary KeyframeAnimationOptions {
 
 Passing a {{CSSKeywordValue}} with a {{CSSKeywordValue/value}} other than "normal"
 as the {{KeyframeAnimationOptions/rangeStart}} or {{KeyframeAnimationOptions/rangeEnd}} value
-to any API defined to accept {{KeyframeAnimationsOptions}}
+to any API defined to accept {{KeyframeAnimationOptions}}
 [=throws=] a <span class="exceptionname">TypeError</span>.
 
 Note: The {{TimelineRangeOffset/rangeName}} and {{TimelineRangeOffset/offset}}


### PR DESCRIPTION
[web-animations-2][scroll-animations-1] Fix bikeshed lint errors for broken / ambiguous links.  Also adds workaround for Chrome bug in list numbering.
