### PR TITLE
[css-text-4] auto-phrase

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -946,7 +946,7 @@ Mapping Rules</h4>
 	The mappings for [=small Kana=] to [=full-size Kana=] are defined in [[#small-kana]].
 
 
-<h3 id=word-space-transform>
+<h3 id=word-space-transform oldids="word-boundary-expansion">
 Expanding Between Words: the 'word-space-transform' property</h3>
 
 	<pre class="propdef">

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -946,11 +946,11 @@ Mapping Rules</h4>
 	The mappings for [=small Kana=] to [=full-size Kana=] are defined in [[#small-kana]].
 
 
-<h3 id=word-boundary-expansion>
-Expanding Between Words: the 'word-boundary-expansion' property</h3>
+<h3 id=word-space-transform>
+Expanding Between Words: the 'word-space-transform' property</h3>
 
 	<pre class="propdef">
-	Name: word-boundary-expansion
+	Name: word-space-transform
 	Value: none | [ space | ideographic-space ] && auto-phrase?
 	Initial: none
 	Applies to: text
@@ -977,7 +977,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 		word-boundary/word-boundary-006.html
 	</wpt>
 
-	<dl dfn-for="word-boundary-expansion" dfn-type="value">
+	<dl dfn-for="word-space-transform" dfn-type="value">
 		<dt><dfn>none</dfn>
 		<dd>This property has no effect.
 
@@ -1090,7 +1090,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 	<a href="#boundary-outermost">are placed in the outermost element that participates in an inline box boundary</a>,
 	if one would coincide with boundary of an inline box
 	whose parent box has a [=used value=]
-	of ''word-boundary-expansion: none'',
+	of ''word-space-transform: none'',
 	that particular [=virtual expandable separator=] is not expanded,
 	since it would be placed in the parent box.
 
@@ -1140,7 +1140,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 
 		<pre><code highlight=css>
 		p {
-			word-boundary-expansion: ideographic-space;
+			word-space-transform: ideographic-space;
 		}
 		</code></pre>
 
@@ -1156,7 +1156,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 		<pre><code highlight=css>
 		p {
 			word-break: keep-all;
-			word-boundary-expansion: ideographic-space;
+			word-space-transform: ideographic-space;
 		}
 		</code></pre>
 
@@ -1221,7 +1221,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 
 			<pre><code highlight=css>
 			p wbr.p {
-				word-boundary-expansion: ideographic-space;
+				word-space-transform: ideographic-space;
 			}
 			</code></pre>
 
@@ -1235,7 +1235,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 
 			<pre><code highlight=css>
 			p wbr {
-				word-boundary-expansion: ideographic-space;
+				word-space-transform: ideographic-space;
 			}
 			</code></pre>
 
@@ -1252,7 +1252,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 				word-break: keep-all;
 			}
 			p wbr.p {
-				word-boundary-expansion: ideographic-space;
+				word-space-transform: ideographic-space;
 			}
 			</code></pre>
 
@@ -1269,7 +1269,7 @@ Expanding Between Words: the 'word-boundary-expansion' property</h3>
 				word-break: keep-all;
 			}
 			p wbr {
-				word-boundary-expansion: ideographic-space;
+				word-space-transform: ideographic-space;
 			}
 			</code></pre>
 
@@ -1287,7 +1287,7 @@ Order of Operations</h3>
 	they are applied in the following order:
 
 	<ol>
-		<li>'word-boundary-expansion'
+		<li>'word-space-transform'
 		<li>''capitalize'', ''uppercase'', and ''lowercase''
 		<li>''full-width''
 		<li>''full-size-kana''
@@ -2144,7 +2144,7 @@ White Space Collapsing: the 'white-space-collapse' property</h3>
 
 			Issue: Does this preserve line break opportunities or no? Do we need a distinct "hide" value?
 			If it preserves line break opportunities,
-			maybe it should be replaced with a 'word-boundary-expansion' value?
+			maybe it should be replaced with a 'word-space-transform' value?
 	</dl>
 
 	[=White space=] that was not removed or collapsed due to white space processing
@@ -9325,7 +9325,7 @@ Text Processing Order of Operations</h2>
 			[[#white-space-phase-1|white space processing]] part I (pre-wrapping)
 
 		<li>
-			[[#word-boundary-expansion]] and
+			[[#word-space-transform]] and
 			[[#transforming|text transformation]]
 
 		<li>
@@ -10322,7 +10322,7 @@ Word and Phrase Detection</h2>
 	The start and end position of each detected word or phrase
 	is called a <dfn>word boundary</dfn> or <dfn>phrase boundary</dfn>.
 	By themselves, word and phrase boundaries are not observable,
-	but properties like 'word-boundary-expansion' or 'word-break'
+	but properties like 'word-space-transform' or 'word-break'
 	can cause visible effects at those positions.
 
 	The specific algorithm to detect word or phrases
@@ -10490,9 +10490,10 @@ Changes</h2>
 		(<a href="https://github.com/w3c/csswg-drafts/issues/8442">Issue 8442</a>)
 	* Redesign of the ''word-break: auto-phrase'' ''word-break: manual'' features
 		(from an earlier attempt as a standalone <code>word-boundary-detection</code> property),
-		and add an ''word-boundary-expansion/auto-phrase'' value to 'word-boundary-expansion'
+		and add an ''word-space-transform/auto-phrase'' value to 'word-space-transform'
 		(since it can no longer depend on <code>word-boundary-detection</code>).
 		and update supporting related mechanics.
+	* Rename <code>word-boundary-expansion</code> to 'word-space-transform'
 
 	Significant changes since the <a href="https://www.w3.org/TR/2023/WD-css-text-4-20230301/">1 March 2022 Working Draft</a> include:
 	* Completed the translation of 'white-space' to multiple longhands by
@@ -10575,7 +10576,7 @@ Additions Since Level 3</h3>
 	New features in Level 4:
 
 	* ''word-break: auto-phrase'', for automaticly determining phrases to keep together while line breaking
-	* 'word-boundary-expansion', for transforming word separators
+	* 'word-space-transform', for transforming word separators
 	* breaking up of the 'white-space' property into multiple longhands:
 		* 'white-space-collapse' and its ''preserve-spaces'' and ''white-space-collapse/discard'' values
 		* 'white-space-trim', for trimming excess white space at the boundaries of an element

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -26,6 +26,22 @@ spec:css-ruby-1; type:dfn; text:ruby
 spec:selectors-4; type:dfn; text:selector
 </pre>
 
+<pre class=biblio>
+{
+	"L2-22-080R": {
+		"authors": [
+			"Norbert Lindenberg",
+			"Elika Etemad",
+			"Vaishnavi Murthy Yerkadithaya"
+		],
+		"href": "https://www.unicode.org/L2/L2022/22080r-line-break-ortho-bnd.pdf",
+		"title": "Line breaking at orthographic syllable boundaries",
+		"status": "Proposal",
+		"publisher": "Unicode Consortium"
+	}
+}
+</pre>
+
 <style type="text/css">
 	img { vertical-align: middle; }
 	span[lang] {
@@ -929,488 +945,13 @@ Mapping Rules</h4>
 
 	The mappings for [=small Kana=] to [=full-size Kana=] are defined in [[#small-kana]].
 
-<h4 id="text-transform-order">
-Order of Operations</h4>
 
-	When multiple values are specified
-	and therefore multiple transformations need to be applied,
-	they are applied in the following order:
-
-	<ol>
-		<li>''capitalize'', ''uppercase'', and ''lowercase''
-		<li>''full-width''
-		<li>''full-size-kana''
-	</ol>
-
-	<wpt>
-	text-transform/text-transform-multiple-001.html
-	</wpt>
-
-	Text transformation happens after [[#white-space-phase-1]]
-	but before [[#white-space-phase-2]].
-	This means that ''full-width'' only transforms
-	spaces (U+0020) to U+3000 IDEOGRAPHIC SPACE within [=preserved=] [=white space=].
-
-	<wpt>
-	text-transform/text-transform-fullwidth-006.html
-	text-transform/text-transform-fullwidth-007.html
-	text-transform/text-transform-fullwidth-008.html
-	text-transform/text-transform-fullwidth-009.html
-	</wpt>
-
-	Note: As defined in [[#order]],
-	transforming text affects line-breaking and other formatting operations.
-
-<h3 id=word-boundaries>
-Word Boundaries</h3>
-
-	In a number of languages and writing system,
-	such as Japanese or Thai,
-	words are not deliminated by spaces (or any other character)
-	as is the case in English
-	(See <a href="https://www.w3.org/International/articles/typography/linebreak">Approaches to line breaking</a>
-	for a discussion the approach various languages take to word separation and line breaking).
-
-	However, even if text without spaces is the dominant style in such languages,
-	there are cases where making word boundaries (or phrase boundaries) visible
-	through the use of spaces
-	is desired.
-	This is a purely stylistic effect,
-	with no implication on the semantics of the text.
-
-	In Japan for instance, this is commonly done in books for people learning the language--
-	young children or foreign students.
-	People with dyslexia also tend to find this style easier to read.
-
-	The mechanism described in this specification builds upon the existing use
-	of the <{wbr}> element
-	or of U+200B ZERO WIDTH SPACE
-	(See [[UNICODE]])
-	in the document markup as a word (or phrase) delimiter.
-
-	Issue: Should we have a shorthand
-	for the following two properties?
-
-<h4 id=word-boundary-detection>
-Detecting Word Boundaries: the 'word-boundary-detection' property</h4>
-
-	<pre class="propdef">
-	Name: word-boundary-detection
-	Value: normal | manual | auto(<<lang>>)
-	Initial: normal
-	Applies to: text
-	Inherited: yes
-	Percentages: N/A
-	Computed value: as specified (However, see special provision for unsupported <<lang>>)
-	Animation type: discrete
-	</pre>
-
-	<wpt>
-		parsing/word-boundary-detection-computed.html
-		parsing/word-boundary-detection-invalid.html
-		parsing/word-boundary-detection-valid.html
-	</wpt>
-
-	ISSUE: The design of this property is still being worked out.
-	Don't implement it just yet!
-	You can ask the editors about status if this is blocking you.
-
-	This property allows the author to decide
-	whether and how
-	the user agent must analyze the content
-	to determine where word boundaries are,
-	and to insert [=virtual word boundaries=] accordingly.
-
-	A <dfn data-dfn-for='' data-dfn-type=dfn>virtual word boundary</dfn> is similar to the presence
-	of the ZERO WIDTH SPACE (U+200B) character:
-	it introduces a [=soft wrap opportunity=]
-	and is affected by the 'word-boundary-expansion' property.
-	However, its presence alone has no effect on text shaping, spacing, or justification.
-	Inserting [=virtual word boundaries=] must have no effect on the underlying content,
-	and must not affect the content of a plain text copy &amp; paste operation.
-
-	<wpt>
-		word-boundary/word-boundary-109.html
-		word-boundary/word-boundary-110.html
-		word-boundary/word-boundary-111.html
-		word-boundary/word-boundary-112.html
-	</wpt>
-	<!-- tests missing for "has no effects on...", but it's hard to prove a negative -->
-
-	<dl dfn-type=value dfn-for=word-boundary-detection>
-		<dt><dfn>manual</dfn>
-		<dd>
-			Linguistic analysis is <em>not</em> used
-			in any language or writing system
-			to determine line wrapping opportunities not indicated by the markup or characters of the element.
-
-			The user agent must not insert [=virtual word boundaries=].
-
-			[=Typographic character units=] with class SA in [[!UAX14]]
-			must be treated as if they had class AL
-			(i.e. assuming ''word-break: normal''
-			and a value of 'line-break' other than ''line-break/anywhere'',
-			there is no [=soft wrap opportunity=]
-			between pairs of such characters).
-
-			<wpt>
-				word-boundary/word-boundary-101.html
-				word-boundary/word-boundary-105.html
-				word-boundary/word-boundary-106.html
-				word-boundary/word-boundary-115.html
-			</wpt>
-
-			<div class=advisement>
-				Authors using this value for Southeast Asian languages
-				are expected to manually indicate word boundaries,
-				for instance using <{wbr}> or U+200B.
-				Otherwise, there will be no [=soft wrap opportunity=]
-				and the text may overflow.
-			</div>
-
-		<dt><dfn>normal</dfn>
-		<dd>
-			The user agent must not insert [=virtual word boundaries=],
-			except within runs of characters belonging to Southeast Asian languages,
-			where content analysis must be performed
-			to determine where to insert [=virtual word boundaries=].
-
-			As with ''word-boundary-detection/manual'',
-			[=typographic character units=] with class SA in [[!UAX14]]
-			must be treated as if they had class AL;
-			however, the user agent must additionally
-			analyze the content of a run of such characters
-			and insert [=virtual word boundaries=] where appropriate.
-			Within the constraints set by this specification,
-			the specific algorithm used is UA-dependent.
-
-			<wpt>
-				word-boundary/word-boundary-102.html
-				word-boundary/word-boundary-103.html
-				word-boundary/word-boundary-104.html
-			</wpt>
-
-			As various languages can be written in scripts
-			which use the characters with class SA,
-			if the [=content language=] is known,
-			the user agent should use this information
-			to tailor its analysis.
-
-			In order to avoid unexpected overflow,
-			if the user agent is unable to perform this analysis
-			for any subset of the characters with class SA--
-			for example due to lacking a dictionary for certain languages--
-			there must be a [=soft wrap opportunity=]
-			between pairs of [=typographic letter units=] in that subset.
-
-			Note: This [=soft wrap opportunity=] is not
-			a [=virtual word boundary=],
-			and is ignored by 'word-boundary-expansion'.
-
-			Note: This provision is not triggered merely when
-			the UA fails to find a word boundary in a particular text run;
-			the text run may well be a single unbreakable word.
-			It applies for example
-			when a text run is composed of Khmer characters (U+1780 to U+17FF)
-			if the user agent does not know how to determine
-			word boundaries in Khmer.
-
-		<dt><dfn>auto(<<lang>>)</dfn>
-		<dd>
-			This value directs the user agent to perform language-specific content analysis
-			to determine where to insert [=virtual word boundaries=].
-
-			<dfn dfn-type=type><<lang>></dfn> must be a valid CSS <<ident>> or <<string>>.
-			It represents an IETF BCP 47 language range
-			(see [[BCP47]]).
-			If the UA does not support word-boundary detection
-			for <em>all</em> languages represented by the specified range,
-			that specified value is invalid
-			(and will cause the declaration to be ignored).
-
-			<wpt>
-				word-boundary/word-boundary-105.html
-				word-boundary/word-boundary-106.html
-				word-boundary/word-boundary-107.html
-				word-boundary/word-boundary-108.html
-				word-boundary/word-boundary-109.html
-				word-boundary/word-boundary-110.html
-				word-boundary/word-boundary-111.html
-				word-boundary/word-boundary-112.html
-				word-boundary/word-boundary-113.html
-				word-boundary/word-boundary-114.html
-				word-boundary/word-boundary-115.html
-				word-boundary/word-boundary-116.html
-				word-boundary/word-boundary-117.html
-				word-boundary/word-boundary-118.html
-				word-boundary/word-boundary-119.html
-				word-boundary/word-boundary-120.html
-				word-boundary/word-boundary-121.html
-				word-boundary/word-boundary-122.html
-				word-boundary/word-boundary-123.html
-				word-boundary/word-boundary-124.html
-				word-boundary/word-boundary-125.html
-				word-boundary/word-boundary-126.html
-				word-boundary/word-boundary-127.html
-			</wpt>
-
-			Note: Wildcards <em>in the language subtag</em> would imply
-			support for detecting word boundaries in an undefined and effectively unlimited set of languages.
-			As this is not possible,
-			wildcards in the language subtag always result in the declaration
-			being treated as invalid.
-
-			Note: Whether a word boundary detection system designed for one language
-			is suitable for some or all dialects of that language is somewhat subjective,
-			and this specifications leaves it at the discretion of the user agent.
-			Even if a detection system is not able to cope with all nuances of a particular dialect,
-			it may be reasonable to claim support
-			if the detection correctly recognizes word boundaries most of the time.
-			However, the user agent would do a disservice to authors and users
-			if it claimed support for languages
-			where it fails to detect most word boundaries
-			or has a high error rate.
-
-			If the element’s [=content language=],
-			as represented in BCP 47 syntax [[BCP47]],
-			does <em>not</em> match the language range described by the computed value's <<lang>>
-			in an extended filtering operation
-			per [[RFC4647]] <cite>Matching of Language Tags</cite> (section 3.3.2)
-			with both the [=content language=] and <<lang>>
-			then the [=used value=] is ''word-boundary-detection/normal'',
-			and this property has no effect on this element.
-			Otherwise,
-			the user agent must insert a [=virtual word boundary=]
-			at each detected word boundary
-			within the [=text sequence=] children of this element.
-			Within the constraints set by this specification,
-			the specific algorithm used is UA-dependent.
-
-			<wpt>
-				word-boundary/word-boundary-105.html
-				word-boundary/word-boundary-106.html
-				word-boundary/word-boundary-107.html
-				word-boundary/word-boundary-108.html
-				word-boundary/word-boundary-109.html
-				word-boundary/word-boundary-110.html
-				word-boundary/word-boundary-111.html
-				word-boundary/word-boundary-112.html
-			</wpt>
-
-			Note: This is the same matching logic as the one used for the '':lang()'' selector.
-	</dl>
-
-	<div class=example>
-		If a user agent has a word-boundary detection system for Cantonese
-		that is not suitable for the broader set of Chinese languages,
-		it is expected to accept ''auto(yue)'', ''auto(zh-yue)'', or ''auto(zh-HK)'',
-		but not ''auto(zh)'' or ''auto(zh-Hant)''.
-
-		However, if the user agent supports a generic word-boundary detection system
-		that is suitable for Chinese in general,
-		it is expected to accept the broad ''auto(zh)'' characterization,
-		as well as any more specific ones,
-		such as ''auto(zh-yue)'', ''auto(zh-Hant-HK)'', ''auto(zh-Hans-SG)'', or ''auto(zh-hak)''.
-	</div>
-
-	<div class=example>
-		Specifying the language for which the word boundary detection is to be performed
-		and making unsupported language ranges invalid
-		is required in order to make this feature meaningfully testable with ''@supports''.
-
-		For example, Japanese text normally allows line breaking between letters of a word
-		(see ''word-break: normal'').
-		The following code disables that in <code>h1</code> elements,
-		and only allows line breaking at autodetected word boundaries instead,
-		without requiring the author to manually indicate word boundaries in the markup.
-		However, if word boundary detection is not supported for Japanese,
-		this change is not applied,
-		as ''word-break: keep-all'' could remove all [=soft wrap opportunities=] from the element,
-		and risk causing overflow.
-		<pre><code class=lang-css>
-		@supports (word-boundary-detection: auto(ja)) {
-			h1:lang(ja) {
-				word-boundary-detection: auto(ja);
-				word-break: keep-all;
-			}
-		}
-		</code></pre>
-	</div>
-
-	User agents may activate
-	language-specific content analysis
-	in response to user preferences.
-	User agents with this behavior must do this
-	by setting the [=declared value=] of 'word-boundary-detection' to ''word-boundary-detection/auto(<<lang>>)''
-	in the [=User Origin=].
-	User agents that do not support the [=User Origin=]
-	may use the [=User-Agent Origin=] instead.
-
-	<div class=advisement>
-		Manual analysis of the content can be more reliable than UA heuristics.
-		For best results, authors who can perform this analysis are encouraged to markup their documents
-		using <{wbr}> or U+200B
-		to exhaustively indicate word boundaries.
-
-		Authors who prepare their content in this manner
-		should not rely on the initial value, and
-		should explicitly specify ''word-boundary-detection: manual'' on the relevant parts of the content,
-		in order to override a potential ''word-boundary-detection: auto(<<lang>>)''
-		in the [=User Origin=] or [=User-Agent Origin=].
-	</div>
-
-	[=Virtual word boundary=] insertion happens before [[CSS-TEXT-3#white-space-phase-1]]
-	and before [[#word-boundary-expansion]].
-	Later operations
-	(including [[CSS-TEXT-3#white-space-rules]], [=line breaking=], and [=intrinsic sizing=])
-	must take the presence of the [=virtual word boundary=] into account.
-	[=Selectors=] are not affected.
-
-	<wpt>
-		word-boundary/word-boundary-109.html
-		word-boundary/word-boundary-110.html
-		word-boundary/word-boundary-111.html
-		word-boundary/word-boundary-112.html
-		word-boundary/word-boundary-113.html
-		word-boundary/word-boundary-114.html
-		word-boundary/word-boundary-115.html
-		word-boundary/word-boundary-116.html
-		word-boundary/word-boundary-117.html
-		word-boundary/word-boundary-118.html
-		word-boundary/word-boundary-119.html
-		word-boundary/word-boundary-120.html
-		word-boundary/word-boundary-121.html
-		word-boundary/word-boundary-122.html
-		word-boundary/word-boundary-123.html
-		word-boundary/word-boundary-124.html
-		word-boundary/word-boundary-125.html
-		word-boundary/word-boundary-126.html
-		word-boundary/word-boundary-127.html
-	</wpt>
-
-	Inline box boundaries
-	and out-of-flow elements must be ignored
-	when determining word boundaries.
-
-	<wpt>
-		word-boundary/word-boundary-113.html
-		word-boundary/word-boundary-114.html
-	</wpt>
-
-	If a word boundary is found at the same position as
-	one or more inline box boundaries,
-	the [=virtual word boundary=] must be inserted
-	in the outermost element that participates in this inline box boundary.
-
-	<wpt>
-		word-boundary/word-boundary-113.html
-		word-boundary/word-boundary-114.html
-	</wpt>
-
-	<div class=example>
-		In the following example,
-		the red “<code><span style="color:red">|</span></code>” indicates
-		reasonable positions for a user agent to insert virtual word boundaries:
-		<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ<span style="color:red">|</span>สวยงาม</code></pre>
-		If that sentence had contained some inline markup,
-		the following example shows the correct position to insert the virtual word boundaries:
-		<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ<span style="color:red">|</span>&lt;em>สวยงาม&lt;/em></code></pre>
-		The following example shows <em>incorrect</em> positions:
-		<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ&lt;em><span style="color:red">|</span>สวยงาม&lt;/em></code></pre>
-		The following shows the correct positions in a more contrived situation:
-		<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>&lt;b>&lt;u>คือ&lt;/u><span style="color:red">|</span>&lt;em>สวยงาม&lt;/em>&lt;/b></code></pre>
-	</div>
-
-	The user agent may tailor its word boundary detection algorithm
-	depending on whether 'line-break' is
-	''loose''/''line-break/normal''/''line-break/strict''.
-
-	The user agent must not insert a [=virtual word boundary=]:
-	<ul>
-		<li>
-			at the beginning or end of any box
-			(including [=inline boxes=])
-			whose parent box has a [=used value=]
-			of ''word-boundary-detection/manual''.
-
-			<wpt>
-				word-boundary/word-boundary-115.html
-			</wpt>
-
-		<li>
-			immediately adjacent to a [=word-separator character=],
-			or an [=other space separator=],
-			or a ZERO WIDTH SPACE (U+200B) character.
-
-			<wpt>
-				word-boundary/word-boundary-116.html
-				word-boundary/word-boundary-117.html
-				word-boundary/word-boundary-118.html
-			</wpt>
-
-			Note: This implies that for languages such as English
-			where words are separated by spaces or other separating characters,
-			''word-boundary-detection/auto(<lang>)'' has no effect.
-
-		<li>
-			between characters that compose a single [=typographic character unit=].
-
-		<li>
-			between a [=typographic letter unit=]
-			and a subsequent [=typographic character unit=] from the [[!UAX14]] CL, CP, IS, or EX line break classes,
-
-			<wpt>
-				word-boundary/word-boundary-122.html
-				word-boundary/word-boundary-123.html
-				word-boundary/word-boundary-124.html
-				word-boundary/word-boundary-125.html
-			</wpt>
-
-		<li>
-			between a [=typographic letter unit=]
-			and a preceding [=typographic character unit=] from the [[!UAX14]] OP line break class,
-
-			<wpt>
-				word-boundary/word-boundary-126.html
-			</wpt>
-
-		<li>
-			between a [=typographic letter unit=]
-			and an adjacent [=typographic character unit=] from the [[!UAX14]] GL, WJ, or ZWJ line break classes.
-
-			<wpt>
-				word-boundary/word-boundary-119.html
-				word-boundary/word-boundary-120.html
-				word-boundary/word-boundary-121.html
-			</wpt>
-	</ul>
-
-	The user agent should not insert a [=virtual word boundary=]:
-	<ul>
-		<li>
-			between a [=typographic letter unit=]
-			and a subsequent [=typographic character unit=] from the [[!UAX14]] PO, NS line break classes,
-
-			<wpt>
-				word-boundary/word-boundary-127.html
-				word-boundary/word-boundary-128.html
-			</wpt>
-
-		<li>
-			between a [=typographic letter unit=]
-			and a preceding [=typographic character unit=] from the [[!UAX14]] PR line break class,
-
-			<wpt>
-				word-boundary/word-boundary-129.html
-			</wpt>
-	</ul>
-
-<h4 id=word-boundary-expansion>
-Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
+<h3 id=word-boundary-expansion>
+Expanding Between Words: the 'word-boundary-expansion' property</h3>
 
 	<pre class="propdef">
 	Name: word-boundary-expansion
-	Value: none | space | ideographic-space
+	Value: none | [ space | ideographic-space ] && auto-phrase?
 	Initial: none
 	Applies to: text
 	Inherited: yes
@@ -1419,9 +960,13 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 	Animation type: discrete
 	</pre>
 
-	ISSUE: The design of this property is still being worked out.
-	Don't implement it just yet!
-	You can ask the editors about status if this is blocking you.
+	Some languages and writing systems have alternative ways
+	of delimiting words,
+	either using different separating characters,
+	or sometimes no visible character at all.
+	This property allows authors to change the rendering
+	from one style to another
+	without needing to change the markup.
 
 	<wpt>
 		parsing/word-boundary-expansion-computed.html
@@ -1431,18 +976,6 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 		word-boundary/word-boundary-005.html
 		word-boundary/word-boundary-006.html
 	</wpt>
-
-	Issue: This name is quite long, we may want to find a better one.
-	We should also consider how we may want to add values to this property,
-	so that the name is compatible with them.
-	For example,
-	it has been suggested that we may want to use this
-	to turn visible “spaces” such as the ETHIOPIC WORD SPACE (U+1361)
-	into an ordinary SPACE (U+0020).
-
-	This property allows transforming certain word-separating characters
-	into other word-separating characters,
-	to accommodate variant typesetting styles.
 
 	<dl dfn-for="word-boundary-expansion" dfn-type="value">
 		<dt><dfn>none</dfn>
@@ -1455,7 +988,7 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 
 		<dt><dfn>space</dfn>
 		<dd>
-			Instances of U+200B ZERO WIDTH SPACE
+			[=Expandable separators=]
 			within the child [=text sequence|text=] of this element
 			are replaced by U+0020 SPACE.
 
@@ -1473,7 +1006,7 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 
 		<dt><dfn>ideographic-space</dfn>
 		<dd>
-			Instances of U+200B ZERO WIDTH SPACE
+			[=Expandable separators=]
 			within the child [=text sequence|text=] of this element
 			are replaced by U+3000 IDEOGRAPHIC SPACE.
 
@@ -1485,23 +1018,36 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 				word-boundary/word-boundary-012.html
 				word-boundary/word-boundary-013.html
 			</wpt>
+
+		<dt><dfn>auto-phrase</dfn>
+		<dd>
+			If the [=content language=] is known
+			and the user agent supports linguistic analysis for this language,
+			the user agent must [=detect phrase boundaries=].
+			If a [=word-separator character=],
+			[=other space separator=],
+			or U+200B ZERO WIDTH SPACE character
+			does not already occur at that boundary,
+			then the UA must insert a [=virtual expandable separator=].
+
+			If this value is omitted,
+			or if the [=content language=] is unknown,
+			or if the user agent does not support
+			[=detecting phrase boundaries=] for that language,
+			there are no [=virtual expandable separator=].
 	</dl>
 
-	The user agent must not replace
-	instances of U+200B immediately preceding or following
-	a [=forced line break=]
-	(ignoring any intervening inline box boundaries,
-	and associated 'margin'/'border'/'padding').
+	For the purpose of this property,
+	<dfn>expandable separators</dfn> are any of:
+	* U+200B ZERO WIDTH SPACE characters
+	* <{wbr}> elements
+	* [=virtual expandable separators=]
 
-	<wpt>
-		word-boundary/word-boundary-010.html
-		word-boundary/word-boundary-011.html
-		word-boundary/word-boundary-012.html
-	</wpt>
-
-	Instances of <{wbr}> are considered equivalent to U+200B,
-	and are also replaced,
-	as are [=virtual word boundaries=] inserted by 'word-boundary-detection'.
+	A <dfn>virtual expandable separator</dfn> is
+	a UA-detected syntactic boundary in the text
+	that represents an [=expandable separator=]
+	not otherwise occuring in the source document.
+	It has no effect other than for this property.
 
 	<wpt>
 		word-boundary/word-boundary-001.html
@@ -1520,42 +1066,45 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 		word-boundary/word-boundary-015-manual.html
 	</wpt>
 
-	Unlike 'text-transform',
-	this substitution happens before [[CSS-TEXT-3#white-space-phase-1]]
-	so that later operations that depend on the characters in the content
-	(including [[CSS-TEXT-3#white-space-rules]], [=line breaking=], and [=intrinsic sizing=])
-	use that character instead of the original U+200B.
+	The user agent must not replace
+	[=expandable separators=]
+	immediately preceding or following
+	a [=forced line break=]
+	(ignoring any intervening inline box boundaries,
+	and associated 'margin'/'border'/'padding').
 
+	<wpt>
+		word-boundary/word-boundary-010.html
+		word-boundary/word-boundary-011.html
+		word-boundary/word-boundary-012.html
+	</wpt>
+
+	<!--these tests are likely wrong now-->
 	<wpt>
 		word-boundary/word-boundary-007.html
 		word-boundary/word-boundary-008.html
 		word-boundary/word-boundary-009.html
 	</wpt>
 
-	Like 'text-transform', this property transforms text for styling purposes.
+	Note: Because [=virtual expandable separators=]
+	<a href="#boundary-outermost">are placed in the outermost element that participates in an inline box boundary</a>,
+	if one would coincide with boundary of an inline box
+	whose parent box has a [=used value=]
+	of ''word-boundary-expansion: none'',
+	that particular [=virtual expandable separator=] is not expanded,
+	since it would be placed in the parent box.
+
+	<wpt>
+		word-boundary/word-boundary-115.html
+	</wpt>
+
+	Like 'text-transform', this property transforms text for styling purposes only.
 	It has no effect on the underlying content,
 	and must not affect the content of a plain text copy &amp; paste operation.
 
 	<wpt>
 		word-boundary/word-boundary-015-manual.html
 	</wpt>
-
-	<div class=note>Note: The effects of this property are similar
-	to those of the 'text-transform' property.
-	However, it is defined as a separate property
-	rather than additional values to 'text-transform' because:
-	* This property needs to take effect before [[CSS-TEXT-3#white-space-rules]],
-		but 'text-transform' happens after that.
-		This is needed so that the spaces inserted by this property
-		behave as normal spaces for text layout purposes,
-		and can collapse with other collapsible spaces
-		or participate in [[CSS-TEXT-3#white-space-phase-2|Trimming and Positioning]].
-	* The uses cases for this property and 'text-transform',
-		and the author's decision to apply either or both,
-		are independent,
-		making it desirable for these two properties to cascade separately.
-
-	</div>
 
 	<div class=example id=wakachigaki>
 		<style>
@@ -1573,6 +1122,7 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 
 		Unlike books for adults, Japanese books for young children often feature spaces between sentence segments,
 		to facilitate reading.
+		People with dyslexia also tend to find this style easier to read.
 
 		Absent any particular styling, the following sentence would be rendered as depicted below.
 
@@ -1728,6 +1278,41 @@ Making Word Boundaries Visible: the 'word-boundary-expansion' property</h4>
 			</samp>
 		</figure>
 	</div>
+
+
+<h3 id="text-transform-order">
+Order of Operations</h3>
+
+	When multiple transformations need to be applied,
+	they are applied in the following order:
+
+	<ol>
+		<li>'word-boundary-expansion'
+		<li>''capitalize'', ''uppercase'', and ''lowercase''
+		<li>''full-width''
+		<li>''full-size-kana''
+	</ol>
+
+	<wpt>
+	text-transform/text-transform-multiple-001.html
+	</wpt>
+
+	Word space transformation and
+	text transformation happen after [[#white-space-phase-1]]
+	but before [[#white-space-phase-2]].
+	This means for instance that ''full-width'' only transforms
+	spaces (U+0020) to U+3000 IDEOGRAPHIC SPACE within [=preserved=] [=white space=].
+
+	<wpt>
+	text-transform/text-transform-fullwidth-006.html
+	text-transform/text-transform-fullwidth-007.html
+	text-transform/text-transform-fullwidth-008.html
+	text-transform/text-transform-fullwidth-009.html
+	</wpt>
+
+	Note: As defined in [[#order]],
+	transforming affects line-breaking and other formatting operations.
+
 
 <h2 id="white-space-property">
 White Space and Wrapping: the 'white-space' property</h2>
@@ -3793,6 +3378,7 @@ Line Breaking and Word Boundaries</h2>
 	in the absence of hyphenation a [=soft wrap opportunity=] occurs only at word boundaries.
 	Many such systems use [=spaces=] or punctuation to explicitly separate words,
 	and [=soft wrap opportunities=] can be identified by these characters.
+
 	Scripts such as Thai, Lao, and Khmer, however,
 	do not use spaces or punctuation to separate words.
 	Although the zero width space (U+200B) can be used as an explicit word delimiter
@@ -3804,9 +3390,14 @@ Line Breaking and Word Boundaries</h2>
 	In some other writing systems,
 	[=soft wrap opportunities=] are based on orthographic syllable boundaries,
 	not word boundaries.
-	Some of these systems, such as Javanese and Balinese,
-	are similar to Thai and Lao in that they
+	Some of these systems,
+	notably Brahmic scripts such as Javanese and Balinese,
 	require analysis of the text to find breaking opportunities.
+	Unlike languages that use characters from the SA line breaking class,
+	this analysis does not depend on the [=content language=]
+	nor requires (language specific) [=word boundary detection=]
+	or a lexical resource.
+
 	In others such as Chinese (as well as Japanese, Yi, and sometimes also Korean),
 	each syllable tends to correspond to a single [=typographic letter unit=],
 	and thus line breaking conventions allow the line to break
@@ -3814,6 +3405,7 @@ Line Breaking and Word Boundaries</h2>
 	Additionally the level of strictness in these restrictions
 	varies with the typesetting style.
 
+	<!-- split these tests between the previous two paragraphs-->
 	<wpt>
 	i18n/css3-text-line-break-baspglwj-003.html
 	i18n/css3-text-line-break-baspglwj-004.html
@@ -4085,7 +3677,9 @@ Line Breaking and Word Boundaries</h2>
 		<li>
 			The 'word-break' property controls what types of letters
 			are glommed together to form unbreakable “words”,
-			causing CJK characters to behave like non-CJK text or vice versa.
+			causing CJK characters to behave like non-CJK text or vice versa,
+			enabling control over word detection in South East Asian Languages,
+			or allowing words to be grouped into phrases…
 		<li>
 			The 'hyphens' property controls whether automatic hyphenation
 			is allowed to break words in scripts that hyphenate.
@@ -4234,7 +3828,7 @@ Line Breaking Details</h3>
 			line-breaking/line-breaking-019.html
 			</wpt>
 
-		<li>
+		<li id=atomic-compat-wrap>
 			For Web-compatibility
 			there is a [=soft wrap opportunity=]
 			before and after each replaced element or other [=atomic inline=],
@@ -4304,23 +3898,6 @@ Line Breaking Details</h3>
 			Line breaking in/around Ruby is defined
 			in [[css-ruby-1#line-breaks]].
 			[[!CSS-RUBY-1]]
-
-		<li>
-			In order to avoid unexpected overflow,
-			if the user agent is unable to perform the requisite lexical
-			or orthographic analysis
-			for line breaking any [=content language=] that requires it--
-			for example due to lacking a dictionary for certain languages--
-			it must assume a [=soft wrap opportunity=]
-			between pairs of [=typographic letter units=] in that writing system.
-
-			Note: This provision is not triggered merely when
-			the UA fails to find a word boundary in a particular text run;
-			the text run may well be a single unbreakable word.
-			It applies for example
-			when a text run is composed of Khmer characters (U+1780 to U+17FF)
-			if the user agent does not know how to determine
-			word boundaries in Khmer.
 	</ul>
 
 <h3 id="word-break-property" caniuse="word-break" oldids="word-break">
@@ -4342,7 +3919,7 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 
 	<pre class="propdef">
 	Name: word-break
-	Value: normal | keep-all | break-all | break-word
+	Value: normal | break-all | keep-all | manual | auto-phrase | break-word
 	Initial: normal
 	Applies to: text
 	Inherited: yes
@@ -4366,9 +3943,17 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 	word-break/word-break-keep-all-063.html
 	</wpt>
 
-	This property specifies [=soft wrap opportunities=] between letters,
+	This property specifies [=soft wrap opportunities=] between and within “words”,
 	i.e. where it is “normal” and permissible to break lines of text.
-	Specifically it controls whether a [=soft wrap opportunity=]
+	It focuses on breaks between letters,
+	and does not define whether and how [=soft wrap opportunities=]
+	are created by [=white space=] and [=other space separators=]
+	(though ''word-break/auto-phrase'' may suppress some),
+	nor around punctuation.
+	(See 'line-break' for controls affecting punctuation and small kana.)
+
+	In particular,
+	'word-break' controls whether a [=soft wrap opportunity=]
 	generally exists
 	between adjacent [=typographic letter units=],
 	treating non-[=letter=] [=typographic character units=]
@@ -4380,11 +3965,6 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 	Unicode line breaking classes
 	as [=typographic letter units=] for this purpose (only).
 	[[!UAX14]]
-	It does not affect rules governing the [=soft wrap opportunities=]
-	created by [=white space=]
-	(as well as by [=other space separators=])
-	and around punctuation.
-	(See 'line-break' for controls affecting punctuation and small kana.)
 
 	<wpt>
 	word-break/word-break-break-all-010.html
@@ -4460,9 +4040,6 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 		</pre>
 	</div>
 
-	Note: To enable additional break opportunities only in the case of overflow,
-	see 'overflow-wrap'.
-
 	Values have the following meanings:
 
 	<dl dfn-for=word-break dfn-type=value>
@@ -4492,6 +4069,10 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 			word-break/word-break-normal-th-000.html
 			word-break/word-break-normal-zh-000.html
 			</wpt>
+
+			Some writing systems require specific processing
+			to obtain the customarily expected [=soft wrap opportunities=],
+			as described in [[#analytical-word-breaking]].
 
 		<dt><dfn>break-all</dfn>
 		<dd>
@@ -4589,7 +4170,7 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 			are suppressed,
 			i.e. breaks are prohibited between pairs of such characters
 			(regardless of 'line-break' settings other than ''line-break/anywhere'')
-			except where opportunities exist due to dictionary-based breaking.
+			except where opportunities exist due to [[#lexical-breaking]].
 			Otherwise this option is equivalent to ''word-break/normal''.
 			In this style, sequences of CJK characters do not break.
 
@@ -4606,10 +4187,137 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 			(which uses [=spaces=] between words),
 			and is also useful for mixed-script text where CJK snippets are mixed
 			into another language that uses [=spaces=] for separation.
+
+		<dt><dfn>manual</dfn>
+		<dd>
+			Behaves the same as ''word-break/normal'',
+			except that
+			[[#lexical-breaking]] must <em>not</em> be performed.
+			Specifically,
+			[=typographic character units=] with class SA in [[!UAX14]]
+			must be treated as if they had class AL
+			(i.e. assuming a value of 'line-break' other than ''line-break/anywhere'',
+			there is no [=soft wrap opportunity=]
+			between pairs of such characters).
+
+			<!--
+			tests to be reviewed and updated
+			-->
+			<wpt>
+				word-boundary/word-boundary-101.html
+				word-boundary/word-boundary-105.html
+				word-boundary/word-boundary-106.html
+				word-boundary/word-boundary-115.html
+			</wpt>
+
+			Note: This value does not affect
+			syllable-based [=soft wrap opportunities=] within words
+			in languages such as Balinese.
+			(See [[#orthographic-breaking]]
+			for some discussion of such writing systems.)
+
+			Issue: alternatively, this value could be based
+			on ''keep-all'' rather than ''word-break/normal''.
+			Yet another variant is to merge this behavior
+			with ''keep-all''.
+
+			<div class=note>
+				Note: Some Southeast Asian languages are commonly misdetected by user agents.
+				With ''word-break: normal'',
+				they would then apply inappropriate language-specific logic
+				to find wrapping opportunities,
+				and place them inappropriately.
+
+				For instance,
+				many languages other than Thai are written using the Thai script,
+				and line-breaking them as if they were Thai
+				will generally produce inadequate--
+				and possibly confusing--
+				results.
+
+				When this occurs,
+				this value enables authors to turn off
+				the word boundary detection
+				built into user agents for ''word-break: normal'',
+				so that they can manually mark up the text to indicate wrapping opportunities
+				and obtain sensible results.
+
+				<div class=advisement>
+					Authors using this value
+					are expected to manually indicate word boundaries for Southeast Asian languages,
+					using <{wbr}> or U+200B.
+					Otherwise, there will be no [=soft wrap opportunity=]
+					and the text may overflow.
+				</div>
+			</div>
+
+		<dt><dfn>auto-phrase</dfn>
+		<dd>
+			Behaves the same as ''word-break/normal'',
+			except that
+			this value directs the user agent to perform language-specific content analysis
+			to prioritize keeping natural phrases (of multiple words) together.
+
+			If the [=content language=] of the element is unknown,
+			or if the user agent does not know how to [=detect phrase boundaries=]
+			for that particular language,
+			this value must behave as ''word-break/normal''.
+			Otherwise,
+			the user agent should [=detect phrase boundaries=]
+			and suppress [=soft wrap opportunities=]
+			within each phrase.
+
+			Regardless of the [=content language=]
+			and support for [=phrase boundary detection=],
+			[=hyphenation opportunities=] are suppressed
+			as if ''hyphens: none'' had been specified.
+
+			<div class=note>
+			Note: Whether a word boundary detection system designed for one language
+			is suitable for some or all dialects of that language is somewhat subjective,
+			and this specifications leaves it at the discretion of the user agent.
+			Even if a detection system is not able to cope
+			with all nuances of a particular dialect,
+			it may be reasonable to claim support
+			if the detection correctly recognizes word boundaries most of the time.
+			However, the user agent would do a disservice to authors and users
+			if it claimed support for languages
+			where it fails to detect most word boundaries
+			or has a high error rate.
+
+				<div class=example>
+					If a user agent has a word-boundary detection system for Cantonese
+					that is not suitable for the broader set of Chinese languages,
+					''word-break/auto-phrase'' should have an effect on content marked as
+					''lang=yue'', ''lang=zh-yue'', or ''lang=zh-HK'',
+					but not ''lang=zh'' or ''lang=zh-Hant''.
+
+					However, if the user agent supports a generic word-boundary detection system
+					that is suitable for Chinese in general,
+					''word-break/auto-phrase'' should have an effect on content
+					marked with the broad ''lang=zh'' characterization,
+					as well as any more specific ones,
+					such as ''lang=zh-yue'', ''lang=zh-Hant-HK'', ''lang=zh-Hans-SG'', or ''lang=zh-hak''.
+				</div>
+			</div>
 	</dl>
 
 	Symbols that line-break the same way as letters of a particular category
 	are affected the same way as those letters.
+
+	User agents must not,
+	in response to any value of this property,
+	suppress [=soft wrap opportunities=] which are:
+	* introduced by the <{wbr}> HTML element or U+200B ZERO WIDTH SPACE
+	* required by the 'line-break' property
+	* <a href=#atomic-compat-wrap>surrounding atomic inlines</a>
+
+	Note: To control additional break opportunities
+	available only in the case of overflow,
+	see 'overflow-wrap'.
+
+	The effects of 'word-break'
+	are taken into account when computing [=intrinsic sizes=].
 
 	<div class="example">
 		Here’s a mixed-script sample text:
@@ -4646,7 +4354,7 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 			#jp-title-break td samp,
 			#jp-title-break td pre {
 				font-size: 1.5em;
-				width: 9em;
+				width: 6em;
 				line-height: 2;
 				padding: 0.5em 1em;
 				display: block;
@@ -4656,56 +4364,95 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 			}
 		</style>
 
-		Japanese is usually typeset allowing line breaks within words.
+		Japanese is usually typeset allowing line breaks between each syllable.
 		However, it is sometimes preferred to suppress these wrapping opportunities
 		and to only allow wrapping at the end of certain sentence fragments.
 		This is most commonly done in very short pieces of text,
 		such as headings and table or figure captions.
 
-		This can be achieved by marking the allowed wrapping points
+		This can be achieved manually by marking the allowed wrapping points
 		with <{wbr}> or U+200B ZERO WIDTH SPACE,
 		and suppressing the other ones using ''word-break: keep-all''.
 
-		For instance, the following markup can produce either of the renderings below,
-		depending on the value of the 'word-break' property:
-
-		<xmp highlight=markup>
-			<h1>窓ぎわの<wbr>トットちゃん</h1>
-		</xmp>
+		Alternatively,
+		in user agents that support detection of phrases boundaries in Japanese,
+		the same results can be achieved automatically
+		by using
+		''word-break: auto-phrase''
+		(assuming the [=content language=] is specified).
 
 		<table class=data>
 			<colgroup span=1></colgroup>
 			<colgroup span=2></colgroup>
 			<thead>
 				<tr>
-					<td>
-					<th><code highlight=css>h1 { word-break: normal }</code>
-					<th><code highlight=css>h1 { word-break: keep-all }</code>
+					<th>Sample markup and style rule
+					<th>Expected rendering
+					<th>Result in your browser
 			<tbody>
 				<tr>
-					<th scope=row>Expected rendering
+					<th scope=row>
+						<xmp highlight=markup>
+							<h1>
+							窓ぎわの<wbr>トットちゃん
+							</h1>
+						</xmp>
+						<pre><code highlight=css>
+						h1 {
+						  word-break: normal;
+						}</code></pre>
 					<td>
 						<pre lang=ja>
-							窓ぎわのトットちゃ
-							ん
+							窓ぎわのトッ
+							トちゃん
 						</pre>
 
+					<td>
+						<samp lang=ja>
+							窓ぎわの<wbr>トットちゃん
+						</samp>
+				<tr>
+					<th scope=row>
+						<xmp highlight=markup>
+							<h1>
+							窓ぎわの<wbr>トットちゃん
+							</h1>
+						</xmp>
+						<pre><code highlight=css>
+						h1 {
+						  word-break: keep-all;
+						}</code></pre>
 					<td>
 						<pre lang=ja>
 							窓ぎわの
 							トットちゃん
 						</pre>
-				<tr>
-					<th scope=row>Result in your browser
-					<td>
-						<samp lang=ja>
-							窓ぎわの<wbr>トットちゃん
-						</samp>
 					<td>
 						<samp style="word-break:keep-all" lang=ja>
 							窓ぎわの<wbr>トットちゃん
 						</samp>
+				<tr>
+					<th scope=row>
+						<xmp highlight=markup>
+							<h1 lang=ja>
+							窓ぎわのトットちゃん
+							</h1>
+						</xmp>
+						<pre><code highlight=css>
+						h1 {
+						  word-break: auto-phrase;
+						}</code></pre>
+					<td>
+						<pre lang=ja>
+							窓ぎわの
+							トットちゃん
+						</pre>
+					<td>
+						<samp style="word-break:auto-phrase" lang=ja>
+							窓ぎわのトットちゃん
+						</samp>
 		</table>
+
 	</div>
 
 	When shaping scripts such as Arabic
@@ -4748,6 +4495,88 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 	white-space/break-spaces-with-ideographic-space-008.html
 	white-space/break-spaces-with-ideographic-space-009.html
 	</wpt>
+
+<h4 id="analytical-word-breaking">
+Analytical Word Breaking</h4>
+
+<h5 id="lexical-breaking">
+Lexical Word Breaking</h5>
+
+	To provide the expected ''word-break/normal'' behavior
+	for Southeast Asian languages,
+	[=typographic character units=] with line breaking class SA in [[!UAX14]]
+	must be treated as if they had class AL.
+	However, the user agent must additionally
+	analyze the content of a run of such characters
+	to [=detect word boundaries=]
+	and treat each boundary as a [=soft wrap opportunities=].
+
+	<wpt>
+		word-boundary/word-boundary-102.html
+		word-boundary/word-boundary-103.html
+		word-boundary/word-boundary-104.html
+	</wpt>
+
+	As various languages can be written in scripts
+	which use the characters with class SA,
+	if the [=content language=] is known,
+	the user agent should use this information
+	to tailor its analysis.
+
+<h5 id="orthographic-breaking">
+Orthographic Breaking</h5>
+
+	For scripts (such as Balinese) that use line breaking based on orthographic syllables,
+	the UA must analyze the content
+	to find the correct points to insert [=soft wrap opportunities=].
+
+	Note: At the time of writing,
+	Unicode does not define how to perform this analysis,
+	and treats all characters in these writing systems
+	as having line breaking class AL.
+	However,
+	[[L2-22-080R inline|a proposal]] has been made to solve that issue.
+	Even though it is not final,
+	it can be informative to consult.
+	[[L2-22-080R]]
+
+<h5 id="fallback-breaking">
+Fallback Breaking</h5>
+
+
+	In order to avoid unexpected overflow,
+	if the user agent is unable to perform the requisite lexical
+	or orthographic analysis
+	for line breaking any [=content language=] that requires it--
+	for example due to lacking a dictionary
+	for languages written in characters with class SA--
+	it must assume a [=soft wrap opportunity=]
+	between pairs of [=typographic letter units=] in that writing system.
+
+	Note: This provision is not triggered merely when
+	the UA fails to find a word boundary in a particular text run;
+	the text run may well be a single unbreakable word.
+	It applies for example
+	when a text run is composed of Khmer characters (U+1780 to U+17FF)
+	if the user agent does not know how to determine
+	word boundaries in Khmer.
+
+
+<h4 id="phrase-pref">
+Expressing User Preferences for Phrase-based Line Breaking</h4>
+
+	User agents may activate
+	language-specific content analysis
+	described in ''word-break/auto-phrase''
+	in response to user preferences.
+	User agents with this behavior must do this
+	by setting the [=declared value=] of 'word-break' to ''word-break/auto-phrase''
+	in the [=user origin=].
+
+	Note: This allows authors to detect
+	whether or not this feature is enabled by calling {{getComputedStyle()}},
+	or to override it in the [=author origin=] where appropriate.
+
 
 <h3 id="line-break-property">
 Line Breaking Strictness: the 'line-break' property</h3>
@@ -5794,6 +5623,35 @@ Overflow Wrapping: the 'overflow-wrap'/'word-wrap' property</h3>
 			overflow-wrap/overflow-wrap-normal-keep-all-001.html
 			</wpt>
 
+			Also, the restrictions introduced by ''word-break: auto-phrase''
+			are relaxed
+			if there are no otherwise-acceptable break points in the line:
+			<ul>
+				<li>
+					If suppressing [=soft wrap opportunities=] within a particular phrase
+					would cause that phrase to overflow even when placed on an otherwise empty line,
+					the user agent must fall back
+					to the same [=soft wrap opportunities=] as ''word-break/normal''
+					within that phrase.
+
+				<li>
+					If that is not enough to prevent overflow,
+					suppression of [=hyphenation opportunities=] must also be abandoned
+					within each line that would overflow.
+
+				<li>
+					As an intermediary measure,
+					user agents may also detect multiple levels of phrases,
+					choosing to shorter ones
+					(possibly down to individual words)
+					when longer ones would lead to overflow.
+			</ul>
+
+			The [=soft wrap opportunities=] obtained by relaxing the restrictions
+			introduced by ''word-break: keep-all'' and ''word-break: auto-phrase''
+			are <em>not</em> considered
+			when calculating [=min-content size|min-content intrinsic sizes=].
+
 		<dt><dfn>anywhere</dfn>
 		<dd>
 			An otherwise unbreakable sequence of [=characters=]
@@ -5843,6 +5701,12 @@ Overflow Wrapping: the 'overflow-wrap'/'word-wrap' property</h3>
 			white-space/break-spaces-with-overflow-wrap-010.html
 			</wpt>
 
+			In the case of ''word-break: auto-phrase'',
+			these additional [=soft wrap opportunities=] are only introduced
+			if relaxing the restrictions introduced by ''word-break: auto-phrase''
+			as described in ''overflow-wrap: normal''
+			is insufficient to prevent overflow.
+
 		<dt><dfn>break-word</dfn>
 		<dd>
 			As for ''overflow-wrap/anywhere''
@@ -5880,6 +5744,10 @@ Overflow Wrapping: the 'overflow-wrap'/'word-wrap' property</h3>
 			white-space/trailing-ideographic-space-016.html
 			</wpt>
 	</dl>
+
+	Issue: Do we need to add a <code>none</code> value to 'overflow-wrap'
+	to opt out of relaxing the ''keep-all' and ''auto-phrase'' restrictions
+	as allowed by ''overflow-wrap: normal''?
 
 	For legacy reasons, UAs must treat 'word-wrap'
 	as a [=legacy name alias=] of the 'overflow-wrap' property.
@@ -9451,12 +9319,13 @@ Text Processing Order of Operations</h2>
 
 	<ol>
 		<li>
-			[[#white-space-trim]] and [[#word-boundary-expansion]]
+			[[#white-space-trim]]
 
 		<li>
 			[[#white-space-phase-1|white space processing]] part I (pre-wrapping)
 
 		<li>
+			[[#word-boundary-expansion]] and
 			[[#transforming|text transformation]]
 
 		<li>
@@ -10400,6 +10269,146 @@ Small Kana Mappings</h2>
 	text-transform/text-transform-full-size-kana-008.html
 	</wpt>
 
+
+<h2 id="word-phrase-detection" class=no-num>
+Appendix H:
+Word and Phrase Detection</h2>
+
+	<i>This appendix is normative.</i>
+
+	A few operations in this specification
+	depend on automated
+	<dfn lt="word boundary detection | detect word boundaries | detecting word boundaries">word boundary detection</dfn>
+	or
+	<dfn lt="phrase boundary detection | detect phrase boundaries | detecting phrase boundaries">phrase boundary detection</dfn>.
+
+	Both operations are similar:
+	the user agent performs linguistic analysis of the text
+	to identify language-specific meaningful sequences of characters.
+	They differ only targetting different units of text:
+	either words or phrases.
+
+	While easily understood in a broad sense,
+	both concepts of word and phrase are difficult to precisely define,
+	especially in a way that works accross multiple languages.
+	Nonetheless, in this context:
+
+	<ul>
+		<li>
+			A word is a recognizable semantic unit which may comprise one or more characters or syllables.
+
+			Note: See <a href="https://www.w3.org/International/articles/typography/linebreak.en#whatisword">What is a word?</a>
+			for some discussion of this concept.
+
+		<li>
+			A phrase is a short grouping of one or several words
+			standing together as a conceptual or grammatical unit,
+			forming a component of a clause or sentence.
+
+			Note:
+			This is not to be confused with the French word <em lang=fr>phrase</em>
+			which means sentence rather than phrase in the English sense used here.
+			In Japanese,
+			this corresponds to the concept of 文節.
+
+			<div class=example>
+				A phrase could be
+				a noun with its article and prepositions or postpositions,
+				a phrasal verb,
+				a compound verb tense…
+			</div>
+	</ul>
+
+	The start and end position of each detected word or phrase
+	is called a <dfn>word boundary</dfn> or <dfn>phrase boundary</dfn>.
+	By themselves, word and phrase boundaries are not observable,
+	but properties like 'word-boundary-expansion' or 'word-break'
+	can cause visible effects at those positions.
+
+	The specific algorithm to detect word or phrases
+	and to place their boundaries is UA-dependent,
+	and may take into account a variety of factors or approaches,
+	such as
+	dictionary-based lexical analysis,
+	identification of punctuation or other delimiting characters,
+	morphological analysis,
+	machine learning methods…
+
+	The following constraints must nevertheless be respected:
+
+	<ul>
+		<li>
+			The user agent must not place a word or phrase boundary
+			between characters that compose a single [=typographic character unit=].
+
+		<li>
+			The user agent must not place a word or phrase boundary
+			adjacent to any characters with the line breaking class GL, WJ, or ZWJ;
+			when two would-be words or phrases are separated by such characters,
+			they must be treated as a single one.
+			[[UAX14]]
+
+		<li>
+			If a word or phrase is immediately followed by one or more of the following characters,
+			the user agent <em>must</em> consider them to be part of the preceeding word or phrase:
+
+			<ul>
+				<li>[=word-separator characters=]
+				<li>[=other space separators=]
+				<li>U+200B ZERO WIDTH SPACE characters
+		</ul>
+
+		<li>
+			<p>
+			Punctuation is not a phrase by itself:
+			it should to be attached to the relevant side of an adjacent linguistic word or phrase.
+			For example,
+			enclosing punctuation such as brackets and quotes
+			are part of the phrase they enclose;
+			commas and semicolons are suffixed to the preceding phrase;
+			U+00BF INVERTED QUESTION MARK is attached to the subsequent word;
+			etc.
+
+			However, unconventional use of punctuation,
+			such as smileys, kaomoji, or Perl snippets,
+			may cause the user agent to need to deviate from this principle.
+
+		<li id=boundary-outermost>
+			Inline box boundaries
+			and out-of-flow elements must be ignored
+			when determining word or phrase boundaries.
+			However,
+			if a [=word boundary|word=] or [=phrase boundary=] is found at the same position as
+			one or more inline box boundaries,
+			the [=word boundary|word=] or [=phrase boundary=] must be inserted
+			in the outermost element that participates in this inline box boundary.
+
+			<wpt title="Tests for ignoring inline box boundaries">
+				word-boundary/word-boundary-113.html
+				word-boundary/word-boundary-114.html
+			</wpt>
+
+			<wpt title="Tests placing the word/phrase boundary in the outermost element">
+				word-boundary/word-boundary-113.html
+				word-boundary/word-boundary-114.html
+			</wpt>
+
+			<div class=example>
+				In the following example,
+				the red “<code><span style="color:red">|</span></code>” indicates
+				reasonable positions for a user agent [=detecting word boundaries=] to place them:
+				<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ<span style="color:red">|</span>สวยงาม</code></pre>
+				If that sentence had contained some inline markup,
+				the following example shows the correct position to place the word boundaries:
+				<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ<span style="color:red">|</span>&lt;em>สวยงาม&lt;/em></code></pre>
+				The following example shows <em>incorrect</em> positions:
+				<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>คือ&lt;em><span style="color:red">|</span>สวยงาม&lt;/em></code></pre>
+				The following shows the correct positions in a more contrived situation:
+				<pre><code highlight=html>กรุงเทพ<span style="color:red">|</span>&lt;b>&lt;u>คือ&lt;/u><span style="color:red">|</span>&lt;em>สวยงาม&lt;/em>&lt;/b></code></pre>
+			</div>
+	</ul>
+
+
 <h2 id="priv-sec" class="no-num">
 Privacy and Security Considerations</h2>
 
@@ -10477,6 +10486,13 @@ Changes</h2>
 		'text-wrap-mode' and 'text-wrap-style',
 		and making 'text-wrap-mode' rather than 'text-wrap'
 		a longhand of the 'white-space' property.
+	* Updated [[#small-kana]] to Unicode 15.0.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/8442">Issue 8442</a>)
+	* Redesign of the ''word-break: auto-phrase'' ''word-break: manual'' features
+		(from an earlier attempt as a standalone <code>word-boundary-detection</code> property),
+		and add an ''word-boundary-expansion/auto-phrase'' value to 'word-boundary-expansion'
+		(since it can no longer depend on <code>word-boundary-detection</code>).
+		and update supporting related mechanics.
 
 	Significant changes since the <a href="https://www.w3.org/TR/2023/WD-css-text-4-20230301/">1 March 2022 Working Draft</a> include:
 	* Completed the translation of 'white-space' to multiple longhands by
@@ -10558,7 +10574,7 @@ Additions Since Level 3</h3>
 
 	New features in Level 4:
 
-	* 'word-boundary-detection', for automatically detecting word boundaries (at risk)
+	* ''word-break: auto-phrase'', for automaticly determining phrases to keep together while line breaking
 	* 'word-boundary-expansion', for transforming word separators
 	* breaking up of the 'white-space' property into multiple longhands:
 		* 'white-space-collapse' and its ''preserve-spaces'' and ''white-space-collapse/discard'' values


### PR DESCRIPTION
Recast `word-boundary-detection: auto()` as `word-break: auto-phrase`, as well as `word-boundary-detection: manual` as `word-break: manual`.

This allows retiring the `word-boundary-detection` property.

Also, the `word-boundary-expansion` property needed to gain its own `auto-phrase` value, since it could no longer depend on `word-boundary-detection: auto()`.

Since there's no longer a pair of `word-boundary-*` properties, there's no need to keep the two names related, and the original name was quite a mouthful. `word-space-transform` is simpler, and better show-cases the similarities with `text-transform`.

Supporting sections had to be reorganized as well to keep the whole thing coherent.

This addresses https://github.com/w3c/csswg-drafts/issues/7193 (and https://github.com/w3c/i18n-activity/issues/1454). It builds upon and is meant to replace https://github.com/w3c/csswg-drafts/pull/9216 (which itself builds upon and replaces https://github.com/w3c/csswg-drafts/pull/8974).

(co-authored with @fantasai)

----

Note: the `<wpt>` annotations have not been fully updated yet. Ignore them for now: I'll update the tests and the corresponding `<wpt>` annotations in the spec once we agree on the behavior described in this PR.