### PR TITLE
[css-backgrounds-3][css-borders-4] Fixed definition for where box shadows apply

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -28,6 +28,7 @@ spec:css2; type:value; text:inline-table
 spec:css2; type:value; text:table-cell
 spec:css2; type:property; text:overflow
 spec:css2; type:value; text:visible
+spec:css-break-4; type:dfn; text:fragment
 spec:css-color-4; type:property; text:color
 spec:css-color-4; type:value; text:transparent
 spec:selectors-3; type:selector; text: ::first-letter
@@ -2512,7 +2513,8 @@ Layering, Layout, and Other Details</h4>
   and the [=inner shadows=] of an element are drawn immediately above the background of that element
   (below the borders and border image, if any).
 
-  <p>If an element has multiple boxes, all of them get drop shadows,
+  <p>Drop shadows are only applied to the [=principal box=].
+  If that box has multiple [=fragments=], then all of them get shadows,
   but shadows are only drawn where borders would also be drawn;
   see 'box-decoration-break'.
 
@@ -2591,6 +2593,8 @@ Changes since the 14 February 2024 Candidate Recommendation Snapshot</h3>
     to include “Animation Type” and “Logical Property Group”.
   <li>Streamlined property grammar definitions using the latest
     [=CSS/value definition syntax=].
+  <li>Fixed the definition for where box shadows apply.
+    (<a href="https://github.com/w3c/csswg-drafts/issues/9286">Issue 9286</a>)
 </ul>
 
 

--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -2513,10 +2513,9 @@ Layering, Layout, and Other Details</h4>
   and the [=inner shadows=] of an element are drawn immediately above the background of that element
   (below the borders and border image, if any).
 
-  <p>Drop shadows are only applied to the [=principal box=].
-  If that box has multiple [=fragments=], then all of them get shadows,
-  but shadows are only drawn where borders would also be drawn;
-  see 'box-decoration-break'.
+  <p>Unless otherwise specified, drop shadows are only applied to the [=principal box=].
+  If the affected box has multiple fragments,
+  the shadows are applied as specified in 'box-decoration-break'.
 
   <p>Shadows do not trigger scrolling or increase the size of the scrollable area.
 

--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -2571,8 +2571,8 @@ The lists below describe which features from this specification are in each leve
 <h2 id="changes">
 Changes</h2>
 
-<h3 id="changes-2024-02">
-Changes since the 14 February 2024 Candidate Recommendation Snapshot</h3>
+<h3 id="changes-2023-02">
+Changes since the 14 February 2023 Candidate Recommendation Snapshot</h3>
 
 <ul>
   <li>Defined serialization of 'background-position' in [[#bg-position-serialization]].

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -961,9 +961,9 @@ Layering, Layout, and Other Details</h4>
 	and the <i>inner shadows</i> of an element are drawn immediately above the background of that element
 	(below the borders and border image, if any).
 
-	<p>If an element has multiple boxes, all of them get drop shadows,
-	but shadows are only drawn where borders would also be drawn;
-	see 'box-decoration-break'.
+	<p>Unless otherwise specified, drop shadows are only applied to the [=principal box=].
+	If the affected box has multiple fragments,
+	the shadows are applied as specified in 'box-decoration-break'.
 
 	<p>Shadows do not trigger scrolling or increase the size of the scrollable area.
 


### PR DESCRIPTION
This corrects the description for where box shadows are applied.

Fixes #9286