### PR TITLE
[css-transforms] Minor syntax rewrite

### DIFF
--- a/css-transforms-1/Overview.bs
+++ b/css-transforms-1/Overview.bs
@@ -912,31 +912,31 @@ A percentage for vertical translations is relative to the height of the [=refere
 ----------------------
 
 <dl dfn-for=transform>
-	: <span class='prod'><dfn>matrix()</dfn> = matrix( <<number>>#{6} )</span>
+	: <span class='prod'><dfn>matrix()</dfn> = matrix( [ <<number>>#{6} ] )</span>
 	:: specifies a 2D transformation in the form of a <a href="#MatrixDefined">transformation matrix</a> of the six values a, b, c, d, e, f.
 
-	: <span class='prod'><dfn>translate()</dfn> = translate( <<length-percentage>> , <<length-percentage>>? )</span>
+	: <span class='prod'><dfn>translate()</dfn> = translate( [ <<length-percentage>>#{1,2} ] )</span>
 	:: specifies a <a href="#TranslateDefined">2D translation</a> by the vector [tx, ty], where tx is the first translation-value parameter and ty is the optional second translation-value parameter. If <em>&lt;ty></em> is not provided, ty has zero as a value.
 
-	: <span class='prod'><dfn>translateX()</dfn> = translateX( <<length-percentage>> )</span>
+	: <span class='prod'><dfn>translateX()</dfn> = translateX( [ <<length-percentage>> ] )</span>
 	:: specifies a <a href="#TranslateDefined">translation</a> by the given amount in the X direction.
 
-	: <span class='prod'><dfn>translateY()</dfn> = translateY( <<length-percentage>> )</span>
+	: <span class='prod'><dfn>translateY()</dfn> = translateY( [ <<length-percentage>> ] )</span>
 	:: specifies a <a href="#TranslateDefined">translation</a> by the given amount in the Y direction.
 
-	: <span class='prod'><dfn>scale()</dfn> = scale( <<number>> , <<number>>? )</span>
+	: <span class='prod'><dfn>scale()</dfn> = scale( [ <<number>>#{1,2} ] )</span>
 	:: specifies a <a href="#ScaleDefined">2D scale</a> operation by the [sx,sy] scaling vector described by the 2 parameters. If the second parameter is not provided, it takes a value equal to the first. For example, scale(1, 1) would leave an element unchanged, while scale(2, 2) would cause it to appear twice as long in both the X and Y axes, or four times its typical geometric size.
 
-	: <span class='prod'><dfn>scaleX()</dfn> = scaleX( <<number>> )</span>
+	: <span class='prod'><dfn>scaleX()</dfn> = scaleX( [ <<number>> ] )</span>
 	:: specifies a <a href="#ScaleDefined">2D scale</a> operation using the [sx,1] scaling vector, where sx is given as the parameter.
 
-	: <span class='prod'><dfn>scaleY()</dfn> = scaleY( <<number>> )</span>
+	: <span class='prod'><dfn>scaleY()</dfn> = scaleY( [ <<number>> ] )</span>
 	:: specifies a <a href="#ScaleDefined">2D scale</a> operation using the [1,sy] scaling vector, where sy is given as the parameter.
 
 	: <span class='prod'><dfn>rotate()</dfn> = rotate( [ <<angle>> | <<zero>> ] )</span>
 	:: specifies a <a href="#RotateDefined">2D rotation</a> by the angle specified in the parameter about the origin of the element, as defined by the 'transform-origin' property. For example, ''rotate(90deg)'' would cause elements to appear rotated one-quarter of a turn in the clockwise direction.
 
-	: <span class='prod'><dfn>skew()</dfn> = skew( [ <<angle>> | <<zero>> ] , [ <<angle>> | <<zero>> ]? )</span>
+	: <span class='prod'><dfn>skew()</dfn> = skew( [ <<angle>> | <<zero>> ]#{1,2} )</span>
 	:: specifies a <a href="#SkewDefined">2D skew</a> by [ax,ay] for X and Y. If the second parameter is not provided, it has a zero value.
 
     	Advisement: ''skew()'' exists for compatibility reasons, and should not be used in new content. Use ''skewX()'' or ''skewY()'' instead, noting that the behavior of ''skew()'' is different from multiplying ''skewX()'' with ''skewY()''.

--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -984,17 +984,17 @@ In the following <dfn export>3d transform functions</dfn>, a <<zero>> behaves th
 ("Unitless 0" angles are preserved for legacy compat reasons.)
 
 
-: <span class='prod'><dfn>matrix3d()</dfn> = matrix3d( <<number>>#{16} )</span>
+: <span class='prod'><dfn>matrix3d()</dfn> = matrix3d( [ <<number>>#{16} ] )</span>
 :: specifies a 3D transformation as a 4x4 homogeneous matrix of 16 values in column-major order.
-: <span class='prod'><dfn>translate3d()</dfn> = translate3d( <<length-percentage>> , <<length-percentage>> , <<length>> )</span>
+: <span class='prod'><dfn>translate3d()</dfn> = translate3d( [ <<length-percentage>>#{2} , <<length>> ] )</span>
 :: specifies a <a href="#Translate3dDefined">3D translation</a> by the vector [tx,ty,tz], with tx, ty and tz being the first, second and third translation-value parameters respectively.
-: <span class='prod'><dfn>translateZ()</dfn> = translateZ( <<length>> )</span>
+: <span class='prod'><dfn>translateZ()</dfn> = translateZ( [ <<length>> ] )</span>
 :: specifies a <a href="#Translate3dDefined">3D translation</a> by the vector [0,0,tz] with the given amount in the Z direction.
 : <span class='prod'><dfn>scale3d()</dfn> = scale3d( [ <<number>> | <<percentage>> ]#{3} )</span>
 :: specifies a <a href="#Scale3dDefined">3D scale</a> operation by the [sx,sy,sz] scaling vector described by the 3 parameters.
 : <span class='prod'><dfn>scaleZ()</dfn> = scaleZ( [ <<number>> | <<percentage>> ] )</span>
 :: specifies a <a href="#Scale3dDefined">3D scale</a> operation using the [1,1,sz] scaling vector, where sz is given as the parameter.
-: <span class='prod'><dfn>rotate3d()</dfn> = rotate3d( <<number>> , <<number>> , <<number>> , [ <<angle>> | <<zero>> ] )</span>
+: <span class='prod'><dfn>rotate3d()</dfn> = rotate3d( [ <<number>>#{3} , [ <<angle>> | <<zero>> ] ] )</span>
 :: specifies a <a href="#Rotate3dDefined">3D rotation</a> by the angle specified in last parameter about the [x,y,z] direction vector described by the first three parameters. A direction vector that cannot be normalized, such as [0,0,0], will cause the rotation to not be applied.
 
 	Note: the rotation is clockwise as one looks from the end of the vector toward the origin.


### PR DESCRIPTION
- add [missing](https://github.com/w3c/csswg-drafts/issues/7582#issuecomment-1210838228) group around function arguments
- use multipliers instead of repeating symbols