### PR TITLE
[css-syntax-3] Rename `<an+b>` to `<an-b>`

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -3271,20 +3271,20 @@ Informal Syntax Description</h3>
 
 
 <h3 id="the-anb-type">
-The <code>&lt;an+b></code> type</h3>
+The <<an-b>> type</h3>
 
 	The <var>An+B</var> notation was originally defined using a slightly different tokenizer than the rest of CSS,
 	resulting in a somewhat odd definition when expressed in terms of CSS tokens.
 	This section describes how to recognize the <var>An+B</var> notation in terms of CSS tokens
-	(thus defining the <var>&lt;an+b></var> type for CSS grammar purposes),
+	(thus defining the <<an-b>> type for CSS grammar purposes),
 	and how to interpret the CSS tokens to obtain values for <var>A</var> and <var>B</var>.
 
-	The <var>&lt;an+b></var> type is defined
+	The <<an-b>> type is defined
 	(using the <a href="https://www.w3.org/TR/css3-values/#value-defs">Value Definition Syntax in the Values &amp; Units spec</a>)
 	as:
 
 	<pre class='prod'>
-		<dfn id="anb-production">&lt;an+b></dfn> =
+		<dfn id="anb-production">&lt;an-b></dfn> =
 		  odd | even |
 		  <var>&lt;integer></var> |
 
@@ -3818,10 +3818,10 @@ Serialization</h2>
 	</div>
 
 <h3 id='serializing-anb'>
-Serializing <var>&lt;an+b></var></h3>
+Serializing <<an-b>></h3>
 
 	<div algorithm>
-		To <dfn export>serialize an <<an+b>> value</dfn>,
+		To <dfn export id='serialize-an-anb-value'>serialize an <<an-b>> value</dfn>,
 		with integer values |A| and |B|:
 
 		1. If |A| is zero,
@@ -3997,7 +3997,7 @@ Changes from the 20 February 2014 Candidate Recommendation</h3>
 		As part of this, rearrange the ordering of the clauses in the "-" step of [=tokenizer/consume a token=]
 		so that <<CDC-token>>s are recognized as such instead of becoming a ''--'' <<ident-token>>.
 
-	* Don't serialize the digit in an <<an+b>> when A is 1 or -1.
+	* Don't serialize the digit in an <<an-b>> when A is 1 or -1.
 
 	* Define all tokens to have a representation.
 


### PR DESCRIPTION
See context in #9473. Rename is aimed at avoiding interpretation of `+` as a component value multiplier by parsing tools. The ID of the definition does not change.

The rename is also done in the definition of the `serialize an <an+b> value` algorithm, preserving the previous ID since the algorithm was exported (and referenced by other specs).

Once construct has been renamed, the following specs will need to be slightly updated as well (they either reference `<an+b>` or `serialize an <an+b> value`):
- cssom-1
- css-gcpm-4
- selectors-4

I'll prepare a follow-up PR for these updates once the cross-references database gets the new definitions.