### PR TITLE
[css-fonts-5] Use local(<family-name>) #8187

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2618,7 +2618,7 @@ or font format.
 	a locally available copy of a given font
 	and download it if it's not,
 	<code>local()</code> can be used.
-	The locally-installed <<font-face-name>> argument to <code>local()</code>
+	The locally-installed <<family-name>> argument to <code>local()</code>
 	is a format-specific string
 	that uniquely identifies a single font face
 	within a larger family.

--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -357,7 +357,7 @@ according to section [[css-syntax#parse-comma-separated-list-of-component-values
 Then each component value is parsed according to this grammar:
 
 
-<pre><<url>> [ format(<<font-format>>)]? [ tech( <<font-tech>>#)]? | local(<<font-face-name>>)</pre>
+<pre><<url>> [ format(<<font-format>>)]? [ tech( <<font-tech>>#)]? | local(<<family-name>>)</pre>
 
 <pre class="prod"><dfn id="font-format-values">&lt;font-format&gt;</dfn>
 	 = [<<string>> | collection | embedded-opentype | opentype


### PR DESCRIPTION
This is the same fix as https://github.com/w3c/csswg-drafts/commit/e6148b9a897359117bf9082d6a48dd0ff75f8767 but applied to CSS Fonts 5 instead of CSS Fonts 4 (oversight).

It also fixes another oversight in CSS Fonts 4, by replacing a remaining occurrence of `<font-face-name>` with `<family-name>`.