### PR TITLE
[css-sizing-4] Fix typo

### DIFF
--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -211,7 +211,7 @@ Preferred Aspect Ratios: the 'aspect-ratio' property</h3>
 			If the <<ratio>> is [=degenerate ratio|degenerate=],
 			the property instead behaves as ''aspect-ratio/auto''.
 
-		<dt><dfn>auto && <<ratio>></dfn>
+		<dt><dfn>auto || <<ratio>></dfn>
 		<dd>
 			If both ''aspect-ratio/auto'' and a <<ratio>> are specified together,
 			the [=preferred aspect ratio=] is the specified ratio


### PR DESCRIPTION
[Resolution](https://github.com/w3c/csswg-drafts/issues/4951#issuecomment-621337849)

  > RESOLVED: Use the `<aspect-ratio>||auto` syntax

[Commit](https://github.com/w3c/csswg-drafts/commit/2ccdc2921ce66217d60fd29653dd3901c856f810) for the current value:

  > **Value:** `auto || <<ratio>>`
  >
  > **`auto && <ratio>`**: [...]

https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio