### PR TITLE
[css-inline-3][css-page-3][css-text] Enforce non-negative value from …

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -964,7 +964,7 @@ Line Spacing: the 'line-height' property</h3>
 
 	<pre class="propdef">
 	Name: line-height
-	Value: normal | <<number>> | <<length-percentage>>
+	Value: normal | <<number [0,∞]>> | <<length-percentage [0,∞]>>
 	Initial: normal
 	Applies to: non-replaced inline boxes and SVG <a>text content elements</a>
 	Inherited: yes
@@ -991,19 +991,19 @@ Line Spacing: the 'line-height' property</h3>
 			Determine the [=preferred line height=]
 			automatically based on font metrics.
 
-		<dt><dfn><<length>></dfn>
+		<dt><dfn><<length [0,∞]>></dfn>
 		<dd>
 			The specified length is used as the [=preferred line height=].
 			Negative values are illegal.
 
-		<dt><dfn><<number>></dfn>
+		<dt><dfn><<number [0,∞]>></dfn>
 		<dd>
 			The [=preferred line height=] is this number
 			multiplied by the element's computed 'font-size'.
 			Negative values are illegal.
 			The [=computed value=] is the same as the [=specified value=].
 
-		<dt><dfn><<percentage>></dfn>
+		<dt><dfn><<percentage [0,∞]>></dfn>
 		<dd>
 			The [=preferred line height=]
 			and [=computed value=] of the property

--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -1660,7 +1660,7 @@ Page size: the 'size' property</h3>
 	<pre class=descdef>
 	Name: size
 	For: @page
-	Value: <<length>>{1,2} | auto | [ <<page-size>> || [ portrait | landscape ] ]
+	Value: <<length [0,∞]>>{1,2} | auto | [ <<page-size>> || [ portrait | landscape ] ]
 	Initial: auto
 	Computed value: specified value, with <<length>>s made absolute.
 	</pre>
@@ -1744,7 +1744,7 @@ Page size: the 'size' property</h3>
 			shorter sides of the page box are horizontal. If a <<page-size>> is not specified, the size of the page sheet
 			is chosen by the UA.
 
-		<dt><dfn><<length>></dfn>
+		<dt><dfn><<length [0,∞]>></dfn>
 		<dd>
 			The page box will be set to the given absolute dimension(s). If only one length
 			value is specified, it sets both the width and height of the page box (i.e.,

--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -2856,7 +2856,7 @@ Tab Character Size: the 'tab-size' property</h3>
 
 	<pre class="propdef">
 	Name: tab-size
-	Value: <<number>> | <<length>>
+	Value: <<number [0,∞]>> | <<length [0,∞]>>
 	Initial: 8
 	Applies to: text
 	Inherited: yes

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -4042,7 +4042,7 @@ Tab Character Size: the 'tab-size' property</h3>
 
 	<pre class="propdef">
 	Name: tab-size
-	Value: <<number>> | <<length>>
+	Value: <<number [0,∞]>> | <<length [0,∞]>>
 	Initial: 8
 	Applies to: text
 	Inherited: yes


### PR DESCRIPTION
Adds `[0,∞]` to CSS types in contexts that require a non-negative value.