### PR TITLE
[css-content-3] Add missing <content-list> sub-productions

### DIFF
--- a/css-content-3/Overview.bs
+++ b/css-content-3/Overview.bs
@@ -177,7 +177,7 @@ Inserting and replacing content with the 'content' property</h2>
 			Equal to:
 
 			<pre class=prod>
-			[ <<string>> | contents | <<image>> | <<counter>> | <<quote>> | <<target>> | <<leader()>> ]+
+			[ <<string>> | <<image>> | contents | <<quote>> | <<leader()>> | <<target>> | <<string()>> | <<content()>> | <<counter>> ]+
 			</pre>
 
 			Replaces the element's contents with one or more anonymous inline boxes


### PR DESCRIPTION
Fixes #7368.

[`<content-list>`](https://drafts.csswg.org/css-content-3/#typedef-content-content-list) currently expands to `<string> | contents | <image> | <counter> | <quote> | <target> | <leader()>`.

But according to the table of contents, it is missing `<string()>` and `<content()>` (annotations added, starting with `->`):

  > 2. `<content-list>` Values and Functions
  >    1. String -> `<string>`
  >    2. `<image>`
  >    3. Element Content -> `contents`
  >    4. Quotes -> `<quote>`
  >    5. Leaders -> `<leader()>`
  >    6. Cross references and the target-* functions -> `<target>`
  >    7. Named strings -> `<string()>`, `<content()>`

The proposed syntax includes `<string()>` and `<content()>`, and have its sub-productions sorted according to the table of contents (which makes it easier to go back and forth between the definitions of `<content-list>` and its sub-productions).

Please correct me if I am wrong, @faceless2: this syntax allows to remove the paragraphs related to `<content-list>` in CSS GCPM 3, below the [`string-set`](https://drafts.csswg.org/css-gcpm-3/#propdef-string-set) property definition table, and to reference `<content-list>` from CSS Content 3 instead, noting that [`<attr()>`](https://drafts.csswg.org/css-values-5/#funcdef-attr), as defined in CSS Values 5, can be used in any property declaration value.

  > `content-list` expands to one or more of the following values, in any order.
  >
  > `content-list = [ <string> | <counter()> | <counters()> | <content()> | attr(<identifier>) ]+`
  >
  > `<string>`: A string, as defined in [CSS21]
  > `<counter()>`: A counter() function, as described in [CSS21].
  > `<counters()>`: A counters() function, as described in [CSS21].
  > `content()`: The content() function, described below.
  > `attr(<identifier>)`: Returns the string value of the attribute `<identifier>`, as defined in [CSS-VALUES-3]