### PR TITLE
[css-anchor-position-1] Fix anchor-center section number

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -644,8 +644,8 @@ This has two effects:
 ██     ██          ██████  ████████ ██    ██    ██    ████████ ██     ██
 -->
 
-<h2 id="anchor-center">
-Centering on the Anchor: the ''anchor-center'' value</h2>
+Centering on the Anchor: the ''anchor-center'' value {#anchor-center}
+------------------------------------------------------------------------
 
 <pre class=propdef>
 Name: justify-self, align-self, justify-items, align-items


### PR DESCRIPTION
`anchor-center` should be a subsection of Anchor-Based Positioning, not a top-level section.

This PR fixes it.