### PR TITLE
[css-contain-3] Define the block contents of `@container` with `<rule-list>`

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -571,7 +571,7 @@ Container Queries: the ''@container'' rule</h3>
 	is a [=conditional group rule=] whose condition contains
 	a <dfn export>container query</dfn>,
 	which is a boolean combination of [=container size queries=] and/or [=container style queries=].
-	Style declarations within the <<block-contents>> block of an ''@container'' rule
+	Style declarations within the ''@container'' rule
 	are [[css-cascade-4#filtering|filtered]] by its condition
 	to only match when the [=container query=]
 	is true for their element’s [=query container=].
@@ -580,7 +580,7 @@ Container Queries: the ''@container'' rule</h3>
 
 	<pre class="prod def">
 	@container <<container-condition>> {
-	  <<block-contents>>
+	  <<rule-list>>
 	}
 	</pre>
 


### PR DESCRIPTION
`<block-contents>` seems confusing to me because declarations are allowed only when `@container` is nested (at any level) in a style rule.

It is also inconsistent with other conditional rules (`@media` and `@supports`), whose block contents is defined with `<rule-list>`.