### PR TITLE
[css-fonts-4] Remove duplicate definition of `<palette-mix()>`

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -7119,7 +7119,7 @@ With the <code>palette-mix()</code> function defined as follows:
 	    be a modification of an existing palette already present in the font,
 	    or be an entirely new palette.
 
-	<dt><dfn function><<palette-mix()>></dfn>
+	<dt><dfn type><<palette-mix()>></dfn>
 	<dd>
         This value defines a position in the interpolation between two palette values,
         identified by <<palette-identifier>>, by the palette keywords

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -7008,7 +7008,7 @@ Applies to: all elements and text
 Inherited: yes
 Percentages: N/a
 Computed value: specified keyword, identifier or <<palette-mix()>> function.
-    <<palette-mix>> must be simplified to a single keyword or identifier if resulting palette is equivalent.
+    <<palette-mix()>> must be simplified to a single keyword or identifier if resulting palette is equivalent.
 Animation type: by computed value
 </pre>
 
@@ -7065,7 +7065,7 @@ Animation type: by computed value
 With the <code>palette-mix()</code> function defined as follows:
 
 <pre class="prod def" nohighlight>
-<dfn>palette-mix()</dfn> = palette-mix(<<color-interpolation-method>> , [ [normal | light | dark | <<palette-identifier>> | <<palette-mix()>> ] && <<percentage [0,100]>>? ]#{2})
+<l><<palette-mix()>></l> = palette-mix(<<color-interpolation-method>> , [ [normal | light | dark | <<palette-identifier>> | <<palette-mix()>> ] && <<percentage [0,100]>>? ]#{2})
 </pre>
 
 <dl dfn-for=font-palette dfn-type=value>
@@ -7119,7 +7119,7 @@ With the <code>palette-mix()</code> function defined as follows:
 	    be a modification of an existing palette already present in the font,
 	    or be an entirely new palette.
 
-	<dt><dfn type><<palette-mix()>></dfn>
+	<dt><dfn function><<palette-mix()>></dfn>
 	<dd>
         This value defines a position in the interpolation between two palette values,
         identified by <<palette-identifier>>, by the palette keywords


### PR DESCRIPTION
  > ```json
  >   {
  >     "name": "<palette-mix()>",
  >     "type": "type"
  >   }
  > ```

https://github.com/w3c/webref/blob/d898c413c384c43f38d20ebf34db2e8fac7e9ce8/ed/css/css-fonts.json#L997

  > ```json
  >   {
  >     "name": "<palette-mix()>",
  >     "type": "function",
  >   }
  > ```

https://github.com/w3c/webref/blob/d898c413c384c43f38d20ebf34db2e8fac7e9ce8/ed/css/css-fonts.json#L1414