### PR TITLE
[css-fonts-4] Define feature and variation names with <opentype-tag>

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6205,9 +6205,12 @@ occurs due to this property.</p>
 
 <p>Feature tag values have the following syntax:</p>
 
-<pre class="prod"><dfn dfn-for="font-feature-settings" dfn-type="value" id="feature-tag-value"><var>&lt;feature-tag-value&gt;</var></dfn> = &lt;string&gt; [ &lt;integer [0,∞]&gt; | on | off ]?</pre>
+<pre class="prod">
+	<dfn dfn-for="font-feature-settings" dfn-type="value" id="feature-tag-value"><var>&lt;feature-tag-value&gt;</var></dfn> = &lt;opentype-tag&gt; [ &lt;integer [0,∞]&gt; | on | off ]?
+	<dfn>&lt;opentype-tag&gt;</dfn> = &lt;string&gt;
+</pre>
 
-<p>The &lt;string&gt; is a case-sensitive OpenType feature tag.
+<p>The <<opentype-tag>> is a case-sensitive OpenType feature tag.
 As specified in the OpenType specification [[!OPENTYPE]],
 feature tags contain four ASCII characters.
 Tag strings longer or shorter than four characters,
@@ -6777,7 +6780,7 @@ Low-level font variation settings control: the 'font-variation-settings' propert
 
 <pre class="propdef">
 Name: font-variation-settings
-Value: normal | [ <<string>> <<number>>]#
+Value: normal | [ <<opentype-tag>> <<number>>]#
 Initial: normal
 Applies to: all elements and text
 Inherited: yes
@@ -6838,7 +6841,7 @@ rather than 'font-variation-settings': "wght" 700.
 
 A value of ''font-variation-settings/normal'' means that no change in glyph shape, matching, or positioning occurs due to this property.
 
-The <<string>> is a case-sensitive OpenType or TrueType variation axis name.
+The <<opentype-tag>> is a case-sensitive OpenType or TrueType variation axis name.
 As specified in the OpenType / TrueType specifications,
 axis names contain four ASCII characters.
 Axis name strings longer or shorter than four characters,


### PR DESCRIPTION
This PR defines `<opentype-tag>` representing the `<string>` in `font-feature-settings` and `font-variation-settings`.

It allows to share a single implementation for parsing this `<string>` as a valid OpenType tag.