### PR TITLE
[cssom-view] Use flat tree instead of shadow-including tree for element.checkVisibility()

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1243,12 +1243,12 @@ Note: The {{DOMRect}} object returned by {{Element/getBoundingClientRect()}} is 
 
     1. If |this| does not have an associated [=CSS/box=],
         return false.
-    1. If a [=shadow-including ancestor=] of |this|
+    1. If an ancestor of |this| in the [=flat tree=]
         has ''content-visibility: hidden'',
         return false.
     1. If the {{CheckVisibilityOptions/checkOpacity}} dictionary member of |options|
         is true,
-        and |this|, or a [=shadow-including ancestor=] of |this|,
+        and |this|, or an ancestor of |this| in the [=flat tree=],
         has a computed 'opacity' value of ''0'',
         return false.
     1. If the {{CheckVisibilityOptions/checkVisibilityCSS}} dictionary member of |options|


### PR DESCRIPTION
`element.checkVisibility()` checks against CSS properties, which apply on the flat tree, not the shadow-including tree.

Fixes #9486