### PR TITLE
[cssom-view] Add segments property to visual viewport (#9237)

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1806,6 +1806,8 @@ interface VisualViewport : EventTarget {
 
   readonly attribute double scale;
 
+  readonly attribute FrozenArray&lt;DOMRect> segments;
+
   attribute EventHandler onresize;
   attribute EventHandler onscroll;
   attribute EventHandler onscrollend;
@@ -1855,6 +1857,19 @@ The <dfn attribute for=VisualViewport>scale</dfn> attribute must run these steps
     and abort these steps.
 1. If there is no output device, return 1 and abort these steps.
 1. Otherwise, return the <a>visual viewport</a>'s <a>scale factor</a>.
+
+The segments is an array of DOMRects that represent the dimensions of each existing viewport segment.
+Additonal details about the defintion of a viewport segment can be found here : [[css-env-1#viewport-segments]].
+
+The segments attribute must run these steps:
+1. If the <a>visual viewport</a>'s <a for=visualviewport>associated document</a> is not <a>fully active</a>, return 0.
+2. Returns null if called from within an iframe context and abort these steps.
+3. Returns null if there is only a single viewport segment and abort these steps.
+4. Otherwise, return the <a>visual viewport</a>'s segments array.
+
+Note: Based on the data returned for each viewport segment, developers will be able to infer the number of hinges available as well as the hinge orientation.
+The browser window can be moved/resized such that the number of segments and/or their dimensions change.
+In these cases, resize events will fire at which point authors should re-query this property, as the returned FrozenArray is just a snapshot of the current state.
 
 <dfn attribute for=VisualViewport>onresize</dfn> is the <a>event handler IDL attribute</a> for the <a event>resize</a> event.
 
@@ -1980,6 +1995,9 @@ Changes {#changes}
 
 This section documents some of the changes between publications of this specification. This section is not exhaustive. Bug fixes and editorial changes are
 generally not listed.
+
+<h3 id='changes-from-2022-07-07' class=no-num>Changes From 14 September 2023</h3>
+* Introduced the {{VisualViewport/segments}} property in the {{VisualViewport}} API.
 
 <h3 id='changes-from-2022-07-07' class=no-num>Changes From 07 July 2022</h3>
 * Introduced the {{VisualViewport}} API and related concepts


### PR DESCRIPTION
[cssom-view]  Add segments property to visual viewport (#9237)

This property exposes in JS what is already exposed to CSS via the env() [viewport segment variables](https://drafts.csswg.org/css-env-1/#viewport-segments). TAG review [here](https://github.com/w3ctag/design-reviews/issues/689).
