### PR TITLE
[css-fonts-5] Set range for font-size-adjust number

### DIFF
--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -102,7 +102,7 @@ Relative sizing: the 'font-size-adjust' property</h3>
 
 	<pre class="propdef">
 	Name: font-size-adjust
-	Value: none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <<number>> ]
+	Value: none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <<number [0,∞]>> ]
 	Initial: none
 	Applies to: all elements and text
 	Inherited: yes
@@ -179,7 +179,7 @@ Relative sizing: the 'font-size-adjust' property</h3>
 			If the required font metric cannot be derived from a font,
 			then that font’s size is not adjusted.
 
-		<dt><dfn><<number>></dfn>
+		<dt><dfn><<number [0,∞]>></dfn>
 		<dd>
 			Each font’s [=used value|used=] size is normalized
 			to match the chosen font metric to


### PR DESCRIPTION
The range already exists in [CSS Fonts 4](https://drafts.csswg.org/css-fonts-4/#propdef-font-size-adjust) and the [current prose](https://drafts.csswg.org/css-fonts-5/#valdef-font-size-adjust-number) in CSS Fonts 5 does not allow negative number as well:

  > Negative values are invalid.