### PR TITLE
[css-namespaces-3] Wrap definition of `@namespace` in `<dfn>`

### DIFF
--- a/css-namespaces-3/Overview.bs
+++ b/css-namespaces-3/Overview.bs
@@ -89,7 +89,7 @@ Terminology</h3>
 
 <h2 id="declaration">Declaring namespaces: the ''@namespace'' rule</h2>
 
-	The ''@namespace'' <a>at-rule</a> declares a namespace prefix
+	The <dfn>@namespace</dfn> <a>at-rule</a> declares a namespace prefix
 	and associates it with a given namespace name (a string).
 	This namespace prefix can then be used in namespace-qualified names
 	such as the <a>CSS qualified names</a> defined below.


### PR DESCRIPTION
The definition of the `@namespace` at-rule was not identified in the spec, preventing cross-references to it, and hiding it from spec crawlers.
