### PR TITLE
[css-speech] Enforce positive absolute frequency in `voice-pitch` and `voice-range`

### DIFF
--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -1201,7 +1201,7 @@ The 'voice-pitch' property</h3>
 
 	<pre class=propdef>
 	Name: voice-pitch
-	Value: <<frequency>> && absolute | [[x-low | low | medium | high | x-high] || [<<frequency>> | <<semitones>> | <<percentage>>]]
+	Value: <<frequency [0Hz,∞]>> && absolute | [[x-low | low | medium | high | x-high] || [<<frequency>> | <<semitones>> | <<percentage>>]]
 	Initial: medium
 	Applies to: all elements
 	Inherited: yes
@@ -1313,7 +1313,7 @@ The 'voice-range' property</h3>
 
 	<pre class=propdef>
 	Name: voice-range
-	Value: <<frequency>> && absolute | [[x-low | low | medium | high | x-high] || [<<frequency>> | <<semitones>> | <<percentage>>]]
+	Value: <<frequency [0Hz,∞]>> && absolute | [[x-low | low | medium | high | x-high] || [<<frequency>> | <<semitones>> | <<percentage>>]]
 	Initial: medium
 	Applies to: all elements
 	Inherited: yes


### PR DESCRIPTION
https://drafts.csswg.org/css-speech-1/#valdef-voice-pitch-frequency

  > **`<frequency>`**: [...] Values are restricted to positive numbers when the `absolute` keyword is specified.

This PR adds the corresponding range.