### PR TITLE
[css-fonts-4] Fix markup for the production rule of <family-name> 

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -239,7 +239,7 @@ Font family: the 'font-family!!property' property</h3>
 Syntax of <<family-name>>
 </h4>
 
-	<pre><l><<family-name>></l> = <<string>> | <<custom-ident>>+</pre>
+	<pre class=prod><l><<family-name>></l> = <<string>> | <<custom-ident>>+</pre>
 
 	Font family names other than generic families must either be given quoted as <<string>>s,
 	or unquoted as a sequence of one or more <<custom-ident>>.


### PR DESCRIPTION
This PR adds a `.prod` class name to the `<pre>` containing the production rule of `<family-name>`.

As [commented in its code](https://github.com/w3c/reffy/blob/bb48cea4635c8dfb33b1ea66f30630e756df0d96/src/browserlib/extract-cssdfn.mjs#L703-L708), `w3c/reffy` extracts a production rule if it is contained in a `<pre class=prod>` of if its left hand side is contained in a `<dfn>`:

```
<pre class=prod><foo> = bar</pre>
<pre><dfn><foo></dfn> = bar</pre>
```