### PR TITLE
[css-gcpm-3] Define :nth() as selector instead of function

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -698,7 +698,7 @@ Page Selectors
 The '':nth()'' page pseudo-class allows the selection of arbitrary document pages. This pseudo-class takes an argument of the form <a href="https://drafts.csswg.org/css-syntax/#anb">An + B</a> as defined in [[CSS3SYN]]. When applied to the default @page rule, '':nth()'' selects the document page whose index matches the argument.
 
 <pre class="prod">
-<dfn>:nth()</dfn> = ( An+B [of <<custom-ident>>]?)
+<dfn>:nth()</dfn> = :nth( <<an+b>> [of <<custom-ident>>]? )
 </pre>
 
 <p class="note">

--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -695,16 +695,16 @@ A paginated document consists of a sequence of pages. [[CSS3PAGE]] defines <dfn>
 <h3 id="document-page-selectors">
 Page Selectors
 </h3>
-The ''nth()'' page pseudo-class allows the selection of arbitrary document pages. This pseudo-class takes an argument of the form <a href="https://drafts.csswg.org/css-syntax/#anb">An + B</a> as defined in [[CSS3SYN]]. When applied to the default @page rule, ''nth()'' selects the document page whose index matches the argument.
+The '':nth()'' page pseudo-class allows the selection of arbitrary document pages. This pseudo-class takes an argument of the form <a href="https://drafts.csswg.org/css-syntax/#anb">An + B</a> as defined in [[CSS3SYN]]. When applied to the default @page rule, '':nth()'' selects the document page whose index matches the argument.
 
 <pre class="prod">
-<dfn>nth()</dfn> = ( An+B [of <<custom-ident>>]?)
+<dfn>:nth()</dfn> = ( An+B [of <<custom-ident>>]?)
 </pre>
 
 <p class="note">
-''nth()'' is not related to the page counter, which may reset and use various numbering schemes.</p>
+'':nth()'' is not related to the page counter, which may reset and use various numbering schemes.</p>
 
-When the ''nth()'' selector is applied to a named page, and that named page is part of a page-group (see below), it selects the nth page in the page group.
+When the '':nth()'' selector is applied to a named page, and that named page is part of a page-group (see below), it selects the nth page in the page group.
 
 
 <div class="example">


### PR DESCRIPTION
This PR prefixes `nth()` with `:`, as required by Bikeshed:

  > Does it start with a `:`? Then it’s a selector.

https://speced.github.io/bikeshed/#dfn-types

  > The `nth()` page pseudo-class allows the selection of arbitrary document pages.

https://drafts.csswg.org/css-gcpm-3/#document-page-selectors