### PR TITLE
[css-text-4] Deduplication of normative text and editorial reorganization

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -5441,6 +5441,7 @@ Line Breaking Strictness: the 'line-break' property</h3>
 		Missing tests:
 		* applies to text
 		* affects intrinsic sizing
+		* Line breaking classes CM and SG must be honored even with line-break: anywhere
 
 		Untestable(?):
 		* behavior of “auto”"></wpt>
@@ -5554,6 +5555,13 @@ Line Breaking Strictness: the 'line-break' property</h3>
 			</wpt>
 
 			Note: This value triggers the line breaking rules typically seen in terminals.
+
+			Note: This values only creates [=soft wrap opportunities=]
+			<em>between</em> [=typographic character units=],
+			not within them.
+			Consequently, the <code>CM</code> and <code>SG</code>
+			Unicode line breaking classes must be honored.
+			[[UAX14]]
 
 			<div class=note>
 				Note: ''line-break/anywhere'' only allows [=preserved white spaces=]

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4098,6 +4098,1746 @@ Tab Character Size: the 'tab-size' property</h3>
 	white-space-processing-042.xht
 	</wpt>
 
+<h2 id="text-wrapping">
+Text Wrapping</h2>
+
+	Where text is allowed to wrap is controlled
+	by the [[#line-breaking|line-breaking rules and controls]] above;
+	<em>whether</em> it is allowed to wrap
+	and how multiple [=soft wrap opportunities=] within a line are prioritized
+	is controlled
+	by the 'text-wrap-mode',
+	'text-wrap-style',
+	'wrap-before',
+	'wrap-after',
+	and
+	'wrap-inside' properties:
+
+<h3 id="text-wrap">
+Text Wrap Setting</h3>
+
+<h4 id="text-wrap-shorthand">
+Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
+
+	<wpt title="This section has limited coverage."></wpt>
+
+	<pre class="propdef">
+	Name: text-wrap
+	Value: <'text-wrap-mode'> || <'text-wrap-style'>
+	Initial: wrap
+	Applies to: see individual properties
+	Inherited: see individual properties
+	Percentages: see individual properties
+	Computed value: see individual properties
+	Animation type: see individual properties
+	</pre>
+
+	<wpt>
+		parsing/text-wrap-invalid.html
+		parsing/text-wrap-valid.html
+	</wpt>
+	<wpt title="TODO: needs review, probably outdated">
+		parsing/white-space-shorthand-text-wrap.html
+	</wpt>
+
+	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
+	Any omitted [=longhand=] is set to its [=initial value=].
+
+<h4 id="text-wrap-mode">
+Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
+
+	<wpt title="
+		This property is tested extensively through its shorthands,
+		but not directly.
+
+		Missing test:
+		* preserved segment breaks are forced line breaks (probably tested already, but need to find those tests)
+		* CR and LF  line breaking class are forced line breaks
+		* Direct tests of this property as a longhand"></wpt>
+
+	<pre class="propdef">
+	Name: text-wrap-mode
+	Value: wrap | nowrap
+	Initial: wrap
+	Applies to: text
+	Inherited: yes
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	Issue: The name of this property is a placeholder,
+	pending the CSSWG finding a better name.
+
+	Note: This property is a [=longhand=]
+	of both 'white-space' and 'text-wrap'.
+
+	This property specifies whether lines may [=wrap=] at unforced [=soft wrap opportunities=]
+	(see [[#line-breaking|Line Breaking]]).
+	Possible values:
+
+	<dl dfn-for=text-wrap-mode dfn-type=value>
+		<dt><dfn>wrap</dfn>
+		<dd>
+			Content may break across lines
+			at allowed <a>soft wrap opportunities</a>,
+			as determined by the line-breaking rules in effect,
+			in order to minimize <a>inline-axis</a> overflow.
+
+			<wpt title="tests using wrap directly through 'text-wrap-mode':">
+			</wpt>
+			<wpt title="CSS 2 indirect tests via 'white-space: normal':" pathprefix="/css/CSS2/text/">
+				white-space-normal-001.xht
+				white-space-normal-002.xht
+				white-space-normal-003.xht
+				white-space-normal-004.xht
+				white-space-normal-005.xht
+				white-space-normal-006.xht
+				white-space-normal-007.xht
+				white-space-normal-008.xht
+				white-space-normal-009.xht
+				white-space-p-element-001.xht
+			</wpt>
+			<wpt title="CSS 2 indirect tests via 'white-space: pre-line':" pathprefix="/css/CSS2/text/">
+				white-space-005.xht
+				white-space-processing-017.xht
+				white-space-processing-053.xht
+			</wpt>
+			<wpt title="tests using wrap through 'text-wrap: wrap':">
+			</wpt>
+			<wpt title="tests using wrap implicitly through 'text-wrap':">
+				parsing/white-space-shorthand-text-wrap.html
+				white-space/text-wrap-balance-001.html
+				white-space/text-wrap-balance-002.html
+				white-space/text-wrap-balance-align-001.html
+				white-space/text-wrap-balance-dynamic-001.html
+				white-space/text-wrap-balance-line-clamp-001.html
+				white-space/text-wrap-balance-narrow-crash.html
+				white-space/text-wrap-balance-text-indent-001.html
+			</wpt>
+			<wpt title="tests using wrap through 'white-space: normal':">
+				hyphens/hyphens-auto-003.html
+				i18n/css3-text-line-break-baspglwj-001.html
+				i18n/css3-text-line-break-baspglwj-002.html
+				i18n/css3-text-line-break-baspglwj-003.html
+				i18n/css3-text-line-break-baspglwj-004.html
+				i18n/css3-text-line-break-baspglwj-005.html
+				i18n/css3-text-line-break-baspglwj-006.html
+				i18n/css3-text-line-break-baspglwj-007.html
+				i18n/css3-text-line-break-baspglwj-008.html
+				i18n/css3-text-line-break-baspglwj-009.html
+				i18n/css3-text-line-break-baspglwj-010.html
+				i18n/css3-text-line-break-baspglwj-011.html
+				i18n/css3-text-line-break-baspglwj-012.html
+				i18n/css3-text-line-break-baspglwj-014.html
+				i18n/css3-text-line-break-baspglwj-015.html
+				i18n/css3-text-line-break-baspglwj-016.html
+				i18n/css3-text-line-break-baspglwj-017.html
+				i18n/css3-text-line-break-baspglwj-018.html
+				i18n/css3-text-line-break-baspglwj-019.html
+				i18n/css3-text-line-break-baspglwj-020.html
+				i18n/css3-text-line-break-baspglwj-021.html
+				i18n/css3-text-line-break-baspglwj-022.html
+				i18n/css3-text-line-break-baspglwj-023.html
+				i18n/css3-text-line-break-baspglwj-024.html
+				i18n/css3-text-line-break-baspglwj-025.html
+				i18n/css3-text-line-break-baspglwj-026.html
+				i18n/css3-text-line-break-baspglwj-030.html
+				i18n/css3-text-line-break-baspglwj-031.html
+				i18n/css3-text-line-break-baspglwj-032.html
+				i18n/css3-text-line-break-baspglwj-033.html
+				i18n/css3-text-line-break-baspglwj-034.html
+				i18n/css3-text-line-break-baspglwj-035.html
+				i18n/css3-text-line-break-baspglwj-036.html
+				i18n/css3-text-line-break-baspglwj-037.html
+				i18n/css3-text-line-break-baspglwj-038.html
+				i18n/css3-text-line-break-baspglwj-039.html
+				i18n/css3-text-line-break-baspglwj-040.html
+				i18n/css3-text-line-break-baspglwj-041.html
+				i18n/css3-text-line-break-baspglwj-042.html
+				i18n/css3-text-line-break-baspglwj-043.html
+				i18n/css3-text-line-break-baspglwj-044.html
+				i18n/css3-text-line-break-baspglwj-045.html
+				i18n/css3-text-line-break-baspglwj-046.html
+				i18n/css3-text-line-break-baspglwj-047.html
+				i18n/css3-text-line-break-baspglwj-048.html
+				i18n/css3-text-line-break-baspglwj-049.html
+				i18n/css3-text-line-break-baspglwj-050.html
+				i18n/css3-text-line-break-baspglwj-051.html
+				i18n/css3-text-line-break-baspglwj-052.html
+				i18n/css3-text-line-break-baspglwj-060.html
+				i18n/css3-text-line-break-baspglwj-061.html
+				i18n/css3-text-line-break-baspglwj-062.html
+				i18n/css3-text-line-break-baspglwj-063.html
+				i18n/css3-text-line-break-baspglwj-064.html
+				i18n/css3-text-line-break-baspglwj-065.html
+				i18n/css3-text-line-break-baspglwj-066.html
+				i18n/css3-text-line-break-baspglwj-067.html
+				i18n/css3-text-line-break-baspglwj-068.html
+				i18n/css3-text-line-break-baspglwj-069.html
+				i18n/css3-text-line-break-baspglwj-070.html
+				i18n/css3-text-line-break-baspglwj-071.html
+				i18n/css3-text-line-break-baspglwj-072.html
+				i18n/css3-text-line-break-baspglwj-073.html
+				i18n/css3-text-line-break-baspglwj-074.html
+				i18n/css3-text-line-break-baspglwj-075.html
+				i18n/css3-text-line-break-baspglwj-076.html
+				i18n/css3-text-line-break-baspglwj-077.html
+				i18n/css3-text-line-break-baspglwj-078.html
+				i18n/css3-text-line-break-baspglwj-080.html
+				i18n/css3-text-line-break-baspglwj-081.html
+				i18n/css3-text-line-break-baspglwj-082.html
+				i18n/css3-text-line-break-baspglwj-083.html
+				i18n/css3-text-line-break-baspglwj-084.html
+				i18n/css3-text-line-break-baspglwj-085.html
+				i18n/css3-text-line-break-baspglwj-086.html
+				i18n/css3-text-line-break-baspglwj-090.html
+				i18n/css3-text-line-break-baspglwj-091.html
+				i18n/css3-text-line-break-baspglwj-092.html
+				i18n/css3-text-line-break-baspglwj-093.html
+				i18n/css3-text-line-break-baspglwj-095.html
+				i18n/css3-text-line-break-baspglwj-096.html
+				i18n/css3-text-line-break-baspglwj-097.html
+				i18n/css3-text-line-break-baspglwj-098.html
+				i18n/css3-text-line-break-baspglwj-099.html
+				i18n/css3-text-line-break-baspglwj-100.html
+				i18n/css3-text-line-break-baspglwj-101.html
+				i18n/css3-text-line-break-baspglwj-102.html
+				i18n/css3-text-line-break-baspglwj-103.html
+				i18n/css3-text-line-break-baspglwj-104.html
+				i18n/css3-text-line-break-baspglwj-105.html
+				i18n/css3-text-line-break-baspglwj-106.html
+				i18n/css3-text-line-break-baspglwj-107.html
+				i18n/css3-text-line-break-baspglwj-108.html
+				i18n/css3-text-line-break-baspglwj-109.html
+				i18n/css3-text-line-break-baspglwj-110.html
+				i18n/css3-text-line-break-baspglwj-111.html
+				i18n/css3-text-line-break-baspglwj-112.html
+				i18n/css3-text-line-break-baspglwj-113.html
+				i18n/css3-text-line-break-baspglwj-114.html
+				i18n/css3-text-line-break-baspglwj-115.html
+				i18n/css3-text-line-break-baspglwj-116.html
+				i18n/css3-text-line-break-baspglwj-117.html
+				i18n/css3-text-line-break-baspglwj-118.html
+				i18n/css3-text-line-break-baspglwj-120.html
+				i18n/css3-text-line-break-baspglwj-121.html
+				i18n/css3-text-line-break-baspglwj-122.html
+				i18n/css3-text-line-break-baspglwj-123.html
+				i18n/css3-text-line-break-baspglwj-124.html
+				i18n/css3-text-line-break-baspglwj-125.html
+				i18n/css3-text-line-break-baspglwj-126.html
+				i18n/css3-text-line-break-baspglwj-127.html
+				i18n/css3-text-line-break-baspglwj-128.html
+				i18n/css3-text-line-break-baspglwj-130.html
+				i18n/css3-text-line-break-baspglwj-131.html
+				line-break/line-break-anywhere-and-white-space-004.html
+				line-break/line-break-anywhere-and-white-space-005.html
+				line-breaking/line-breaking-001.html
+				line-breaking/line-breaking-002.html
+				line-breaking/line-breaking-003.html
+				line-breaking/line-breaking-004.html
+				line-breaking/line-breaking-005.html
+				line-breaking/line-breaking-006.html
+				line-breaking/line-breaking-007.html
+				line-breaking/line-breaking-008.html
+				line-breaking/line-breaking-009.html
+				line-breaking/line-breaking-010.html
+				line-breaking/line-breaking-011.html
+				line-breaking/line-breaking-ic-001.html
+				line-breaking/line-breaking-ic-002.html
+				line-breaking/line-breaking-ic-003.html
+				overflow-wrap/overflow-wrap-anywhere-011.html
+				overflow-wrap/overflow-wrap-break-word-white-space-crash.html
+				parsing/white-space-shorthand-text-wrap.html
+				white-space/trailing-ideographic-space-005.html
+				white-space/trailing-ideographic-space-006.html
+				white-space/trailing-space-and-text-alignment-001.html
+				white-space/trailing-space-and-text-alignment-rtl-001.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-normal-011.html
+				white-space/white-space-nowrap-011.html
+				white-space/white-space-pre-011.html
+				white-space/white-space-pre-031.html
+				white-space/white-space-pre-032.html
+				white-space/white-space-pre-034.html
+				white-space/white-space-pre-035.html
+				white-space/white-space-pre-wrap-justify-001.html
+				white-space/white-space-pre-wrap-justify-002.html
+				white-space/white-space-pre-wrap-justify-003.html
+				white-space/white-space-pre-wrap-justify-004.html
+				white-space/white-space-pre-wrap-trailing-spaces-021.html
+				white-space/white-space-wrap-after-nowrap-001.html
+				white-space/ws-break-spaces-applies-to-012.html
+				white-space/ws-break-spaces-applies-to-013.html
+				word-break/break-boundary-2-chars-001.html
+				word-break/word-break-break-all-062.html
+				word-break/word-break-keep-all-063.html
+			</wpt>
+			<wpt title="tests using wrap through 'white-space: pre-wrap':">
+				crashtests/trailing-space-with-cr-crash.html
+				crashtests/white-space-pre-wrap-chash.html
+				hyphens/hyphens-auto-002.html
+				i18n/css3-text-line-break-baspglwj-001.html
+				i18n/css3-text-line-break-baspglwj-002.html
+				i18n/css3-text-line-break-baspglwj-003.html
+				i18n/css3-text-line-break-baspglwj-004.html
+				i18n/css3-text-line-break-baspglwj-005.html
+				i18n/css3-text-line-break-baspglwj-006.html
+				i18n/css3-text-line-break-baspglwj-007.html
+				i18n/css3-text-line-break-baspglwj-008.html
+				i18n/css3-text-line-break-baspglwj-009.html
+				i18n/css3-text-line-break-baspglwj-010.html
+				i18n/css3-text-line-break-baspglwj-011.html
+				i18n/css3-text-line-break-baspglwj-012.html
+				i18n/css3-text-line-break-baspglwj-014.html
+				i18n/css3-text-line-break-baspglwj-015.html
+				i18n/css3-text-line-break-baspglwj-016.html
+				i18n/css3-text-line-break-baspglwj-017.html
+				i18n/css3-text-line-break-baspglwj-018.html
+				i18n/css3-text-line-break-baspglwj-019.html
+				i18n/css3-text-line-break-baspglwj-020.html
+				i18n/css3-text-line-break-baspglwj-021.html
+				i18n/css3-text-line-break-baspglwj-022.html
+				i18n/css3-text-line-break-baspglwj-023.html
+				i18n/css3-text-line-break-baspglwj-024.html
+				i18n/css3-text-line-break-baspglwj-025.html
+				i18n/css3-text-line-break-baspglwj-026.html
+				i18n/css3-text-line-break-baspglwj-030.html
+				i18n/css3-text-line-break-baspglwj-031.html
+				i18n/css3-text-line-break-baspglwj-032.html
+				i18n/css3-text-line-break-baspglwj-033.html
+				i18n/css3-text-line-break-baspglwj-034.html
+				i18n/css3-text-line-break-baspglwj-035.html
+				i18n/css3-text-line-break-baspglwj-036.html
+				i18n/css3-text-line-break-baspglwj-037.html
+				i18n/css3-text-line-break-baspglwj-038.html
+				i18n/css3-text-line-break-baspglwj-039.html
+				i18n/css3-text-line-break-baspglwj-040.html
+				i18n/css3-text-line-break-baspglwj-041.html
+				i18n/css3-text-line-break-baspglwj-042.html
+				i18n/css3-text-line-break-baspglwj-043.html
+				i18n/css3-text-line-break-baspglwj-044.html
+				i18n/css3-text-line-break-baspglwj-045.html
+				i18n/css3-text-line-break-baspglwj-046.html
+				i18n/css3-text-line-break-baspglwj-047.html
+				i18n/css3-text-line-break-baspglwj-048.html
+				i18n/css3-text-line-break-baspglwj-049.html
+				i18n/css3-text-line-break-baspglwj-050.html
+				i18n/css3-text-line-break-baspglwj-051.html
+				i18n/css3-text-line-break-baspglwj-052.html
+				i18n/css3-text-line-break-baspglwj-060.html
+				i18n/css3-text-line-break-baspglwj-061.html
+				i18n/css3-text-line-break-baspglwj-062.html
+				i18n/css3-text-line-break-baspglwj-063.html
+				i18n/css3-text-line-break-baspglwj-064.html
+				i18n/css3-text-line-break-baspglwj-065.html
+				i18n/css3-text-line-break-baspglwj-066.html
+				i18n/css3-text-line-break-baspglwj-067.html
+				i18n/css3-text-line-break-baspglwj-068.html
+				i18n/css3-text-line-break-baspglwj-069.html
+				i18n/css3-text-line-break-baspglwj-070.html
+				i18n/css3-text-line-break-baspglwj-071.html
+				i18n/css3-text-line-break-baspglwj-072.html
+				i18n/css3-text-line-break-baspglwj-073.html
+				i18n/css3-text-line-break-baspglwj-074.html
+				i18n/css3-text-line-break-baspglwj-075.html
+				i18n/css3-text-line-break-baspglwj-076.html
+				i18n/css3-text-line-break-baspglwj-077.html
+				i18n/css3-text-line-break-baspglwj-078.html
+				i18n/css3-text-line-break-baspglwj-080.html
+				i18n/css3-text-line-break-baspglwj-081.html
+				i18n/css3-text-line-break-baspglwj-082.html
+				i18n/css3-text-line-break-baspglwj-083.html
+				i18n/css3-text-line-break-baspglwj-084.html
+				i18n/css3-text-line-break-baspglwj-085.html
+				i18n/css3-text-line-break-baspglwj-086.html
+				i18n/css3-text-line-break-baspglwj-090.html
+				i18n/css3-text-line-break-baspglwj-091.html
+				i18n/css3-text-line-break-baspglwj-092.html
+				i18n/css3-text-line-break-baspglwj-093.html
+				i18n/css3-text-line-break-baspglwj-095.html
+				i18n/css3-text-line-break-baspglwj-096.html
+				i18n/css3-text-line-break-baspglwj-097.html
+				i18n/css3-text-line-break-baspglwj-098.html
+				i18n/css3-text-line-break-baspglwj-099.html
+				i18n/css3-text-line-break-baspglwj-100.html
+				i18n/css3-text-line-break-baspglwj-101.html
+				i18n/css3-text-line-break-baspglwj-102.html
+				i18n/css3-text-line-break-baspglwj-103.html
+				i18n/css3-text-line-break-baspglwj-104.html
+				i18n/css3-text-line-break-baspglwj-105.html
+				i18n/css3-text-line-break-baspglwj-106.html
+				i18n/css3-text-line-break-baspglwj-107.html
+				i18n/css3-text-line-break-baspglwj-108.html
+				i18n/css3-text-line-break-baspglwj-109.html
+				i18n/css3-text-line-break-baspglwj-110.html
+				i18n/css3-text-line-break-baspglwj-111.html
+				i18n/css3-text-line-break-baspglwj-112.html
+				i18n/css3-text-line-break-baspglwj-113.html
+				i18n/css3-text-line-break-baspglwj-114.html
+				i18n/css3-text-line-break-baspglwj-115.html
+				i18n/css3-text-line-break-baspglwj-116.html
+				i18n/css3-text-line-break-baspglwj-117.html
+				i18n/css3-text-line-break-baspglwj-118.html
+				i18n/css3-text-line-break-baspglwj-120.html
+				i18n/css3-text-line-break-baspglwj-121.html
+				i18n/css3-text-line-break-baspglwj-122.html
+				i18n/css3-text-line-break-baspglwj-123.html
+				i18n/css3-text-line-break-baspglwj-124.html
+				i18n/css3-text-line-break-baspglwj-125.html
+				i18n/css3-text-line-break-baspglwj-126.html
+				i18n/css3-text-line-break-baspglwj-127.html
+				i18n/css3-text-line-break-baspglwj-128.html
+				i18n/css3-text-line-break-baspglwj-130.html
+				i18n/css3-text-line-break-baspglwj-131.html
+				letter-spacing/letter-spacing-200.html
+				letter-spacing/letter-spacing-201.html
+				letter-spacing/letter-spacing-203.html
+				letter-spacing/letter-spacing-204.html
+				letter-spacing/letter-spacing-205.html
+				letter-spacing/letter-spacing-211.html
+				letter-spacing/letter-spacing-212.html
+				line-break/line-break-anywhere-008.html
+				line-break/line-break-anywhere-010.html
+				line-break/line-break-anywhere-and-white-space-006.html
+				line-break/line-break-anywhere-and-white-space-007.html
+				overflow-wrap/overflow-wrap-anywhere-004.html
+				overflow-wrap/overflow-wrap-anywhere-005.html
+				overflow-wrap/overflow-wrap-break-word-004.html
+				overflow-wrap/overflow-wrap-break-word-005.html
+				overflow-wrap/overflow-wrap-break-word-007.html
+				overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
+				overflow-wrap/overflow-wrap-min-content-size-009.html
+				text-justify/text-justify-and-trailing-spaces-001.html
+				text-justify/text-justify-and-trailing-spaces-002.html
+				text-justify/text-justify-and-trailing-spaces-003.html
+				text-justify/text-justify-and-trailing-spaces-004.html
+				text-justify/text-justify-and-trailing-spaces-005.html
+				text-justify/text-justify-and-trailing-spaces-006.html
+				text-transform/text-transform-fullwidth-007.html
+				text-transform/text-transform-fullwidth-009.html
+				white-space/break-spaces-newline-011.html
+				white-space/break-spaces-newline-012.html
+				white-space/break-spaces-newline-013.html
+				white-space/break-spaces-newline-014.html
+				white-space/break-spaces-newline-015.html
+				white-space/break-spaces-newline-016.html
+				white-space/control-chars-00D.html
+				white-space/eol-spaces-bidi-002.html
+				white-space/eol-spaces-bidi-003.html
+				white-space/pre-wrap-001.html
+				white-space/pre-wrap-002.html
+				white-space/pre-wrap-003.html
+				white-space/pre-wrap-004.html
+				white-space/pre-wrap-005.html
+				white-space/pre-wrap-006.html
+				white-space/pre-wrap-007.html
+				white-space/pre-wrap-008.html
+				white-space/pre-wrap-009.html
+				white-space/pre-wrap-010.html
+				white-space/pre-wrap-011.html
+				white-space/pre-wrap-012.html
+				white-space/pre-wrap-013.html
+				white-space/pre-wrap-014.html
+				white-space/pre-wrap-015.html
+				white-space/pre-wrap-016.html
+				white-space/pre-wrap-017.html
+				white-space/pre-wrap-018.html
+				white-space/pre-wrap-019.html
+				white-space/pre-wrap-020.html
+				white-space/pre-wrap-051.html
+				white-space/pre-wrap-052.html
+				white-space/pre-wrap-align-center-001.html
+				white-space/pre-wrap-align-center-002.html
+				white-space/pre-wrap-align-center-003.html
+				white-space/pre-wrap-align-end-001.html
+				white-space/pre-wrap-align-end-002.html
+				white-space/pre-wrap-align-end-003.html
+				white-space/pre-wrap-align-left-001.html
+				white-space/pre-wrap-align-left-002.html
+				white-space/pre-wrap-align-left-003.html
+				white-space/pre-wrap-align-right-001.html
+				white-space/pre-wrap-align-right-002.html
+				white-space/pre-wrap-align-right-003.html
+				white-space/pre-wrap-align-start-001.html
+				white-space/pre-wrap-align-start-002.html
+				white-space/pre-wrap-align-start-003.html
+				white-space/pre-wrap-float-001.html
+				white-space/pre-wrap-leading-spaces-001.html
+				white-space/pre-wrap-leading-spaces-002.html
+				white-space/pre-wrap-leading-spaces-003.html
+				white-space/pre-wrap-leading-spaces-004.html
+				white-space/pre-wrap-leading-spaces-005.html
+				white-space/pre-wrap-leading-spaces-006.html
+				white-space/pre-wrap-leading-spaces-007.html
+				white-space/pre-wrap-leading-spaces-008.html
+				white-space/pre-wrap-leading-spaces-009.html
+				white-space/pre-wrap-leading-spaces-010.html
+				white-space/pre-wrap-leading-spaces-011.html
+				white-space/pre-wrap-leading-spaces-012.html
+				white-space/pre-wrap-leading-spaces-013.html
+				white-space/pre-wrap-leading-spaces-014.html
+				white-space/pre-wrap-leading-spaces-015.html
+				white-space/pre-wrap-leading-spaces-016.html
+				white-space/pre-wrap-leading-spaces-017.html
+				white-space/pre-wrap-tab-001.html
+				white-space/pre-wrap-tab-002.html
+				white-space/pre-wrap-tab-003.html
+				white-space/pre-wrap-tab-004.html
+				white-space/pre-wrap-tab-005.html
+				white-space/pre-wrap-tab-006.html
+				white-space/tab-stop-threshold-003.html
+				white-space/tab-stop-threshold-004.html
+				white-space/textarea-pre-wrap-001.html
+				white-space/textarea-pre-wrap-002.html
+				white-space/textarea-pre-wrap-003.html
+				white-space/textarea-pre-wrap-004.html
+				white-space/textarea-pre-wrap-005.html
+				white-space/textarea-pre-wrap-006.html
+				white-space/textarea-pre-wrap-007.html
+				white-space/textarea-pre-wrap-011.html
+				white-space/textarea-pre-wrap-012.html
+				white-space/textarea-pre-wrap-013.html
+				white-space/textarea-pre-wrap-014.html
+				white-space/trailing-ideographic-space-003.html
+				white-space/trailing-ideographic-space-004.html
+				white-space/trailing-other-space-separators-002.html
+				white-space/trailing-space-align-start.tentative.html
+				white-space/trailing-space-and-text-alignment-003.html
+				white-space/trailing-space-and-text-alignment-rtl-003.html
+				white-space/trailing-space-in-inline-box.html
+				white-space/trailing-space-position-001.html
+				white-space/trailing-space-rtl-001.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-intrinsic-size-003.html
+				white-space/white-space-intrinsic-size-004.html
+				white-space/white-space-intrinsic-size-005.html
+				white-space/white-space-intrinsic-size-006.html
+				white-space/white-space-intrinsic-size-013.html
+				white-space/white-space-intrinsic-size-014.html
+				white-space/white-space-intrinsic-size-017.html
+				white-space/white-space-letter-spacing-001.html
+				white-space/white-space-pre-032.html
+				white-space/white-space-pre-wrap-justify-001.html
+				white-space/white-space-pre-wrap-justify-002.html
+				white-space/white-space-pre-wrap-justify-003.html
+				white-space/white-space-pre-wrap-justify-004.html
+				white-space/white-space-pre-wrap-trailing-spaces-001.html
+				white-space/white-space-pre-wrap-trailing-spaces-002.html
+				white-space/white-space-pre-wrap-trailing-spaces-003.html
+				white-space/white-space-pre-wrap-trailing-spaces-004.html
+				white-space/white-space-pre-wrap-trailing-spaces-005.html
+				white-space/white-space-pre-wrap-trailing-spaces-006.html
+				white-space/white-space-pre-wrap-trailing-spaces-007.html
+				white-space/white-space-pre-wrap-trailing-spaces-008.html
+				white-space/white-space-pre-wrap-trailing-spaces-010.html
+				white-space/white-space-pre-wrap-trailing-spaces-011.html
+				white-space/white-space-pre-wrap-trailing-spaces-012.html
+				white-space/white-space-pre-wrap-trailing-spaces-013.html
+				white-space/white-space-pre-wrap-trailing-spaces-014.html
+				white-space/white-space-pre-wrap-trailing-spaces-015.html
+				white-space/white-space-pre-wrap-trailing-spaces-021.html
+				white-space/white-space-pre-wrap-trailing-spaces-022.html
+				white-space/white-space-pre-wrap-trailing-spaces-023.html
+				word-break/break-boundary-2-chars-001.html
+				word-break/word-break-break-all-010.html
+				word-break/word-break-break-all-011.html
+				word-break/word-break-break-all-015.html
+				word-break/word-break-break-all-019.html
+				word-break/word-break-break-all-021.html
+				word-break/word-break-break-all-062.html
+				word-break/word-break-keep-all-007.html
+				word-break/word-break-keep-all-063.html
+				word-break/word-break-min-content-007.html
+			</wpt>
+			<wpt title="tests using wrap through 'white-space: pre-line':">
+				i18n/css3-text-line-break-baspglwj-001.html
+				i18n/css3-text-line-break-baspglwj-002.html
+				i18n/css3-text-line-break-baspglwj-003.html
+				i18n/css3-text-line-break-baspglwj-004.html
+				i18n/css3-text-line-break-baspglwj-005.html
+				i18n/css3-text-line-break-baspglwj-006.html
+				i18n/css3-text-line-break-baspglwj-007.html
+				i18n/css3-text-line-break-baspglwj-008.html
+				i18n/css3-text-line-break-baspglwj-009.html
+				i18n/css3-text-line-break-baspglwj-010.html
+				i18n/css3-text-line-break-baspglwj-011.html
+				i18n/css3-text-line-break-baspglwj-012.html
+				i18n/css3-text-line-break-baspglwj-014.html
+				i18n/css3-text-line-break-baspglwj-015.html
+				i18n/css3-text-line-break-baspglwj-016.html
+				i18n/css3-text-line-break-baspglwj-017.html
+				i18n/css3-text-line-break-baspglwj-018.html
+				i18n/css3-text-line-break-baspglwj-019.html
+				i18n/css3-text-line-break-baspglwj-020.html
+				i18n/css3-text-line-break-baspglwj-021.html
+				i18n/css3-text-line-break-baspglwj-022.html
+				i18n/css3-text-line-break-baspglwj-023.html
+				i18n/css3-text-line-break-baspglwj-024.html
+				i18n/css3-text-line-break-baspglwj-025.html
+				i18n/css3-text-line-break-baspglwj-026.html
+				i18n/css3-text-line-break-baspglwj-030.html
+				i18n/css3-text-line-break-baspglwj-031.html
+				i18n/css3-text-line-break-baspglwj-032.html
+				i18n/css3-text-line-break-baspglwj-033.html
+				i18n/css3-text-line-break-baspglwj-034.html
+				i18n/css3-text-line-break-baspglwj-035.html
+				i18n/css3-text-line-break-baspglwj-036.html
+				i18n/css3-text-line-break-baspglwj-037.html
+				i18n/css3-text-line-break-baspglwj-038.html
+				i18n/css3-text-line-break-baspglwj-039.html
+				i18n/css3-text-line-break-baspglwj-040.html
+				i18n/css3-text-line-break-baspglwj-041.html
+				i18n/css3-text-line-break-baspglwj-042.html
+				i18n/css3-text-line-break-baspglwj-043.html
+				i18n/css3-text-line-break-baspglwj-044.html
+				i18n/css3-text-line-break-baspglwj-045.html
+				i18n/css3-text-line-break-baspglwj-046.html
+				i18n/css3-text-line-break-baspglwj-047.html
+				i18n/css3-text-line-break-baspglwj-048.html
+				i18n/css3-text-line-break-baspglwj-049.html
+				i18n/css3-text-line-break-baspglwj-050.html
+				i18n/css3-text-line-break-baspglwj-051.html
+				i18n/css3-text-line-break-baspglwj-052.html
+				i18n/css3-text-line-break-baspglwj-060.html
+				i18n/css3-text-line-break-baspglwj-061.html
+				i18n/css3-text-line-break-baspglwj-062.html
+				i18n/css3-text-line-break-baspglwj-063.html
+				i18n/css3-text-line-break-baspglwj-064.html
+				i18n/css3-text-line-break-baspglwj-065.html
+				i18n/css3-text-line-break-baspglwj-066.html
+				i18n/css3-text-line-break-baspglwj-067.html
+				i18n/css3-text-line-break-baspglwj-068.html
+				i18n/css3-text-line-break-baspglwj-069.html
+				i18n/css3-text-line-break-baspglwj-070.html
+				i18n/css3-text-line-break-baspglwj-071.html
+				i18n/css3-text-line-break-baspglwj-072.html
+				i18n/css3-text-line-break-baspglwj-073.html
+				i18n/css3-text-line-break-baspglwj-074.html
+				i18n/css3-text-line-break-baspglwj-075.html
+				i18n/css3-text-line-break-baspglwj-076.html
+				i18n/css3-text-line-break-baspglwj-077.html
+				i18n/css3-text-line-break-baspglwj-078.html
+				i18n/css3-text-line-break-baspglwj-080.html
+				i18n/css3-text-line-break-baspglwj-081.html
+				i18n/css3-text-line-break-baspglwj-082.html
+				i18n/css3-text-line-break-baspglwj-083.html
+				i18n/css3-text-line-break-baspglwj-084.html
+				i18n/css3-text-line-break-baspglwj-085.html
+				i18n/css3-text-line-break-baspglwj-086.html
+				i18n/css3-text-line-break-baspglwj-090.html
+				i18n/css3-text-line-break-baspglwj-091.html
+				i18n/css3-text-line-break-baspglwj-092.html
+				i18n/css3-text-line-break-baspglwj-093.html
+				i18n/css3-text-line-break-baspglwj-095.html
+				i18n/css3-text-line-break-baspglwj-096.html
+				i18n/css3-text-line-break-baspglwj-097.html
+				i18n/css3-text-line-break-baspglwj-098.html
+				i18n/css3-text-line-break-baspglwj-099.html
+				i18n/css3-text-line-break-baspglwj-100.html
+				i18n/css3-text-line-break-baspglwj-101.html
+				i18n/css3-text-line-break-baspglwj-102.html
+				i18n/css3-text-line-break-baspglwj-103.html
+				i18n/css3-text-line-break-baspglwj-104.html
+				i18n/css3-text-line-break-baspglwj-105.html
+				i18n/css3-text-line-break-baspglwj-106.html
+				i18n/css3-text-line-break-baspglwj-107.html
+				i18n/css3-text-line-break-baspglwj-108.html
+				i18n/css3-text-line-break-baspglwj-109.html
+				i18n/css3-text-line-break-baspglwj-110.html
+				i18n/css3-text-line-break-baspglwj-111.html
+				i18n/css3-text-line-break-baspglwj-112.html
+				i18n/css3-text-line-break-baspglwj-113.html
+				i18n/css3-text-line-break-baspglwj-114.html
+				i18n/css3-text-line-break-baspglwj-115.html
+				i18n/css3-text-line-break-baspglwj-116.html
+				i18n/css3-text-line-break-baspglwj-117.html
+				i18n/css3-text-line-break-baspglwj-118.html
+				i18n/css3-text-line-break-baspglwj-120.html
+				i18n/css3-text-line-break-baspglwj-121.html
+				i18n/css3-text-line-break-baspglwj-122.html
+				i18n/css3-text-line-break-baspglwj-123.html
+				i18n/css3-text-line-break-baspglwj-124.html
+				i18n/css3-text-line-break-baspglwj-125.html
+				i18n/css3-text-line-break-baspglwj-126.html
+				i18n/css3-text-line-break-baspglwj-127.html
+				i18n/css3-text-line-break-baspglwj-128.html
+				i18n/css3-text-line-break-baspglwj-130.html
+				i18n/css3-text-line-break-baspglwj-131.html
+				white-space/control-chars-00D.html
+				white-space/pre-line-051.html
+				white-space/pre-line-052.html
+				white-space/pre-line-br-with-whitespace-child-crash.html
+				white-space/pre-line-with-space-and-newline.html
+				white-space/trailing-ideographic-space-008.html
+				white-space/trailing-ideographic-space-010.html
+				white-space/trailing-ogham-002.html
+				white-space/trailing-other-space-separators-003.html
+				white-space/trailing-space-and-text-alignment-005.html
+				white-space/trailing-space-and-text-alignment-rtl-005.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-intrinsic-size-019.html
+				white-space/white-space-intrinsic-size-020.html
+				white-space/white-space-letter-spacing-001.html
+				white-space/white-space-pre-035.html
+				word-break/break-boundary-2-chars-001.html
+				word-break/word-break-break-all-062.html
+				word-break/word-break-keep-all-063.html
+			</wpt>
+			<wpt title="tests using wrap through 'white-space: break-spaces':">
+				i18n/css3-text-line-break-baspglwj-001.html
+				i18n/css3-text-line-break-baspglwj-002.html
+				i18n/css3-text-line-break-baspglwj-003.html
+				i18n/css3-text-line-break-baspglwj-004.html
+				i18n/css3-text-line-break-baspglwj-005.html
+				i18n/css3-text-line-break-baspglwj-006.html
+				i18n/css3-text-line-break-baspglwj-007.html
+				i18n/css3-text-line-break-baspglwj-008.html
+				i18n/css3-text-line-break-baspglwj-009.html
+				i18n/css3-text-line-break-baspglwj-010.html
+				i18n/css3-text-line-break-baspglwj-011.html
+				i18n/css3-text-line-break-baspglwj-012.html
+				i18n/css3-text-line-break-baspglwj-014.html
+				i18n/css3-text-line-break-baspglwj-015.html
+				i18n/css3-text-line-break-baspglwj-016.html
+				i18n/css3-text-line-break-baspglwj-017.html
+				i18n/css3-text-line-break-baspglwj-018.html
+				i18n/css3-text-line-break-baspglwj-019.html
+				i18n/css3-text-line-break-baspglwj-020.html
+				i18n/css3-text-line-break-baspglwj-021.html
+				i18n/css3-text-line-break-baspglwj-022.html
+				i18n/css3-text-line-break-baspglwj-023.html
+				i18n/css3-text-line-break-baspglwj-024.html
+				i18n/css3-text-line-break-baspglwj-025.html
+				i18n/css3-text-line-break-baspglwj-026.html
+				i18n/css3-text-line-break-baspglwj-030.html
+				i18n/css3-text-line-break-baspglwj-031.html
+				i18n/css3-text-line-break-baspglwj-032.html
+				i18n/css3-text-line-break-baspglwj-033.html
+				i18n/css3-text-line-break-baspglwj-034.html
+				i18n/css3-text-line-break-baspglwj-035.html
+				i18n/css3-text-line-break-baspglwj-036.html
+				i18n/css3-text-line-break-baspglwj-037.html
+				i18n/css3-text-line-break-baspglwj-038.html
+				i18n/css3-text-line-break-baspglwj-039.html
+				i18n/css3-text-line-break-baspglwj-040.html
+				i18n/css3-text-line-break-baspglwj-041.html
+				i18n/css3-text-line-break-baspglwj-042.html
+				i18n/css3-text-line-break-baspglwj-043.html
+				i18n/css3-text-line-break-baspglwj-044.html
+				i18n/css3-text-line-break-baspglwj-045.html
+				i18n/css3-text-line-break-baspglwj-046.html
+				i18n/css3-text-line-break-baspglwj-047.html
+				i18n/css3-text-line-break-baspglwj-048.html
+				i18n/css3-text-line-break-baspglwj-049.html
+				i18n/css3-text-line-break-baspglwj-050.html
+				i18n/css3-text-line-break-baspglwj-051.html
+				i18n/css3-text-line-break-baspglwj-052.html
+				i18n/css3-text-line-break-baspglwj-060.html
+				i18n/css3-text-line-break-baspglwj-061.html
+				i18n/css3-text-line-break-baspglwj-062.html
+				i18n/css3-text-line-break-baspglwj-063.html
+				i18n/css3-text-line-break-baspglwj-064.html
+				i18n/css3-text-line-break-baspglwj-065.html
+				i18n/css3-text-line-break-baspglwj-066.html
+				i18n/css3-text-line-break-baspglwj-067.html
+				i18n/css3-text-line-break-baspglwj-068.html
+				i18n/css3-text-line-break-baspglwj-069.html
+				i18n/css3-text-line-break-baspglwj-070.html
+				i18n/css3-text-line-break-baspglwj-071.html
+				i18n/css3-text-line-break-baspglwj-072.html
+				i18n/css3-text-line-break-baspglwj-073.html
+				i18n/css3-text-line-break-baspglwj-074.html
+				i18n/css3-text-line-break-baspglwj-075.html
+				i18n/css3-text-line-break-baspglwj-076.html
+				i18n/css3-text-line-break-baspglwj-077.html
+				i18n/css3-text-line-break-baspglwj-078.html
+				i18n/css3-text-line-break-baspglwj-080.html
+				i18n/css3-text-line-break-baspglwj-081.html
+				i18n/css3-text-line-break-baspglwj-082.html
+				i18n/css3-text-line-break-baspglwj-083.html
+				i18n/css3-text-line-break-baspglwj-084.html
+				i18n/css3-text-line-break-baspglwj-085.html
+				i18n/css3-text-line-break-baspglwj-086.html
+				i18n/css3-text-line-break-baspglwj-090.html
+				i18n/css3-text-line-break-baspglwj-091.html
+				i18n/css3-text-line-break-baspglwj-092.html
+				i18n/css3-text-line-break-baspglwj-093.html
+				i18n/css3-text-line-break-baspglwj-095.html
+				i18n/css3-text-line-break-baspglwj-096.html
+				i18n/css3-text-line-break-baspglwj-097.html
+				i18n/css3-text-line-break-baspglwj-098.html
+				i18n/css3-text-line-break-baspglwj-099.html
+				i18n/css3-text-line-break-baspglwj-100.html
+				i18n/css3-text-line-break-baspglwj-101.html
+				i18n/css3-text-line-break-baspglwj-102.html
+				i18n/css3-text-line-break-baspglwj-103.html
+				i18n/css3-text-line-break-baspglwj-104.html
+				i18n/css3-text-line-break-baspglwj-105.html
+				i18n/css3-text-line-break-baspglwj-106.html
+				i18n/css3-text-line-break-baspglwj-107.html
+				i18n/css3-text-line-break-baspglwj-108.html
+				i18n/css3-text-line-break-baspglwj-109.html
+				i18n/css3-text-line-break-baspglwj-110.html
+				i18n/css3-text-line-break-baspglwj-111.html
+				i18n/css3-text-line-break-baspglwj-112.html
+				i18n/css3-text-line-break-baspglwj-113.html
+				i18n/css3-text-line-break-baspglwj-114.html
+				i18n/css3-text-line-break-baspglwj-115.html
+				i18n/css3-text-line-break-baspglwj-116.html
+				i18n/css3-text-line-break-baspglwj-117.html
+				i18n/css3-text-line-break-baspglwj-118.html
+				i18n/css3-text-line-break-baspglwj-120.html
+				i18n/css3-text-line-break-baspglwj-121.html
+				i18n/css3-text-line-break-baspglwj-122.html
+				i18n/css3-text-line-break-baspglwj-123.html
+				i18n/css3-text-line-break-baspglwj-124.html
+				i18n/css3-text-line-break-baspglwj-125.html
+				i18n/css3-text-line-break-baspglwj-126.html
+				i18n/css3-text-line-break-baspglwj-127.html
+				i18n/css3-text-line-break-baspglwj-128.html
+				i18n/css3-text-line-break-baspglwj-130.html
+				i18n/css3-text-line-break-baspglwj-131.html
+				line-break/line-break-anywhere-005.html
+				line-break/line-break-anywhere-009.html
+				line-break/line-break-anywhere-and-white-space-008.html
+				line-break/line-break-anywhere-and-white-space-009.html
+				overflow-wrap/overflow-wrap-anywhere-002.html
+				overflow-wrap/overflow-wrap-anywhere-003.html
+				overflow-wrap/overflow-wrap-break-word-002.html
+				overflow-wrap/overflow-wrap-break-word-003.html
+				overflow-wrap/overflow-wrap-break-word-006.html
+				overflow-wrap/overflow-wrap-break-word-008.html
+				white-space/break-spaces-001.html
+				white-space/break-spaces-002.html
+				white-space/break-spaces-003.html
+				white-space/break-spaces-004.html
+				white-space/break-spaces-005.html
+				white-space/break-spaces-006.html
+				white-space/break-spaces-007.html
+				white-space/break-spaces-008.html
+				white-space/break-spaces-009.html
+				white-space/break-spaces-010.html
+				white-space/break-spaces-011.html
+				white-space/break-spaces-051.html
+				white-space/break-spaces-052.html
+				white-space/break-spaces-before-first-char-001.html
+				white-space/break-spaces-before-first-char-002.html
+				white-space/break-spaces-before-first-char-003.html
+				white-space/break-spaces-before-first-char-004.html
+				white-space/break-spaces-before-first-char-005.html
+				white-space/break-spaces-before-first-char-006.html
+				white-space/break-spaces-before-first-char-007.html
+				white-space/break-spaces-before-first-char-008.html
+				white-space/break-spaces-before-first-char-009.html
+				white-space/break-spaces-before-first-char-010.html
+				white-space/break-spaces-before-first-char-011.html
+				white-space/break-spaces-before-first-char-012.html
+				white-space/break-spaces-before-first-char-013.html
+				white-space/break-spaces-before-first-char-014.html
+				white-space/break-spaces-before-first-char-015.html
+				white-space/break-spaces-before-first-char-016.html
+				white-space/break-spaces-before-first-char-017.html
+				white-space/break-spaces-before-first-char-018.html
+				white-space/break-spaces-before-first-ideographic-char-001.html
+				white-space/break-spaces-before-first-ideographic-char-002.html
+				white-space/break-spaces-before-first-ideographic-char-003.html
+				white-space/break-spaces-before-first-ideographic-char-004.html
+				white-space/break-spaces-before-first-ideographic-char-005.html
+				white-space/break-spaces-before-first-ideographic-char-006.html
+				white-space/break-spaces-before-first-ideographic-char-007.html
+				white-space/break-spaces-before-first-ideographic-char-008.html
+				white-space/break-spaces-before-first-ideographic-char-009.html
+				white-space/break-spaces-before-first-ideographic-char-010.html
+				white-space/break-spaces-before-first-ideographic-char-011.html
+				white-space/break-spaces-before-first-ideographic-char-012.html
+				white-space/break-spaces-before-first-ideographic-char-013.html
+				white-space/break-spaces-before-first-ideographic-char-014.html
+				white-space/break-spaces-before-first-ideographic-char-015.html
+				white-space/break-spaces-before-first-ideographic-char-016.html
+				white-space/break-spaces-before-first-ideographic-char-017.html
+				white-space/break-spaces-before-first-ideographic-char-018.html
+				white-space/break-spaces-newline-011.html
+				white-space/break-spaces-newline-012.html
+				white-space/break-spaces-newline-013.html
+				white-space/break-spaces-newline-014.html
+				white-space/break-spaces-newline-015.html
+				white-space/break-spaces-newline-016.html
+				white-space/break-spaces-tab-001.html
+				white-space/break-spaces-tab-002.html
+				white-space/break-spaces-tab-003.html
+				white-space/break-spaces-tab-004.html
+				white-space/break-spaces-tab-005.html
+				white-space/break-spaces-tab-006.html
+				white-space/break-spaces-with-ideographic-space-001.html
+				white-space/break-spaces-with-ideographic-space-002.html
+				white-space/break-spaces-with-ideographic-space-003.html
+				white-space/break-spaces-with-ideographic-space-004.html
+				white-space/break-spaces-with-ideographic-space-005.html
+				white-space/break-spaces-with-ideographic-space-006.html
+				white-space/break-spaces-with-ideographic-space-007.html
+				white-space/break-spaces-with-ideographic-space-008.html
+				white-space/break-spaces-with-ideographic-space-009.html
+				white-space/break-spaces-with-ideographic-space-010.html
+				white-space/break-spaces-with-overflow-wrap-001.html
+				white-space/break-spaces-with-overflow-wrap-002.html
+				white-space/break-spaces-with-overflow-wrap-003.html
+				white-space/break-spaces-with-overflow-wrap-004.html
+				white-space/break-spaces-with-overflow-wrap-005.html
+				white-space/break-spaces-with-overflow-wrap-006.html
+				white-space/break-spaces-with-overflow-wrap-007.html
+				white-space/break-spaces-with-overflow-wrap-008.html
+				white-space/break-spaces-with-overflow-wrap-009.html
+				white-space/break-spaces-with-overflow-wrap-010.html
+				white-space/control-chars-00D.html
+				white-space/tab-stop-threshold-005.html
+				white-space/tab-stop-threshold-006.html
+				white-space/textarea-break-spaces-001.html
+				white-space/textarea-break-spaces-002.html
+				white-space/trailing-ideographic-space-break-spaces-001.html
+				white-space/trailing-ideographic-space-break-spaces-002.html
+				white-space/trailing-ideographic-space-break-spaces-003.html
+				white-space/trailing-ideographic-space-break-spaces-004.html
+				white-space/trailing-ideographic-space-break-spaces-005.html
+				white-space/trailing-ideographic-space-break-spaces-006.html
+				white-space/trailing-ideographic-space-break-spaces-007.html
+				white-space/trailing-ideographic-space-break-spaces-008.html
+				white-space/trailing-other-space-separators-break-spaces-001.html
+				white-space/trailing-other-space-separators-break-spaces-002.html
+				white-space/trailing-other-space-separators-break-spaces-003.html
+				white-space/trailing-other-space-separators-break-spaces-004.html
+				white-space/trailing-other-space-separators-break-spaces-005.html
+				white-space/trailing-other-space-separators-break-spaces-006.html
+				white-space/trailing-other-space-separators-break-spaces-007.html
+				white-space/trailing-other-space-separators-break-spaces-008.html
+				white-space/trailing-other-space-separators-break-spaces-009.html
+				white-space/trailing-other-space-separators-break-spaces-010.html
+				white-space/trailing-other-space-separators-break-spaces-011.html
+				white-space/trailing-other-space-separators-break-spaces-012.html
+				white-space/trailing-other-space-separators-break-spaces-013.html
+				white-space/trailing-other-space-separators-break-spaces-014.html
+				white-space/trailing-other-space-separators-break-spaces-015.html
+				white-space/trailing-space-and-text-alignment-004.html
+				white-space/trailing-space-and-text-alignment-rtl-004.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-intrinsic-size-001.html
+				white-space/white-space-intrinsic-size-002.html
+				white-space/white-space-letter-spacing-001.html
+				white-space/white-space-pre-034.html
+				white-space/ws-break-spaces-applies-to-001.html
+				white-space/ws-break-spaces-applies-to-002.html
+				white-space/ws-break-spaces-applies-to-003.html
+				white-space/ws-break-spaces-applies-to-005.html
+				white-space/ws-break-spaces-applies-to-006.html
+				white-space/ws-break-spaces-applies-to-007.html
+				white-space/ws-break-spaces-applies-to-008.html
+				white-space/ws-break-spaces-applies-to-009.html
+				white-space/ws-break-spaces-applies-to-010.html
+				white-space/ws-break-spaces-applies-to-011.html
+				white-space/ws-break-spaces-applies-to-012.html
+				white-space/ws-break-spaces-applies-to-013.html
+				white-space/ws-break-spaces-applies-to-014.html
+				white-space/ws-break-spaces-applies-to-015.html
+				word-break/break-boundary-2-chars-001.html
+				word-break/word-break-break-all-012.html
+				word-break/word-break-break-all-013.html
+				word-break/word-break-break-all-017.html
+				word-break/word-break-break-all-022.html
+				word-break/word-break-break-all-062.html
+				word-break/word-break-keep-all-008.html
+				word-break/word-break-keep-all-063.html
+			</wpt>
+
+			Note: See [[#line-break-details]] for more information
+			about rules and constrains on [=soft wrap opportunities=].
+
+		<dt><dfn>nowrap</dfn>
+		<dd>
+			Inline-level content does not break across lines;
+			content that does not fit within the block container overflows it.
+
+			<wpt title="tests using nowrap directly through 'text-wrap-mode':">
+			</wpt>
+			<wpt title="tests using nowrap through 'text-wrap: nowrap':">
+			</wpt>
+			<wpt title="CSS 2 indirect tests via 'white-space: pre':" pathprefix="/css/CSS2/text/">
+				white-space-pre-001.xht
+				white-space-pre-002.xht
+				white-space-pre-005.xht
+				white-space-pre-006.xht
+			</wpt>
+			<wpt title="CSS 2 indirect tests via 'white-space: nowrap':" pathprefix="/css/CSS2/text/">
+				white-space-nowrap-001.xht
+				white-space-nowrap-005.xht
+				white-space-nowrap-006.xht
+				text-align-white-space-004.xht
+				text-align-white-space-008.xht
+				white-space-nowrap-attribute-001.xht
+				white-space-processing-006.xht
+			</wpt>
+			<wpt title="tests using nowrap through 'white-space: pre':">
+				bidi/bidi-lines-001.html
+				bidi/bidi-tab-001.html
+				letter-spacing/letter-spacing-206.html
+				letter-spacing/letter-spacing-bidi-003.xht
+				letter-spacing/letter-spacing-bidi-004.xht
+				letter-spacing/letter-spacing-bidi-005.xht
+				letter-spacing/letter-spacing-nesting-003.xht
+				line-break/line-break-anywhere-005.html
+				line-break/line-break-anywhere-and-white-space-001.html
+				line-break/line-break-anywhere-and-white-space-003.html
+				line-breaking/line-breaking-009.html
+				line-breaking/line-breaking-010.html
+				line-breaking/line-breaking-011.html
+				line-breaking/line-breaking-023.html
+				line-breaking/line-breaking-024.html
+				line-breaking/line-breaking-025.html
+				line-breaking/line-breaking-026.html
+				line-breaking/line-breaking-027.html
+				line-breaking/line-breaking-ic-001.html
+				line-breaking/line-breaking-ic-002.html
+				line-breaking/line-breaking-ic-003.html
+				line-breaking/line-breaking-replaced-006.html
+				overflow-wrap/overflow-wrap-break-word-007.html
+				overflow-wrap/overflow-wrap-break-word-008.html
+				overflow-wrap/overflow-wrap-break-word-white-space-crash.html
+				tab-size/tab-size-block-ancestor.html
+				tab-size/tab-size-inheritance-001.html
+				tab-size/tab-size-inline-001.html
+				tab-size/tab-size-inline-002.html
+				tab-size/tab-size-integer-004.html
+				tab-size/tab-size-spacing-001.html
+				tab-size/tab-size-spacing-002.html
+				tab-size/tab-size-spacing-003.html
+				text-indent/text-indent-length-002.html
+				text-indent/text-indent-tab-positions-001.html
+				text-justify/text-justify-006.html
+				text-transform/text-transform-capitalize-035.html
+				text-transform/text-transform-fullwidth-008.html
+				text-transform/text-transform-fullwidth-009.html
+				white-space/break-spaces-009.html
+				white-space/break-spaces-newline-011.html
+				white-space/break-spaces-newline-012.html
+				white-space/break-spaces-newline-013.html
+				white-space/break-spaces-newline-014.html
+				white-space/break-spaces-newline-015.html
+				white-space/break-spaces-newline-016.html
+				white-space/break-spaces-tab-005.html
+				white-space/break-spaces-tab-006.html
+				white-space/break-spaces-with-ideographic-space-009.html
+				white-space/break-spaces-with-overflow-wrap-009.html
+				white-space/break-spaces-with-overflow-wrap-010.html
+				white-space/control-chars-00D.html
+				white-space/eol-spaces-bidi-001.html
+				white-space/eol-spaces-bidi-002.html
+				white-space/pre-float-001.html
+				white-space/pre-with-whitespace-crash.html
+				white-space/pre-wrap-008.html
+				white-space/pre-wrap-009.html
+				white-space/pre-wrap-010.html
+				white-space/pre-wrap-016.html
+				white-space/pre-wrap-018.html
+				white-space/pre-wrap-019.html
+				white-space/pre-wrap-020.html
+				white-space/tab-bidi-001.html
+				white-space/tab-stop-threshold-001.html
+				white-space/tab-stop-threshold-002.html
+				white-space/trailing-other-space-separators-001.html
+				white-space/trailing-other-space-separators-003.html
+				white-space/trailing-other-space-separators-004.html
+				white-space/trailing-other-space-separators-break-spaces-001.html
+				white-space/trailing-other-space-separators-break-spaces-002.html
+				white-space/trailing-other-space-separators-break-spaces-003.html
+				white-space/trailing-other-space-separators-break-spaces-004.html
+				white-space/trailing-other-space-separators-break-spaces-005.html
+				white-space/trailing-other-space-separators-break-spaces-006.html
+				white-space/trailing-other-space-separators-break-spaces-007.html
+				white-space/trailing-other-space-separators-break-spaces-008.html
+				white-space/trailing-other-space-separators-break-spaces-009.html
+				white-space/trailing-other-space-separators-break-spaces-010.html
+				white-space/trailing-other-space-separators-break-spaces-011.html
+				white-space/trailing-other-space-separators-break-spaces-012.html
+				white-space/trailing-other-space-separators-break-spaces-013.html
+				white-space/trailing-other-space-separators-break-spaces-014.html
+				white-space/trailing-other-space-separators-break-spaces-015.html
+				white-space/trailing-space-align-start.tentative.html
+				white-space/trailing-space-and-text-alignment-002.html
+				white-space/trailing-space-and-text-alignment-rtl-002.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-intrinsic-size-015.html
+				white-space/white-space-intrinsic-size-016.html
+				white-space/white-space-intrinsic-size-018.html
+				white-space/white-space-letter-spacing-001.html
+				white-space/white-space-normal-011.html
+				white-space/white-space-pre-011.html
+				white-space/white-space-pre-031.html
+				white-space/white-space-pre-032.html
+				white-space/white-space-pre-034.html
+				white-space/white-space-pre-035.html
+				white-space/white-space-pre-051.html
+				white-space/white-space-pre-052.html
+				white-space/ws-break-spaces-applies-to-001.html
+				white-space/ws-break-spaces-applies-to-002.html
+				white-space/ws-break-spaces-applies-to-003.html
+				white-space/ws-break-spaces-applies-to-005.html
+				white-space/ws-break-spaces-applies-to-006.html
+				white-space/ws-break-spaces-applies-to-007.html
+				white-space/ws-break-spaces-applies-to-008.html
+				white-space/ws-break-spaces-applies-to-009.html
+				white-space/ws-break-spaces-applies-to-010.html
+				white-space/ws-break-spaces-applies-to-011.html
+				white-space/ws-break-spaces-applies-to-014.html
+				white-space/ws-break-spaces-applies-to-015.html
+				word-break/break-boundary-2-chars-001.html
+				word-break/break-boundary-2-chars-002.html
+				word-break/word-break-break-all-010.html
+				word-break/word-break-break-all-011.html
+				word-break/word-break-break-all-012.html
+				word-break/word-break-break-all-013.html
+				word-break/word-break-break-all-015.html
+				word-break/word-break-break-all-017.html
+				word-break/word-break-break-all-ethiopic.html
+				word-break/word-break-normal-ethiopic.html
+				word-space-transform/word-space-transform-008.html
+				word-space-transform/word-space-transform-011.html
+			</wpt>
+			<wpt title="tests using nowrap through 'white-space: nowrap':">
+				hanging-punctuation/hanging-punctuation-allow-end-001.xht
+				hanging-punctuation/hanging-punctuation-first-001.xht
+				hanging-punctuation/hanging-punctuation-force-end-001.xht
+				hanging-punctuation/hanging-punctuation-last-001.xht
+				letter-spacing/letter-spacing-206.html
+				line-break/line-break-anywhere-and-white-space-002.html
+				line-breaking/line-breaking-012.html
+				line-breaking/line-breaking-atomic-nowrap-001.html
+				overflow-wrap/overflow-wrap-002.html
+				overflow-wrap/overflow-wrap-anywhere-008.html
+				overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
+				overflow-wrap/word-wrap-002.html
+				text-transform/text-transform-capitalize-001.html
+				text-transform/text-transform-capitalize-003.html
+				text-transform/text-transform-capitalize-005.html
+				text-transform/text-transform-capitalize-007.html
+				text-transform/text-transform-capitalize-009.html
+				text-transform/text-transform-capitalize-010.html
+				text-transform/text-transform-capitalize-011.html
+				text-transform/text-transform-capitalize-014.html
+				text-transform/text-transform-capitalize-016.html
+				text-transform/text-transform-capitalize-018.html
+				text-transform/text-transform-capitalize-020.html
+				text-transform/text-transform-capitalize-022.html
+				text-transform/text-transform-capitalize-024.html
+				text-transform/text-transform-capitalize-026.html
+				text-transform/text-transform-capitalize-028.html
+				text-transform/text-transform-capitalize-030.html
+				text-transform/text-transform-full-size-kana-005.html
+				text-transform/text-transform-full-size-kana-006.html
+				text-transform/text-transform-full-size-kana-007.html
+				text-transform/text-transform-fullwidth-001.xht
+				text-transform/text-transform-upperlower-001.html
+				text-transform/text-transform-upperlower-002.html
+				text-transform/text-transform-upperlower-003.html
+				text-transform/text-transform-upperlower-004.html
+				text-transform/text-transform-upperlower-005.html
+				text-transform/text-transform-upperlower-006.html
+				text-transform/text-transform-upperlower-007.html
+				text-transform/text-transform-upperlower-008.html
+				text-transform/text-transform-upperlower-009.html
+				text-transform/text-transform-upperlower-010.html
+				text-transform/text-transform-upperlower-011.html
+				text-transform/text-transform-upperlower-012.html
+				text-transform/text-transform-upperlower-014.html
+				text-transform/text-transform-upperlower-015.html
+				text-transform/text-transform-upperlower-016.html
+				text-transform/text-transform-upperlower-017.html
+				text-transform/text-transform-upperlower-018.html
+				text-transform/text-transform-upperlower-019.html
+				text-transform/text-transform-upperlower-020.html
+				text-transform/text-transform-upperlower-021.html
+				text-transform/text-transform-upperlower-022.html
+				text-transform/text-transform-upperlower-023.html
+				text-transform/text-transform-upperlower-024.html
+				text-transform/text-transform-upperlower-025.html
+				text-transform/text-transform-upperlower-026.html
+				text-transform/text-transform-upperlower-027.html
+				text-transform/text-transform-upperlower-028.html
+				text-transform/text-transform-upperlower-029.html
+				text-transform/text-transform-upperlower-030.html
+				text-transform/text-transform-upperlower-031.html
+				text-transform/text-transform-upperlower-032.html
+				text-transform/text-transform-upperlower-033.html
+				text-transform/text-transform-upperlower-034.html
+				text-transform/text-transform-upperlower-035.html
+				text-transform/text-transform-upperlower-039.html
+				text-transform/text-transform-upperlower-040.html
+				text-transform/text-transform-upperlower-041.html
+				text-transform/text-transform-upperlower-042.html
+				text-transform/text-transform-upperlower-043.html
+				text-transform/text-transform-upperlower-044.html
+				text-transform/text-transform-upperlower-101.html
+				text-transform/text-transform-upperlower-102.html
+				text-transform/text-transform-upperlower-103.html
+				text-transform/text-transform-upperlower-104.html
+				white-space/control-chars-00D.html
+				white-space/nowrap-wbr-and-space-crash.html
+				white-space/trailing-ideographic-space-007.html
+				white-space/trailing-ideographic-space-009.html
+				white-space/trailing-ogham-003.html
+				white-space/trailing-other-space-separators-004.html
+				white-space/white-space-applies-to-text-001.html
+				white-space/white-space-nowrap-011.html
+				white-space/white-space-wrap-after-nowrap-001.html
+				word-break/auto-phrase/word-break-auto-phrase-wbr-nobr-002.html
+				word-break/break-boundary-2-chars-002.html
+				word-break/word-break-break-word-crash-001.html
+			</wpt>
+	</dl>
+
+	Regardless of the 'text-wrap-mode' value,
+	[=preserved=] [=segment breaks=],
+	and any Unicode character with the <code>BK</code>, <code>CR</code>, <code>LF</code>, and <code>NL</code> line breaking class,
+	must be treated as [=forced line breaks=].
+	[[!UAX14]]
+
+	<wpt>
+	line-breaking/line-breaking-022.html
+	</wpt>
+
+	Note: The bidi implications of such [=forced line breaks=]
+	are defined by the <a href="https://www.unicode.org/reports/tr9/"><cite>Unicode Bidirectional Algorithm</cite></a>.
+	[[!UAX9]]
+
+<h4 id="text-wrap-style">
+Selecting How to Wrap: the 'text-wrap-style' property</h4>
+
+	<wpt title="
+		This property has limited coverage.
+
+		Missing test:
+		* tests for values other than balance
+		* Direct tests of this property as a longhand"></wpt>
+
+	<pre class="propdef">
+	Name: text-wrap-style
+	Value: auto| balance | stable | pretty
+	Initial: auto
+	Applies to: [=block containers=] hat establish an [=inline formatting context=]
+	Inherited: yes
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	When wrapping is allowed
+	(see 'text-wrap-mode'),
+	this property selects between several approaches for wrapping lines,
+	trading off between speed, quality and style of layout, or stability.
+	It does not change which [=soft wrap opportunity=] exist,
+	but changes how the user agent selects among them.
+	Possible values:
+
+	<dl dfn-for=text-wrap-style dfn-type=value>
+		<dt><dfn>auto</dfn>
+		<dd>
+			The exact algorithm for selecting
+			which [=soft wrap opportunity=] to break at is UA-defined.
+			The algorithm <em>may</em> consider multiple lines
+			when making break decisions.
+			The UA <em>may</em> bias for speed over best layout.
+			The UA <em>must not</em> attempt to even out all lines
+			(including the last) as for ''text-wrap-style/balance''.
+			This value selects the UA’s preferred (or most Web-compatible)
+			wrapping algorithm.
+
+		<dt><dfn>balance</dfn>
+		<dd>
+			Line breaks are chosen to balance
+			the remaining (empty) space in each line box,
+			if better balance than ''text-wrap-style/auto'' is possible.
+			This must not change the number of line boxes
+			the block would contain
+			if 'text-wrap' were set to ''text-wrap-style/auto''.
+
+			<wpt>
+				white-space/text-wrap-balance-001.html
+				white-space/text-wrap-balance-002.html
+				white-space/text-wrap-balance-align-001.html
+				white-space/text-wrap-balance-dynamic-001.html
+				white-space/text-wrap-balance-line-clamp-001.html
+				white-space/text-wrap-balance-narrow-crash.html
+				crashtests/text-wrap-balance-float-crash.html
+			</wpt>
+
+			The remaining space to consider
+			is that which remains after placing floats and inline content,
+			but before any adjustments due to text justification.
+			Line boxes are balanced when the standard deviation
+			from the average <a>inline-size</a> of the remaining space in each line box
+			is reduced over the block
+			(including lines that end in a forced break).
+
+			<wpt>
+				white-space/text-wrap-balance-text-indent-001.html
+			</wpt>
+
+			The exact algorithm is UA-defined.
+
+			UAs may treat this value as ''text-wrap-style/auto'' if there are more than ten lines to balance.
+
+		<dt><dfn>stable</dfn>
+		<dd>
+			Specifies that content on subsequent lines
+			<em>should not</em> be considered when making break decisions
+			so that when editing text any content before the cursor
+			remains stable;
+			otherwise equivalent to ''text-wrap-style/auto'',
+
+		<dt><dfn>pretty</dfn>
+		<dd>
+			Specifies the UA <em>should</em> bias for better layout over speed,
+			and is expected to consider multiple lines,
+			when making break decisions.
+			Otherwise equivalent to ''text-wrap-style/auto'',
+	</dl>
+
+	<!-- add a sample prioritization algorithm -->
+
+	Note: The ''text-wrap-style/auto'' value will typically map
+	to Web browsers’ speedy legacy line breaking,
+	which has so far used first-fit/greedy algorithms
+	that can often give sub-optimal results.
+	UAs can experiment with better line breaking algorithms
+	with this default value,
+	but as optimal results often take more time,
+	''text-wrap-style/pretty'' is offered as an opt-in
+	to take more time for better results.
+	The ''text-wrap-style/pretty'' value is intended for body text,
+	where the last line is expected to be a bit shorter than the average line;
+	the ''text-wrap-style/balance'' value is intended for titles and captions,
+	where equal-length lines of text tend to be preferred;
+	and the ''text-wrap-style/stable'' is intended for sections that are,
+	or are likely become toggled as,
+	editable.
+
+	<div class="issue" id="last-line-limits">
+		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
+		Issue is about requiring a minimum length for lines.
+		Common measures seem to be
+
+		<ul>
+			<li>At least as long as the text-indent.
+			<li>At least X characters.
+			<li>Percentage-based.
+		</ul>
+
+		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
+		(with ''Xch'' given as an example to make that use case clear).
+		Alternately <<integer>> could actually count the characters.
+
+		It's unclear how this would interact with text balancing (above);
+		one earlier proposal had them be the same property
+		(with ''100%'' meaning full balancing).
+
+		People have requested word-based limits, but since this is really
+		dependent on the length of the word, character-based is better.
+	</div>
+
+<h3 id="wrap-before">
+Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
+
+	<wpt title="This section lacks tests."></wpt>
+
+	<pre class="propdef">
+	Name: wrap-before, wrap-after
+	Value: auto | avoid | avoid-line | avoid-flex | line | flex
+	Initial: auto
+	Applies to: <a>inline-level</a> boxes and <a>flex items</a>
+	Inherited: no
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	These properties specify modifications to break opportunities
+	in line breaking (and <a>flex line</a> breaking [[CSS3-FLEXBOX]]).
+	Possible values:
+
+	<dl dfn-for="wrap-before, wrap-after" dfn-type=value>
+		<dt><dfn>auto</dfn>
+		<dd>
+			Lines may break at allowed break points
+			before and after the box,
+			as determined by the line-breaking rules in effect.
+
+		<dt><dfn>avoid</dfn>
+		<dd>
+			Line breaking is suppressed immediately before/after the box:
+			the UA may only break there
+			if there are no other valid break points
+			in the line.
+			If the text breaks,
+			line-breaking restrictions are honored as for
+			''wrap-before/auto''.
+
+		<dt><dfn>avoid-line</dfn>
+		<dd>
+			Same as ''wrap-before/avoid'',
+			but only for line breaks.
+
+		<dt><dfn>avoid-flex</dfn>
+		<dd>
+			Same as ''wrap-before/avoid'',
+			but only for flex line breaks.
+
+		<dt><dfn>line</dfn>
+		<dd>
+			Force a line break immediately before/after the box
+			if the box is an <a>inline-level</a> box.
+
+		<dt><dfn>flex</dfn>
+		<dd>
+			Force a <a>flex line</a> break immediately before/after the box
+			if the box is a <a>flex item</a>
+			in a <a>multi-line flex container</a>.
+	</dl>
+
+	Forced line breaks on <a>inline-level</a> boxes propagate upward
+	through any parent <a>inline boxes</a>
+	the same way forced breaks on <a>block-level</a> boxes propagate upward
+	through any parent <a>block boxes</a>
+	in the same <a>fragmentation context</a>.
+	[[!CSS3-BREAK]]
+
+<h3 id="wrap-inside">
+Controlling Breaks Within Boxes: the 'wrap-inside' property</h3>
+
+	<wpt title="This section lacks tests."></wpt>
+
+	<pre class="propdef">
+	Name: wrap-inside
+	Value: auto | avoid
+	Initial: auto
+	Applies to: <a>inline boxes</a>
+	Inherited: no
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	<dl dfn-for=wrap-inside dfn-type=value>
+		<dt><dfn>auto</dfn>
+		<dd>
+			Lines may break at allowed break points
+			within the box,
+			as determined by the line-breaking rules in effect.
+
+		<dt><dfn>avoid</dfn>
+		<dd>
+			Line breaking is suppressed within the box:
+			the UA may only break within the box
+			if there are no other valid break points in the line.
+			If the text breaks,
+			line-breaking restrictions are honored as for
+			''wrap-inside/auto''.
+
+			If boxes with ''wrap-inside/avoid'' are nested
+			and the UA must break within these boxes,
+			a break in an outer box must be used
+			before a break within an inner box may be used.
+	</dl>
+
+<h4 id="example-avoid">
+Example of using 'wrap-inside: avoid' in presenting a footer</h4>
+
+	<wpt title="This section does not need tests."></wpt>
+
+	<div class="example">
+
+		The priority of breakpoints can be set
+		to reflect the intended grouping of text.
+
+		Given the rules
+
+		<pre>
+			footer { wrap-inside: avoid; }
+			venue { wrap-inside: avoid; }
+			date { wrap-inside: avoid; }
+			place { wrap-inside: avoid; }
+		</pre>
+
+		and the following markup:
+
+		<pre>
+			&lt;footer>
+			&lt;venue>27th Internationalization and Unicode Conference&lt;/venue>
+			&amp;#8226; &lt;date>April 7, 2005&lt;/date> &amp;#8226;
+			&lt;place>Berlin, Germany&lt;/place>
+			&lt;/footer>
+		</pre>
+
+		In a narrow window the footer could be broken as
+
+		<pre>
+			27th Internationalization and Unicode Conference &#8226;
+			April 7, 2005 &#8226; Berlin, Germany
+		</pre>
+
+		or in a narrower window as
+
+		<pre>
+			27th Internationalization and Unicode
+			Conference &#8226; April 7, 2005 &#8226;
+			Berlin, Germany
+		</pre>
+
+		but not as
+
+		<pre>
+			27th Internationalization and Unicode Conference &#8226; April
+			7, 2005 &#8226; Berlin, Germany
+		</pre>
+	</div>
+
+<h3 id="line-break-details">
+Line Breaking Details</h3>
+
+	<wpt title="
+		This section has partial test coverage.
+
+		Missing tests:
+
+		* For soft wrap opportunities before the first or after the last character of a box, the break occurs immediately before/after the box (at its margin edge) rather than breaking the box between its content edge and the content.
+		* Line breaking classes CM and SG must be honored
+
+		Untestable(?):
+
+		* UAs that allow wrapping at punctuation other than spaces should prioritize breakpoints. […]"></wpt>
+
+	When determining [=line breaks=]:
+
+	<ul>
+		<li>
+			The interaction of [=line breaking=] and bidirectional text is defined by
+			[[css-writing-modes-4#bidi-algo]]
+			and the <cite>Unicode Bidirectional Algorithm</cite>
+			(<a href="http://unicode.org/reports/tr9/#Reordering_Resolved_Levels">UAX9&sect;3.4 Reordering Resolved Levels</a> in particular).
+			[[!CSS-WRITING-MODES-4]]
+			[[!UAX9]]
+
+			<wpt pathprefix="/css/CSS2/bidi-text/">
+			bidi-breaking-001.xht
+			bidi-breaking-002.xht
+			bidi-breaking-003.xht
+			</wpt>
+
+		<li>
+			Except where explicitly defined otherwise
+			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
+			line breaking behavior defined for
+			the <code>CM</code>,
+			and <code>SG</code>,
+			<code>WJ</code>,
+			<code>ZW</code>,
+			<code>GL</code>,
+			and <code>ZWJ</code>
+			Unicode line breaking classes
+			must be honored.
+			[[!UAX14]]
+
+			<wpt>
+			word-break/word-break-normal-001.html
+			line-breaking/line-breaking-001.html
+			line-breaking/line-breaking-002.html
+			line-breaking/line-breaking-003.html
+			line-breaking/line-breaking-004.html
+			line-breaking/line-breaking-005.html
+			line-breaking/line-breaking-006.html
+			line-breaking/line-breaking-007.html
+			line-breaking/line-breaking-008.html
+			line-breaking/line-breaking-021.html
+			i18n/css3-text-line-break-baspglwj-001.html
+			i18n/css3-text-line-break-baspglwj-002.html
+			i18n/css3-text-line-break-baspglwj-120.html
+			i18n/css3-text-line-break-baspglwj-121.html
+			i18n/css3-text-line-break-baspglwj-122.html
+			i18n/css3-text-line-break-baspglwj-123.html
+			i18n/css3-text-line-break-baspglwj-124.html
+			i18n/css3-text-line-break-baspglwj-125.html
+			i18n/css3-text-line-break-baspglwj-126.html
+			i18n/css3-text-line-break-baspglwj-127.html
+			i18n/css3-text-line-break-baspglwj-128.html
+			i18n/css3-text-line-break-baspglwj-130.html
+			i18n/css3-text-line-break-baspglwj-131.html
+			word-break/word-break-break-all-018.html
+			word-break/word-break-break-all-021.html
+			word-break/word-break-break-all-022.html
+			</wpt>
+
+		<li>
+			UAs that allow wrapping at punctuation
+			other than [=word separators=]
+			in writing systems that use them
+			<em>should</em> prioritize breakpoints.
+			(For example, if breaks after slashes are given a lower priority than spaces,
+			the sequence “check /etc” will never break between the "/" and the "e".)
+			As long as care is taken to avoid such awkward breaks,
+			allowing breaks at appropriate punctuation other than [=word separators=]
+			is recommended,
+			as it results in more even-looking margins, particularly in narrow measures.
+			The UA may use the width of the containing block, the text's language,
+			the 'line-break' value,
+			and other factors in assigning priorities:
+			CSS does not define prioritization of [=soft wrap opportunities=].
+			Prioritization of [=word separators=] is not expected,
+			however,
+			if ''word-break: break-all'' is specified
+			(since this value explicitly requests line breaking behavior
+			not based on breaking at [=word separators=])--
+			and is forbidden under ''line-break: anywhere''.
+
+		<li>
+			Out-of-flow elements
+			and inline element boundaries
+			do not introduce a [=forced line break=]
+			or [=soft wrap opportunity=] in the flow.
+
+			<wpt>
+			line-breaking/line-breaking-012.html
+			line-breaking/line-breaking-015.html
+			line-breaking/line-breaking-016.html
+			line-breaking/line-breaking-017.html
+			line-breaking/line-breaking-018.html
+			line-breaking/line-breaking-019.html
+			</wpt>
+
+		<li id=atomic-compat-wrap>
+			For Web-compatibility
+			there is a [=soft wrap opportunity=]
+			before and after each replaced element or other [=atomic inline=],
+			even when adjacent to a character that would normally suppress them,
+			including U+00A0 NO-BREAK SPACE.
+			However,
+			with the exception of U+00A0 NO-BREAK SPACE,
+			there must be no [=soft wrap opportunity=]
+			between [=atomic inlines=] and adjacent characters
+			belonging to the Unicode GL, WJ, or ZWJ line breaking classes.
+			[[UAX14]]
+
+			<wpt>
+			line-breaking/line-breaking-atomic-001.html
+			line-breaking/line-breaking-atomic-002.html
+			line-breaking/line-breaking-atomic-003.html
+			line-breaking/line-breaking-atomic-004.html
+			line-breaking/line-breaking-atomic-005.html
+			line-breaking/line-breaking-atomic-006.html
+			line-breaking/line-breaking-atomic-007.html
+			line-breaking/line-breaking-atomic-008.html
+			line-breaking/line-breaking-atomic-009.html
+			line-breaking/line-breaking-atomic-010.html
+			line-breaking/line-breaking-atomic-011.html
+			line-breaking/line-breaking-atomic-012.html
+			line-breaking/line-breaking-atomic-013.html
+			line-breaking/line-breaking-atomic-014.html
+			line-breaking/line-breaking-atomic-015.html
+			line-breaking/line-breaking-atomic-016.html
+			line-breaking/line-breaking-atomic-017.html
+			line-breaking/line-breaking-atomic-018.html
+			line-breaking/line-breaking-atomic-019.html
+			line-breaking/line-breaking-atomic-020.html
+			line-breaking/line-breaking-atomic-021.html
+			line-breaking/line-breaking-atomic-022.html
+			line-breaking/line-breaking-atomic-023.html
+			line-breaking/line-breaking-atomic-024.html
+			line-breaking/line-breaking-atomic-025.html
+			line-breaking/line-breaking-atomic-026.html
+			line-breaking/line-breaking-atomic-027.html
+			line-breaking/line-breaking-replaced-001.html
+			line-breaking/line-breaking-replaced-002.html
+			line-breaking/line-breaking-replaced-003.html
+			line-breaking/line-breaking-replaced-004.html
+			line-breaking/line-breaking-replaced-005.html
+			line-breaking/line-breaking-replaced-006.html
+			line-breaking/line-breaking-atomic-nowrap-001.html
+			</wpt>
+
+		<li>
+			For [=soft wrap opportunities=] created by characters
+			that disappear at the line break (e.g. U+0020 SPACE),
+			properties on the box directly containing that character
+			control the line breaking at that opportunity.
+			For [=soft wrap opportunities=] defined by the boundary between two characters,
+			the 'white-space' property
+			on the nearest common ancestor of the two characters
+			controls breaking;
+			<!-- http://lists.w3.org/Archives/Public/www-style/2008Dec/0043.html -->
+			which elements’ 'line-break', 'word-break', and 'overflow-wrap' properties
+			control the determination of [=soft wrap opportunities=]
+			at such boundaries
+			is undefined in Level 3.
+
+			<wpt>
+			line-breaking/line-breaking-009.html
+			line-breaking/line-breaking-010.html
+			line-breaking/line-breaking-011.html
+			line-breaking/line-breaking-ic-001.html
+			line-breaking/line-breaking-ic-002.html
+			line-breaking/line-breaking-ic-003.html
+			white-space/white-space-wrap-after-nowrap-001.html
+			word-break/break-boundary-2-chars-001.html
+
+			overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
+			overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
+			overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
+			word-break/word-break-break-all-inline-004.tentative.html
+			word-break/word-break-break-all-inline-007.tentative.html
+			word-break/word-break-break-all-inline-010.tentative.html
+			</wpt>
+
+		<li>
+			For [=soft wrap opportunities=] before the first
+			or after the last character of a box,
+			the break occurs immediately before/after the box
+			(at its margin edge)
+			rather than breaking the box
+			between its content edge and the content.
+
+		<li>
+			Line breaking in/around Ruby is defined
+			in [[css-ruby-1#line-breaks]].
+			[[!CSS-RUBY-1]]
+
+		<li id="word-break-shaping">
+			When shaping scripts such as Arabic
+			[=wrap=] at unforced [=soft wrap opportunities=] within words
+			(such as when breaking due to
+			''word-break: break-all'',
+			''line-break: anywhere'',
+			''overflow-wrap: break-word'',
+			''overflow-wrap: anywhere'',
+			or when [=hyphenating=])
+			the characters must still be shaped
+			(their joining forms chosen)
+			as if the word were still whole.
+
+			<wpt>
+			hyphens/hyphens-shaping-001.html
+			hyphens/hyphens-shaping-002.html
+			line-break/line-break-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-002.html
+			word-break/word-break-break-all-004.html
+			</wpt>
+
+			<div class="example">
+				For example,
+				if the word “نوشتن” is broken between the “ش” and “ت”,
+				the “ش” still takes its initial form (“ﺷ”),
+				and the “ت” its medial form (“ﺘ”)--
+				forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
+			</div>
+	</ul>
+
+
 <h2 id="line-breaking">
 Line Breaking and Word Boundaries</h2>
 
@@ -6510,1745 +8250,6 @@ Overflow Wrapping: the 'overflow-wrap'/'word-wrap' property</h3>
 	overflow-wrap/word-wrap-002.html
 	overflow-wrap/word-wrap-004.html
 	</wpt>
-
-<h2 id="text-wrapping">
-Text Wrapping</h2>
-
-	Where text is allowed to wrap is controlled
-	by the [[#line-breaking|line-breaking rules and controls]] above;
-	<em>whether</em> it is allowed to wrap
-	and how multiple [=soft wrap opportunities=] within a line are prioritized
-	is controlled
-	by the 'text-wrap-mode',
-	'text-wrap-style',
-	'wrap-before',
-	'wrap-after',
-	and
-	'wrap-inside' properties:
-
-<h3 id="text-wrap">
-Text Wrap Setting</h3>
-
-<h4 id="text-wrap-shorthand">
-Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
-
-	<wpt title="This section has limited coverage."></wpt>
-
-	<pre class="propdef">
-	Name: text-wrap
-	Value: <'text-wrap-mode'> || <'text-wrap-style'>
-	Initial: wrap
-	Applies to: see individual properties
-	Inherited: see individual properties
-	Percentages: see individual properties
-	Computed value: see individual properties
-	Animation type: see individual properties
-	</pre>
-
-	<wpt>
-		parsing/text-wrap-invalid.html
-		parsing/text-wrap-valid.html
-	</wpt>
-	<wpt title="TODO: needs review, probably outdated">
-		parsing/white-space-shorthand-text-wrap.html
-	</wpt>
-
-	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
-	Any omitted [=longhand=] is set to its [=initial value=].
-
-<h4 id="text-wrap-mode">
-Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
-
-	<wpt title="
-		This property is tested extensively through its shorthands,
-		but not directly.
-
-		Missing test:
-		* preserved segment breaks are forced line breaks (probably tested already, but need to find those tests)
-		* CR and LF  line breaking class are forced line breaks
-		* Direct tests of this property as a longhand"></wpt>
-
-	<pre class="propdef">
-	Name: text-wrap-mode
-	Value: wrap | nowrap
-	Initial: wrap
-	Applies to: text
-	Inherited: yes
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	Issue: The name of this property is a placeholder,
-	pending the CSSWG finding a better name.
-
-	Note: This property is a [=longhand=]
-	of both 'white-space' and 'text-wrap'.
-
-	This property specifies whether lines may [=wrap=] at unforced [=soft wrap opportunities=]
-	(see [[#line-breaking|Line Breaking]]).
-	Possible values:
-
-	<dl dfn-for=text-wrap-mode dfn-type=value>
-		<dt><dfn>wrap</dfn>
-		<dd>
-			Content may break across lines
-			at allowed <a>soft wrap opportunities</a>,
-			as determined by the line-breaking rules in effect,
-			in order to minimize <a>inline-axis</a> overflow.
-
-			<wpt title="tests using wrap directly through 'text-wrap-mode':">
-			</wpt>
-			<wpt title="CSS 2 indirect tests via 'white-space: normal':" pathprefix="/css/CSS2/text/">
-				white-space-normal-001.xht
-				white-space-normal-002.xht
-				white-space-normal-003.xht
-				white-space-normal-004.xht
-				white-space-normal-005.xht
-				white-space-normal-006.xht
-				white-space-normal-007.xht
-				white-space-normal-008.xht
-				white-space-normal-009.xht
-				white-space-p-element-001.xht
-			</wpt>
-			<wpt title="CSS 2 indirect tests via 'white-space: pre-line':" pathprefix="/css/CSS2/text/">
-				white-space-005.xht
-				white-space-processing-017.xht
-				white-space-processing-053.xht
-			</wpt>
-			<wpt title="tests using wrap through 'text-wrap: wrap':">
-			</wpt>
-			<wpt title="tests using wrap implicitly through 'text-wrap':">
-				parsing/white-space-shorthand-text-wrap.html
-				white-space/text-wrap-balance-001.html
-				white-space/text-wrap-balance-002.html
-				white-space/text-wrap-balance-align-001.html
-				white-space/text-wrap-balance-dynamic-001.html
-				white-space/text-wrap-balance-line-clamp-001.html
-				white-space/text-wrap-balance-narrow-crash.html
-				white-space/text-wrap-balance-text-indent-001.html
-			</wpt>
-			<wpt title="tests using wrap through 'white-space: normal':">
-				hyphens/hyphens-auto-003.html
-				i18n/css3-text-line-break-baspglwj-001.html
-				i18n/css3-text-line-break-baspglwj-002.html
-				i18n/css3-text-line-break-baspglwj-003.html
-				i18n/css3-text-line-break-baspglwj-004.html
-				i18n/css3-text-line-break-baspglwj-005.html
-				i18n/css3-text-line-break-baspglwj-006.html
-				i18n/css3-text-line-break-baspglwj-007.html
-				i18n/css3-text-line-break-baspglwj-008.html
-				i18n/css3-text-line-break-baspglwj-009.html
-				i18n/css3-text-line-break-baspglwj-010.html
-				i18n/css3-text-line-break-baspglwj-011.html
-				i18n/css3-text-line-break-baspglwj-012.html
-				i18n/css3-text-line-break-baspglwj-014.html
-				i18n/css3-text-line-break-baspglwj-015.html
-				i18n/css3-text-line-break-baspglwj-016.html
-				i18n/css3-text-line-break-baspglwj-017.html
-				i18n/css3-text-line-break-baspglwj-018.html
-				i18n/css3-text-line-break-baspglwj-019.html
-				i18n/css3-text-line-break-baspglwj-020.html
-				i18n/css3-text-line-break-baspglwj-021.html
-				i18n/css3-text-line-break-baspglwj-022.html
-				i18n/css3-text-line-break-baspglwj-023.html
-				i18n/css3-text-line-break-baspglwj-024.html
-				i18n/css3-text-line-break-baspglwj-025.html
-				i18n/css3-text-line-break-baspglwj-026.html
-				i18n/css3-text-line-break-baspglwj-030.html
-				i18n/css3-text-line-break-baspglwj-031.html
-				i18n/css3-text-line-break-baspglwj-032.html
-				i18n/css3-text-line-break-baspglwj-033.html
-				i18n/css3-text-line-break-baspglwj-034.html
-				i18n/css3-text-line-break-baspglwj-035.html
-				i18n/css3-text-line-break-baspglwj-036.html
-				i18n/css3-text-line-break-baspglwj-037.html
-				i18n/css3-text-line-break-baspglwj-038.html
-				i18n/css3-text-line-break-baspglwj-039.html
-				i18n/css3-text-line-break-baspglwj-040.html
-				i18n/css3-text-line-break-baspglwj-041.html
-				i18n/css3-text-line-break-baspglwj-042.html
-				i18n/css3-text-line-break-baspglwj-043.html
-				i18n/css3-text-line-break-baspglwj-044.html
-				i18n/css3-text-line-break-baspglwj-045.html
-				i18n/css3-text-line-break-baspglwj-046.html
-				i18n/css3-text-line-break-baspglwj-047.html
-				i18n/css3-text-line-break-baspglwj-048.html
-				i18n/css3-text-line-break-baspglwj-049.html
-				i18n/css3-text-line-break-baspglwj-050.html
-				i18n/css3-text-line-break-baspglwj-051.html
-				i18n/css3-text-line-break-baspglwj-052.html
-				i18n/css3-text-line-break-baspglwj-060.html
-				i18n/css3-text-line-break-baspglwj-061.html
-				i18n/css3-text-line-break-baspglwj-062.html
-				i18n/css3-text-line-break-baspglwj-063.html
-				i18n/css3-text-line-break-baspglwj-064.html
-				i18n/css3-text-line-break-baspglwj-065.html
-				i18n/css3-text-line-break-baspglwj-066.html
-				i18n/css3-text-line-break-baspglwj-067.html
-				i18n/css3-text-line-break-baspglwj-068.html
-				i18n/css3-text-line-break-baspglwj-069.html
-				i18n/css3-text-line-break-baspglwj-070.html
-				i18n/css3-text-line-break-baspglwj-071.html
-				i18n/css3-text-line-break-baspglwj-072.html
-				i18n/css3-text-line-break-baspglwj-073.html
-				i18n/css3-text-line-break-baspglwj-074.html
-				i18n/css3-text-line-break-baspglwj-075.html
-				i18n/css3-text-line-break-baspglwj-076.html
-				i18n/css3-text-line-break-baspglwj-077.html
-				i18n/css3-text-line-break-baspglwj-078.html
-				i18n/css3-text-line-break-baspglwj-080.html
-				i18n/css3-text-line-break-baspglwj-081.html
-				i18n/css3-text-line-break-baspglwj-082.html
-				i18n/css3-text-line-break-baspglwj-083.html
-				i18n/css3-text-line-break-baspglwj-084.html
-				i18n/css3-text-line-break-baspglwj-085.html
-				i18n/css3-text-line-break-baspglwj-086.html
-				i18n/css3-text-line-break-baspglwj-090.html
-				i18n/css3-text-line-break-baspglwj-091.html
-				i18n/css3-text-line-break-baspglwj-092.html
-				i18n/css3-text-line-break-baspglwj-093.html
-				i18n/css3-text-line-break-baspglwj-095.html
-				i18n/css3-text-line-break-baspglwj-096.html
-				i18n/css3-text-line-break-baspglwj-097.html
-				i18n/css3-text-line-break-baspglwj-098.html
-				i18n/css3-text-line-break-baspglwj-099.html
-				i18n/css3-text-line-break-baspglwj-100.html
-				i18n/css3-text-line-break-baspglwj-101.html
-				i18n/css3-text-line-break-baspglwj-102.html
-				i18n/css3-text-line-break-baspglwj-103.html
-				i18n/css3-text-line-break-baspglwj-104.html
-				i18n/css3-text-line-break-baspglwj-105.html
-				i18n/css3-text-line-break-baspglwj-106.html
-				i18n/css3-text-line-break-baspglwj-107.html
-				i18n/css3-text-line-break-baspglwj-108.html
-				i18n/css3-text-line-break-baspglwj-109.html
-				i18n/css3-text-line-break-baspglwj-110.html
-				i18n/css3-text-line-break-baspglwj-111.html
-				i18n/css3-text-line-break-baspglwj-112.html
-				i18n/css3-text-line-break-baspglwj-113.html
-				i18n/css3-text-line-break-baspglwj-114.html
-				i18n/css3-text-line-break-baspglwj-115.html
-				i18n/css3-text-line-break-baspglwj-116.html
-				i18n/css3-text-line-break-baspglwj-117.html
-				i18n/css3-text-line-break-baspglwj-118.html
-				i18n/css3-text-line-break-baspglwj-120.html
-				i18n/css3-text-line-break-baspglwj-121.html
-				i18n/css3-text-line-break-baspglwj-122.html
-				i18n/css3-text-line-break-baspglwj-123.html
-				i18n/css3-text-line-break-baspglwj-124.html
-				i18n/css3-text-line-break-baspglwj-125.html
-				i18n/css3-text-line-break-baspglwj-126.html
-				i18n/css3-text-line-break-baspglwj-127.html
-				i18n/css3-text-line-break-baspglwj-128.html
-				i18n/css3-text-line-break-baspglwj-130.html
-				i18n/css3-text-line-break-baspglwj-131.html
-				line-break/line-break-anywhere-and-white-space-004.html
-				line-break/line-break-anywhere-and-white-space-005.html
-				line-breaking/line-breaking-001.html
-				line-breaking/line-breaking-002.html
-				line-breaking/line-breaking-003.html
-				line-breaking/line-breaking-004.html
-				line-breaking/line-breaking-005.html
-				line-breaking/line-breaking-006.html
-				line-breaking/line-breaking-007.html
-				line-breaking/line-breaking-008.html
-				line-breaking/line-breaking-009.html
-				line-breaking/line-breaking-010.html
-				line-breaking/line-breaking-011.html
-				line-breaking/line-breaking-ic-001.html
-				line-breaking/line-breaking-ic-002.html
-				line-breaking/line-breaking-ic-003.html
-				overflow-wrap/overflow-wrap-anywhere-011.html
-				overflow-wrap/overflow-wrap-break-word-white-space-crash.html
-				parsing/white-space-shorthand-text-wrap.html
-				white-space/trailing-ideographic-space-005.html
-				white-space/trailing-ideographic-space-006.html
-				white-space/trailing-space-and-text-alignment-001.html
-				white-space/trailing-space-and-text-alignment-rtl-001.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-normal-011.html
-				white-space/white-space-nowrap-011.html
-				white-space/white-space-pre-011.html
-				white-space/white-space-pre-031.html
-				white-space/white-space-pre-032.html
-				white-space/white-space-pre-034.html
-				white-space/white-space-pre-035.html
-				white-space/white-space-pre-wrap-justify-001.html
-				white-space/white-space-pre-wrap-justify-002.html
-				white-space/white-space-pre-wrap-justify-003.html
-				white-space/white-space-pre-wrap-justify-004.html
-				white-space/white-space-pre-wrap-trailing-spaces-021.html
-				white-space/white-space-wrap-after-nowrap-001.html
-				white-space/ws-break-spaces-applies-to-012.html
-				white-space/ws-break-spaces-applies-to-013.html
-				word-break/break-boundary-2-chars-001.html
-				word-break/word-break-break-all-062.html
-				word-break/word-break-keep-all-063.html
-			</wpt>
-			<wpt title="tests using wrap through 'white-space: pre-wrap':">
-				crashtests/trailing-space-with-cr-crash.html
-				crashtests/white-space-pre-wrap-chash.html
-				hyphens/hyphens-auto-002.html
-				i18n/css3-text-line-break-baspglwj-001.html
-				i18n/css3-text-line-break-baspglwj-002.html
-				i18n/css3-text-line-break-baspglwj-003.html
-				i18n/css3-text-line-break-baspglwj-004.html
-				i18n/css3-text-line-break-baspglwj-005.html
-				i18n/css3-text-line-break-baspglwj-006.html
-				i18n/css3-text-line-break-baspglwj-007.html
-				i18n/css3-text-line-break-baspglwj-008.html
-				i18n/css3-text-line-break-baspglwj-009.html
-				i18n/css3-text-line-break-baspglwj-010.html
-				i18n/css3-text-line-break-baspglwj-011.html
-				i18n/css3-text-line-break-baspglwj-012.html
-				i18n/css3-text-line-break-baspglwj-014.html
-				i18n/css3-text-line-break-baspglwj-015.html
-				i18n/css3-text-line-break-baspglwj-016.html
-				i18n/css3-text-line-break-baspglwj-017.html
-				i18n/css3-text-line-break-baspglwj-018.html
-				i18n/css3-text-line-break-baspglwj-019.html
-				i18n/css3-text-line-break-baspglwj-020.html
-				i18n/css3-text-line-break-baspglwj-021.html
-				i18n/css3-text-line-break-baspglwj-022.html
-				i18n/css3-text-line-break-baspglwj-023.html
-				i18n/css3-text-line-break-baspglwj-024.html
-				i18n/css3-text-line-break-baspglwj-025.html
-				i18n/css3-text-line-break-baspglwj-026.html
-				i18n/css3-text-line-break-baspglwj-030.html
-				i18n/css3-text-line-break-baspglwj-031.html
-				i18n/css3-text-line-break-baspglwj-032.html
-				i18n/css3-text-line-break-baspglwj-033.html
-				i18n/css3-text-line-break-baspglwj-034.html
-				i18n/css3-text-line-break-baspglwj-035.html
-				i18n/css3-text-line-break-baspglwj-036.html
-				i18n/css3-text-line-break-baspglwj-037.html
-				i18n/css3-text-line-break-baspglwj-038.html
-				i18n/css3-text-line-break-baspglwj-039.html
-				i18n/css3-text-line-break-baspglwj-040.html
-				i18n/css3-text-line-break-baspglwj-041.html
-				i18n/css3-text-line-break-baspglwj-042.html
-				i18n/css3-text-line-break-baspglwj-043.html
-				i18n/css3-text-line-break-baspglwj-044.html
-				i18n/css3-text-line-break-baspglwj-045.html
-				i18n/css3-text-line-break-baspglwj-046.html
-				i18n/css3-text-line-break-baspglwj-047.html
-				i18n/css3-text-line-break-baspglwj-048.html
-				i18n/css3-text-line-break-baspglwj-049.html
-				i18n/css3-text-line-break-baspglwj-050.html
-				i18n/css3-text-line-break-baspglwj-051.html
-				i18n/css3-text-line-break-baspglwj-052.html
-				i18n/css3-text-line-break-baspglwj-060.html
-				i18n/css3-text-line-break-baspglwj-061.html
-				i18n/css3-text-line-break-baspglwj-062.html
-				i18n/css3-text-line-break-baspglwj-063.html
-				i18n/css3-text-line-break-baspglwj-064.html
-				i18n/css3-text-line-break-baspglwj-065.html
-				i18n/css3-text-line-break-baspglwj-066.html
-				i18n/css3-text-line-break-baspglwj-067.html
-				i18n/css3-text-line-break-baspglwj-068.html
-				i18n/css3-text-line-break-baspglwj-069.html
-				i18n/css3-text-line-break-baspglwj-070.html
-				i18n/css3-text-line-break-baspglwj-071.html
-				i18n/css3-text-line-break-baspglwj-072.html
-				i18n/css3-text-line-break-baspglwj-073.html
-				i18n/css3-text-line-break-baspglwj-074.html
-				i18n/css3-text-line-break-baspglwj-075.html
-				i18n/css3-text-line-break-baspglwj-076.html
-				i18n/css3-text-line-break-baspglwj-077.html
-				i18n/css3-text-line-break-baspglwj-078.html
-				i18n/css3-text-line-break-baspglwj-080.html
-				i18n/css3-text-line-break-baspglwj-081.html
-				i18n/css3-text-line-break-baspglwj-082.html
-				i18n/css3-text-line-break-baspglwj-083.html
-				i18n/css3-text-line-break-baspglwj-084.html
-				i18n/css3-text-line-break-baspglwj-085.html
-				i18n/css3-text-line-break-baspglwj-086.html
-				i18n/css3-text-line-break-baspglwj-090.html
-				i18n/css3-text-line-break-baspglwj-091.html
-				i18n/css3-text-line-break-baspglwj-092.html
-				i18n/css3-text-line-break-baspglwj-093.html
-				i18n/css3-text-line-break-baspglwj-095.html
-				i18n/css3-text-line-break-baspglwj-096.html
-				i18n/css3-text-line-break-baspglwj-097.html
-				i18n/css3-text-line-break-baspglwj-098.html
-				i18n/css3-text-line-break-baspglwj-099.html
-				i18n/css3-text-line-break-baspglwj-100.html
-				i18n/css3-text-line-break-baspglwj-101.html
-				i18n/css3-text-line-break-baspglwj-102.html
-				i18n/css3-text-line-break-baspglwj-103.html
-				i18n/css3-text-line-break-baspglwj-104.html
-				i18n/css3-text-line-break-baspglwj-105.html
-				i18n/css3-text-line-break-baspglwj-106.html
-				i18n/css3-text-line-break-baspglwj-107.html
-				i18n/css3-text-line-break-baspglwj-108.html
-				i18n/css3-text-line-break-baspglwj-109.html
-				i18n/css3-text-line-break-baspglwj-110.html
-				i18n/css3-text-line-break-baspglwj-111.html
-				i18n/css3-text-line-break-baspglwj-112.html
-				i18n/css3-text-line-break-baspglwj-113.html
-				i18n/css3-text-line-break-baspglwj-114.html
-				i18n/css3-text-line-break-baspglwj-115.html
-				i18n/css3-text-line-break-baspglwj-116.html
-				i18n/css3-text-line-break-baspglwj-117.html
-				i18n/css3-text-line-break-baspglwj-118.html
-				i18n/css3-text-line-break-baspglwj-120.html
-				i18n/css3-text-line-break-baspglwj-121.html
-				i18n/css3-text-line-break-baspglwj-122.html
-				i18n/css3-text-line-break-baspglwj-123.html
-				i18n/css3-text-line-break-baspglwj-124.html
-				i18n/css3-text-line-break-baspglwj-125.html
-				i18n/css3-text-line-break-baspglwj-126.html
-				i18n/css3-text-line-break-baspglwj-127.html
-				i18n/css3-text-line-break-baspglwj-128.html
-				i18n/css3-text-line-break-baspglwj-130.html
-				i18n/css3-text-line-break-baspglwj-131.html
-				letter-spacing/letter-spacing-200.html
-				letter-spacing/letter-spacing-201.html
-				letter-spacing/letter-spacing-203.html
-				letter-spacing/letter-spacing-204.html
-				letter-spacing/letter-spacing-205.html
-				letter-spacing/letter-spacing-211.html
-				letter-spacing/letter-spacing-212.html
-				line-break/line-break-anywhere-008.html
-				line-break/line-break-anywhere-010.html
-				line-break/line-break-anywhere-and-white-space-006.html
-				line-break/line-break-anywhere-and-white-space-007.html
-				overflow-wrap/overflow-wrap-anywhere-004.html
-				overflow-wrap/overflow-wrap-anywhere-005.html
-				overflow-wrap/overflow-wrap-break-word-004.html
-				overflow-wrap/overflow-wrap-break-word-005.html
-				overflow-wrap/overflow-wrap-break-word-007.html
-				overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
-				overflow-wrap/overflow-wrap-min-content-size-009.html
-				text-justify/text-justify-and-trailing-spaces-001.html
-				text-justify/text-justify-and-trailing-spaces-002.html
-				text-justify/text-justify-and-trailing-spaces-003.html
-				text-justify/text-justify-and-trailing-spaces-004.html
-				text-justify/text-justify-and-trailing-spaces-005.html
-				text-justify/text-justify-and-trailing-spaces-006.html
-				text-transform/text-transform-fullwidth-007.html
-				text-transform/text-transform-fullwidth-009.html
-				white-space/break-spaces-newline-011.html
-				white-space/break-spaces-newline-012.html
-				white-space/break-spaces-newline-013.html
-				white-space/break-spaces-newline-014.html
-				white-space/break-spaces-newline-015.html
-				white-space/break-spaces-newline-016.html
-				white-space/control-chars-00D.html
-				white-space/eol-spaces-bidi-002.html
-				white-space/eol-spaces-bidi-003.html
-				white-space/pre-wrap-001.html
-				white-space/pre-wrap-002.html
-				white-space/pre-wrap-003.html
-				white-space/pre-wrap-004.html
-				white-space/pre-wrap-005.html
-				white-space/pre-wrap-006.html
-				white-space/pre-wrap-007.html
-				white-space/pre-wrap-008.html
-				white-space/pre-wrap-009.html
-				white-space/pre-wrap-010.html
-				white-space/pre-wrap-011.html
-				white-space/pre-wrap-012.html
-				white-space/pre-wrap-013.html
-				white-space/pre-wrap-014.html
-				white-space/pre-wrap-015.html
-				white-space/pre-wrap-016.html
-				white-space/pre-wrap-017.html
-				white-space/pre-wrap-018.html
-				white-space/pre-wrap-019.html
-				white-space/pre-wrap-020.html
-				white-space/pre-wrap-051.html
-				white-space/pre-wrap-052.html
-				white-space/pre-wrap-align-center-001.html
-				white-space/pre-wrap-align-center-002.html
-				white-space/pre-wrap-align-center-003.html
-				white-space/pre-wrap-align-end-001.html
-				white-space/pre-wrap-align-end-002.html
-				white-space/pre-wrap-align-end-003.html
-				white-space/pre-wrap-align-left-001.html
-				white-space/pre-wrap-align-left-002.html
-				white-space/pre-wrap-align-left-003.html
-				white-space/pre-wrap-align-right-001.html
-				white-space/pre-wrap-align-right-002.html
-				white-space/pre-wrap-align-right-003.html
-				white-space/pre-wrap-align-start-001.html
-				white-space/pre-wrap-align-start-002.html
-				white-space/pre-wrap-align-start-003.html
-				white-space/pre-wrap-float-001.html
-				white-space/pre-wrap-leading-spaces-001.html
-				white-space/pre-wrap-leading-spaces-002.html
-				white-space/pre-wrap-leading-spaces-003.html
-				white-space/pre-wrap-leading-spaces-004.html
-				white-space/pre-wrap-leading-spaces-005.html
-				white-space/pre-wrap-leading-spaces-006.html
-				white-space/pre-wrap-leading-spaces-007.html
-				white-space/pre-wrap-leading-spaces-008.html
-				white-space/pre-wrap-leading-spaces-009.html
-				white-space/pre-wrap-leading-spaces-010.html
-				white-space/pre-wrap-leading-spaces-011.html
-				white-space/pre-wrap-leading-spaces-012.html
-				white-space/pre-wrap-leading-spaces-013.html
-				white-space/pre-wrap-leading-spaces-014.html
-				white-space/pre-wrap-leading-spaces-015.html
-				white-space/pre-wrap-leading-spaces-016.html
-				white-space/pre-wrap-leading-spaces-017.html
-				white-space/pre-wrap-tab-001.html
-				white-space/pre-wrap-tab-002.html
-				white-space/pre-wrap-tab-003.html
-				white-space/pre-wrap-tab-004.html
-				white-space/pre-wrap-tab-005.html
-				white-space/pre-wrap-tab-006.html
-				white-space/tab-stop-threshold-003.html
-				white-space/tab-stop-threshold-004.html
-				white-space/textarea-pre-wrap-001.html
-				white-space/textarea-pre-wrap-002.html
-				white-space/textarea-pre-wrap-003.html
-				white-space/textarea-pre-wrap-004.html
-				white-space/textarea-pre-wrap-005.html
-				white-space/textarea-pre-wrap-006.html
-				white-space/textarea-pre-wrap-007.html
-				white-space/textarea-pre-wrap-011.html
-				white-space/textarea-pre-wrap-012.html
-				white-space/textarea-pre-wrap-013.html
-				white-space/textarea-pre-wrap-014.html
-				white-space/trailing-ideographic-space-003.html
-				white-space/trailing-ideographic-space-004.html
-				white-space/trailing-other-space-separators-002.html
-				white-space/trailing-space-align-start.tentative.html
-				white-space/trailing-space-and-text-alignment-003.html
-				white-space/trailing-space-and-text-alignment-rtl-003.html
-				white-space/trailing-space-in-inline-box.html
-				white-space/trailing-space-position-001.html
-				white-space/trailing-space-rtl-001.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-intrinsic-size-003.html
-				white-space/white-space-intrinsic-size-004.html
-				white-space/white-space-intrinsic-size-005.html
-				white-space/white-space-intrinsic-size-006.html
-				white-space/white-space-intrinsic-size-013.html
-				white-space/white-space-intrinsic-size-014.html
-				white-space/white-space-intrinsic-size-017.html
-				white-space/white-space-letter-spacing-001.html
-				white-space/white-space-pre-032.html
-				white-space/white-space-pre-wrap-justify-001.html
-				white-space/white-space-pre-wrap-justify-002.html
-				white-space/white-space-pre-wrap-justify-003.html
-				white-space/white-space-pre-wrap-justify-004.html
-				white-space/white-space-pre-wrap-trailing-spaces-001.html
-				white-space/white-space-pre-wrap-trailing-spaces-002.html
-				white-space/white-space-pre-wrap-trailing-spaces-003.html
-				white-space/white-space-pre-wrap-trailing-spaces-004.html
-				white-space/white-space-pre-wrap-trailing-spaces-005.html
-				white-space/white-space-pre-wrap-trailing-spaces-006.html
-				white-space/white-space-pre-wrap-trailing-spaces-007.html
-				white-space/white-space-pre-wrap-trailing-spaces-008.html
-				white-space/white-space-pre-wrap-trailing-spaces-010.html
-				white-space/white-space-pre-wrap-trailing-spaces-011.html
-				white-space/white-space-pre-wrap-trailing-spaces-012.html
-				white-space/white-space-pre-wrap-trailing-spaces-013.html
-				white-space/white-space-pre-wrap-trailing-spaces-014.html
-				white-space/white-space-pre-wrap-trailing-spaces-015.html
-				white-space/white-space-pre-wrap-trailing-spaces-021.html
-				white-space/white-space-pre-wrap-trailing-spaces-022.html
-				white-space/white-space-pre-wrap-trailing-spaces-023.html
-				word-break/break-boundary-2-chars-001.html
-				word-break/word-break-break-all-010.html
-				word-break/word-break-break-all-011.html
-				word-break/word-break-break-all-015.html
-				word-break/word-break-break-all-019.html
-				word-break/word-break-break-all-021.html
-				word-break/word-break-break-all-062.html
-				word-break/word-break-keep-all-007.html
-				word-break/word-break-keep-all-063.html
-				word-break/word-break-min-content-007.html
-			</wpt>
-			<wpt title="tests using wrap through 'white-space: pre-line':">
-				i18n/css3-text-line-break-baspglwj-001.html
-				i18n/css3-text-line-break-baspglwj-002.html
-				i18n/css3-text-line-break-baspglwj-003.html
-				i18n/css3-text-line-break-baspglwj-004.html
-				i18n/css3-text-line-break-baspglwj-005.html
-				i18n/css3-text-line-break-baspglwj-006.html
-				i18n/css3-text-line-break-baspglwj-007.html
-				i18n/css3-text-line-break-baspglwj-008.html
-				i18n/css3-text-line-break-baspglwj-009.html
-				i18n/css3-text-line-break-baspglwj-010.html
-				i18n/css3-text-line-break-baspglwj-011.html
-				i18n/css3-text-line-break-baspglwj-012.html
-				i18n/css3-text-line-break-baspglwj-014.html
-				i18n/css3-text-line-break-baspglwj-015.html
-				i18n/css3-text-line-break-baspglwj-016.html
-				i18n/css3-text-line-break-baspglwj-017.html
-				i18n/css3-text-line-break-baspglwj-018.html
-				i18n/css3-text-line-break-baspglwj-019.html
-				i18n/css3-text-line-break-baspglwj-020.html
-				i18n/css3-text-line-break-baspglwj-021.html
-				i18n/css3-text-line-break-baspglwj-022.html
-				i18n/css3-text-line-break-baspglwj-023.html
-				i18n/css3-text-line-break-baspglwj-024.html
-				i18n/css3-text-line-break-baspglwj-025.html
-				i18n/css3-text-line-break-baspglwj-026.html
-				i18n/css3-text-line-break-baspglwj-030.html
-				i18n/css3-text-line-break-baspglwj-031.html
-				i18n/css3-text-line-break-baspglwj-032.html
-				i18n/css3-text-line-break-baspglwj-033.html
-				i18n/css3-text-line-break-baspglwj-034.html
-				i18n/css3-text-line-break-baspglwj-035.html
-				i18n/css3-text-line-break-baspglwj-036.html
-				i18n/css3-text-line-break-baspglwj-037.html
-				i18n/css3-text-line-break-baspglwj-038.html
-				i18n/css3-text-line-break-baspglwj-039.html
-				i18n/css3-text-line-break-baspglwj-040.html
-				i18n/css3-text-line-break-baspglwj-041.html
-				i18n/css3-text-line-break-baspglwj-042.html
-				i18n/css3-text-line-break-baspglwj-043.html
-				i18n/css3-text-line-break-baspglwj-044.html
-				i18n/css3-text-line-break-baspglwj-045.html
-				i18n/css3-text-line-break-baspglwj-046.html
-				i18n/css3-text-line-break-baspglwj-047.html
-				i18n/css3-text-line-break-baspglwj-048.html
-				i18n/css3-text-line-break-baspglwj-049.html
-				i18n/css3-text-line-break-baspglwj-050.html
-				i18n/css3-text-line-break-baspglwj-051.html
-				i18n/css3-text-line-break-baspglwj-052.html
-				i18n/css3-text-line-break-baspglwj-060.html
-				i18n/css3-text-line-break-baspglwj-061.html
-				i18n/css3-text-line-break-baspglwj-062.html
-				i18n/css3-text-line-break-baspglwj-063.html
-				i18n/css3-text-line-break-baspglwj-064.html
-				i18n/css3-text-line-break-baspglwj-065.html
-				i18n/css3-text-line-break-baspglwj-066.html
-				i18n/css3-text-line-break-baspglwj-067.html
-				i18n/css3-text-line-break-baspglwj-068.html
-				i18n/css3-text-line-break-baspglwj-069.html
-				i18n/css3-text-line-break-baspglwj-070.html
-				i18n/css3-text-line-break-baspglwj-071.html
-				i18n/css3-text-line-break-baspglwj-072.html
-				i18n/css3-text-line-break-baspglwj-073.html
-				i18n/css3-text-line-break-baspglwj-074.html
-				i18n/css3-text-line-break-baspglwj-075.html
-				i18n/css3-text-line-break-baspglwj-076.html
-				i18n/css3-text-line-break-baspglwj-077.html
-				i18n/css3-text-line-break-baspglwj-078.html
-				i18n/css3-text-line-break-baspglwj-080.html
-				i18n/css3-text-line-break-baspglwj-081.html
-				i18n/css3-text-line-break-baspglwj-082.html
-				i18n/css3-text-line-break-baspglwj-083.html
-				i18n/css3-text-line-break-baspglwj-084.html
-				i18n/css3-text-line-break-baspglwj-085.html
-				i18n/css3-text-line-break-baspglwj-086.html
-				i18n/css3-text-line-break-baspglwj-090.html
-				i18n/css3-text-line-break-baspglwj-091.html
-				i18n/css3-text-line-break-baspglwj-092.html
-				i18n/css3-text-line-break-baspglwj-093.html
-				i18n/css3-text-line-break-baspglwj-095.html
-				i18n/css3-text-line-break-baspglwj-096.html
-				i18n/css3-text-line-break-baspglwj-097.html
-				i18n/css3-text-line-break-baspglwj-098.html
-				i18n/css3-text-line-break-baspglwj-099.html
-				i18n/css3-text-line-break-baspglwj-100.html
-				i18n/css3-text-line-break-baspglwj-101.html
-				i18n/css3-text-line-break-baspglwj-102.html
-				i18n/css3-text-line-break-baspglwj-103.html
-				i18n/css3-text-line-break-baspglwj-104.html
-				i18n/css3-text-line-break-baspglwj-105.html
-				i18n/css3-text-line-break-baspglwj-106.html
-				i18n/css3-text-line-break-baspglwj-107.html
-				i18n/css3-text-line-break-baspglwj-108.html
-				i18n/css3-text-line-break-baspglwj-109.html
-				i18n/css3-text-line-break-baspglwj-110.html
-				i18n/css3-text-line-break-baspglwj-111.html
-				i18n/css3-text-line-break-baspglwj-112.html
-				i18n/css3-text-line-break-baspglwj-113.html
-				i18n/css3-text-line-break-baspglwj-114.html
-				i18n/css3-text-line-break-baspglwj-115.html
-				i18n/css3-text-line-break-baspglwj-116.html
-				i18n/css3-text-line-break-baspglwj-117.html
-				i18n/css3-text-line-break-baspglwj-118.html
-				i18n/css3-text-line-break-baspglwj-120.html
-				i18n/css3-text-line-break-baspglwj-121.html
-				i18n/css3-text-line-break-baspglwj-122.html
-				i18n/css3-text-line-break-baspglwj-123.html
-				i18n/css3-text-line-break-baspglwj-124.html
-				i18n/css3-text-line-break-baspglwj-125.html
-				i18n/css3-text-line-break-baspglwj-126.html
-				i18n/css3-text-line-break-baspglwj-127.html
-				i18n/css3-text-line-break-baspglwj-128.html
-				i18n/css3-text-line-break-baspglwj-130.html
-				i18n/css3-text-line-break-baspglwj-131.html
-				white-space/control-chars-00D.html
-				white-space/pre-line-051.html
-				white-space/pre-line-052.html
-				white-space/pre-line-br-with-whitespace-child-crash.html
-				white-space/pre-line-with-space-and-newline.html
-				white-space/trailing-ideographic-space-008.html
-				white-space/trailing-ideographic-space-010.html
-				white-space/trailing-ogham-002.html
-				white-space/trailing-other-space-separators-003.html
-				white-space/trailing-space-and-text-alignment-005.html
-				white-space/trailing-space-and-text-alignment-rtl-005.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-intrinsic-size-019.html
-				white-space/white-space-intrinsic-size-020.html
-				white-space/white-space-letter-spacing-001.html
-				white-space/white-space-pre-035.html
-				word-break/break-boundary-2-chars-001.html
-				word-break/word-break-break-all-062.html
-				word-break/word-break-keep-all-063.html
-			</wpt>
-			<wpt title="tests using wrap through 'white-space: break-spaces':">
-				i18n/css3-text-line-break-baspglwj-001.html
-				i18n/css3-text-line-break-baspglwj-002.html
-				i18n/css3-text-line-break-baspglwj-003.html
-				i18n/css3-text-line-break-baspglwj-004.html
-				i18n/css3-text-line-break-baspglwj-005.html
-				i18n/css3-text-line-break-baspglwj-006.html
-				i18n/css3-text-line-break-baspglwj-007.html
-				i18n/css3-text-line-break-baspglwj-008.html
-				i18n/css3-text-line-break-baspglwj-009.html
-				i18n/css3-text-line-break-baspglwj-010.html
-				i18n/css3-text-line-break-baspglwj-011.html
-				i18n/css3-text-line-break-baspglwj-012.html
-				i18n/css3-text-line-break-baspglwj-014.html
-				i18n/css3-text-line-break-baspglwj-015.html
-				i18n/css3-text-line-break-baspglwj-016.html
-				i18n/css3-text-line-break-baspglwj-017.html
-				i18n/css3-text-line-break-baspglwj-018.html
-				i18n/css3-text-line-break-baspglwj-019.html
-				i18n/css3-text-line-break-baspglwj-020.html
-				i18n/css3-text-line-break-baspglwj-021.html
-				i18n/css3-text-line-break-baspglwj-022.html
-				i18n/css3-text-line-break-baspglwj-023.html
-				i18n/css3-text-line-break-baspglwj-024.html
-				i18n/css3-text-line-break-baspglwj-025.html
-				i18n/css3-text-line-break-baspglwj-026.html
-				i18n/css3-text-line-break-baspglwj-030.html
-				i18n/css3-text-line-break-baspglwj-031.html
-				i18n/css3-text-line-break-baspglwj-032.html
-				i18n/css3-text-line-break-baspglwj-033.html
-				i18n/css3-text-line-break-baspglwj-034.html
-				i18n/css3-text-line-break-baspglwj-035.html
-				i18n/css3-text-line-break-baspglwj-036.html
-				i18n/css3-text-line-break-baspglwj-037.html
-				i18n/css3-text-line-break-baspglwj-038.html
-				i18n/css3-text-line-break-baspglwj-039.html
-				i18n/css3-text-line-break-baspglwj-040.html
-				i18n/css3-text-line-break-baspglwj-041.html
-				i18n/css3-text-line-break-baspglwj-042.html
-				i18n/css3-text-line-break-baspglwj-043.html
-				i18n/css3-text-line-break-baspglwj-044.html
-				i18n/css3-text-line-break-baspglwj-045.html
-				i18n/css3-text-line-break-baspglwj-046.html
-				i18n/css3-text-line-break-baspglwj-047.html
-				i18n/css3-text-line-break-baspglwj-048.html
-				i18n/css3-text-line-break-baspglwj-049.html
-				i18n/css3-text-line-break-baspglwj-050.html
-				i18n/css3-text-line-break-baspglwj-051.html
-				i18n/css3-text-line-break-baspglwj-052.html
-				i18n/css3-text-line-break-baspglwj-060.html
-				i18n/css3-text-line-break-baspglwj-061.html
-				i18n/css3-text-line-break-baspglwj-062.html
-				i18n/css3-text-line-break-baspglwj-063.html
-				i18n/css3-text-line-break-baspglwj-064.html
-				i18n/css3-text-line-break-baspglwj-065.html
-				i18n/css3-text-line-break-baspglwj-066.html
-				i18n/css3-text-line-break-baspglwj-067.html
-				i18n/css3-text-line-break-baspglwj-068.html
-				i18n/css3-text-line-break-baspglwj-069.html
-				i18n/css3-text-line-break-baspglwj-070.html
-				i18n/css3-text-line-break-baspglwj-071.html
-				i18n/css3-text-line-break-baspglwj-072.html
-				i18n/css3-text-line-break-baspglwj-073.html
-				i18n/css3-text-line-break-baspglwj-074.html
-				i18n/css3-text-line-break-baspglwj-075.html
-				i18n/css3-text-line-break-baspglwj-076.html
-				i18n/css3-text-line-break-baspglwj-077.html
-				i18n/css3-text-line-break-baspglwj-078.html
-				i18n/css3-text-line-break-baspglwj-080.html
-				i18n/css3-text-line-break-baspglwj-081.html
-				i18n/css3-text-line-break-baspglwj-082.html
-				i18n/css3-text-line-break-baspglwj-083.html
-				i18n/css3-text-line-break-baspglwj-084.html
-				i18n/css3-text-line-break-baspglwj-085.html
-				i18n/css3-text-line-break-baspglwj-086.html
-				i18n/css3-text-line-break-baspglwj-090.html
-				i18n/css3-text-line-break-baspglwj-091.html
-				i18n/css3-text-line-break-baspglwj-092.html
-				i18n/css3-text-line-break-baspglwj-093.html
-				i18n/css3-text-line-break-baspglwj-095.html
-				i18n/css3-text-line-break-baspglwj-096.html
-				i18n/css3-text-line-break-baspglwj-097.html
-				i18n/css3-text-line-break-baspglwj-098.html
-				i18n/css3-text-line-break-baspglwj-099.html
-				i18n/css3-text-line-break-baspglwj-100.html
-				i18n/css3-text-line-break-baspglwj-101.html
-				i18n/css3-text-line-break-baspglwj-102.html
-				i18n/css3-text-line-break-baspglwj-103.html
-				i18n/css3-text-line-break-baspglwj-104.html
-				i18n/css3-text-line-break-baspglwj-105.html
-				i18n/css3-text-line-break-baspglwj-106.html
-				i18n/css3-text-line-break-baspglwj-107.html
-				i18n/css3-text-line-break-baspglwj-108.html
-				i18n/css3-text-line-break-baspglwj-109.html
-				i18n/css3-text-line-break-baspglwj-110.html
-				i18n/css3-text-line-break-baspglwj-111.html
-				i18n/css3-text-line-break-baspglwj-112.html
-				i18n/css3-text-line-break-baspglwj-113.html
-				i18n/css3-text-line-break-baspglwj-114.html
-				i18n/css3-text-line-break-baspglwj-115.html
-				i18n/css3-text-line-break-baspglwj-116.html
-				i18n/css3-text-line-break-baspglwj-117.html
-				i18n/css3-text-line-break-baspglwj-118.html
-				i18n/css3-text-line-break-baspglwj-120.html
-				i18n/css3-text-line-break-baspglwj-121.html
-				i18n/css3-text-line-break-baspglwj-122.html
-				i18n/css3-text-line-break-baspglwj-123.html
-				i18n/css3-text-line-break-baspglwj-124.html
-				i18n/css3-text-line-break-baspglwj-125.html
-				i18n/css3-text-line-break-baspglwj-126.html
-				i18n/css3-text-line-break-baspglwj-127.html
-				i18n/css3-text-line-break-baspglwj-128.html
-				i18n/css3-text-line-break-baspglwj-130.html
-				i18n/css3-text-line-break-baspglwj-131.html
-				line-break/line-break-anywhere-005.html
-				line-break/line-break-anywhere-009.html
-				line-break/line-break-anywhere-and-white-space-008.html
-				line-break/line-break-anywhere-and-white-space-009.html
-				overflow-wrap/overflow-wrap-anywhere-002.html
-				overflow-wrap/overflow-wrap-anywhere-003.html
-				overflow-wrap/overflow-wrap-break-word-002.html
-				overflow-wrap/overflow-wrap-break-word-003.html
-				overflow-wrap/overflow-wrap-break-word-006.html
-				overflow-wrap/overflow-wrap-break-word-008.html
-				white-space/break-spaces-001.html
-				white-space/break-spaces-002.html
-				white-space/break-spaces-003.html
-				white-space/break-spaces-004.html
-				white-space/break-spaces-005.html
-				white-space/break-spaces-006.html
-				white-space/break-spaces-007.html
-				white-space/break-spaces-008.html
-				white-space/break-spaces-009.html
-				white-space/break-spaces-010.html
-				white-space/break-spaces-011.html
-				white-space/break-spaces-051.html
-				white-space/break-spaces-052.html
-				white-space/break-spaces-before-first-char-001.html
-				white-space/break-spaces-before-first-char-002.html
-				white-space/break-spaces-before-first-char-003.html
-				white-space/break-spaces-before-first-char-004.html
-				white-space/break-spaces-before-first-char-005.html
-				white-space/break-spaces-before-first-char-006.html
-				white-space/break-spaces-before-first-char-007.html
-				white-space/break-spaces-before-first-char-008.html
-				white-space/break-spaces-before-first-char-009.html
-				white-space/break-spaces-before-first-char-010.html
-				white-space/break-spaces-before-first-char-011.html
-				white-space/break-spaces-before-first-char-012.html
-				white-space/break-spaces-before-first-char-013.html
-				white-space/break-spaces-before-first-char-014.html
-				white-space/break-spaces-before-first-char-015.html
-				white-space/break-spaces-before-first-char-016.html
-				white-space/break-spaces-before-first-char-017.html
-				white-space/break-spaces-before-first-char-018.html
-				white-space/break-spaces-before-first-ideographic-char-001.html
-				white-space/break-spaces-before-first-ideographic-char-002.html
-				white-space/break-spaces-before-first-ideographic-char-003.html
-				white-space/break-spaces-before-first-ideographic-char-004.html
-				white-space/break-spaces-before-first-ideographic-char-005.html
-				white-space/break-spaces-before-first-ideographic-char-006.html
-				white-space/break-spaces-before-first-ideographic-char-007.html
-				white-space/break-spaces-before-first-ideographic-char-008.html
-				white-space/break-spaces-before-first-ideographic-char-009.html
-				white-space/break-spaces-before-first-ideographic-char-010.html
-				white-space/break-spaces-before-first-ideographic-char-011.html
-				white-space/break-spaces-before-first-ideographic-char-012.html
-				white-space/break-spaces-before-first-ideographic-char-013.html
-				white-space/break-spaces-before-first-ideographic-char-014.html
-				white-space/break-spaces-before-first-ideographic-char-015.html
-				white-space/break-spaces-before-first-ideographic-char-016.html
-				white-space/break-spaces-before-first-ideographic-char-017.html
-				white-space/break-spaces-before-first-ideographic-char-018.html
-				white-space/break-spaces-newline-011.html
-				white-space/break-spaces-newline-012.html
-				white-space/break-spaces-newline-013.html
-				white-space/break-spaces-newline-014.html
-				white-space/break-spaces-newline-015.html
-				white-space/break-spaces-newline-016.html
-				white-space/break-spaces-tab-001.html
-				white-space/break-spaces-tab-002.html
-				white-space/break-spaces-tab-003.html
-				white-space/break-spaces-tab-004.html
-				white-space/break-spaces-tab-005.html
-				white-space/break-spaces-tab-006.html
-				white-space/break-spaces-with-ideographic-space-001.html
-				white-space/break-spaces-with-ideographic-space-002.html
-				white-space/break-spaces-with-ideographic-space-003.html
-				white-space/break-spaces-with-ideographic-space-004.html
-				white-space/break-spaces-with-ideographic-space-005.html
-				white-space/break-spaces-with-ideographic-space-006.html
-				white-space/break-spaces-with-ideographic-space-007.html
-				white-space/break-spaces-with-ideographic-space-008.html
-				white-space/break-spaces-with-ideographic-space-009.html
-				white-space/break-spaces-with-ideographic-space-010.html
-				white-space/break-spaces-with-overflow-wrap-001.html
-				white-space/break-spaces-with-overflow-wrap-002.html
-				white-space/break-spaces-with-overflow-wrap-003.html
-				white-space/break-spaces-with-overflow-wrap-004.html
-				white-space/break-spaces-with-overflow-wrap-005.html
-				white-space/break-spaces-with-overflow-wrap-006.html
-				white-space/break-spaces-with-overflow-wrap-007.html
-				white-space/break-spaces-with-overflow-wrap-008.html
-				white-space/break-spaces-with-overflow-wrap-009.html
-				white-space/break-spaces-with-overflow-wrap-010.html
-				white-space/control-chars-00D.html
-				white-space/tab-stop-threshold-005.html
-				white-space/tab-stop-threshold-006.html
-				white-space/textarea-break-spaces-001.html
-				white-space/textarea-break-spaces-002.html
-				white-space/trailing-ideographic-space-break-spaces-001.html
-				white-space/trailing-ideographic-space-break-spaces-002.html
-				white-space/trailing-ideographic-space-break-spaces-003.html
-				white-space/trailing-ideographic-space-break-spaces-004.html
-				white-space/trailing-ideographic-space-break-spaces-005.html
-				white-space/trailing-ideographic-space-break-spaces-006.html
-				white-space/trailing-ideographic-space-break-spaces-007.html
-				white-space/trailing-ideographic-space-break-spaces-008.html
-				white-space/trailing-other-space-separators-break-spaces-001.html
-				white-space/trailing-other-space-separators-break-spaces-002.html
-				white-space/trailing-other-space-separators-break-spaces-003.html
-				white-space/trailing-other-space-separators-break-spaces-004.html
-				white-space/trailing-other-space-separators-break-spaces-005.html
-				white-space/trailing-other-space-separators-break-spaces-006.html
-				white-space/trailing-other-space-separators-break-spaces-007.html
-				white-space/trailing-other-space-separators-break-spaces-008.html
-				white-space/trailing-other-space-separators-break-spaces-009.html
-				white-space/trailing-other-space-separators-break-spaces-010.html
-				white-space/trailing-other-space-separators-break-spaces-011.html
-				white-space/trailing-other-space-separators-break-spaces-012.html
-				white-space/trailing-other-space-separators-break-spaces-013.html
-				white-space/trailing-other-space-separators-break-spaces-014.html
-				white-space/trailing-other-space-separators-break-spaces-015.html
-				white-space/trailing-space-and-text-alignment-004.html
-				white-space/trailing-space-and-text-alignment-rtl-004.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-intrinsic-size-001.html
-				white-space/white-space-intrinsic-size-002.html
-				white-space/white-space-letter-spacing-001.html
-				white-space/white-space-pre-034.html
-				white-space/ws-break-spaces-applies-to-001.html
-				white-space/ws-break-spaces-applies-to-002.html
-				white-space/ws-break-spaces-applies-to-003.html
-				white-space/ws-break-spaces-applies-to-005.html
-				white-space/ws-break-spaces-applies-to-006.html
-				white-space/ws-break-spaces-applies-to-007.html
-				white-space/ws-break-spaces-applies-to-008.html
-				white-space/ws-break-spaces-applies-to-009.html
-				white-space/ws-break-spaces-applies-to-010.html
-				white-space/ws-break-spaces-applies-to-011.html
-				white-space/ws-break-spaces-applies-to-012.html
-				white-space/ws-break-spaces-applies-to-013.html
-				white-space/ws-break-spaces-applies-to-014.html
-				white-space/ws-break-spaces-applies-to-015.html
-				word-break/break-boundary-2-chars-001.html
-				word-break/word-break-break-all-012.html
-				word-break/word-break-break-all-013.html
-				word-break/word-break-break-all-017.html
-				word-break/word-break-break-all-022.html
-				word-break/word-break-break-all-062.html
-				word-break/word-break-keep-all-008.html
-				word-break/word-break-keep-all-063.html
-			</wpt>
-
-			Note: See [[#line-break-details]] for more information
-			about rules and constrains on [=soft wrap opportunities=].
-
-		<dt><dfn>nowrap</dfn>
-		<dd>
-			Inline-level content does not break across lines;
-			content that does not fit within the block container overflows it.
-
-			<wpt title="tests using nowrap directly through 'text-wrap-mode':">
-			</wpt>
-			<wpt title="tests using nowrap through 'text-wrap: nowrap':">
-			</wpt>
-			<wpt title="CSS 2 indirect tests via 'white-space: pre':" pathprefix="/css/CSS2/text/">
-				white-space-pre-001.xht
-				white-space-pre-002.xht
-				white-space-pre-005.xht
-				white-space-pre-006.xht
-			</wpt>
-			<wpt title="CSS 2 indirect tests via 'white-space: nowrap':" pathprefix="/css/CSS2/text/">
-				white-space-nowrap-001.xht
-				white-space-nowrap-005.xht
-				white-space-nowrap-006.xht
-				text-align-white-space-004.xht
-				text-align-white-space-008.xht
-				white-space-nowrap-attribute-001.xht
-				white-space-processing-006.xht
-			</wpt>
-			<wpt title="tests using nowrap through 'white-space: pre':">
-				bidi/bidi-lines-001.html
-				bidi/bidi-tab-001.html
-				letter-spacing/letter-spacing-206.html
-				letter-spacing/letter-spacing-bidi-003.xht
-				letter-spacing/letter-spacing-bidi-004.xht
-				letter-spacing/letter-spacing-bidi-005.xht
-				letter-spacing/letter-spacing-nesting-003.xht
-				line-break/line-break-anywhere-005.html
-				line-break/line-break-anywhere-and-white-space-001.html
-				line-break/line-break-anywhere-and-white-space-003.html
-				line-breaking/line-breaking-009.html
-				line-breaking/line-breaking-010.html
-				line-breaking/line-breaking-011.html
-				line-breaking/line-breaking-023.html
-				line-breaking/line-breaking-024.html
-				line-breaking/line-breaking-025.html
-				line-breaking/line-breaking-026.html
-				line-breaking/line-breaking-027.html
-				line-breaking/line-breaking-ic-001.html
-				line-breaking/line-breaking-ic-002.html
-				line-breaking/line-breaking-ic-003.html
-				line-breaking/line-breaking-replaced-006.html
-				overflow-wrap/overflow-wrap-break-word-007.html
-				overflow-wrap/overflow-wrap-break-word-008.html
-				overflow-wrap/overflow-wrap-break-word-white-space-crash.html
-				tab-size/tab-size-block-ancestor.html
-				tab-size/tab-size-inheritance-001.html
-				tab-size/tab-size-inline-001.html
-				tab-size/tab-size-inline-002.html
-				tab-size/tab-size-integer-004.html
-				tab-size/tab-size-spacing-001.html
-				tab-size/tab-size-spacing-002.html
-				tab-size/tab-size-spacing-003.html
-				text-indent/text-indent-length-002.html
-				text-indent/text-indent-tab-positions-001.html
-				text-justify/text-justify-006.html
-				text-transform/text-transform-capitalize-035.html
-				text-transform/text-transform-fullwidth-008.html
-				text-transform/text-transform-fullwidth-009.html
-				white-space/break-spaces-009.html
-				white-space/break-spaces-newline-011.html
-				white-space/break-spaces-newline-012.html
-				white-space/break-spaces-newline-013.html
-				white-space/break-spaces-newline-014.html
-				white-space/break-spaces-newline-015.html
-				white-space/break-spaces-newline-016.html
-				white-space/break-spaces-tab-005.html
-				white-space/break-spaces-tab-006.html
-				white-space/break-spaces-with-ideographic-space-009.html
-				white-space/break-spaces-with-overflow-wrap-009.html
-				white-space/break-spaces-with-overflow-wrap-010.html
-				white-space/control-chars-00D.html
-				white-space/eol-spaces-bidi-001.html
-				white-space/eol-spaces-bidi-002.html
-				white-space/pre-float-001.html
-				white-space/pre-with-whitespace-crash.html
-				white-space/pre-wrap-008.html
-				white-space/pre-wrap-009.html
-				white-space/pre-wrap-010.html
-				white-space/pre-wrap-016.html
-				white-space/pre-wrap-018.html
-				white-space/pre-wrap-019.html
-				white-space/pre-wrap-020.html
-				white-space/tab-bidi-001.html
-				white-space/tab-stop-threshold-001.html
-				white-space/tab-stop-threshold-002.html
-				white-space/trailing-other-space-separators-001.html
-				white-space/trailing-other-space-separators-003.html
-				white-space/trailing-other-space-separators-004.html
-				white-space/trailing-other-space-separators-break-spaces-001.html
-				white-space/trailing-other-space-separators-break-spaces-002.html
-				white-space/trailing-other-space-separators-break-spaces-003.html
-				white-space/trailing-other-space-separators-break-spaces-004.html
-				white-space/trailing-other-space-separators-break-spaces-005.html
-				white-space/trailing-other-space-separators-break-spaces-006.html
-				white-space/trailing-other-space-separators-break-spaces-007.html
-				white-space/trailing-other-space-separators-break-spaces-008.html
-				white-space/trailing-other-space-separators-break-spaces-009.html
-				white-space/trailing-other-space-separators-break-spaces-010.html
-				white-space/trailing-other-space-separators-break-spaces-011.html
-				white-space/trailing-other-space-separators-break-spaces-012.html
-				white-space/trailing-other-space-separators-break-spaces-013.html
-				white-space/trailing-other-space-separators-break-spaces-014.html
-				white-space/trailing-other-space-separators-break-spaces-015.html
-				white-space/trailing-space-align-start.tentative.html
-				white-space/trailing-space-and-text-alignment-002.html
-				white-space/trailing-space-and-text-alignment-rtl-002.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-intrinsic-size-015.html
-				white-space/white-space-intrinsic-size-016.html
-				white-space/white-space-intrinsic-size-018.html
-				white-space/white-space-letter-spacing-001.html
-				white-space/white-space-normal-011.html
-				white-space/white-space-pre-011.html
-				white-space/white-space-pre-031.html
-				white-space/white-space-pre-032.html
-				white-space/white-space-pre-034.html
-				white-space/white-space-pre-035.html
-				white-space/white-space-pre-051.html
-				white-space/white-space-pre-052.html
-				white-space/ws-break-spaces-applies-to-001.html
-				white-space/ws-break-spaces-applies-to-002.html
-				white-space/ws-break-spaces-applies-to-003.html
-				white-space/ws-break-spaces-applies-to-005.html
-				white-space/ws-break-spaces-applies-to-006.html
-				white-space/ws-break-spaces-applies-to-007.html
-				white-space/ws-break-spaces-applies-to-008.html
-				white-space/ws-break-spaces-applies-to-009.html
-				white-space/ws-break-spaces-applies-to-010.html
-				white-space/ws-break-spaces-applies-to-011.html
-				white-space/ws-break-spaces-applies-to-014.html
-				white-space/ws-break-spaces-applies-to-015.html
-				word-break/break-boundary-2-chars-001.html
-				word-break/break-boundary-2-chars-002.html
-				word-break/word-break-break-all-010.html
-				word-break/word-break-break-all-011.html
-				word-break/word-break-break-all-012.html
-				word-break/word-break-break-all-013.html
-				word-break/word-break-break-all-015.html
-				word-break/word-break-break-all-017.html
-				word-break/word-break-break-all-ethiopic.html
-				word-break/word-break-normal-ethiopic.html
-				word-space-transform/word-space-transform-008.html
-				word-space-transform/word-space-transform-011.html
-			</wpt>
-			<wpt title="tests using nowrap through 'white-space: nowrap':">
-				hanging-punctuation/hanging-punctuation-allow-end-001.xht
-				hanging-punctuation/hanging-punctuation-first-001.xht
-				hanging-punctuation/hanging-punctuation-force-end-001.xht
-				hanging-punctuation/hanging-punctuation-last-001.xht
-				letter-spacing/letter-spacing-206.html
-				line-break/line-break-anywhere-and-white-space-002.html
-				line-breaking/line-breaking-012.html
-				line-breaking/line-breaking-atomic-nowrap-001.html
-				overflow-wrap/overflow-wrap-002.html
-				overflow-wrap/overflow-wrap-anywhere-008.html
-				overflow-wrap/overflow-wrap-break-word-white-space-crash-002.html
-				overflow-wrap/word-wrap-002.html
-				text-transform/text-transform-capitalize-001.html
-				text-transform/text-transform-capitalize-003.html
-				text-transform/text-transform-capitalize-005.html
-				text-transform/text-transform-capitalize-007.html
-				text-transform/text-transform-capitalize-009.html
-				text-transform/text-transform-capitalize-010.html
-				text-transform/text-transform-capitalize-011.html
-				text-transform/text-transform-capitalize-014.html
-				text-transform/text-transform-capitalize-016.html
-				text-transform/text-transform-capitalize-018.html
-				text-transform/text-transform-capitalize-020.html
-				text-transform/text-transform-capitalize-022.html
-				text-transform/text-transform-capitalize-024.html
-				text-transform/text-transform-capitalize-026.html
-				text-transform/text-transform-capitalize-028.html
-				text-transform/text-transform-capitalize-030.html
-				text-transform/text-transform-full-size-kana-005.html
-				text-transform/text-transform-full-size-kana-006.html
-				text-transform/text-transform-full-size-kana-007.html
-				text-transform/text-transform-fullwidth-001.xht
-				text-transform/text-transform-upperlower-001.html
-				text-transform/text-transform-upperlower-002.html
-				text-transform/text-transform-upperlower-003.html
-				text-transform/text-transform-upperlower-004.html
-				text-transform/text-transform-upperlower-005.html
-				text-transform/text-transform-upperlower-006.html
-				text-transform/text-transform-upperlower-007.html
-				text-transform/text-transform-upperlower-008.html
-				text-transform/text-transform-upperlower-009.html
-				text-transform/text-transform-upperlower-010.html
-				text-transform/text-transform-upperlower-011.html
-				text-transform/text-transform-upperlower-012.html
-				text-transform/text-transform-upperlower-014.html
-				text-transform/text-transform-upperlower-015.html
-				text-transform/text-transform-upperlower-016.html
-				text-transform/text-transform-upperlower-017.html
-				text-transform/text-transform-upperlower-018.html
-				text-transform/text-transform-upperlower-019.html
-				text-transform/text-transform-upperlower-020.html
-				text-transform/text-transform-upperlower-021.html
-				text-transform/text-transform-upperlower-022.html
-				text-transform/text-transform-upperlower-023.html
-				text-transform/text-transform-upperlower-024.html
-				text-transform/text-transform-upperlower-025.html
-				text-transform/text-transform-upperlower-026.html
-				text-transform/text-transform-upperlower-027.html
-				text-transform/text-transform-upperlower-028.html
-				text-transform/text-transform-upperlower-029.html
-				text-transform/text-transform-upperlower-030.html
-				text-transform/text-transform-upperlower-031.html
-				text-transform/text-transform-upperlower-032.html
-				text-transform/text-transform-upperlower-033.html
-				text-transform/text-transform-upperlower-034.html
-				text-transform/text-transform-upperlower-035.html
-				text-transform/text-transform-upperlower-039.html
-				text-transform/text-transform-upperlower-040.html
-				text-transform/text-transform-upperlower-041.html
-				text-transform/text-transform-upperlower-042.html
-				text-transform/text-transform-upperlower-043.html
-				text-transform/text-transform-upperlower-044.html
-				text-transform/text-transform-upperlower-101.html
-				text-transform/text-transform-upperlower-102.html
-				text-transform/text-transform-upperlower-103.html
-				text-transform/text-transform-upperlower-104.html
-				white-space/control-chars-00D.html
-				white-space/nowrap-wbr-and-space-crash.html
-				white-space/trailing-ideographic-space-007.html
-				white-space/trailing-ideographic-space-009.html
-				white-space/trailing-ogham-003.html
-				white-space/trailing-other-space-separators-004.html
-				white-space/white-space-applies-to-text-001.html
-				white-space/white-space-nowrap-011.html
-				white-space/white-space-wrap-after-nowrap-001.html
-				word-break/auto-phrase/word-break-auto-phrase-wbr-nobr-002.html
-				word-break/break-boundary-2-chars-002.html
-				word-break/word-break-break-word-crash-001.html
-			</wpt>
-	</dl>
-
-	Regardless of the 'text-wrap-mode' value,
-	[=preserved=] [=segment breaks=],
-	and any Unicode character with the <code>BK</code>, <code>CR</code>, <code>LF</code>, and <code>NL</code> line breaking class,
-	must be treated as [=forced line breaks=].
-	[[!UAX14]]
-
-	<wpt>
-	line-breaking/line-breaking-022.html
-	</wpt>
-
-	Note: The bidi implications of such [=forced line breaks=]
-	are defined by the <a href="https://www.unicode.org/reports/tr9/"><cite>Unicode Bidirectional Algorithm</cite></a>.
-	[[!UAX9]]
-
-<h4 id="text-wrap-style">
-Selecting How to Wrap: the 'text-wrap-style' property</h4>
-
-	<wpt title="
-		This property has limited coverage.
-
-		Missing test:
-		* tests for values other than balance
-		* Direct tests of this property as a longhand"></wpt>
-
-	<pre class="propdef">
-	Name: text-wrap-style
-	Value: auto| balance | stable | pretty
-	Initial: auto
-	Applies to: [=block containers=] hat establish an [=inline formatting context=]
-	Inherited: yes
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	When wrapping is allowed
-	(see 'text-wrap-mode'),
-	this property selects between several approaches for wrapping lines,
-	trading off between speed, quality and style of layout, or stability.
-	It does not change which [=soft wrap opportunity=] exist,
-	but changes how the user agent selects among them.
-	Possible values:
-
-	<dl dfn-for=text-wrap-style dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			The exact algorithm for selecting
-			which [=soft wrap opportunity=] to break at is UA-defined.
-			The algorithm <em>may</em> consider multiple lines
-			when making break decisions.
-			The UA <em>may</em> bias for speed over best layout.
-			The UA <em>must not</em> attempt to even out all lines
-			(including the last) as for ''text-wrap-style/balance''.
-			This value selects the UA’s preferred (or most Web-compatible)
-			wrapping algorithm.
-
-		<dt><dfn>balance</dfn>
-		<dd>
-			Line breaks are chosen to balance
-			the remaining (empty) space in each line box,
-			if better balance than ''text-wrap-style/auto'' is possible.
-			This must not change the number of line boxes
-			the block would contain
-			if 'text-wrap' were set to ''text-wrap-style/auto''.
-
-			<wpt>
-				white-space/text-wrap-balance-001.html
-				white-space/text-wrap-balance-002.html
-				white-space/text-wrap-balance-align-001.html
-				white-space/text-wrap-balance-dynamic-001.html
-				white-space/text-wrap-balance-line-clamp-001.html
-				white-space/text-wrap-balance-narrow-crash.html
-				crashtests/text-wrap-balance-float-crash.html
-			</wpt>
-
-			The remaining space to consider
-			is that which remains after placing floats and inline content,
-			but before any adjustments due to text justification.
-			Line boxes are balanced when the standard deviation
-			from the average <a>inline-size</a> of the remaining space in each line box
-			is reduced over the block
-			(including lines that end in a forced break).
-
-			<wpt>
-				white-space/text-wrap-balance-text-indent-001.html
-			</wpt>
-
-			The exact algorithm is UA-defined.
-
-			UAs may treat this value as ''text-wrap-style/auto'' if there are more than ten lines to balance.
-
-		<dt><dfn>stable</dfn>
-		<dd>
-			Specifies that content on subsequent lines
-			<em>should not</em> be considered when making break decisions
-			so that when editing text any content before the cursor
-			remains stable;
-			otherwise equivalent to ''text-wrap-style/auto'',
-
-		<dt><dfn>pretty</dfn>
-		<dd>
-			Specifies the UA <em>should</em> bias for better layout over speed,
-			and is expected to consider multiple lines,
-			when making break decisions.
-			Otherwise equivalent to ''text-wrap-style/auto'',
-	</dl>
-
-	<!-- add a sample prioritization algorithm -->
-
-	Note: The ''text-wrap-style/auto'' value will typically map
-	to Web browsers’ speedy legacy line breaking,
-	which has so far used first-fit/greedy algorithms
-	that can often give sub-optimal results. 
-	UAs can experiment with better line breaking algorithms
-	with this default value, 
-	but as optimal results often take more time,
-	''text-wrap-style/pretty'' is offered as an opt-in
-	to take more time for better results.
-	The ''text-wrap-style/pretty'' value is intended for body text,
-	where the last line is expected to be a bit shorter than the average line;
-	the ''text-wrap-style/balance'' value is intended for titles and captions,
-	where equal-length lines of text tend to be preferred;
-	and the ''text-wrap-style/stable'' is intended for sections that are,
-	or are likely become toggled as,
-	editable.
-
-	<div class="issue" id="last-line-limits">
-		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
-		Issue is about requiring a minimum length for lines.
-		Common measures seem to be
-
-		<ul>
-			<li>At least as long as the text-indent.
-			<li>At least X characters.
-			<li>Percentage-based.
-		</ul>
-
-		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
-		(with ''Xch'' given as an example to make that use case clear).
-		Alternately <<integer>> could actually count the characters.
-
-		It's unclear how this would interact with text balancing (above);
-		one earlier proposal had them be the same property
-		(with ''100%'' meaning full balancing).
-
-		People have requested word-based limits, but since this is really
-		dependent on the length of the word, character-based is better.
-	</div>
-
-<h3 id="wrap-before">
-Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
-
-	<wpt title="This section lacks tests."></wpt>
-
-	<pre class="propdef">
-	Name: wrap-before, wrap-after
-	Value: auto | avoid | avoid-line | avoid-flex | line | flex
-	Initial: auto
-	Applies to: <a>inline-level</a> boxes and <a>flex items</a>
-	Inherited: no
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	These properties specify modifications to break opportunities
-	in line breaking (and <a>flex line</a> breaking [[CSS3-FLEXBOX]]).
-	Possible values:
-
-	<dl dfn-for="wrap-before, wrap-after" dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			Lines may break at allowed break points
-			before and after the box,
-			as determined by the line-breaking rules in effect.
-
-		<dt><dfn>avoid</dfn>
-		<dd>
-			Line breaking is suppressed immediately before/after the box:
-			the UA may only break there
-			if there are no other valid break points
-			in the line.
-			If the text breaks,
-			line-breaking restrictions are honored as for
-			''wrap-before/auto''.
-
-		<dt><dfn>avoid-line</dfn>
-		<dd>
-			Same as ''wrap-before/avoid'',
-			but only for line breaks.
-
-		<dt><dfn>avoid-flex</dfn>
-		<dd>
-			Same as ''wrap-before/avoid'',
-			but only for flex line breaks.
-
-		<dt><dfn>line</dfn>
-		<dd>
-			Force a line break immediately before/after the box
-			if the box is an <a>inline-level</a> box.
-
-		<dt><dfn>flex</dfn>
-		<dd>
-			Force a <a>flex line</a> break immediately before/after the box
-			if the box is a <a>flex item</a>
-			in a <a>multi-line flex container</a>.
-	</dl>
-
-	Forced line breaks on <a>inline-level</a> boxes propagate upward
-	through any parent <a>inline boxes</a>
-	the same way forced breaks on <a>block-level</a> boxes propagate upward
-	through any parent <a>block boxes</a>
-	in the same <a>fragmentation context</a>.
-	[[!CSS3-BREAK]]
-
-<h3 id="wrap-inside">
-Controlling Breaks Within Boxes: the 'wrap-inside' property</h3>
-
-	<wpt title="This section lacks tests."></wpt>
-
-	<pre class="propdef">
-	Name: wrap-inside
-	Value: auto | avoid
-	Initial: auto
-	Applies to: <a>inline boxes</a>
-	Inherited: no
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	<dl dfn-for=wrap-inside dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			Lines may break at allowed break points
-			within the box,
-			as determined by the line-breaking rules in effect.
-
-		<dt><dfn>avoid</dfn>
-		<dd>
-			Line breaking is suppressed within the box:
-			the UA may only break within the box
-			if there are no other valid break points in the line.
-			If the text breaks,
-			line-breaking restrictions are honored as for
-			''wrap-inside/auto''.
-
-			If boxes with ''wrap-inside/avoid'' are nested
-			and the UA must break within these boxes,
-			a break in an outer box must be used
-			before a break within an inner box may be used.
-	</dl>
-
-<h4 id="example-avoid">
-Example of using 'wrap-inside: avoid' in presenting a footer</h4>
-
-	<wpt title="This section does not need tests."></wpt>
-
-	<div class="example">
-
-		The priority of breakpoints can be set
-		to reflect the intended grouping of text.
-
-		Given the rules
-
-		<pre>
-			footer { wrap-inside: avoid; }
-			venue { wrap-inside: avoid; }
-			date { wrap-inside: avoid; }
-			place { wrap-inside: avoid; }
-		</pre>
-
-		and the following markup:
-
-		<pre>
-			&lt;footer>
-			&lt;venue>27th Internationalization and Unicode Conference&lt;/venue>
-			&amp;#8226; &lt;date>April 7, 2005&lt;/date> &amp;#8226;
-			&lt;place>Berlin, Germany&lt;/place>
-			&lt;/footer>
-		</pre>
-
-		In a narrow window the footer could be broken as
-
-		<pre>
-			27th Internationalization and Unicode Conference &#8226;
-			April 7, 2005 &#8226; Berlin, Germany
-		</pre>
-
-		or in a narrower window as
-
-		<pre>
-			27th Internationalization and Unicode
-			Conference &#8226; April 7, 2005 &#8226;
-			Berlin, Germany
-		</pre>
-
-		but not as
-
-		<pre>
-			27th Internationalization and Unicode Conference &#8226; April
-			7, 2005 &#8226; Berlin, Germany
-		</pre>
-	</div>
-
-<h3 id="line-break-details">
-Line Breaking Details</h3>
-
-	<wpt title="
-		This section has partial test coverage.
-
-		Missing tests:
-
-		* For soft wrap opportunities before the first or after the last character of a box, the break occurs immediately before/after the box (at its margin edge) rather than breaking the box between its content edge and the content.
-		* Line breaking classes CM and SG must be honored
-
-		Untestable(?):
-
-		* UAs that allow wrapping at punctuation other than spaces should prioritize breakpoints. […]"></wpt>
-
-	When determining [=line breaks=]:
-
-	<ul>
-		<li>
-			The interaction of [=line breaking=] and bidirectional text is defined by
-			[[css-writing-modes-4#bidi-algo]]
-			and the <cite>Unicode Bidirectional Algorithm</cite>
-			(<a href="http://unicode.org/reports/tr9/#Reordering_Resolved_Levels">UAX9&sect;3.4 Reordering Resolved Levels</a> in particular).
-			[[!CSS-WRITING-MODES-4]]
-			[[!UAX9]]
-
-			<wpt pathprefix="/css/CSS2/bidi-text/">
-			bidi-breaking-001.xht
-			bidi-breaking-002.xht
-			bidi-breaking-003.xht
-			</wpt>
-
-		<li>
-			Except where explicitly defined otherwise
-			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
-			line breaking behavior defined for
-			the <code>CM</code>,
-			and <code>SG</code>,
-			<code>WJ</code>,
-			<code>ZW</code>,
-			<code>GL</code>,
-			and <code>ZWJ</code>
-			Unicode line breaking classes
-			must be honored.
-			[[!UAX14]]
-
-			<wpt>
-			word-break/word-break-normal-001.html
-			line-breaking/line-breaking-001.html
-			line-breaking/line-breaking-002.html
-			line-breaking/line-breaking-003.html
-			line-breaking/line-breaking-004.html
-			line-breaking/line-breaking-005.html
-			line-breaking/line-breaking-006.html
-			line-breaking/line-breaking-007.html
-			line-breaking/line-breaking-008.html
-			line-breaking/line-breaking-021.html
-			i18n/css3-text-line-break-baspglwj-001.html
-			i18n/css3-text-line-break-baspglwj-002.html
-			i18n/css3-text-line-break-baspglwj-120.html
-			i18n/css3-text-line-break-baspglwj-121.html
-			i18n/css3-text-line-break-baspglwj-122.html
-			i18n/css3-text-line-break-baspglwj-123.html
-			i18n/css3-text-line-break-baspglwj-124.html
-			i18n/css3-text-line-break-baspglwj-125.html
-			i18n/css3-text-line-break-baspglwj-126.html
-			i18n/css3-text-line-break-baspglwj-127.html
-			i18n/css3-text-line-break-baspglwj-128.html
-			i18n/css3-text-line-break-baspglwj-130.html
-			i18n/css3-text-line-break-baspglwj-131.html
-			word-break/word-break-break-all-018.html
-			word-break/word-break-break-all-021.html
-			word-break/word-break-break-all-022.html
-			</wpt>
-
-		<li>
-			UAs that allow wrapping at punctuation
-			other than [=word separators=]
-			in writing systems that use them
-			<em>should</em> prioritize breakpoints.
-			(For example, if breaks after slashes are given a lower priority than spaces,
-			the sequence “check /etc” will never break between the "/" and the "e".)
-			As long as care is taken to avoid such awkward breaks,
-			allowing breaks at appropriate punctuation other than [=word separators=]
-			is recommended,
-			as it results in more even-looking margins, particularly in narrow measures.
-			The UA may use the width of the containing block, the text's language,
-			the 'line-break' value,
-			and other factors in assigning priorities:
-			CSS does not define prioritization of [=soft wrap opportunities=].
-			Prioritization of [=word separators=] is not expected,
-			however,
-			if ''word-break: break-all'' is specified
-			(since this value explicitly requests line breaking behavior
-			not based on breaking at [=word separators=])--
-			and is forbidden under ''line-break: anywhere''.
-
-		<li>
-			Out-of-flow elements
-			and inline element boundaries
-			do not introduce a [=forced line break=]
-			or [=soft wrap opportunity=] in the flow.
-
-			<wpt>
-			line-breaking/line-breaking-012.html
-			line-breaking/line-breaking-015.html
-			line-breaking/line-breaking-016.html
-			line-breaking/line-breaking-017.html
-			line-breaking/line-breaking-018.html
-			line-breaking/line-breaking-019.html
-			</wpt>
-
-		<li id=atomic-compat-wrap>
-			For Web-compatibility
-			there is a [=soft wrap opportunity=]
-			before and after each replaced element or other [=atomic inline=],
-			even when adjacent to a character that would normally suppress them,
-			including U+00A0 NO-BREAK SPACE.
-			However,
-			with the exception of U+00A0 NO-BREAK SPACE,
-			there must be no [=soft wrap opportunity=]
-			between [=atomic inlines=] and adjacent characters
-			belonging to the Unicode GL, WJ, or ZWJ line breaking classes.
-			[[UAX14]]
-
-			<wpt>
-			line-breaking/line-breaking-atomic-001.html
-			line-breaking/line-breaking-atomic-002.html
-			line-breaking/line-breaking-atomic-003.html
-			line-breaking/line-breaking-atomic-004.html
-			line-breaking/line-breaking-atomic-005.html
-			line-breaking/line-breaking-atomic-006.html
-			line-breaking/line-breaking-atomic-007.html
-			line-breaking/line-breaking-atomic-008.html
-			line-breaking/line-breaking-atomic-009.html
-			line-breaking/line-breaking-atomic-010.html
-			line-breaking/line-breaking-atomic-011.html
-			line-breaking/line-breaking-atomic-012.html
-			line-breaking/line-breaking-atomic-013.html
-			line-breaking/line-breaking-atomic-014.html
-			line-breaking/line-breaking-atomic-015.html
-			line-breaking/line-breaking-atomic-016.html
-			line-breaking/line-breaking-atomic-017.html
-			line-breaking/line-breaking-atomic-018.html
-			line-breaking/line-breaking-atomic-019.html
-			line-breaking/line-breaking-atomic-020.html
-			line-breaking/line-breaking-atomic-021.html
-			line-breaking/line-breaking-atomic-022.html
-			line-breaking/line-breaking-atomic-023.html
-			line-breaking/line-breaking-atomic-024.html
-			line-breaking/line-breaking-atomic-025.html
-			line-breaking/line-breaking-atomic-026.html
-			line-breaking/line-breaking-atomic-027.html
-			line-breaking/line-breaking-replaced-001.html
-			line-breaking/line-breaking-replaced-002.html
-			line-breaking/line-breaking-replaced-003.html
-			line-breaking/line-breaking-replaced-004.html
-			line-breaking/line-breaking-replaced-005.html
-			line-breaking/line-breaking-replaced-006.html
-			line-breaking/line-breaking-atomic-nowrap-001.html
-			</wpt>
-
-		<li>
-			For [=soft wrap opportunities=] created by characters
-			that disappear at the line break (e.g. U+0020 SPACE),
-			properties on the box directly containing that character
-			control the line breaking at that opportunity.
-			For [=soft wrap opportunities=] defined by the boundary between two characters,
-			the 'white-space' property
-			on the nearest common ancestor of the two characters
-			controls breaking;
-			<!-- http://lists.w3.org/Archives/Public/www-style/2008Dec/0043.html -->
-			which elements’ 'line-break', 'word-break', and 'overflow-wrap' properties
-			control the determination of [=soft wrap opportunities=]
-			at such boundaries
-			is undefined in Level 3.
-
-			<wpt>
-			line-breaking/line-breaking-009.html
-			line-breaking/line-breaking-010.html
-			line-breaking/line-breaking-011.html
-			line-breaking/line-breaking-ic-001.html
-			line-breaking/line-breaking-ic-002.html
-			line-breaking/line-breaking-ic-003.html
-			white-space/white-space-wrap-after-nowrap-001.html
-			word-break/break-boundary-2-chars-001.html
-
-			overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
-			overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
-			overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
-			word-break/word-break-break-all-inline-004.tentative.html
-			word-break/word-break-break-all-inline-007.tentative.html
-			word-break/word-break-break-all-inline-010.tentative.html
-			</wpt>
-
-		<li>
-			For [=soft wrap opportunities=] before the first
-			or after the last character of a box,
-			the break occurs immediately before/after the box
-			(at its margin edge)
-			rather than breaking the box
-			between its content edge and the content.
-
-		<li>
-			Line breaking in/around Ruby is defined
-			in [[css-ruby-1#line-breaks]].
-			[[!CSS-RUBY-1]]
-
-		<li id="word-break-shaping">
-			When shaping scripts such as Arabic
-			[=wrap=] at unforced [=soft wrap opportunities=] within words
-			(such as when breaking due to
-			''word-break: break-all'',
-			''line-break: anywhere'',
-			''overflow-wrap: break-word'',
-			''overflow-wrap: anywhere'',
-			or when [=hyphenating=])
-			the characters must still be shaped
-			(their joining forms chosen)
-			as if the word were still whole.
-
-			<wpt>
-			hyphens/hyphens-shaping-001.html
-			hyphens/hyphens-shaping-002.html
-			line-break/line-break-shaping-001.html
-			overflow-wrap/overflow-wrap-shaping-001.html
-			overflow-wrap/overflow-wrap-shaping-002.html
-			word-break/word-break-break-all-004.html
-			</wpt>
-
-			<div class="example">
-				For example,
-				if the word “نوشتن” is broken between the “ش” and “ت”,
-				the “ش” still takes its initial form (“ﺷ”),
-				and the “ت” its medial form (“ﺘ”)--
-				forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
-			</div>
-	</ul>
 
 
 <h2 id="justification">

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4707,6 +4707,36 @@ Line Breaking Details</h3>
 			Line breaking in/around Ruby is defined
 			in [[css-ruby-1#line-breaks]].
 			[[!CSS-RUBY-1]]
+
+		<li id="word-break-shaping">
+			When shaping scripts such as Arabic
+			[=wrap=] at unforced [=soft wrap opportunities=] within words
+			(such as when breaking due to
+			''word-break: break-all'',
+			''line-break: anywhere'',
+			''overflow-wrap: break-word'',
+			''overflow-wrap: anywhere'',
+			or when [=hyphenating=])
+			the characters must still be shaped
+			(their joining forms chosen)
+			as if the word were still whole.
+
+			<wpt>
+			hyphens/hyphens-shaping-001.html
+			hyphens/hyphens-shaping-002.html
+			line-break/line-break-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-002.html
+			word-break/word-break-break-all-004.html
+			</wpt>
+
+			<div class="example">
+				For example,
+				if the word “نوشتن” is broken between the “ش” and “ت”,
+				the “ش” still takes its initial form (“ﺷ”),
+				and the “ت” its medial form (“ﺘ”)--
+				forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
+			</div>
 	</ul>
 
 <h3 id="word-break-property" caniuse="word-break" oldids="word-break">
@@ -5287,8 +5317,7 @@ Breaking Rules for Letters: the 'word-break' property</h3>
 	When shaping scripts such as Arabic
 	are allowed to break within words due to ''word-break/break-all''
 	the characters must still be shaped
-	as if the word were [[#word-break-shaping|not broken]]
-	(see [[#word-break-shaping]]).
+	as if the word were <a href=#word-break-shaping>not broken</a>.
 
 	<wpt>
 	word-break/word-break-break-all-004.html
@@ -6201,8 +6230,7 @@ Hyphenation Control: the 'hyphens' property</h4>
 	When shaping scripts such as Arabic are allowed to break within words
 	due to hyphenation,
 	the characters must still be shaped
-	as if the word were [[#word-break-shaping|not broken]]
-	(see [[#word-break-shaping]]).
+	as if the word were <a href=#word-break-shaping>not broken</a>.
 
 	<wpt>
 	hyphens/hyphens-shaping-001.html
@@ -8217,40 +8245,6 @@ Example of using 'wrap-inside: avoid' in presenting a footer</h4>
 			27th Internationalization and Unicode Conference &#8226; April
 			7, 2005 &#8226; Berlin, Germany
 		</pre>
-	</div>
-
-<h3 id="word-break-shaping">
-Shaping Across Intra-word Breaks</h3>
-
-	<wpt title="This section has good test coverage."></wpt>
-
-	When shaping scripts such as Arabic
-	[=wrap=] at unforced [=soft wrap opportunities=] within words
-	(such as when breaking due to
-	''word-break: break-all'',
-	''line-break: anywhere'',
-	''overflow-wrap: break-word'',
-	''overflow-wrap: anywhere'',
-	or when [=hyphenating=])
-	the characters must still be shaped
-	(their joining forms chosen)
-	as if the word were still whole.
-
-	<wpt>
-	hyphens/hyphens-shaping-001.html
-	hyphens/hyphens-shaping-002.html
-	line-break/line-break-shaping-001.html
-	overflow-wrap/overflow-wrap-shaping-001.html
-	overflow-wrap/overflow-wrap-shaping-002.html
-	word-break/word-break-break-all-004.html
-	</wpt>
-
-	<div class="example">
-		For example,
-		if the word “نوشتن” is broken between the “ش” and “ت”,
-		the “ش” still takes its initial form (“ﺷ”),
-		and the “ت” its medial form (“ﺘ”)--
-		forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
 	</div>
 
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4098,7 +4098,7 @@ Tab Character Size: the 'tab-size' property</h3>
 	white-space-processing-042.xht
 	</wpt>
 
-<h2 id="text-wrapping">
+<h2 id="text-wrapping" oldids="text-wrap">
 Text Wrapping</h2>
 
 	<wpt title="
@@ -4142,38 +4142,8 @@ Text Wrapping</h2>
 	and
 	'wrap-inside' properties.
 
-<h3 id="text-wrap">
-Text Wrap Setting</h3>
-
-<h4 id="text-wrap-shorthand">
-Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
-
-	<wpt title="This section has limited coverage."></wpt>
-
-	<pre class="propdef">
-	Name: text-wrap
-	Value: <'text-wrap-mode'> || <'text-wrap-style'>
-	Initial: wrap
-	Applies to: see individual properties
-	Inherited: see individual properties
-	Percentages: see individual properties
-	Computed value: see individual properties
-	Animation type: see individual properties
-	</pre>
-
-	<wpt>
-		parsing/text-wrap-invalid.html
-		parsing/text-wrap-valid.html
-	</wpt>
-	<wpt title="TODO: needs review, probably outdated">
-		parsing/white-space-shorthand-text-wrap.html
-	</wpt>
-
-	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
-	Any omitted [=longhand=] is set to its [=initial value=].
-
-<h4 id="text-wrap-mode">
-Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
+<h3 id="text-wrap-mode">
+Deciding Whether to Wrap: the 'text-wrap-mode' property</h3>
 
 	<wpt title="
 		This property is tested extensively through its shorthands,
@@ -5335,141 +5305,6 @@ Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 	are defined by the <a href="https://www.unicode.org/reports/tr9/"><cite>Unicode Bidirectional Algorithm</cite></a>.
 	[[!UAX9]]
 
-<h4 id="text-wrap-style">
-Selecting How to Wrap: the 'text-wrap-style' property</h4>
-
-	<wpt title="
-		This property has limited coverage.
-
-		Missing test:
-		* tests for values other than balance
-		* Direct tests of this property as a longhand"></wpt>
-
-	<pre class="propdef">
-	Name: text-wrap-style
-	Value: auto| balance | stable | pretty
-	Initial: auto
-	Applies to: [=block containers=] hat establish an [=inline formatting context=]
-	Inherited: yes
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	When wrapping is allowed
-	(see 'text-wrap-mode'),
-	this property selects between several approaches for wrapping lines,
-	trading off between speed, quality and style of layout, or stability.
-	It does not change which [=soft wrap opportunity=] exist,
-	but changes how the user agent selects among them.
-	Possible values:
-
-	<dl dfn-for=text-wrap-style dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			The exact algorithm for selecting
-			which [=soft wrap opportunity=] to break at is UA-defined.
-			The algorithm <em>may</em> consider multiple lines
-			when making break decisions.
-			The UA <em>may</em> bias for speed over best layout.
-			The UA <em>must not</em> attempt to even out all lines
-			(including the last) as for ''text-wrap-style/balance''.
-			This value selects the UA’s preferred (or most Web-compatible)
-			wrapping algorithm.
-
-		<dt><dfn>balance</dfn>
-		<dd>
-			Line breaks are chosen to balance
-			the remaining (empty) space in each line box,
-			if better balance than ''text-wrap-style/auto'' is possible.
-			This must not change the number of line boxes
-			the block would contain
-			if 'text-wrap' were set to ''text-wrap-style/auto''.
-
-			<wpt>
-				white-space/text-wrap-balance-001.html
-				white-space/text-wrap-balance-002.html
-				white-space/text-wrap-balance-align-001.html
-				white-space/text-wrap-balance-dynamic-001.html
-				white-space/text-wrap-balance-line-clamp-001.html
-				white-space/text-wrap-balance-narrow-crash.html
-				crashtests/text-wrap-balance-float-crash.html
-			</wpt>
-
-			The remaining space to consider
-			is that which remains after placing floats and inline content,
-			but before any adjustments due to text justification.
-			Line boxes are balanced when the standard deviation
-			from the average <a>inline-size</a> of the remaining space in each line box
-			is reduced over the block
-			(including lines that end in a forced break).
-
-			<wpt>
-				white-space/text-wrap-balance-text-indent-001.html
-			</wpt>
-
-			The exact algorithm is UA-defined.
-
-			UAs may treat this value as ''text-wrap-style/auto'' if there are more than ten lines to balance.
-
-		<dt><dfn>stable</dfn>
-		<dd>
-			Specifies that content on subsequent lines
-			<em>should not</em> be considered when making break decisions
-			so that when editing text any content before the cursor
-			remains stable;
-			otherwise equivalent to ''text-wrap-style/auto'',
-
-		<dt><dfn>pretty</dfn>
-		<dd>
-			Specifies the UA <em>should</em> bias for better layout over speed,
-			and is expected to consider multiple lines,
-			when making break decisions.
-			Otherwise equivalent to ''text-wrap-style/auto'',
-	</dl>
-
-	<!-- add a sample prioritization algorithm -->
-
-	Note: The ''text-wrap-style/auto'' value will typically map
-	to Web browsers’ speedy legacy line breaking,
-	which has so far used first-fit/greedy algorithms
-	that can often give sub-optimal results.
-	UAs can experiment with better line breaking algorithms
-	with this default value,
-	but as optimal results often take more time,
-	''text-wrap-style/pretty'' is offered as an opt-in
-	to take more time for better results.
-	The ''text-wrap-style/pretty'' value is intended for body text,
-	where the last line is expected to be a bit shorter than the average line;
-	the ''text-wrap-style/balance'' value is intended for titles and captions,
-	where equal-length lines of text tend to be preferred;
-	and the ''text-wrap-style/stable'' is intended for sections that are,
-	or are likely become toggled as,
-	editable.
-
-	<div class="issue" id="last-line-limits">
-		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
-		Issue is about requiring a minimum length for lines.
-		Common measures seem to be
-
-		<ul>
-			<li>At least as long as the text-indent.
-			<li>At least X characters.
-			<li>Percentage-based.
-		</ul>
-
-		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
-		(with ''Xch'' given as an example to make that use case clear).
-		Alternately <<integer>> could actually count the characters.
-
-		It's unclear how this would interact with text balancing (above);
-		one earlier proposal had them be the same property
-		(with ''100%'' meaning full balancing).
-
-		People have requested word-based limits, but since this is really
-		dependent on the length of the word, character-based is better.
-	</div>
-
 <h3 id="wrap-inside">
 Controlling Breaks Within Boxes: the 'wrap-inside' property</h3>
 
@@ -5625,6 +5460,168 @@ Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
 	through any parent <a>block boxes</a>
 	in the same <a>fragmentation context</a>.
 	[[!CSS3-BREAK]]
+
+<h3 id="text-wrap-style">
+Selecting How to Wrap: the 'text-wrap-style' property</h3>
+
+	<wpt title="
+		This property has limited coverage.
+
+		Missing test:
+		* tests for values other than balance
+		* Direct tests of this property as a longhand"></wpt>
+
+	<pre class="propdef">
+	Name: text-wrap-style
+	Value: auto| balance | stable | pretty
+	Initial: auto
+	Applies to: [=block containers=] hat establish an [=inline formatting context=]
+	Inherited: yes
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	When wrapping is allowed
+	(see 'text-wrap-mode'),
+	this property selects between several approaches for wrapping lines,
+	trading off between speed, quality and style of layout, or stability.
+	It does not change which [=soft wrap opportunity=] exist,
+	but changes how the user agent selects among them.
+	Possible values:
+
+	<dl dfn-for=text-wrap-style dfn-type=value>
+		<dt><dfn>auto</dfn>
+		<dd>
+			The exact algorithm for selecting
+			which [=soft wrap opportunity=] to break at is UA-defined.
+			The algorithm <em>may</em> consider multiple lines
+			when making break decisions.
+			The UA <em>may</em> bias for speed over best layout.
+			The UA <em>must not</em> attempt to even out all lines
+			(including the last) as for ''text-wrap-style/balance''.
+			This value selects the UA’s preferred (or most Web-compatible)
+			wrapping algorithm.
+
+		<dt><dfn>balance</dfn>
+		<dd>
+			Line breaks are chosen to balance
+			the remaining (empty) space in each line box,
+			if better balance than ''text-wrap-style/auto'' is possible.
+			This must not change the number of line boxes
+			the block would contain
+			if 'text-wrap' were set to ''text-wrap-style/auto''.
+
+			<wpt>
+				white-space/text-wrap-balance-001.html
+				white-space/text-wrap-balance-002.html
+				white-space/text-wrap-balance-align-001.html
+				white-space/text-wrap-balance-dynamic-001.html
+				white-space/text-wrap-balance-line-clamp-001.html
+				white-space/text-wrap-balance-narrow-crash.html
+				crashtests/text-wrap-balance-float-crash.html
+			</wpt>
+
+			The remaining space to consider
+			is that which remains after placing floats and inline content,
+			but before any adjustments due to text justification.
+			Line boxes are balanced when the standard deviation
+			from the average <a>inline-size</a> of the remaining space in each line box
+			is reduced over the block
+			(including lines that end in a forced break).
+
+			<wpt>
+				white-space/text-wrap-balance-text-indent-001.html
+			</wpt>
+
+			The exact algorithm is UA-defined.
+
+			UAs may treat this value as ''text-wrap-style/auto'' if there are more than ten lines to balance.
+
+		<dt><dfn>stable</dfn>
+		<dd>
+			Specifies that content on subsequent lines
+			<em>should not</em> be considered when making break decisions
+			so that when editing text any content before the cursor
+			remains stable;
+			otherwise equivalent to ''text-wrap-style/auto'',
+
+		<dt><dfn>pretty</dfn>
+		<dd>
+			Specifies the UA <em>should</em> bias for better layout over speed,
+			and is expected to consider multiple lines,
+			when making break decisions.
+			Otherwise equivalent to ''text-wrap-style/auto'',
+	</dl>
+
+	<!-- add a sample prioritization algorithm -->
+
+	Note: The ''text-wrap-style/auto'' value will typically map
+	to Web browsers’ speedy legacy line breaking,
+	which has so far used first-fit/greedy algorithms
+	that can often give sub-optimal results.
+	UAs can experiment with better line breaking algorithms
+	with this default value,
+	but as optimal results often take more time,
+	''text-wrap-style/pretty'' is offered as an opt-in
+	to take more time for better results.
+	The ''text-wrap-style/pretty'' value is intended for body text,
+	where the last line is expected to be a bit shorter than the average line;
+	the ''text-wrap-style/balance'' value is intended for titles and captions,
+	where equal-length lines of text tend to be preferred;
+	and the ''text-wrap-style/stable'' is intended for sections that are,
+	or are likely become toggled as,
+	editable.
+
+	<div class="issue" id="last-line-limits">
+		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
+		Issue is about requiring a minimum length for lines.
+		Common measures seem to be
+
+		<ul>
+			<li>At least as long as the text-indent.
+			<li>At least X characters.
+			<li>Percentage-based.
+		</ul>
+
+		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
+		(with ''Xch'' given as an example to make that use case clear).
+		Alternately <<integer>> could actually count the characters.
+
+		It's unclear how this would interact with text balancing (above);
+		one earlier proposal had them be the same property
+		(with ''100%'' meaning full balancing).
+
+		People have requested word-based limits, but since this is really
+		dependent on the length of the word, character-based is better.
+	</div>
+
+<h3 id="text-wrap-shorthand">
+Joint Wrapping Control: the 'text-wrap' shorthand property</h3>
+
+	<wpt title="This section has limited coverage."></wpt>
+
+	<pre class="propdef">
+	Name: text-wrap
+	Value: <'text-wrap-mode'> || <'text-wrap-style'>
+	Initial: wrap
+	Applies to: see individual properties
+	Inherited: see individual properties
+	Percentages: see individual properties
+	Computed value: see individual properties
+	Animation type: see individual properties
+	</pre>
+
+	<wpt>
+		parsing/text-wrap-invalid.html
+		parsing/text-wrap-valid.html
+	</wpt>
+	<wpt title="TODO: needs review, probably outdated">
+		parsing/white-space-shorthand-text-wrap.html
+	</wpt>
+
+	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
+	Any omitted [=longhand=] is set to its [=initial value=].
 
 <h3 id="line-break-details">
 Line Breaking Details</h3>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -8040,6 +8040,29 @@ Selecting How to Wrap: the 'text-wrap-style' property</h4>
 	or are likely become toggled as,
 	editable.
 
+	<div class="issue" id="last-line-limits">
+		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
+		Issue is about requiring a minimum length for lines.
+		Common measures seem to be
+
+		<ul>
+			<li>At least as long as the text-indent.
+			<li>At least X characters.
+			<li>Percentage-based.
+		</ul>
+
+		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
+		(with ''Xch'' given as an example to make that use case clear).
+		Alternately <<integer>> could actually count the characters.
+
+		It's unclear how this would interact with text balancing (above);
+		one earlier proposal had them be the same property
+		(with ''100%'' meaning full balancing).
+
+		People have requested word-based limits, but since this is really
+		dependent on the length of the word, character-based is better.
+	</div>
+
 <h3 id="wrap-before">
 Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
 
@@ -8228,34 +8251,6 @@ Shaping Across Intra-word Breaks</h3>
 		the “ش” still takes its initial form (“ﺷ”),
 		and the “ت” its medial form (“ﺘ”)--
 		forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
-	</div>
-
-<h3 id="last-line-limits">
-Last Line Minimum Length</h3>
-
-	<wpt title="This section has no normative text, so it cannot have tests."></wpt>
-
-	<div class="issue">
-		See <a href="http://www.w3.org/mid/0BD85DFF-A147-44EF-B18A-FF03C3D67EF0@verou.me">thread</a>.
-		Issue is about requiring a minimum length for lines.
-		Common measures seem to be
-
-		<ul>
-			<li>At least as long as the text-indent.
-			<li>At least X characters.
-			<li>Percentage-based.
-		</ul>
-
-		Suggestion for value space is ''match-indent | <<length>> | <<percentage>>''
-		(with ''Xch'' given as an example to make that use case clear).
-		Alternately <<integer>> could actually count the characters.
-
-		It's unclear how this would interact with text balancing (above);
-		one earlier proposal had them be the same property
-		(with ''100%'' meaning full balancing).
-
-		People have requested word-based limits, but since this is really
-		dependent on the length of the word, character-based is better.
 	</div>
 
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -5801,7 +5801,7 @@ Line Breaking Details</h3>
 			which elements’ 'line-break', 'word-break', and 'overflow-wrap' properties
 			control the determination of [=soft wrap opportunities=]
 			at such boundaries
-			is undefined in Level 3.
+			is undefined in this level.
 
 			<wpt>
 			line-breaking/line-breaking-009.html

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4509,6 +4509,7 @@ Line Breaking Details</h3>
 		Missing tests:
 
 		* For soft wrap opportunities before the first or after the last character of a box, the break occurs immediately before/after the box (at its margin edge) rather than breaking the box between its content edge and the content.
+		* Line breaking classes CM and SG must be honored
 
 		Untestable(?):
 
@@ -4535,7 +4536,9 @@ Line Breaking Details</h3>
 			Except where explicitly defined otherwise
 			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
 			line breaking behavior defined for
-			the <code>WJ</code>,
+			the <code>CM</code>,
+			and <code>SG</code>,
+			<code>WJ</code>,
 			<code>ZW</code>,
 			<code>GL</code>,
 			and <code>ZWJ</code>
@@ -6755,11 +6758,6 @@ Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
 
 	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
 	Any omitted [=longhand=] is set to its [=initial value=].
-
-	Additionally, if wrapping is allowed (i.e. 'text-wrap-mode' is ''text-wrap-mode/wrap''),
-	line breaking behavior defined
-	for the CM, SG, WJ, ZW, and GL line-breaking classes
-	in [[!UAX14]] must be honored.
 
 	UAs that allow breaks at punctuation other than spaces
 	should prioritize breakpoints.

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -6767,21 +6767,6 @@ Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
 	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
 	Any omitted [=longhand=] is set to its [=initial value=].
 
-	UAs that allow breaks at punctuation other than spaces
-	should prioritize breakpoints.
-	For example,
-	if breaks after slashes have a lower priority than spaces,
-	the sequence “check /etc”
-	will never break between the ‘/’ and the ‘e’.
-	The UA may use the width of the containing block,
-	the text's language,
-	and other factors in assigning priorities.
-	As long as care is taken to avoid such awkward breaks,
-	allowing breaks at appropriate punctuation other than spaces
-	is recommended,
-	as it results in more even-looking margins,
-	particularly in narrow measures.
-
 <h4 id="text-wrap-mode">
 Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4101,8 +4101,37 @@ Tab Character Size: the 'tab-size' property</h3>
 <h2 id="text-wrapping">
 Text Wrapping</h2>
 
+	<wpt title="
+		Tests mostly not needed for this section:
+		these are definitions,
+		they get tested through their application,
+		not by themselves."></wpt>
+
+	When inline-level content is laid out into lines, it is broken across line boxes.
+	Such a break is called a <dfn export>line break</dfn>.
+	When a line is broken due to explicit line-breaking controls
+	(such as a <a>preserved</a> newline character),
+	or due to the start or end of a block,
+	it is a <dfn export>forced line break</dfn>.
+	When a line is broken due to content <dfn lt="wrapping|wrap">wrapping</dfn>
+	(i.e. when the UA creates unforced line breaks
+	in order to fit the content within the measure),
+	it is a <dfn>soft wrap break</dfn>.
+	The process of breaking inline-level content into lines is called <dfn export lt="line breaking process | line breaking">line breaking</dfn>.
+
+	Wrapping is only performed at an allowed break point,
+	called a <dfn export>soft wrap opportunity</dfn>.
+	When wrapping is enabled (see 'white-space'),
+	the UA must minimize the amount of content overflowing a line
+	by wrapping the line at a [=soft wrap opportunity=],
+	if one exists.
+
+	<wpt>
+	line-breaking/line-breaking-020.html
+	</wpt>
+
 	Where text is allowed to wrap is controlled
-	by the [[#line-breaking|line-breaking rules and controls]] above;
+	by the [[#line-breaking|line-breaking rules and controls]];
 	<em>whether</em> it is allowed to wrap
 	and how multiple [=soft wrap opportunities=] within a line are prioritized
 	is controlled
@@ -4111,7 +4140,7 @@ Text Wrapping</h2>
 	'wrap-before',
 	'wrap-after',
 	and
-	'wrap-inside' properties:
+	'wrap-inside' properties.
 
 <h3 id="text-wrap">
 Text Wrap Setting</h3>
@@ -5841,41 +5870,22 @@ Line Breaking Details</h3>
 Line Breaking and Word Boundaries</h2>
 
 	<wpt title="
-		Tests mostly not needed for this section:
-		these are definitions,
-		they get tested through their application,
-		not by themselves.
+		This section deals in generalities
+		rather than specific requirements.
+		Exhaustive coverage is neither practical
+		nor needed,
+		as more specific requirements
+		are made in different sections,
+		and can be tested there.
 
-		Can be a good section
+		Nonetheless,
+		this can be a good section
 		to host tests for i18n requirements
 		not covered in detail by the spec.
 
 		Possible additions:
 		* tests for at least one language with line breaking based on orthographic syllable boundaries
 		* Basic line breaking tests for some languages mentioned: Javanese, Balinese, Yi"></wpt>
-
-	When inline-level content is laid out into lines, it is broken across line boxes.
-	Such a break is called a <dfn export>line break</dfn>.
-	When a line is broken due to explicit line-breaking controls
-	(such as a <a>preserved</a> newline character),
-	or due to the start or end of a block,
-	it is a <dfn export>forced line break</dfn>.
-	When a line is broken due to content <dfn lt="wrapping|wrap">wrapping</dfn>
-	(i.e. when the UA creates unforced line breaks
-	in order to fit the content within the measure),
-	it is a <dfn>soft wrap break</dfn>.
-	The process of breaking inline-level content into lines is called <dfn export lt="line breaking process | line breaking">line breaking</dfn>.
-
-	Wrapping is only performed at an allowed break point,
-	called a <dfn export>soft wrap opportunity</dfn>.
-	When wrapping is enabled (see 'white-space'),
-	the UA must minimize the amount of content overflowing a line
-	by wrapping the line at a [=soft wrap opportunity=],
-	if one exists.
-
-	<wpt>
-	line-breaking/line-breaking-020.html
-	</wpt>
 
 	In most writing systems,
 	in the absence of hyphenation a [=soft wrap opportunity=] occurs only at word boundaries.

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -6776,11 +6776,11 @@ Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
 	lines always break at forced breaks:
 	for all values,
 	line-breaking behavior defined
-	for the BK, CR, LF, CM, NL, and SG line breaking classes
+	for the BK, CR, LF, and NL line breaking classes
 	in [[!UAX14]] must be honored.
 	Additionally, if wrapping is allowed (i.e. 'text-wrap-mode' is ''text-wrap-mode/wrap''),
 	line breaking behavior defined
-	for the WJ, ZW, and GL line-breaking classes
+	for the CM, SG, WJ, ZW, and GL line-breaking classes
 	in [[!UAX14]] must be honored.
 
 	UAs that allow breaks at punctuation other than spaces

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4500,245 +4500,6 @@ Line Breaking and Word Boundaries</h2>
 	shaping/shaping_lig-001.html
 	</wpt>
 
-<h3 id="line-break-details">
-Line Breaking Details</h3>
-
-	<wpt title="
-		This section has partial test coverage.
-
-		Missing tests:
-
-		* For soft wrap opportunities before the first or after the last character of a box, the break occurs immediately before/after the box (at its margin edge) rather than breaking the box between its content edge and the content.
-		* Line breaking classes CM and SG must be honored
-
-		Untestable(?):
-
-		* UAs that allow wrapping at punctuation other than spaces should prioritize breakpoints. […]"></wpt>
-
-	When determining [=line breaks=]:
-
-	<ul>
-		<li>
-			The interaction of [=line breaking=] and bidirectional text is defined by
-			[[css-writing-modes-4#bidi-algo]]
-			and the <cite>Unicode Bidirectional Algorithm</cite>
-			(<a href="http://unicode.org/reports/tr9/#Reordering_Resolved_Levels">UAX9&sect;3.4 Reordering Resolved Levels</a> in particular).
-			[[!CSS-WRITING-MODES-4]]
-			[[!UAX9]]
-
-			<wpt pathprefix="/css/CSS2/bidi-text/">
-			bidi-breaking-001.xht
-			bidi-breaking-002.xht
-			bidi-breaking-003.xht
-			</wpt>
-
-		<li>
-			Except where explicitly defined otherwise
-			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
-			line breaking behavior defined for
-			the <code>CM</code>,
-			and <code>SG</code>,
-			<code>WJ</code>,
-			<code>ZW</code>,
-			<code>GL</code>,
-			and <code>ZWJ</code>
-			Unicode line breaking classes
-			must be honored.
-			[[!UAX14]]
-
-			<wpt>
-			word-break/word-break-normal-001.html
-			line-breaking/line-breaking-001.html
-			line-breaking/line-breaking-002.html
-			line-breaking/line-breaking-003.html
-			line-breaking/line-breaking-004.html
-			line-breaking/line-breaking-005.html
-			line-breaking/line-breaking-006.html
-			line-breaking/line-breaking-007.html
-			line-breaking/line-breaking-008.html
-			line-breaking/line-breaking-021.html
-			i18n/css3-text-line-break-baspglwj-001.html
-			i18n/css3-text-line-break-baspglwj-002.html
-			i18n/css3-text-line-break-baspglwj-120.html
-			i18n/css3-text-line-break-baspglwj-121.html
-			i18n/css3-text-line-break-baspglwj-122.html
-			i18n/css3-text-line-break-baspglwj-123.html
-			i18n/css3-text-line-break-baspglwj-124.html
-			i18n/css3-text-line-break-baspglwj-125.html
-			i18n/css3-text-line-break-baspglwj-126.html
-			i18n/css3-text-line-break-baspglwj-127.html
-			i18n/css3-text-line-break-baspglwj-128.html
-			i18n/css3-text-line-break-baspglwj-130.html
-			i18n/css3-text-line-break-baspglwj-131.html
-			word-break/word-break-break-all-018.html
-			word-break/word-break-break-all-021.html
-			word-break/word-break-break-all-022.html
-			</wpt>
-
-		<li>
-			UAs that allow wrapping at punctuation
-			other than [=word separators=]
-			in writing systems that use them
-			<em>should</em> prioritize breakpoints.
-			(For example, if breaks after slashes are given a lower priority than spaces,
-			the sequence “check /etc” will never break between the "/" and the "e".)
-			As long as care is taken to avoid such awkward breaks,
-			allowing breaks at appropriate punctuation other than [=word separators=]
-			is recommended,
-			as it results in more even-looking margins, particularly in narrow measures.
-			The UA may use the width of the containing block, the text's language,
-			the 'line-break' value,
-			and other factors in assigning priorities:
-			CSS does not define prioritization of [=soft wrap opportunities=].
-			Prioritization of [=word separators=] is not expected,
-			however,
-			if ''word-break: break-all'' is specified
-			(since this value explicitly requests line breaking behavior
-			not based on breaking at [=word separators=])--
-			and is forbidden under ''line-break: anywhere''.
-
-		<li>
-			Out-of-flow elements
-			and inline element boundaries
-			do not introduce a [=forced line break=]
-			or [=soft wrap opportunity=] in the flow.
-
-			<wpt>
-			line-breaking/line-breaking-012.html
-			line-breaking/line-breaking-015.html
-			line-breaking/line-breaking-016.html
-			line-breaking/line-breaking-017.html
-			line-breaking/line-breaking-018.html
-			line-breaking/line-breaking-019.html
-			</wpt>
-
-		<li id=atomic-compat-wrap>
-			For Web-compatibility
-			there is a [=soft wrap opportunity=]
-			before and after each replaced element or other [=atomic inline=],
-			even when adjacent to a character that would normally suppress them,
-			including U+00A0 NO-BREAK SPACE.
-			However,
-			with the exception of U+00A0 NO-BREAK SPACE,
-			there must be no [=soft wrap opportunity=]
-			between [=atomic inlines=] and adjacent characters
-			belonging to the Unicode GL, WJ, or ZWJ line breaking classes.
-			[[UAX14]]
-
-			<wpt>
-			line-breaking/line-breaking-atomic-001.html
-			line-breaking/line-breaking-atomic-002.html
-			line-breaking/line-breaking-atomic-003.html
-			line-breaking/line-breaking-atomic-004.html
-			line-breaking/line-breaking-atomic-005.html
-			line-breaking/line-breaking-atomic-006.html
-			line-breaking/line-breaking-atomic-007.html
-			line-breaking/line-breaking-atomic-008.html
-			line-breaking/line-breaking-atomic-009.html
-			line-breaking/line-breaking-atomic-010.html
-			line-breaking/line-breaking-atomic-011.html
-			line-breaking/line-breaking-atomic-012.html
-			line-breaking/line-breaking-atomic-013.html
-			line-breaking/line-breaking-atomic-014.html
-			line-breaking/line-breaking-atomic-015.html
-			line-breaking/line-breaking-atomic-016.html
-			line-breaking/line-breaking-atomic-017.html
-			line-breaking/line-breaking-atomic-018.html
-			line-breaking/line-breaking-atomic-019.html
-			line-breaking/line-breaking-atomic-020.html
-			line-breaking/line-breaking-atomic-021.html
-			line-breaking/line-breaking-atomic-022.html
-			line-breaking/line-breaking-atomic-023.html
-			line-breaking/line-breaking-atomic-024.html
-			line-breaking/line-breaking-atomic-025.html
-			line-breaking/line-breaking-atomic-026.html
-			line-breaking/line-breaking-atomic-027.html
-			line-breaking/line-breaking-replaced-001.html
-			line-breaking/line-breaking-replaced-002.html
-			line-breaking/line-breaking-replaced-003.html
-			line-breaking/line-breaking-replaced-004.html
-			line-breaking/line-breaking-replaced-005.html
-			line-breaking/line-breaking-replaced-006.html
-			line-breaking/line-breaking-atomic-nowrap-001.html
-			</wpt>
-
-		<li>
-			For [=soft wrap opportunities=] created by characters
-			that disappear at the line break (e.g. U+0020 SPACE),
-			properties on the box directly containing that character
-			control the line breaking at that opportunity.
-			For [=soft wrap opportunities=] defined by the boundary between two characters,
-			the 'white-space' property
-			on the nearest common ancestor of the two characters
-			controls breaking;
-			<!-- http://lists.w3.org/Archives/Public/www-style/2008Dec/0043.html -->
-			which elements’ 'line-break', 'word-break', and 'overflow-wrap' properties
-			control the determination of [=soft wrap opportunities=]
-			at such boundaries
-			is undefined in Level 3.
-
-			<wpt>
-			line-breaking/line-breaking-009.html
-			line-breaking/line-breaking-010.html
-			line-breaking/line-breaking-011.html
-			line-breaking/line-breaking-ic-001.html
-			line-breaking/line-breaking-ic-002.html
-			line-breaking/line-breaking-ic-003.html
-			white-space/white-space-wrap-after-nowrap-001.html
-			word-break/break-boundary-2-chars-001.html
-
-			overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
-			overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
-			overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
-			word-break/word-break-break-all-inline-004.tentative.html
-			word-break/word-break-break-all-inline-007.tentative.html
-			word-break/word-break-break-all-inline-010.tentative.html
-			</wpt>
-
-		<li>
-			For [=soft wrap opportunities=] before the first
-			or after the last character of a box,
-			the break occurs immediately before/after the box
-			(at its margin edge)
-			rather than breaking the box
-			between its content edge and the content.
-
-		<li>
-			Line breaking in/around Ruby is defined
-			in [[css-ruby-1#line-breaks]].
-			[[!CSS-RUBY-1]]
-
-		<li id="word-break-shaping">
-			When shaping scripts such as Arabic
-			[=wrap=] at unforced [=soft wrap opportunities=] within words
-			(such as when breaking due to
-			''word-break: break-all'',
-			''line-break: anywhere'',
-			''overflow-wrap: break-word'',
-			''overflow-wrap: anywhere'',
-			or when [=hyphenating=])
-			the characters must still be shaped
-			(their joining forms chosen)
-			as if the word were still whole.
-
-			<wpt>
-			hyphens/hyphens-shaping-001.html
-			hyphens/hyphens-shaping-002.html
-			line-break/line-break-shaping-001.html
-			overflow-wrap/overflow-wrap-shaping-001.html
-			overflow-wrap/overflow-wrap-shaping-002.html
-			word-break/word-break-break-all-004.html
-			</wpt>
-
-			<div class="example">
-				For example,
-				if the word “نوشتن” is broken between the “ش” and “ت”,
-				the “ش” still takes its initial form (“ﺷ”),
-				and the “ت” its medial form (“ﺘ”)--
-				forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
-			</div>
-	</ul>
-
 <h3 id="word-break-property" caniuse="word-break" oldids="word-break">
 Breaking Rules for Letters: the 'word-break' property</h3>
 
@@ -7700,6 +7461,9 @@ Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 				word-break/word-break-keep-all-063.html
 			</wpt>
 
+			Note: See [[#line-break-details]] for more information
+			about rules and constrains on [=soft wrap opportunities=].
+
 		<dt><dfn>nowrap</dfn>
 		<dd>
 			Inline-level content does not break across lines;
@@ -8246,6 +8010,245 @@ Example of using 'wrap-inside: avoid' in presenting a footer</h4>
 			7, 2005 &#8226; Berlin, Germany
 		</pre>
 	</div>
+
+<h3 id="line-break-details">
+Line Breaking Details</h3>
+
+	<wpt title="
+		This section has partial test coverage.
+
+		Missing tests:
+
+		* For soft wrap opportunities before the first or after the last character of a box, the break occurs immediately before/after the box (at its margin edge) rather than breaking the box between its content edge and the content.
+		* Line breaking classes CM and SG must be honored
+
+		Untestable(?):
+
+		* UAs that allow wrapping at punctuation other than spaces should prioritize breakpoints. […]"></wpt>
+
+	When determining [=line breaks=]:
+
+	<ul>
+		<li>
+			The interaction of [=line breaking=] and bidirectional text is defined by
+			[[css-writing-modes-4#bidi-algo]]
+			and the <cite>Unicode Bidirectional Algorithm</cite>
+			(<a href="http://unicode.org/reports/tr9/#Reordering_Resolved_Levels">UAX9&sect;3.4 Reordering Resolved Levels</a> in particular).
+			[[!CSS-WRITING-MODES-4]]
+			[[!UAX9]]
+
+			<wpt pathprefix="/css/CSS2/bidi-text/">
+			bidi-breaking-001.xht
+			bidi-breaking-002.xht
+			bidi-breaking-003.xht
+			</wpt>
+
+		<li>
+			Except where explicitly defined otherwise
+			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
+			line breaking behavior defined for
+			the <code>CM</code>,
+			and <code>SG</code>,
+			<code>WJ</code>,
+			<code>ZW</code>,
+			<code>GL</code>,
+			and <code>ZWJ</code>
+			Unicode line breaking classes
+			must be honored.
+			[[!UAX14]]
+
+			<wpt>
+			word-break/word-break-normal-001.html
+			line-breaking/line-breaking-001.html
+			line-breaking/line-breaking-002.html
+			line-breaking/line-breaking-003.html
+			line-breaking/line-breaking-004.html
+			line-breaking/line-breaking-005.html
+			line-breaking/line-breaking-006.html
+			line-breaking/line-breaking-007.html
+			line-breaking/line-breaking-008.html
+			line-breaking/line-breaking-021.html
+			i18n/css3-text-line-break-baspglwj-001.html
+			i18n/css3-text-line-break-baspglwj-002.html
+			i18n/css3-text-line-break-baspglwj-120.html
+			i18n/css3-text-line-break-baspglwj-121.html
+			i18n/css3-text-line-break-baspglwj-122.html
+			i18n/css3-text-line-break-baspglwj-123.html
+			i18n/css3-text-line-break-baspglwj-124.html
+			i18n/css3-text-line-break-baspglwj-125.html
+			i18n/css3-text-line-break-baspglwj-126.html
+			i18n/css3-text-line-break-baspglwj-127.html
+			i18n/css3-text-line-break-baspglwj-128.html
+			i18n/css3-text-line-break-baspglwj-130.html
+			i18n/css3-text-line-break-baspglwj-131.html
+			word-break/word-break-break-all-018.html
+			word-break/word-break-break-all-021.html
+			word-break/word-break-break-all-022.html
+			</wpt>
+
+		<li>
+			UAs that allow wrapping at punctuation
+			other than [=word separators=]
+			in writing systems that use them
+			<em>should</em> prioritize breakpoints.
+			(For example, if breaks after slashes are given a lower priority than spaces,
+			the sequence “check /etc” will never break between the "/" and the "e".)
+			As long as care is taken to avoid such awkward breaks,
+			allowing breaks at appropriate punctuation other than [=word separators=]
+			is recommended,
+			as it results in more even-looking margins, particularly in narrow measures.
+			The UA may use the width of the containing block, the text's language,
+			the 'line-break' value,
+			and other factors in assigning priorities:
+			CSS does not define prioritization of [=soft wrap opportunities=].
+			Prioritization of [=word separators=] is not expected,
+			however,
+			if ''word-break: break-all'' is specified
+			(since this value explicitly requests line breaking behavior
+			not based on breaking at [=word separators=])--
+			and is forbidden under ''line-break: anywhere''.
+
+		<li>
+			Out-of-flow elements
+			and inline element boundaries
+			do not introduce a [=forced line break=]
+			or [=soft wrap opportunity=] in the flow.
+
+			<wpt>
+			line-breaking/line-breaking-012.html
+			line-breaking/line-breaking-015.html
+			line-breaking/line-breaking-016.html
+			line-breaking/line-breaking-017.html
+			line-breaking/line-breaking-018.html
+			line-breaking/line-breaking-019.html
+			</wpt>
+
+		<li id=atomic-compat-wrap>
+			For Web-compatibility
+			there is a [=soft wrap opportunity=]
+			before and after each replaced element or other [=atomic inline=],
+			even when adjacent to a character that would normally suppress them,
+			including U+00A0 NO-BREAK SPACE.
+			However,
+			with the exception of U+00A0 NO-BREAK SPACE,
+			there must be no [=soft wrap opportunity=]
+			between [=atomic inlines=] and adjacent characters
+			belonging to the Unicode GL, WJ, or ZWJ line breaking classes.
+			[[UAX14]]
+
+			<wpt>
+			line-breaking/line-breaking-atomic-001.html
+			line-breaking/line-breaking-atomic-002.html
+			line-breaking/line-breaking-atomic-003.html
+			line-breaking/line-breaking-atomic-004.html
+			line-breaking/line-breaking-atomic-005.html
+			line-breaking/line-breaking-atomic-006.html
+			line-breaking/line-breaking-atomic-007.html
+			line-breaking/line-breaking-atomic-008.html
+			line-breaking/line-breaking-atomic-009.html
+			line-breaking/line-breaking-atomic-010.html
+			line-breaking/line-breaking-atomic-011.html
+			line-breaking/line-breaking-atomic-012.html
+			line-breaking/line-breaking-atomic-013.html
+			line-breaking/line-breaking-atomic-014.html
+			line-breaking/line-breaking-atomic-015.html
+			line-breaking/line-breaking-atomic-016.html
+			line-breaking/line-breaking-atomic-017.html
+			line-breaking/line-breaking-atomic-018.html
+			line-breaking/line-breaking-atomic-019.html
+			line-breaking/line-breaking-atomic-020.html
+			line-breaking/line-breaking-atomic-021.html
+			line-breaking/line-breaking-atomic-022.html
+			line-breaking/line-breaking-atomic-023.html
+			line-breaking/line-breaking-atomic-024.html
+			line-breaking/line-breaking-atomic-025.html
+			line-breaking/line-breaking-atomic-026.html
+			line-breaking/line-breaking-atomic-027.html
+			line-breaking/line-breaking-replaced-001.html
+			line-breaking/line-breaking-replaced-002.html
+			line-breaking/line-breaking-replaced-003.html
+			line-breaking/line-breaking-replaced-004.html
+			line-breaking/line-breaking-replaced-005.html
+			line-breaking/line-breaking-replaced-006.html
+			line-breaking/line-breaking-atomic-nowrap-001.html
+			</wpt>
+
+		<li>
+			For [=soft wrap opportunities=] created by characters
+			that disappear at the line break (e.g. U+0020 SPACE),
+			properties on the box directly containing that character
+			control the line breaking at that opportunity.
+			For [=soft wrap opportunities=] defined by the boundary between two characters,
+			the 'white-space' property
+			on the nearest common ancestor of the two characters
+			controls breaking;
+			<!-- http://lists.w3.org/Archives/Public/www-style/2008Dec/0043.html -->
+			which elements’ 'line-break', 'word-break', and 'overflow-wrap' properties
+			control the determination of [=soft wrap opportunities=]
+			at such boundaries
+			is undefined in Level 3.
+
+			<wpt>
+			line-breaking/line-breaking-009.html
+			line-breaking/line-breaking-010.html
+			line-breaking/line-breaking-011.html
+			line-breaking/line-breaking-ic-001.html
+			line-breaking/line-breaking-ic-002.html
+			line-breaking/line-breaking-ic-003.html
+			white-space/white-space-wrap-after-nowrap-001.html
+			word-break/break-boundary-2-chars-001.html
+
+			overflow-wrap/overflow-wrap-anywhere-inline-002.tentative.html
+			overflow-wrap/overflow-wrap-anywhere-inline-003.tentative.html
+			overflow-wrap/overflow-wrap-anywhere-inline-004.tentative.html
+			word-break/word-break-break-all-inline-004.tentative.html
+			word-break/word-break-break-all-inline-007.tentative.html
+			word-break/word-break-break-all-inline-010.tentative.html
+			</wpt>
+
+		<li>
+			For [=soft wrap opportunities=] before the first
+			or after the last character of a box,
+			the break occurs immediately before/after the box
+			(at its margin edge)
+			rather than breaking the box
+			between its content edge and the content.
+
+		<li>
+			Line breaking in/around Ruby is defined
+			in [[css-ruby-1#line-breaks]].
+			[[!CSS-RUBY-1]]
+
+		<li id="word-break-shaping">
+			When shaping scripts such as Arabic
+			[=wrap=] at unforced [=soft wrap opportunities=] within words
+			(such as when breaking due to
+			''word-break: break-all'',
+			''line-break: anywhere'',
+			''overflow-wrap: break-word'',
+			''overflow-wrap: anywhere'',
+			or when [=hyphenating=])
+			the characters must still be shaped
+			(their joining forms chosen)
+			as if the word were still whole.
+
+			<wpt>
+			hyphens/hyphens-shaping-001.html
+			hyphens/hyphens-shaping-002.html
+			line-break/line-break-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-001.html
+			overflow-wrap/overflow-wrap-shaping-002.html
+			word-break/word-break-break-all-004.html
+			</wpt>
+
+			<div class="example">
+				For example,
+				if the word “نوشتن” is broken between the “ش” and “ت”,
+				the “ش” still takes its initial form (“ﺷ”),
+				and the “ت” its medial form (“ﺘ”)--
+				forming as in “ﻧﻮﺷ | ﺘﻦ”, not as in “نوش | تن”.
+			</div>
+	</ul>
 
 
 <h2 id="justification">

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -5470,72 +5470,6 @@ Selecting How to Wrap: the 'text-wrap-style' property</h4>
 		dependent on the length of the word, character-based is better.
 	</div>
 
-<h3 id="wrap-before">
-Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
-
-	<wpt title="This section lacks tests."></wpt>
-
-	<pre class="propdef">
-	Name: wrap-before, wrap-after
-	Value: auto | avoid | avoid-line | avoid-flex | line | flex
-	Initial: auto
-	Applies to: <a>inline-level</a> boxes and <a>flex items</a>
-	Inherited: no
-	Percentages: n/a
-	Computed value: specified keyword
-	Animation type: discrete
-	</pre>
-
-	These properties specify modifications to break opportunities
-	in line breaking (and <a>flex line</a> breaking [[CSS3-FLEXBOX]]).
-	Possible values:
-
-	<dl dfn-for="wrap-before, wrap-after" dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			Lines may break at allowed break points
-			before and after the box,
-			as determined by the line-breaking rules in effect.
-
-		<dt><dfn>avoid</dfn>
-		<dd>
-			Line breaking is suppressed immediately before/after the box:
-			the UA may only break there
-			if there are no other valid break points
-			in the line.
-			If the text breaks,
-			line-breaking restrictions are honored as for
-			''wrap-before/auto''.
-
-		<dt><dfn>avoid-line</dfn>
-		<dd>
-			Same as ''wrap-before/avoid'',
-			but only for line breaks.
-
-		<dt><dfn>avoid-flex</dfn>
-		<dd>
-			Same as ''wrap-before/avoid'',
-			but only for flex line breaks.
-
-		<dt><dfn>line</dfn>
-		<dd>
-			Force a line break immediately before/after the box
-			if the box is an <a>inline-level</a> box.
-
-		<dt><dfn>flex</dfn>
-		<dd>
-			Force a <a>flex line</a> break immediately before/after the box
-			if the box is a <a>flex item</a>
-			in a <a>multi-line flex container</a>.
-	</dl>
-
-	Forced line breaks on <a>inline-level</a> boxes propagate upward
-	through any parent <a>inline boxes</a>
-	the same way forced breaks on <a>block-level</a> boxes propagate upward
-	through any parent <a>block boxes</a>
-	in the same <a>fragmentation context</a>.
-	[[!CSS3-BREAK]]
-
 <h3 id="wrap-inside">
 Controlling Breaks Within Boxes: the 'wrap-inside' property</h3>
 
@@ -5625,6 +5559,72 @@ Example of using 'wrap-inside: avoid' in presenting a footer</h4>
 			7, 2005 &#8226; Berlin, Germany
 		</pre>
 	</div>
+
+<h3 id="wrap-before">
+Controlling Breaks Between Boxes: the 'wrap-before'/'wrap-after' properties</h3>
+
+	<wpt title="This section lacks tests."></wpt>
+
+	<pre class="propdef">
+	Name: wrap-before, wrap-after
+	Value: auto | avoid | avoid-line | avoid-flex | line | flex
+	Initial: auto
+	Applies to: <a>inline-level</a> boxes and <a>flex items</a>
+	Inherited: no
+	Percentages: n/a
+	Computed value: specified keyword
+	Animation type: discrete
+	</pre>
+
+	These properties specify modifications to break opportunities
+	in line breaking (and <a>flex line</a> breaking [[CSS3-FLEXBOX]]).
+	Possible values:
+
+	<dl dfn-for="wrap-before, wrap-after" dfn-type=value>
+		<dt><dfn>auto</dfn>
+		<dd>
+			Lines may break at allowed break points
+			before and after the box,
+			as determined by the line-breaking rules in effect.
+
+		<dt><dfn>avoid</dfn>
+		<dd>
+			Line breaking is suppressed immediately before/after the box:
+			the UA may only break there
+			if there are no other valid break points
+			in the line.
+			If the text breaks,
+			line-breaking restrictions are honored as for
+			''wrap-before/auto''.
+
+		<dt><dfn>avoid-line</dfn>
+		<dd>
+			Same as ''wrap-before/avoid'',
+			but only for line breaks.
+
+		<dt><dfn>avoid-flex</dfn>
+		<dd>
+			Same as ''wrap-before/avoid'',
+			but only for flex line breaks.
+
+		<dt><dfn>line</dfn>
+		<dd>
+			Force a line break immediately before/after the box
+			if the box is an <a>inline-level</a> box.
+
+		<dt><dfn>flex</dfn>
+		<dd>
+			Force a <a>flex line</a> break immediately before/after the box
+			if the box is a <a>flex item</a>
+			in a <a>multi-line flex container</a>.
+	</dl>
+
+	Forced line breaks on <a>inline-level</a> boxes propagate upward
+	through any parent <a>inline boxes</a>
+	the same way forced breaks on <a>block-level</a> boxes propagate upward
+	through any parent <a>block boxes</a>
+	in the same <a>fragmentation context</a>.
+	[[!CSS3-BREAK]]
 
 <h3 id="line-break-details">
 Line Breaking Details</h3>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4532,22 +4532,6 @@ Line Breaking Details</h3>
 			</wpt>
 
 		<li>
-			Preserved segment breaks, and--
-			regardless of the 'white-space' value--
-			any Unicode character with the <code>BK</code> and <code>NL</code> line breaking class,
-			must be treated as forced line breaks.
-			[[!UAX14]]
-
-			<wpt>
-			line-breaking/line-breaking-022.html
-			</wpt>
-
-
-			Note: The bidi implications of such [=forced line breaks=]
-			are defined by the <a href="https://www.unicode.org/reports/tr9/"><cite>Unicode Bidirectional Algorithm</cite></a>.
-			[[!UAX9]]
-
-		<li>
 			Except where explicitly defined otherwise
 			(e.g. for ''line-break: anywhere'' or ''overflow-wrap: anywhere'')
 			line breaking behavior defined for
@@ -6772,12 +6756,6 @@ Joint Wrapping Control: the 'text-wrap' shorthand property</h4>
 	This property is a shorthand for 'text-wrap-mode' and 'text-wrap-style' properties.
 	Any omitted [=longhand=] is set to its [=initial value=].
 
-	Regardless of the 'text-wrap-mode' and 'text-wrap-style' values,
-	lines always break at forced breaks:
-	for all values,
-	line-breaking behavior defined
-	for the BK, CR, LF, and NL line breaking classes
-	in [[!UAX14]] must be honored.
 	Additionally, if wrapping is allowed (i.e. 'text-wrap-mode' is ''text-wrap-mode/wrap''),
 	line breaking behavior defined
 	for the CM, SG, WJ, ZW, and GL line-breaking classes
@@ -6806,6 +6784,8 @@ Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 		but not directly.
 
 		Missing test:
+		* preserved segment breaks are forced line breaks (probably tested already, but need to find those tests)
+		* CR and LF  line breaking class are forced line breaks
 		* Direct tests of this property as a longhand"></wpt>
 
 	<pre class="propdef">
@@ -7942,6 +7922,20 @@ Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 				word-break/word-break-break-word-crash-001.html
 			</wpt>
 	</dl>
+
+	Regardless of the 'text-wrap-mode' value,
+	[=preserved=] [=segment breaks=],
+	and any Unicode character with the <code>BK</code>, <code>CR</code>, <code>LF</code>, and <code>NL</code> line breaking class,
+	must be treated as [=forced line breaks=].
+	[[!UAX14]]
+
+	<wpt>
+	line-breaking/line-breaking-022.html
+	</wpt>
+
+	Note: The bidi implications of such [=forced line breaks=]
+	are defined by the <a href="https://www.unicode.org/reports/tr9/"><cite>Unicode Bidirectional Algorithm</cite></a>.
+	[[!UAX9]]
 
 <h4 id="text-wrap-style">
 Selecting How to Wrap: the 'text-wrap-style' property</h4>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1473,7 +1473,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 		<li>whether and how [=white space=] is collapsed;
 			see [[#white-space-processing|White Space Processing]]
 		<li>whether lines may [=wrap=] at unforced [=soft wrap opportunities=];
-			see [[#line-breaking|Line Breaking]]
+			see [[#text-wrapping]] and [[#line-breaking|Line Breaking]]
 	</ul>
 
 	Note: This shorthand combines both inheritable and non-inheritable properties.
@@ -4172,8 +4172,7 @@ Deciding Whether to Wrap: the 'text-wrap-mode' property</h4>
 	Note: This property is a [=longhand=]
 	of both 'white-space' and 'text-wrap'.
 
-	This property specifies whether lines may [=wrap=] at unforced [=soft wrap opportunities=]
-	(see [[#line-breaking|Line Breaking]]).
+	This property specifies whether lines may [=wrap=] at unforced [=soft wrap opportunities=].
 	Possible values:
 
 	<dl dfn-for=text-wrap-mode dfn-type=value>


### PR DESCRIPTION
Some redundant text had appeared through parallel history in css-text-3 and css-text-4. This PR deduplicates them, and takes the opportunity for shuffling some paragraphs and sections around to try and make things a little more coherent.