### PR TITLE
[css-color-5] Serialization of color-mix edge case with not normalized values including 50% #8564

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2629,11 +2629,11 @@ followed by the specified <<color-space>> in all-lowercase,
 followed by ", ",
 followed by the first specified color,
 followed by a space,
-followed by the specified (un-normalized) first percentage (unless that is 50%),
+followed by the specified (un-normalized) first percentage (unless both percentages are 50%),
 followed by ", ",
 followed by the second specified color,
 followed by the specified (un-normalized) second percentage 
-(unless either that is 50%, or the two specified percentages add to 100%),
+(unless the two specified percentages add to 100%),
 followed by ")".
 
 Following the principle of shortest serialization,


### PR DESCRIPTION
With the current instructions in the spec for serializing `color-mix`, values of `50%` are incorrectly excluded from the serialization when the specified percentages don't add up to 100% and need normalization.

The proposed wording makes it more clear when to exclude these percentage values for both the first and the second color. The first percentage is excluded only if both are `50%`, and the second one only when normalization is not required and therefore the information from the first color is enough. 