### PR TITLE
[css-color-5] fix typo

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -451,7 +451,7 @@ The choice of mixing color space can have a large effect on the end result.
 	* the lightness is 25.334 × 0.8 + 50 × 0.2 = 30.2672
 	* the mixed result is
 	    <span class="swatch oog" style="--color: rgb(72.66% 100% 0%)"></span> hsl(114.3032 261.5568 30.2672) which is
-	    <span class="swatch oog" style="--color: rgb(72.66% 100% 0%)"></span> color(srgb -0.3387 1.0943, -0.48899)
+	    <span class="swatch oog" style="--color: rgb(72.66% 100% 0%)"></span> color(srgb -0.3387 1.0943 -0.48899)
 </div>
 
 <h3 id="color-mix-with-alpha">


### PR DESCRIPTION
The `color()` function doesn't use comma tokens as separators.
I think this was a simple typo.