### PR TITLE
[web-animation-2] Avoid using a dictionary for range in animation IDL

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2395,11 +2395,17 @@ rangeStart and rangeEnd as follows:
 
 <pre class="idl">
 [Exposed=Window]
+interface AnimationRangeBoundary {
+    attribute readonly DOMString range;
+    attribute readonly CSSNumberish offset;
+}
+
+[Exposed=Window]
 partial interface Animation {
     attribute CSSNumberish?       startTime;
     attribute CSSNumberish?       currentTime;
-    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
-    attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
+    attribute any rangeStart;
+    attribute any rangeEnd;
 };
 </pre>
 
@@ -2435,15 +2441,15 @@ Add:
 > ::  Specifies the start of the <a>animation</a>’s [=animation attachment range=].
 >     Setting the attribute follows the same rules as the KeyframeAnimationOption
 >     <a href="#dom-keyframeanimationoptions-rangestart">rangeStart</a>.
->     When reading the attribute, the returned value is either a
->     {{TimelineRangeOffset}} or the {{DOMString}} "normal".
+>     When reading the attribute, the returned value is either an
+>     {{AnimationRangeBoundary}} or the {{DOMString}} "normal".
 >
 > :  <dfn attribute for=Animation>rangeEnd</dfn>
 > ::  Specifies the end of the <a>animation</a>’s [=animation attachment range=].
 >     Setting the attribute follows the same rules as the KeyframeAnimationOption
 >      <a href="#dom-keyframeanimationoptions-rangeend">rangeEnd</a>.
->     When reading the attribute, the returned value is either a
->     {{TimelineRangeOffset}} or the {{DOMString}} "normal".
+>     When reading the attribute, the returned value is either an
+>     {{AnimationRangeBoundary}} or the {{DOMString}} "normal".
 </div>
 
 <h3 id="the-animationeffect-interface">The <code>AnimationEffect</code> interface</h3>


### PR DESCRIPTION
[web-animation-2] Avoid using a dictionary for range in animation IDL

Remove use of TimelineRangeOffset dictionary in range(Start|End).  Instead use any for the type and use an interface instead of a dictionary for the getter's output value.

Addresses issue #9355
