### PR TITLE
[css-anchor-position-1] Add more properties to position fallback

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -948,6 +948,9 @@ The ''@try'' rule only <dfn lt="accepted @try properties">accepts</dfn>
 the following [=properties=]:
 
 * [=inset properties=]
+* [=margin properties=]
+* [=border properties=]
+* [=padding properties=]
 * [=sizing properties=]
 * [=box alignment properties=]
 


### PR DESCRIPTION
Per resolution https://github.com/w3c/csswg-drafts/issues/9195#issuecomment-1690141172

This PR allows more properties in a `@position-fallback` rule:
- All margin properties in [CSS-BOX-4](https://drafts.csswg.org/css-box-4/#margins):
  - `margin-top`, `margin-bottom`, `margin-left`, `margin-right` and their logical equivalents
  - `margin`, `margin-block`, `margin-inline` shorthands
  - `margin-trim`, as it's also a margin property if I read the spec correctly
- All border properties in [CSS-BOX-4](https://drafts.csswg.org/css-box-4/#borders):
  - border color, border style and border width properties, and related shorthands
- All padding properties in [CSS-BOX-4](https://drafts.csswg.org/css-box-4/#paddings):
  - `padding-top`, `padding-bottom`, `padding-left`, `padding-right` and their logical equivalents
  - `padding`, `padding-block`, `padding-inline` shorthands


Note: [CSS-BOX-4](https://drafts.csswg.org/css-box-4/#borders) doesn't explicitly list border radius and border images as border properties, but they should also be allowed in position fallbacks. I suppose this is and editorial issue that should be fixed in CSS-BOX-4 instead.