### PR TITLE
[css-fonts-4] Add missing numeric range annotations

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2784,7 +2784,7 @@ Font property descriptors: the 'font-style!!descriptor', 'font-weight!!descripto
 
 	<pre class='descdef'>
 	Name: font-style
-	Value: auto | normal | italic | oblique [ <<angle>>{1,2} ]?
+	Value: auto | normal | italic | oblique [ <<angle [-90deg,90deg]>>{1,2} ]?
 	For: @font-face
 	Initial: auto
 	</pre>
@@ -6203,7 +6203,7 @@ occurs due to this property.</p>
 
 <p>Feature tag values have the following syntax:</p>
 
-<pre class="prod"><dfn dfn-for="font-feature-settings" dfn-type="value" id="feature-tag-value"><var>&lt;feature-tag-value&gt;</var></dfn> = &lt;string&gt; [ &lt;integer&gt; | on | off ]?</pre>
+<pre class="prod"><dfn dfn-for="font-feature-settings" dfn-type="value" id="feature-tag-value"><var>&lt;feature-tag-value&gt;</var></dfn> = &lt;string&gt; [ &lt;integer [0,∞]&gt; | on | off ]?</pre>
 
 <p>The &lt;string&gt; is a case-sensitive OpenType feature tag.
 As specified in the OpenType specification [[!OPENTYPE]],


### PR DESCRIPTION
A numeric range is missing for the `<integer>` in `<feature-tag-value>`:

  > `<feature-tag-value> = <string> [ <integer> | on | off ]?`
  >
  > If present, a value indicates an index used for glyph selection. An `<integer>` value must be 0 or greater.

A numeric range is missing for the `<angle>` in `font-style` in `@font-face`:

  > **Value:** `auto | normal | italic | oblique [ <angle>{1,2} ]?`
  >
  > The meaning of the values for these descriptors are the same as those for the corresponding font properties [...]. If specified values are out of range of the accepted values of the property of the same name, the descriptor is treated as a parse error.