### PR TITLE
[css-view-transitions-2] Add transition types

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -221,7 +221,6 @@ It has the following syntax definition:
 An ''::active-view-transition()'' pseudo-class matches the [=document element=] when it has an non-null [=active view transition=] |viewTransition|, for which any of the following are true:
 
 * The <<vt-type-selector>> is ''*''
-* |viewTransition|'s [=ViewTransition/active types=] is null
 * |viewTransition|'s [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> values of the <<vt-type-selector>>.
 
 
@@ -299,11 +298,13 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 ### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}
 
 	<div algorithm="start-vt-with-options">
-		The [=method steps=] for <dfn method for=Document>startViewTransition(|options|)</dfn> are as follows:
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOrOptions|)</dfn> are as follows:
 
-		1. Let |viewTransition| be the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |options|'s {{StartViewTransitionOptions/update}}.
+		1. If |callbackOrOptions| is an {{UpdateCallback}}, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions| and return the result.
 
-		1. Set |transition|'s [=ViewTransition/active types=] to |options|'s {{StartViewTransitionOptions/types}}.
+		1. Let |viewTransition| be the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions|'s {{StartViewTransitionOptions/update}}.
+
+		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOrOptions|'s {{StartViewTransitionOptions/types}}.
 
 		1. Return |viewTransition|.
 	</div>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -324,20 +324,20 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		partial interface Document {
 
-			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions)? callbackOrOptions = null);
+			ViewTransition startViewTransition((UpdateCallback or StartViewTransitionOptions?) callbackOptionsOrNull);
 		};
 	</xmp>
 
 ### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}
 
 	<div algorithm="start-vt-with-options">
-		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOrOptions|)</dfn> are as follows:
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptionsOrNull|)</dfn> are as follows:
 
-		1. If |callbackOrOptions| is an {{UpdateCallback}}, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions| and return the result.
+		1. If |callbackOptionsOrNull| is an {{UpdateCallback}} or null, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions| and return the result.
 
 		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions|'s {{StartViewTransitionOptions/update}}.
 
-		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOrOptions|'s {{StartViewTransitionOptions/types}}.
+		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOptionsOrNull|'s {{StartViewTransitionOptions/types}}.
 
 		1. Return |viewTransition|.
 	</div>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -333,9 +333,9 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	<div algorithm="start-vt-with-options">
 		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptionsOrNull|)</dfn> are as follows:
 
-		1. If |callbackOptionsOrNull| is an {{UpdateCallback}} or null, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions| and return the result.
+		1. If |callbackOptionsOrNull| is an {{UpdateCallback}} or null, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptionsOrNull| and return the result.
 
-		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions|'s {{StartViewTransitionOptions/update}}.
+		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptionsOrNull|'s {{StartViewTransitionOptions/update}}.
 
 		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOptionsOrNull|'s {{StartViewTransitionOptions/types}}.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -223,6 +223,39 @@ An ''::active-view-transition()'' pseudo-class matches the [=document element=] 
 * The <<vt-type-selector>> is ''*''
 * |viewTransition|'s [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> values of the <<vt-type-selector>>.
 
+<div class=example>
+For example, the developer might start a transition in the following manner:
+```js
+document.startViewTransition({update: updateTheDOMSomehow, types: ["slide-in", "reverse"]});
+```
+
+This will activate any of the following '::active-view-transition()'' selectors:
+```css
+:root:active-view-transition(slide-in) {}
+:root:active-view-transition(reverse) {}
+:root:active-view-transition(slide-in, reverse) {}
+:root:active-view-transition(slide-in, something-else) {}
+:root:active-view-transition(*) {}
+```
+
+While starting a transition without selecting transition types, would only activate '::active-view-transition()'' with ''*'':
+
+```js
+document.startViewTransition(updateTheDOMSomehow);
+// or
+document.startViewTransition({update: updateTheDOMSomehow});
+```
+
+```css
+/* This would be active */
+:root { }
+:root:active-view-transition(*) {}
+
+/* This would not be active */
+:root:active-view-transition(slide-in) {}
+:root:active-view-transition(any-type-at-all-except-star) {}
+```
+</div>
 
 # CSS rules # {#css-rules}
 
@@ -302,7 +335,7 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 
 		1. If |callbackOrOptions| is an {{UpdateCallback}}, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions| and return the result.
 
-		1. Let |viewTransition| be the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions|'s {{StartViewTransitionOptions/update}}.
+		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOrOptions|'s {{StartViewTransitionOptions/update}}.
 
 		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOrOptions|'s {{StartViewTransitionOptions/types}}.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -287,7 +287,8 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		};
 
 		partial interface Document {
-			ViewTransition startViewTransition(optional StartViewTransitionOptions options);
+
+			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions)? callbackOrOptions = null);
 		};
 	</xmp>
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -41,6 +41,7 @@ spec:html
 	text: run the animation frame callbacks; type: dfn;
 	text: unload; type: dfn;
 	text: update the rendering; type: dfn;
+spec:infra; type:dfn; text:list
 </pre>
 
 <pre class=anchors>
@@ -209,17 +210,20 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 ## Active View Transition Pseudo-class '':active-view-transition()''' ## {#the-active-view-transition-pseudo}
 
-The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
+The <dfn id='active-view-transition-pseudo'>:active-view-transition(<<vt-type-selector>>)</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
 It has the following syntax definition:
 
 <pre class=prod>
 	:active-view-transition(<<vt-type-selector>>)
