### PR TITLE
[css-overflow-4] Rephrased description of `max-lines` to avoid double negative

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -961,9 +961,9 @@ Forcing a Break After a Set Number of Lines: the 'max-lines' property</h3>
 		Animation type: by computed value type
 	</pre>
 
-	This property has no effect on boxes that are not [=fragmentation containers=] that capture [=region breaks=].
+	This property only has an effect on boxes that are [=fragmentation containers=] that capture [=region breaks=].
 
-	Otherwise, if the value of 'max-lines' is not <dfn for=max-lines dfn-type=value>none</dfn>,
+	Also, if the value of 'max-lines' is not <dfn for=max-lines dfn-type=value>none</dfn>,
 	a <a>region break</a>
 	is forced after its <var>N</var>th
 	descendant <a>in-flow</a> <a>line box</a>,


### PR DESCRIPTION
The first sentence of the description of `max-lines` included a double negative. I rephrased that sentence to avoid that double negative, so it's easier understandable.

Sebastian