### PR TITLE
[css-spec-shortname-1] Wrap definition of `@content-list` in <dfn>

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -68,7 +68,7 @@ Animation type: discrete
 
 	<p class=all-media>User agents are expected to support this property on all media, including non-visual ones.</p>
 
-The 'string-set' property contains one or more pairs, each consisting of an custom identifier (the name of the named string) followed by a ''content-list'' describing how to construct the value of the named string.
+The 'string-set' property contains one or more pairs, each consisting of an custom identifier (the name of the named string) followed by a <dfn>content-list</dfn> describing how to construct the value of the named string.
 
 
 ''content-list'' expands to one or more of the following values, in any order.


### PR DESCRIPTION
- same as https://github.com/w3c/csswg-drafts/pull/9402

Without the `<dfn>` tag the crowler [is not able to pick the syntax](https://github.com/w3c/webref/blob/bdf788eacf5ff7e542bd1e39ffbec7c2e1ca6100/ed/css/css-gcpm.json#L149).

There are 4-5 more docs in different modules that need such change. Should I create a separate PR for each module or include those changes here?
