### PR TITLE
[css-contain-2] Removed "Twitter" from CSS Contain 2

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1830,7 +1830,7 @@ Using ''content-visibility: auto''</h3>
 	it's best to use at a reasonably fine granularity.
 
 	<div class=example>
-		For example, on Twitter,
+		For example, on Mastodon,
 		applying ''content-visibility: auto'' to the entire timeline
 		wouldn't accomplish much--
 		it's always on-screen,
@@ -1862,8 +1862,8 @@ Using ''content-visibility: auto''</h3>
 			to be used before it's rendered and can have its size snapshotted)
 
 		For example,
-		on Twitter,
-		the average tweet is approximately 200px tall,
+		on Mastodon,
+		the average post is approximately 200px tall,
 		so ''contain-intrinsic-size: auto 500px 200px''
 		will ensure that the scrollbar thumb is in approximately the correct size and position
 		even when preceding or following tweets are [=skipped=],


### PR DESCRIPTION
Twitter was rebranded to "X". With the latest development I think that a more persistent platform like Mastodon is a better example for this document.  Thus changed all occurrences of Twitter to Mastodon.