### PR TITLE
[css-view-transitions-2] Apply renames based on TPAC discussion

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -118,7 +118,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
 		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
 
-	1. An event named {{ReadyToRenderEvent|readytorender}} is fired on the new {{Document}}, with a `viewTransition` property,
+	1. An event named {{RevealEvent|reveal}} is fired on the new {{Document}}, with a `viewTransition` property,
 		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
 		and its [=captured elements=] are populated from the old {{Document}}.
 
@@ -137,7 +137,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		```css
 		// in both documents:
-		@view-transition {
+		@view-transition same-origin {
 			trigger: navigation;
 		}
 		```
@@ -153,7 +153,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		- Opt-in to navigation-triggered view-transitions in both pages.
 		- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
-		- Intercept the {{ViewTransition}} object in the new document, using the {{ReadyToRenderEvent}}.
+		- Intercept the {{ViewTransition}} object in the new document, using the {{RevealEvent}}.
 
 		In both pages:
 		```css
@@ -174,7 +174,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		In the new page:
 		```js
 		// This would run both on initial load and on reactivation from BFCache.
-		addEventListener("readytorender", async event => {
+		addEventListener("reveal", async event => {
 			if (!event.viewTransition)
 				return;
 
@@ -259,20 +259,21 @@ document.startViewTransition({update: updateTheDOMSomehow});
 
 # CSS rules # {#css-rules}
 
-## The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ## {#view-transition}
+## The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ## {#view-transition-rule}
 
 The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
 should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
 when unloading, and in the new document when it is [=ready to render=].
 
 
-## @view-transition rule grammar ## {#view-transition-grammer}
+## @view-transition rule grammar ## {#view-transition-grammar}
 
-''@view-transition'' rules are [=CSS/parsed=] according to the following grammar,
-plus the additional rules noted below:
+The ''@view-transition'' rule has the following syntax:
 
 <pre class=prod>
-	@view-transition = @view-transition same-origin { <<declaration-rule-list>> }
+	@view-transition same-origin {
+		<<declaration-rule-list>>
+	}
 </pre>
 
 Note: currently <code>same-origin</code> has to be present, as a future placeholder for customizing
@@ -306,20 +307,20 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 
 # API # {#api}
 
-## The <dfn interface>ReadyToRenderEvent</dfn> ## {#ready-to-render-event}
+## The <dfn interface>RevealEvent</dfn> ## {#ready-to-render-event}
 
 Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatwg/html/issues/9315).
 
 <xmp class=idl>
 		[Exposed=Window]
-		interface ReadyToRenderEvent : Event {
+		interface RevealEvent : Event {
 			readonly attribute ViewTransition? viewTransition;
 		};
 </xmp>
 
 Note: this event is fired when the document is [=ready to render=].
 
-The <dfn attribute for=ReadyToRenderEvent>viewTransition</dfn> [=getter steps=] are to return the
+The <dfn attribute for=RevealEvent>viewTransition</dfn> [=getter steps=] are to return the
 [=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
 
 ## Additions to {{Document}} ## {#additions-to-document-api}
@@ -356,7 +357,7 @@ The <code>CSSRule</code> interface is extended as follows:
 
 <pre class='idl'>
 partial interface CSSRule {
-    const unsigned short NAVIGATION_BEHAVIOR_RULE = 15;
+    const unsigned short VIEW_TRANSITION_RULE = 15;
 };
 </pre>
 
@@ -427,8 +428,8 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. If |transition| is not null and |document| does not [=opt in to cross-document view transitions=], then [=skip the view transition|skip=] |transition| and set |transition| to null.
 
-		1. Fire a new event named <code>readytorender</code> on |document|'s [=relevant global object=],
-			using {{ReadyToRenderEvent}}.
+		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
+			using {{RevealEvent}}.
 
 		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -133,12 +133,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
 		but across documents, we don't need JavaScript.
 
-		Instead, we opt in to navigation-behaviors in both page 1 and page 2:
+		Instead, we opt in to triggering view-transitions on navigation in both page 1 and page 2:
 
 		```css
 		// in both documents:
-		@navigation-behaviors {
-			same-origin: enable;
+		@navigation-behavior {
+			view-transition: trigger;
 		}
 		```
 
@@ -278,6 +278,9 @@ plus the additional rules noted below:
 Note: currently <code>same-origin</code> has to be present, as a future placeholder for customizing
 the navigation behavior based on the URL.
 
+Note: as per default behavior, the ''@navigation-behavior'' rule can be nested inside a
+[=conditional group rule=] such as ''@media'' or ''@supports''.
+
 ## The [=@navigation-behavior/view-transition=] property ## {#view-transition-name-prop}
 
 	<pre class='descdef'>
@@ -298,6 +301,8 @@ the navigation behavior based on the URL.
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
 			redirects.
 	</dl>
+
+
 
 # API # {#api}
 
@@ -345,6 +350,28 @@ The <dfn attribute for=ReadyToRenderEvent>viewTransition</dfn> [=getter steps=] 
 		1. Return |viewTransition|.
 	</div>
 
+## Extensions to the <code>CSSRule</code> interface</h3> ## {#extensions-to-cssrule-interface}
+
+The <code>CSSRule</code> interface is extended as follows:
+
+<pre class='idl'>
+partial interface CSSRule {
+    const unsigned short NAVIGATION_BEHAVIOR_RULE = 15;
+};
+</pre>
+
+## The <code>CSSNavigationBehaviorRule</code> interface</h3> ## {#navgation-behavior-rule-interface}
+
+The {{CSSNavigationBehaviorRule}} represents a ''@navigation-behavior'' rule.
+
+<xmp class=idl>
+		enum NavigationViewTransitionBehavior { "skip", "trigger" };
+		[Exposed=Window]
+		interface CSSNavigationBehaviorRule : CSSRule {
+			readonly attribute CSSOMString navigationConditionText;
+			attribute NavigationViewTransitionBehavior viewTransitionBehavior;
+		};
+</xmp>
 
 
 # Algorithms # {#algorithms}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -137,8 +137,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		```css
 		// in both documents:
-		@navigation-behavior {
-			view-transition: trigger;
+		@view-transition {
+			trigger: navigation;
 		}
 		```
 
@@ -157,8 +157,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		In both pages:
 		```css
-		@navigation-behavior same-origin {
-			view-transition: trigger;
+		@view-transition same-origin {
+			trigger: navigation;
 		}
 
 		```
@@ -259,45 +259,45 @@ document.startViewTransition({update: updateTheDOMSomehow});
 
 # CSS rules # {#css-rules}
 
-## The <dfn id="at-navigation-behavior-rule">''@navigation-behavior''</dfn> rule ## {#navigation-behavior}
+## The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ## {#view-transition}
 
-The ''@navigation-behavior'' rule is used by a document to indicate that cross-document navigations
+The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
 should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
 when unloading, and in the new document when it is [=ready to render=].
 
 
-## @navigation-behavior rule grammar ## {#navigation-behavior-grammer}
+## @view-transition rule grammar ## {#view-transition-grammer}
 
-''@navigation-behavior'' rules are [=CSS/parsed=] according to the following grammar,
+''@view-transition'' rules are [=CSS/parsed=] according to the following grammar,
 plus the additional rules noted below:
 
 <pre class=prod>
-	@navigation-behavior = @navigation-behavior same-origin { <<declaration-rule-list>> }
+	@view-transition = @view-transition same-origin { <<declaration-rule-list>> }
 </pre>
 
 Note: currently <code>same-origin</code> has to be present, as a future placeholder for customizing
 the navigation behavior based on the URL.
 
-Note: as per default behavior, the ''@navigation-behavior'' rule can be nested inside a
+Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
 [=conditional group rule=] such as ''@media'' or ''@supports''.
 
-## The [=@navigation-behavior/view-transition=] property ## {#view-transition-name-prop}
+## The [=@view-transition/view-transition=] property ## {#view-transition-name-prop}
 
 	<pre class='descdef'>
-	Name: view-transition
-	For: @navigation-behavior
-	Value: trigger | skip
-	Initial: skip
+	Name: trigger
+	For: @view-transition
+	Value: navigation | none
+	Initial: none
 	</pre>
 
-	The '<dfn for="@navigation-behavior">view-transition</dfn>' property opts in to automatically performing a view transition when performing a navigation.
+	The '<dfn for="@view-transition">trigger</dfn>' property opts in to automatically starting a view transition when performing a navigation.
 	It needs to be enabled both in the old document (when unloading) and in the new document (when ready to render).
 
-	<dl dfn-type=value dfn-for="view-transition">
-		: <dfn>skip</dfn>
+	<dl dfn-type=value dfn-for="trigger">
+		: <dfn>none</dfn>
 		:: There will be no transition.
 
-		: <dfn>trigger</dfn>
+		: <dfn>navigation</dfn>
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
 			redirects.
 	</dl>
@@ -360,16 +360,16 @@ partial interface CSSRule {
 };
 </pre>
 
-## The <code>CSSNavigationBehaviorRule</code> interface</h3> ## {#navgation-behavior-rule-interface}
+## The <code>CSSViewTransitionRule</code> interface</h3> ## {#navgation-behavior-rule-interface}
 
-The {{CSSNavigationBehaviorRule}} represents a ''@navigation-behavior'' rule.
+The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 <xmp class=idl>
-		enum NavigationViewTransitionBehavior { "skip", "trigger" };
+		enum ViewTransitionTrigger { "navigation", "none" };
 		[Exposed=Window]
-		interface CSSNavigationBehaviorRule : CSSRule {
+		interface CSSViewTransitionRule : CSSRule {
 			readonly attribute CSSOMString navigationConditionText;
-			attribute NavigationViewTransitionBehavior viewTransitionBehavior;
+			attribute ViewTransitionTrigger trigger;
 		};
 </xmp>
 
@@ -512,8 +512,8 @@ The {{CSSNavigationBehaviorRule}} represents a ''@navigation-behavior'' rule.
 
 	<div algorithm>
 		A {{Document}} |document| is said to <dfn>opt in to cross-document view transitions</dfn>
-		if the [=computed value=] of <a data-xref-type="css-descriptor" data-xref-for="@navigation-behavior">view-transition</a>
-		for |document| is <code>trigger</code>.
+		if the [=computed value=] of <a data-xref-type="css-descriptor" data-xref-for="@view-transition">trigger</a>
+		for |document| is <code>navigation</code>.
 	</div>
 
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -118,7 +118,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
 		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
 
-	1. An event named {{PageRevealEvent|reveal}} is fired on the new {{Document}}, with a `viewTransition` property,
+	1. An event named {{ReadyToRenderEvent|readytorender}} is fired on the new {{Document}}, with a `viewTransition` property,
 		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
 		and its [=captured elements=] are populated from the old {{Document}}.
 
@@ -133,11 +133,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
 		but across documents, we don't need JavaScript.
 
-		Instead, we opt in to auto-view-transitions in both page 1 and page 2:
+		Instead, we opt in to navigation-behaviors in both page 1 and page 2:
 
 		```css
 		// in both documents:
-		@auto-view-transitions {
+		@navigation-behaviors {
 			same-origin: enable;
 		}
 		```
@@ -151,14 +151,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		To achieve the effect in [[css-view-transitions-1#examples|example 5]], we have to do several
 		things:
 
-		- Opt-in to auto-view-transitions in both pages.
+		- Opt-in to navigation-triggered view-transitions in both pages.
 		- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
-		- Intercept the {{ViewTransition}} object in the new document, using the {{PageRevealEvent|reveal event}}.
+		- Intercept the {{ViewTransition}} object in the new document, using the {{ReadyToRenderEvent}}.
 
 		In both pages:
 		```css
-		@auto-view-transitions {
-			same-origin: enable;
+		@navigation-behavior same-origin {
+			view-transition: trigger;
 		}
 
 		```
@@ -174,7 +174,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		In the new page:
 		```js
 		// This would run both on initial load and on reactivation from BFCache.
-		addEventListener("reveal", async event => {
+		addEventListener("readytorender", async event => {
 			if (!event.viewTransition)
 				return;
 
@@ -259,59 +259,62 @@ document.startViewTransition({update: updateTheDOMSomehow});
 
 # CSS rules # {#css-rules}
 
-## The <dfn id="at-auto-view-transition-rule">''@auto-view-transition''</dfn> rule ## {#auto-view-transition-rule}
+## The <dfn id="at-navigation-behavior-rule">''@navigation-behavior''</dfn> rule ## {#navigation-behavior}
 
-The ''@auto-view-transition'' rule is used by a document to indicate that cross-document navigations
+The ''@navigation-behavior'' rule is used by a document to indicate that cross-document navigations
 should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
-when unloading, and in the new document when it is being [=reveal document|revealed=].
+when unloading, and in the new document when it is [=ready to render=].
 
 
-## @auto-view-transition rule grammar ## {#auto-view-transition-grammer}
+## @navigation-behavior rule grammar ## {#navigation-behavior-grammer}
 
-''@auto-view-transition'' rules are [=CSS/parsed=] according to the following grammar,
+''@navigation-behavior'' rules are [=CSS/parsed=] according to the following grammar,
 plus the additional rules noted below:
 
 <pre class=prod>
-	@auto-view-transition = @auto-view-transition { <<declaration-rule-list>> }
+	@navigation-behavior = @navigation-behavior same-origin { <<declaration-rule-list>> }
 </pre>
 
-## The [=@auto-view-transition/same-origin=] property ## {#view-transition-name-prop}
+Note: currently <code>same-origin</code> has to be present, as a future placeholder for customizing
+the navigation behavior based on the URL.
+
+## The [=@navigation-behavior/view-transition=] property ## {#view-transition-name-prop}
 
 	<pre class='descdef'>
-	Name: same-origin
-	For: @auto-view-transition
-	Value: enabled | disabled
-	Initial: disabled
+	Name: view-transition
+	For: @navigation-behavior
+	Value: trigger | skip
+	Initial: skip
 	</pre>
 
-	The '<dfn for="@auto-view-transition">same-origin</dfn>' property opts in to automatically performing a view transition when performing a [=same origin=] navigation.
+	The '<dfn for="@navigation-behavior">view-transition</dfn>' property opts in to automatically performing a view transition when performing a navigation.
 	It needs to be enabled both in the old document (when unloading) and in the new document (when ready to render).
 
-	<dl dfn-type=value dfn-for="same-origin">
-		: <dfn>disabled</dfn>
+	<dl dfn-type=value dfn-for="view-transition">
+		: <dfn>skip</dfn>
 		:: There will be no transition.
 
-		: <dfn>enabled</dfn>
+		: <dfn>trigger</dfn>
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
 			redirects.
 	</dl>
 
 # API # {#api}
 
-## The <dfn interface>PageRevealEvent</dfn> ## {#reveal-event}
+## The <dfn interface>ReadyToRenderEvent</dfn> ## {#ready-to-render-event}
 
 Note: this should go in the HTML spec. See [Issue 9315](https://github.com/whatwg/html/issues/9315).
 
 <xmp class=idl>
 		[Exposed=Window]
-		interface PageRevealEvent : Event {
+		interface ReadyToRenderEvent : Event {
 			readonly attribute ViewTransition? viewTransition;
 		};
 </xmp>
 
-Note: this event is fired when [=reveal document|revealing a document=].
+Note: this event is fired when the document is [=ready to render=].
 
-The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are to return the
+The <dfn attribute for=ReadyToRenderEvent>viewTransition</dfn> [=getter steps=] are to return the
 [=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
 
 ## Additions to {{Document}} ## {#additions-to-document-api}
@@ -352,10 +355,10 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	A {{Document}} additionally has:
 
 	<dl dfn-for=document>
-		: <dfn>is revealed</dfn>
+		: <dfn>ready to render fired</dfn>
 		:: a boolean, initially false.
 
-### Additions to {{ViewTransition}} ## {#view-transitions-extension}
+### Additions to {{ViewTransition}} ### {#view-transitions-extension}
 
 	A {{ViewTransition}} additionally has:
 	<dl dfn-for=ViewTransition>
@@ -380,29 +383,29 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	<div algorithm="monkey patch to rendering">
 		Run the following step in [=update the rendering|updating the renedering=], before [=running the animation frame callbacks=]:
 
-		1. For each [=fully active=] {{Document}} |doc| in |docs|, [=reveal document|reveal=] |doc|.
+		1. For each [=fully active=] {{Document}} |doc| in |docs|, run the [=ready to render=] steps for |doc|.
 	</div>
 
 	<div algorithm="monkey patch to reactivation">
 		Run the following step at the end of [=Document/reactivate=]:
 
-		1. Set |document|'s [=is revealed=] to false.
+		1. Set |document|'s [=ready to render fired=] to false.
 	</div>
 
-	<div algorithm="page reveal">
-	To <dfn>reveal {{Document}}</dfn> |document|:
-		1. If |document|'s [=document/is revealed=] is true, then return.
+	<div algorithm="page ready to render">
+	When {{Document}} |document| is <dfn>ready to render</dfn>:
+		1. If |document|'s [=document/ready to render fired=] is true, then return.
 
 		1. Let |transition| be the result of getting the [=inbound cross-document view-transition=] for |document|.
 
 		1. If |transition| is not null and |document| does not [=opt in to cross-document view transitions=], then [=skip the view transition|skip=] |transition| and set |transition| to null.
 
-		1. Fire a new event named <code>reveal</code> on |document|'s [=relevant global object=],
-			using {{PageRevealEvent}}.
+		1. Fire a new event named <code>readytorender</code> on |document|'s [=relevant global object=],
+			using {{ReadyToRenderEvent}}.
 
 		1. If |transition| is not null, then [=activate view transition|activate=] |transition|.
 
-		1. Set |document|'s [=document/is revealed=] to true.
+		1. Set |document|'s [=document/ready to render fired=] to true.
 	</div>
 
 ## Setting up and activating the cross-document view transition ## {#setting-up-and-activating-the-cross-document-view-transition}
@@ -423,7 +426,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		1. If |oldDocument| does not [=opt in to cross-document view transitions=], then call |onReady| and return.
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
-			We check the opt-in for |newDocument| when it is [=reveal document|revealed=].
+			We check the opt-in for |newDocument| when it is [=ready to render=].
 
 		1. If |oldDocument|'s [=active view transition=] is not null,
 			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
@@ -475,15 +478,15 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 			then return null.
 
 			Note: |transition|'s [=ViewTransition/is inbound cross-document transition=] would be false if a same-document
-			transition was started before the page was revealed.
+			transition was started before the page was [=ready to render=].
 
 		1. Return |transition|.
 	</div>
 
 	<div algorithm>
 		A {{Document}} |document| is said to <dfn>opt in to cross-document view transitions</dfn>
-		if the [=computed value=] of <a data-xref-type="css-descriptor" data-xref-for="@auto-view-transition">same-origin</a>
-		is <code>enabled</code>.
+		if the [=computed value=] of <a data-xref-type="css-descriptor" data-xref-for="@navigation-behavior">view-transition</a>
+		for |document| is <code>trigger</code>.
 	</div>
 
 


### PR DESCRIPTION
Rename based on TPAC conversation: auto-view-transition => view-transition (with `trigger: navigation` as the descriptor)

Also added CSSOM support for the new rule.

Close #8048 as per [TPAC discussion](https://github.com/w3c/csswg-drafts/issues/8048#issuecomment-1719751618).

Opened #9383 to continue bikeshedding discussion about the at-rule name. We can update the spec once that's finalized.