### PR TITLE
[css-conditional-5] Define the block contents of `@container` with `<rule-list>`

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -467,7 +467,7 @@ Container Queries</h2>
 		There are cases where the box for a [=pseudo-element=] is generated as a
 		sibling box of its originating element's box. If we allowed querying the size
 		of a sibling box, it would introduce layout cycles.
-		
+
 		For example, the ''::scroll-marker-group'' and ''::scroll-button()'' pseudo-elements
 		generate sibling boxes of their originating element's box.
 		These pseudo-elements will not be able to query their originating scroller
@@ -1027,7 +1027,7 @@ Container Queries: the ''@container'' rule</h3>
 	is a [=conditional group rule=] whose condition contains
 	a <dfn export>container query</dfn>,
 	which is a boolean combination of [=container size queries=] and/or [=container style queries=].
-	Style declarations within the <<block-contents>> block of an ''@container'' rule
+	Style declarations within the ''@container'' rule
 	are [[css-cascade-4#filtering|filtered]] by its condition
 	to only match when the [=container query=]
 	is true for their element’s [=query container=].
@@ -1036,7 +1036,7 @@ Container Queries: the ''@container'' rule</h3>
 
 	<pre class="prod def">
 	@container <<container-condition>># {
-	  <<block-contents>>
+	  <<rule-list>>
 	}
 	</pre>
 


### PR DESCRIPTION
`<block-contents>` seems confusing to me because declarations are allowed only when `@container` is nested (at any level) in a style rule.

It is also inconsistent with other conditional rules (`@media` and `@supports`), whose block contents is defined with `<rule-list>`.

 > All conditional group rules are defined to take a `<rule-list>` in their block

https://drafts.csswg.org/css-conditional-3/#contents-of