### PR TITLE
[web-animations-1] Define 'start time' for animation effects

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -449,7 +449,7 @@ Specification conventions {#spec-conventions}
 
   Where this specification does not specifically link to a procedure,
   text that requires the user agent to update a property,
-  such as “make |animation|'s [=start time=] [=unresolved=]”,
+  such as “make |animation|'s [=animation/start time=] [=unresolved=]”,
   should be understood to refer to updating the property directly
   <em>without</em> invoking any related procedure.
 
@@ -906,7 +906,7 @@ Animations {#animations}
   : If <em>any</em> of the following are true:
     * the animation has no associated [=timeline=], or
     * the associated [=timeline=] is [=inactive timeline|inactive=], or
-    * the animation's [=start time=] is [=unresolved=],
+    * the animation's [=animation/start time=] is [=unresolved=],
   ::
       The [=animation/current time=] is an [=unresolved=] time value.
 
@@ -942,7 +942,7 @@ Animations {#animations}
     1. Let the [=timeline=] of |animation| be
         |new timeline|.
 
-    1. If the [=start time=] of |animation| is [=unresolved|resolved=],
+    1. If the [=animation/start time=] of |animation| is [=unresolved|resolved=],
         make |animation|'s [=hold time=] [=unresolved=].
 
         Note: This step ensures that the [=finished play state=] of |animation|
@@ -1014,14 +1014,14 @@ Setting the associated effect of an animation</h4>
         1. Abort these steps.
 
     2. Update either |animation|'s [=hold time=] or
-        [=start time=] as follows:
+        [=animation/start time=] as follows:
 
         <dl class=switch>
 
         : If <em>any</em> of the following conditions are true:
             * |animation|'s [=hold time=] is
                 [=unresolved|resolved=], or
-            * |animation|'s [=start time=]
+            * |animation|'s [=animation/start time=]
                 is [=unresolved|unresolved=], or
             * |animation| has no associated [=timeline=] or the
                 associated [=timeline=] is
@@ -1032,7 +1032,7 @@ Setting the associated effect of an animation</h4>
 
         : Otherwise,
         ::
-            Set |animation|'s [=start time=] to the result of evaluating
+            Set |animation|'s [=animation/start time=] to the result of evaluating
             <code><var>timeline time</var> − (<var>seek time</var> / <a>playback rate</a>)</code>
             where |timeline time| is the current [=time value=]
             of the [=timeline=] associated with |animation|.
@@ -1041,11 +1041,11 @@ Setting the associated effect of an animation</h4>
 
     1. If |animation| has no associated [=timeline=]
         or the associated [=timeline=] is [=inactive timeline|inactive=],
-        make |animation|'s [=start time=] [=unresolved=].
+        make |animation|'s [=animation/start time=] [=unresolved=].
 
         Note: This preserves the invariant that
         when we don't have an active timeline
-        it is only possible to set <em>either</em> the [=start time=]
+        it is only possible to set <em>either</em> the [=animation/start time=]
         <em>or</em> the animation's [=animation/current time=].
 
     1. Make |animation|'s [=previous current time=] [=unresolved=].
@@ -1063,7 +1063,7 @@ Setting the associated effect of an animation</h4>
         by performing the following steps:
         1. Set |animation|'s [=hold time=] to |seek time|.
         1. [=Apply any pending playback rate=] to |animation|.
-        1. Make |animation|'s [=start time=] [=unresolved=].
+        1. Make |animation|'s [=animation/start time=] [=unresolved=].
         1. Cancel the [=pending pause task=].
         1. [=resolve a Promise|Resolve=]
             |animation|'s [=current ready promise=]
@@ -1094,8 +1094,9 @@ Setting the associated effect of an animation</h4>
 
         Note: This preserves the invariant that
         when we don't have an active timeline
-        it is only possible to set <em>either</em> the [=start time=]
-        <em>or</em> the animation's [=animation/current time=].
+        it is only possible to set <em>either</em>
+        the [=animation=]’s [=animation/start time=]
+        <em>or</em> its [=animation/current time=].
 
     1. Let |previous current time| be
         |animation|'s [=animation/current time=].
@@ -1106,7 +1107,7 @@ Setting the associated effect of an animation</h4>
 
     1. [=Apply any pending playback rate=] on |animation|.
 
-    1. Set |animation|'s [=start time=] to |new start time|.
+    1. Set |animation|'s [=animation/start time=] to |new start time|.
 
     1. Update |animation|'s [=hold time=] based on
         the first matching condition from the following:
@@ -1157,10 +1158,10 @@ Waiting for the associated effect</h4>
   To avoid this problem,
   Web Animations typically begins timing animations
   from the moment when the first frame of the animation is complete.
-  This is represented by an [=unresolved=] [=start time=] on the [=animation=]
+  This is represented by an [=unresolved=] [=animation/start time=] on the [=animation=]
   which becomes resolved when the animation is [=ready=].
   Content can opt out of this behavior by setting
-  the [=start time=] to a [=unresolved|resolved=] [=time value=].
+  the [=animation/start time=] to a [=unresolved|resolved=] [=time value=].
 
 </div>
 
@@ -1268,7 +1269,7 @@ Waiting for the associated effect</h4>
 
     1. If the following three conditions are <em>all</em> satisfied:
         * |seek time| is [=unresolved=], and
-        * |animation|'s [=start time=] is [=unresolved=], and
+        * |animation|'s [=animation/start time=] is [=unresolved=], and
         * |animation|'s [=animation/current time=] is [=unresolved=],
 
         set |seek time| to zero.
@@ -1285,7 +1286,7 @@ Waiting for the associated effect</h4>
 
         : If |has finite timeline| is true,
         ::
-            1. Set |animation|'s [=start time=] to |seek time|.
+            1. Set |animation|'s [=animation/start time=] to |seek time|.
             1. Let |animation|'s [=hold time=] be [=unresolved=].
             1. [=Apply any pending playback rate=] on |animation|.
 
@@ -1296,7 +1297,7 @@ Waiting for the associated effect</h4>
         </div>
 
     1. If |animation|'s [=hold time=] is [=unresolved|resolved=],
-        let its [=start time=] be [=unresolved=].
+        let its [=animation/start time=] be [=unresolved=].
 
     1. If |animation| has a [=pending play task=] or a [=pending pause task=],
 
@@ -1319,7 +1320,7 @@ Waiting for the associated effect</h4>
     1. Schedule a task to run as soon as |animation| is [=ready=].
         The task shall perform the following steps:
 
-        1. Assert that at least one of |animation|'s [=start time=] or [=hold time=]
+        1. Assert that at least one of |animation|'s [=animation/start time=] or [=hold time=]
             is [=unresolved|resolved=].
 
         1. Let |ready time| be the [=time value=] of
@@ -1342,12 +1343,12 @@ Waiting for the associated effect</h4>
                     If the [=playback rate=] is zero,
                     let |new start time| be simply |ready time|.
 
-                1. Set the [=start time=] of |animation| to |new start time|.
+                1. Set the [=animation/start time=] of |animation| to |new start time|.
 
                 1. If |animation|'s [=playback rate=] is not 0,
                     make |animation|'s [=hold time=] [=unresolved=].
 
-            : If |animation|'s [=start time=] is resolved
+            : If |animation|'s [=animation/start time=] is resolved
                 and |animation| has a [=pending playback rate=],
 
             ::
@@ -1368,7 +1369,7 @@ Waiting for the associated effect</h4>
                     If the [=playback rate=] is zero,
                     let |new start time| be simply |ready time|.
 
-                1. Set the [=start time=] of |animation| to |new start time|.
+                1. Set the [=animation/start time=] of |animation| to |new start time|.
 
             </div>
 
@@ -1427,7 +1428,7 @@ Waiting for the associated effect</h4>
 
 ### Pausing an animation ### {#pausing-an-animation-section}
 
-  Whenever an [=animation=] has an [=unresolved=] [=start time=],
+  Whenever an [=animation=] has an [=unresolved=] [=animation/start time=],
   its [=animation/current time=] will be suspended.
 
   As with [=play an animation|playing an animation=],
@@ -1483,11 +1484,11 @@ Waiting for the associated effect</h4>
 
             : If |has finite timeline| is true,
             ::
-                Set |animation|'s [=start time=] to |seek time|.
+                Set |animation|'s [=animation/start time=] to |seek time|.
 
             : Otherwise,
             ::
-                Set |animation|'s [=hold time=] to |seek time|.
+                Set |animation|'s [=animation/hold time=] to |seek time|.
 
             </div>
 
@@ -1517,7 +1518,7 @@ Waiting for the associated effect</h4>
             at the moment when the user agent completed processing necessary
             to suspend playback of |animation|'s [=associated effect=].
 
-        1. If |animation|'s [=start time=] is [=unresolved|resolved=]
+        1. If |animation|'s [=animation/start time=] is [=unresolved|resolved=]
             and its [=hold time=] is <em>not</em> resolved,
             let |animation|'s [=hold time=] be the result of evaluating
             <code>(<var>ready time</var> − <a>start time</a>)
@@ -1531,7 +1532,7 @@ Waiting for the associated effect</h4>
 
         1. [=Apply any pending playback rate=] on |animation|.
 
-        1. Make |animation|'s [=start time=] unresolved.
+        1. Make |animation|'s [=animation/start time=] unresolved.
 
         1. [=resolve a Promise|Resolve=] |animation|'s [=current ready promise=]
             with |animation|.
@@ -1638,7 +1639,7 @@ Waiting for the associated effect</h4>
   until it reaches zero.
 
   A running animation that has reached this boundary (or overshot it)
-  and has a [=unresolved|resolved=] [=start time=]
+  and has a [=unresolved|resolved=] [=animation/start time=]
   is said to be [=play state/finished=].
 
   The crossing of this boundary
@@ -1690,7 +1691,7 @@ Waiting for the associated effect</h4>
 
         * the |unconstrained current time| is [=unresolved|resolved=],
             <em>and</em>
-        * |animation|'s [=start time=] is [=unresolved|resolved=],
+        * |animation|'s [=animation/start time=] is [=unresolved|resolved=],
             <em>and</em>
         * |animation| does <em>not</em> have
             a [=pending play task=] or a [=pending pause task=],
@@ -1732,7 +1733,7 @@ Waiting for the associated effect</h4>
 
             1. If |did seek| is true
                 and the [=hold time=] is [=unresolved|resolved=],
-                let |animation|'s [=start time=] be equal to
+                let |animation|'s [=animation/start time=] be equal to
                 the result of evaluating
                 <code><var>timeline time</var>
                       − (<a>hold time</a> / <a>playback rate</a>)</code>
@@ -1893,16 +1894,16 @@ Waiting for the associated effect</h4>
 
     1. [=Silently set the current time=] to |limit|.
 
-    1. If |animation|'s [=start time=] is [=unresolved=]
+    1. If |animation|'s [=animation/start time=] is [=unresolved=]
         and |animation| has an associated [=active timeline=],
-        let the [=start time=] be the result of evaluating
+        let the [=animation/start time=] be the result of evaluating
         <code><var>timeline time</var>
               − (<var>limit</var> / <a>playback rate</a>)</code>
         where |timeline time| is the current [=time value=]
         of the associated [=timeline=].
 
       1. If there is a [=pending pause task=]
-          and [=start time=] is [=unresolved|resolved=],
+          and [=animation/ time=] is [=unresolved|resolved=],
 
         1. Let the [=hold time=] be [=unresolved=].
 
@@ -1916,7 +1917,7 @@ Waiting for the associated effect</h4>
             of |animation| with |animation|.
 
     1. If there is a [=pending play task=]
-        and [=start time=] is [=unresolved|resolved=],
+        and [=animation/start time=] is [=unresolved|resolved=],
         cancel that task and [=resolve a Promise|resolve=]
         the [=current ready promise=] of |animation|
         with |animation|.
@@ -1982,7 +1983,7 @@ Waiting for the associated effect</h4>
             the [=DOM manipulation task source=].
 
     1. Make |animation|'s [=hold time=] [=unresolved=].
-    1. Make |animation|'s [=start time=] [=unresolved=].
+    1. Make |animation|'s [=animation/start time=] [=unresolved=].
   </div>
 
   <div algorithm>
@@ -2069,7 +2070,7 @@ Waiting for the associated effect</h4>
 
         : If |animation| is associated with a non-null [=timeline=]
             that is not [=monotonically increasing=],
-            the [=start time=] of |animation| is [=resolved=],
+            the [=animation/start time=] of |animation| is [=resolved=],
             [=associated effect end=] is not infinity,
             and <em>either</em>:
 
@@ -2078,7 +2079,7 @@ Waiting for the associated effect</h4>
             * the |previous playback rate| ≥ 0
                 and the |new playback rate| < 0,
 
-        ::  Set |animation|'s [=start time=] to the result of evaluating
+        ::  Set |animation|'s [=animation/start time=] to the result of evaluating
             <code><a>associated effect end</a> − <a>start time</a></code>
             for |animation|.
 
@@ -2180,7 +2181,7 @@ Waiting for the associated effect</h4>
                 substituting an [=unresolved=] time value
                 for the [=hold time=].
 
-            1. Let |animation|'s [=start time=] be
+            1. Let |animation|'s [=animation/start time=] be
                 the result of evaluating the following expression:
 
                  <blockquote>
@@ -2193,7 +2194,7 @@ Waiting for the associated effect</h4>
                 the [=timeline=] associated with |animation|.
 
                 If [=pending playback rate=] is zero,
-                let |animation|'s [=start time=] be |timeline time|.
+                let |animation|'s [=animation/start time=] be |timeline time|.
 
             1. [=Apply any pending playback rate=] on |animation|.
 
@@ -2250,7 +2251,7 @@ Waiting for the associated effect</h4>
   : [=play state/idle=]
   ::
       The [=animation/current time=] of the animation is [=unresolved=]
-      and the [=start time=] of the animation is [=unresolved=]
+      and the [=animation/start time=] of the animation is [=unresolved=]
       and there are no pending tasks.
       In this state the animation has no effect.
 
@@ -2283,7 +2284,7 @@ Waiting for the associated effect</h4>
       * The [=animation/current time=] of |animation|
           is [=unresolved=],
           <em>and</em>
-      * the [=start time=] of |animation| is [=unresolved=],
+      * the [=animation/start time=] of |animation| is [=unresolved=],
           <em>and</em>
       * |animation| does <em>not</em> have <em>either</em>
           a [=pending play task=] <em>or</em> a [=pending pause task=],
@@ -2292,7 +2293,7 @@ Waiting for the associated effect</h4>
 
   : <em>Either</em> of the following conditions are true:
       * |animation| has a [=pending pause task=], <em>or</em>
-      * <em>both</em> the [=start time=] of |animation| is [=unresolved=]
+      * <em>both</em> the [=animation/start time=] of |animation| is [=unresolved=]
           <em>and</em> it does <em>not</em> have a [=pending play task=],
   ::
       &rarr; <dfn for="play state" local-lt="paused play state" export>paused</dfn>
@@ -2323,7 +2324,7 @@ Waiting for the associated effect</h4>
     outside of its natural playback range
     can be converted from a [=play state/paused=] animation
     into a [=play state/finished=] animation
-    without restarting by setting the [=start time=]
+    without restarting by setting the [=animation/start time=]
     such as below:
 
     <div class=example>
@@ -2375,7 +2376,7 @@ Waiting for the associated effect</h4>
     To <dfn lt="animation time to timeline time">convert
     an animation time to timeline time</a></dfn>
     a [=time value=], |time|, that is relative to
-    the [=start time=] of an animation, |animation|,
+    the [=animation/start time=] of an animation, |animation|,
     perform the following steps:
 
     1.  If |time| is [=unresolved=],
@@ -2387,14 +2388,14 @@ Waiting for the associated effect</h4>
     1.  If |animation|'s [=playback rate=] is zero,
          return an [=unresolved=] [=time value=].
 
-    1.  If |animation|'s [=start time=] is [=unresolved=],
+    1.  If |animation|'s [=animation/start time=] is [=unresolved=],
          return an [=unresolved=] [=time value=].
 
     1.  Return the result of calculating
          <code><var>time</var> × (1 / <var>playback rate</var>) +
                <var>start time</var></code>,
          where |playback rate| and |start time| are
-         the [=playback rate=] and [=start time=] of |animation|,
+         the [=playback rate=] and [=animation/start time=] of |animation|,
          respectively.
   </div>
 
@@ -2553,7 +2554,7 @@ Animation effects {#animation-effects}
   provided by the [=associated animation=]
   through a series of [=time spaces=]:
   * the <dfn noexport>local time space</dfn>,
-      relative to the [=start time=] of the [=associated animation=],
+      relative to the [=animation/start time=] of the [=associated animation=],
       yielding the [=local time=]
   * the <dfn noexport>active time space</dfn>,
       relative to the start of the [=active interval=],
@@ -2615,7 +2616,7 @@ Animation effects {#animation-effects}
   <div class=informative-bg>
 
     The relationship between
-    the [=start time=], [=start delay=], and [=active duration=]
+    the [=animation effect/start time=], [=start delay=], and [=active duration=]
     is illustrated below.
 
     <figure>
@@ -2626,7 +2627,7 @@ Animation effects {#animation-effects}
         Examples of the effect of the [=start delay=]
         on the endpoints of the [=active interval=].<br>
         (a) An animation effect with no delay;
-        the [=start time=] and beginning of the [=active interval=]
+        the [=animation effect/start time=] and beginning of the [=active interval=]
         are coincident.<br>
         (b) An animation effect with a positive delay;
         the beginning of the [=active interval=]
@@ -2638,12 +2639,14 @@ Animation effects {#animation-effects}
     </figure>
   </div>
 
-#### The start delay #### {#the-start-delay}
+#### The start delay and start time #### {#the-start-delay}
 
+  The <dfn for="animation effect">start time</dfn> of an [=animation effect=]
+  is the [=animation/start time=] of its [=associated animation=].
   The lower bound of the [=active interval=]
-  by default corresponds to the [=start time=] of the [=associated animation=],
+  by default corresponds to this [=animation effect/start time=],
   but can be shifted by the <dfn>start delay</dfn>,
-  which is a signed offset from the [=start time=] of the [=animation=].
+  which is a signed offset (defaulting to zero).
 
 #### The active duration #### {#the-active-duration}
 
@@ -4727,8 +4730,8 @@ The {{Animation}} interface {#the-animation-interface}
 
   : <dfn>startTime</dfn>
   ::
-      Returns the [=start time=] of this animation.
-      Setting this attribute updates the [=start time=]
+      Returns the [=animation/start time=] of this animation.
+      Setting this attribute updates the [=animation/start time=]
       using the procedure to [=set the start time=]
       of this object to the new value.
 
@@ -5171,8 +5174,8 @@ The {{AnimationEffect}} interface {#the-animationeffect-interface}
   ::
       The [=start delay=],
       which represents the number of milliseconds
-      from the [=start time=] of the associated [=animation=]
-      to the start of the [=active interval=].
+      from the [=animation effect/start time=] of the [=animation effect=]
+      to the start of its [=active interval=].
 
   : <dfn>endDelay</dfn>
   ::
@@ -5409,8 +5412,7 @@ The {{AnimationEffect}} interface {#the-animationeffect-interface}
   ::
       The [=end time=] of the [=animation effect=]
       expressed in milliseconds since zero [=local time=]
-      (that is, since the associated [=animation=]’s [=start time=]
-       if this [=animation effect=] is [=associated with an animation=]).
+      (that is, since the [=animation effect=]’s [=animation effect/start time=]).
       This corresponds to
       the end of the [=animation effect=]’s [=active interval=]
       plus any [=end delay=].


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/pull/8985#discussion_r1300440338

In Level 2, we can change just the definition of "start time" to handle sequencing, and those adjustments will flow through the rest of the definitions appropriately.