### PR TITLE
[css-gcpm-3] Remove duplicate definitions of <string()>

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -162,10 +162,6 @@ The value of the “header” string will be “Loomings”.
 </h4>
 The ''string()'' function is used to copy the value of a named string to the document, via the 'content' property. This function requires one argument, the name of the named string. Since the value of a named string may change several times on a page (as new instances of the element defining the string appear) an optional second argument indicates which value of the named string should be used.
 
-<pre class="prod">
-	<dfn>string()</dfn> = string( <<custom-ident>> , [ first | start | last | first-except ]? )
-</pre>
-
 
 The second argument of the ''string()'' function is one of the following keywords:
 <dl dfn-type="value" dfn-for="string()">


### PR DESCRIPTION
`<string()>` is defined with the same value definition in [CSS Content 3](https://drafts.csswg.org/css-content-3/#funcdef-string) and [CSS GCPM 3](https://drafts.csswg.org/css-gcpm-3/#funcdef-string).

This PR removes the definition in CSS GCPM 3.