### PR TITLE
[css-fonts-4] Fix ambiguous descriptor auto-links

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -3344,7 +3344,7 @@ h2 {
 </pre>
 
 In cases where textual content is loaded before downloadable fonts are available,
-user agents must render text according to the 'font-display!!descriptor' descriptor of that ''@font-face'' block.
+user agents must render text according to the '@font-face/font-display' descriptor of that ''@font-face'' block.
 In cases where the font download fails, user agents must
 display the text visibly. Authors are advised to use fallback fonts in
 their font lists that closely match the metrics of the
@@ -3443,7 +3443,7 @@ For: @font-face
 
 Note: For all of these values,
 user agents may use slightly different durations,
-or more sophisticated behaviors that can't be directly expressed in the 'font-display!!descriptor' syntax,
+or more sophisticated behaviors that can't be directly expressed in the '@font-face/font-display' syntax,
 in order to provide more useful behavior for their users.
 They may also provide the ability for users to override author-chosen behavior
 with something more desirable;
@@ -7289,7 +7289,7 @@ User-defined font color palettes: The ''@font-palette-values'' rule</h3>
 	the behavior of individual descriptors as defined in this specification should not be altered.
 
 <h4 id="font-family-2-desc">
-Font family: the 'font-family!!descriptor' descriptor</h4>
+Font family: the '@font-palette-values/font-family' descriptor</h4>
 
 	<pre class='descdef'>
 	Name: font-family


### PR DESCRIPTION
Fixes Bikeshed warnings for *Multiple possible 'descriptor' local refs*.