### PR TITLE
[css-transforms-2] Make backface-visibility:hidden create a stacking context and containing block when participating in a 3D rendering context.

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -933,6 +933,11 @@ Computed value: specified keyword
 Animation type: discrete
 </pre>
 
+A computed value of ''backface-visibility/hidden'' for 'backface-visibility'
+on a <a>transformable element</a> that participates in a <a>3D rendering context</a>
+establishes both a stacking context and
+a [=containing block for all descendants=].
+
 The visibility of an element with ''backface-visibility: hidden'' is determined as follows:
 
 1. Compute the element's <a>accumulated 3D transformation matrix</a>.


### PR DESCRIPTION
The first (simpler) half of what was discussed in https://github.com/w3c/csswg-drafts/issues/918.

Will try write some new tentative tests for this too.