### PR TITLE
[css-gcpm-4] Fix <content-level> definition

### DIFF
--- a/css-gcpm-4/Overview.bs
+++ b/css-gcpm-4/Overview.bs
@@ -65,10 +65,10 @@ Animation type: discrete
 
 The 'copy-into' property contains one or more pairs, each consisting of a custom identifier followed by a content-level keyword describing how to construct the value of the named content fragment.
 
-''content-level'' expands to the following values:
+<<content-level>> expands to the following values:
 
 <pre class="prod">
-	<dfn id="content-list">content-list</dfn> = element | content | text | attr(&lt;identifier>) | counter() | counters()
+	<dfn>&lt;content-level></dfn> = element | content | text | <<counter>>
 </pre>
 
 
@@ -77,7 +77,7 @@ The 'copy-into' property contains one or more pairs, each consisting of a custom
 <dd>the entire element is copied into the named content fragment</dd>
 
 <dt>contents</dt>
-<dd>only the element’s contents are copied into the named content fragment. This is the default if ''content-level'' is not specified.</dd>
+<dd>only the element’s contents are copied into the named content fragment. This is the default if <<content-level>> is not specified.</dd>
 
 <dt>text</dt>
 <dd>only the element’s text (including normally collapsed white space) is copied into the named content fragment.</dd>


### PR DESCRIPTION
Fixes #2919.

I removed [`<attr()>`](https://drafts.csswg.org/css-values-5/#attr-notation) from its definition because it can be used at any place in a property value.