### PR TITLE
[css-fonts-4] Make color interpolation method optional in palette-mix()

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -7065,7 +7065,7 @@ Animation type: by computed value
 With the <code>palette-mix()</code> function defined as follows:
 
 <pre class="prod def" nohighlight>
-<dfn>palette-mix()</dfn> = palette-mix(<<color-interpolation-method>> , [ [normal | light | dark | <<palette-identifier>> | <<palette-mix()>> ] && <<percentage [0,100]>>? ]#{2})
+<dfn>palette-mix()</dfn> = palette-mix(<<color-interpolation-method>>? , [ [normal | light | dark | <<palette-identifier>> | <<palette-mix()>> ] && <<percentage [0,100]>>? ]#{2})
 </pre>
 
 <dl dfn-for=font-palette dfn-type=value>


### PR DESCRIPTION
`<color-interpolation-method>` is defined as optional in prose for [`<palette-mix()>`](https://drafts.csswg.org/css-fonts-4/#typedef-font-palette-palette-mix):

  > When not specified otherwise the <color-interpolation-method> is in oklab as recommended by CSS Color 5 § 7.1 Color Space for Interpolation.

But not in its value definition:

  > `palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})`

I suppose this is an oversight.