-	<<vt-type-selector>> = '*' | <<custom-ident>>#
+	<dfn>&lt;vt-type-selector></dfn> = '*' | <<custom-ident>>#
 </pre>
 
-An '':active-view-transition()'' pseudo-class matches the [=document element=] if its
-[=node document=] has an [=active view transition=] whose [=ViewTransition/active types=] is null or
-matches <<vt-type-selector>>, i.e. it's either ''*'' or has a matching <<custom-ident>>.
+An ''::active-view-transition()'' pseudo-class matches the [=document element=] when it has an non-null [=active view transition=] |viewTransition|, for which any of the following are true:
+
+* The <<vt-type-selector>> is ''*''
+* |viewTransition|'s [=ViewTransition/active types=] is null
+* |viewTransition|'s [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> values of the <<vt-type-selector>>.
+
 
 # CSS rules # {#css-rules}
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -217,7 +217,7 @@ It has the following syntax definition:
 	<<vt-type-selector>> = '*' | <<custom-ident>>#
 </pre>
 
-An ''::active-view-transition()'' [=selector=] matches the [=document element=] if its
+An '':active-view-transition()'' pseudo-class matches the [=document element=] if its
 [=node document=] has an [=active view transition=] whose [=ViewTransition/active types=] is null or
 matches <<vt-type-selector>>, i.e. it's either ''*'' or has a matching <<custom-ident>>.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -205,7 +205,22 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		```
 	</div>
 
+# Pseudo-classes # {#pseudo-classes}
 
+## Active View Transition Pseudo-class '':active-view-transition()''' ## {#the-active-view-transition-pseudo}
+
+The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class represents
+the root element of the document, if it has a matching [=active view transition=].
+It has the following syntax definition:
+
+<pre class=prod>
+	:active-view-transition(<<vt-type-selector>>)
+	<<vt-type-selector>> = '*' | <<custom-ident>>#
+</pre>
+
+An ''::active-view-transition()'' [=selector=] matches the corresponding [=document element=] if its
+[=node document=] has an [=active view transition=] whose [=ViewTransition/active types=] is null or
+matches <<vt-type-selector>>, i.e. it's either ''*'' or has a matching <<custom-ident>>.
 
 # CSS rules # {#css-rules}
 
@@ -264,6 +279,33 @@ Note: this event is fired when [=reveal document|revealing a document=].
 The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are to return the
 [=inbound cross-document view-transition=] for [=this's=] [=relevant global object's=] [=associated document=].
 
+## Additions to {{Document}} ## {#additions-to-document-api}
+
+	<xmp class=idl>
+		dictionary StartViewTransitionOptions {
+			UpdateCallback? update = null;
+			sequence<DOMString>? types = null;
+		};
+
+		partial interface Document {
+			ViewTransition startViewTransition(optional StartViewTransitionOptions options);
+		};
+
+		callback UpdateCallback = Promise<any> ();
+	</xmp>
+
+### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}
+
+	<div algorithm="start-vt-with-options">
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|options|)</dfn> are as follows:
+
+		1. Let |viewTransition| be the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |options|'s {{StartViewTransitionOptions/update}}.
+
+		1. Set |transition|'s [=ViewTransition/active types=] to |options|'s {{StartViewTransitionOptions/types}}.
+
+		1. Return |viewTransition|.
+	</div>
+
 
 
 # Algorithms # {#algorithms}
@@ -283,6 +325,9 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 	<dl dfn-for=ViewTransition>
 		: <dfn>is inbound cross-document transition</dfn>
 		:: a boolean, initially false.
+
+		: <dfn>active types</dfn>
+		:: Null or a [=list=] of strings, initially null.
 	</dl>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -209,8 +209,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 ## Active View Transition Pseudo-class '':active-view-transition()''' ## {#the-active-view-transition-pseudo}
 
-The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class applies to
-the root element of the document, if it has a matching [=active view transition=].
+The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
 It has the following syntax definition:
 
 <pre class=prod>
@@ -290,8 +289,6 @@ The <dfn attribute for=PageRevealEvent>viewTransition</dfn> [=getter steps=] are
 		partial interface Document {
 			ViewTransition startViewTransition(optional StartViewTransitionOptions options);
 		};
-
-		callback UpdateCallback = Promise<any> ();
 	</xmp>
 
 ### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -209,7 +209,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 ## Active View Transition Pseudo-class '':active-view-transition()''' ## {#the-active-view-transition-pseudo}
 
-The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class represents
+The <dfn id='active-view-transition-pseudo'>:active-view-transition(* | <<transition-types>>)</dfn> pseudo-class applies to
 the root element of the document, if it has a matching [=active view transition=].
 It has the following syntax definition:
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -218,7 +218,7 @@ It has the following syntax definition:
 	<<vt-type-selector>> = '*' | <<custom-ident>>#
 </pre>
 
-An ''::active-view-transition()'' [=selector=] matches the corresponding [=document element=] if its
+An ''::active-view-transition()'' [=selector=] matches the [=document element=] if its
 [=node document=] has an [=active view transition=] whose [=ViewTransition/active types=] is null or
 matches <<vt-type-selector>>, i.e. it's either ''*'' or has a matching <<custom-ident>>.
 


### PR DESCRIPTION
As per [resolution at TPAC](https://github.com/w3c/csswg-drafts/issues/8960#issuecomment-1719695337), adding a concept of "active types" to a view transition, with an `active-view-transition` pseudo-class that matches the root element if it has an active view transition that matches the list of active types.

To set the active types, `startViewTransition` now accepts options, like `startViewTransition(update, types: ["slide", "reverse"]})`

Closes #8960 