### PR TITLE
[css-contain-2] Update selection link to point to selection API instead of highlight pseudos.

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1685,7 +1685,7 @@ Suppressing An Element's Contents Entirely: the 'content-visibility' property {#
 
 		* Either the element or its [=contents=]
 			are selected,
-			as described in [[css-pseudo-4#highlight-pseudos]].
+			where selection is described in the <a href="https://www.w3.org/TR/selection-api/#dfn-selection">selection API</a>
 
 			<wpt>
 			content-visibility/content-visibility-070.html
@@ -2302,6 +2302,7 @@ This appendix is <em>informative</em>.
 Changes from <a href="https://www.w3.org/TR/2022/WD-css-contain-2-20220917/">2022-09-17 Working Draft</a>
 </h3>
 
+* Updated relevant to the user selection to point to the selection API instead of highlight pseudos.
 * Referenced the HTML event loop process model in the [[#cv-notes]], clarification 4.
 * defined [=proximity to the viewport=] and used it in the [[#cv-notes]], clarification 4.
 * 'content-visibility' applies to the same properties as [=size containment=] rather than [=layout containment=]


### PR DESCRIPTION
[css-contain-2] Update selection link to point to selection API instead of highlight pseudos.

Fixes #9277 

