### PR TITLE
[css-view-transitions] Make the startViewTransition non-nullable

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -179,7 +179,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	1. Rendering paused.
 
-	1. Developer's {{UpdateCallback|updateCallback}} function is called,
+	1. Developer's {{UpdateCallback|updateCallback}} function, if provided, is called,
 		which updates the document state.
 
 	1. <code><var>viewTransition</var>.{{ViewTransition/updateCallbackDone}}</code> fulfills.
@@ -901,7 +901,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<xmp class=idl>
 		partial interface Document {
-			ViewTransition startViewTransition(optional UpdateCallback? updateCallback = null);
+			ViewTransition startViewTransition(optional UpdateCallback updateCallback);
 		};
 
 		callback UpdateCallback = Promise<any> ();
@@ -912,12 +912,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		:: Starts a new [=view transition=]
 			(canceling the {{Document|document}}’s existing [=active view transition=], if any).
 
-			{{UpdateCallback|updateCallback}} is called asynchronously, once the current state of the document is captured.
+			{{UpdateCallback|updateCallback}}, if provided, is called asynchronously, once the current state of the document is captured.
 			Then, when the promise returned by {{UpdateCallback|updateCallback}} fulfills,
 			the new state of the document is captured
 			and the transition is initiated.
 
-			Note that {{UpdateCallback|updateCallback}} is *always* called,
+			Note that {{UpdateCallback|updateCallback}}, if provided, is *always* called,
 			even if the transition cannot happen
 			(e.g. due to duplicate `view-transition-name` values).
 			The transition is an enhancement around the state change, so a failure to create a transition never prevents the state change.
@@ -933,7 +933,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |transition| be a new {{ViewTransition}} object in [=this's=] [=relevant Realm=].
 
-		1. Set |transition|'s [=ViewTransition/update callback=] to |updateCallback|.
+		1. If |updateCallback| is provided, set |transition|'s [=ViewTransition/update callback=] to |updateCallback|.
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
@@ -1884,6 +1884,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add mix-blend-mode to list of properties copied over to the ''::view-transition-group''. See <a href="https://github.com/w3c/csswg-drafts/issues/8962">issue 8962</a>.
 * Add text-orientation to list of properties copied over to the ''::view-transition-group''. See <a href="https://github.com/w3c/csswg-drafts/issues/8230">issue 8230</a>.
 * Refactor the old capture algorithm to properly set [=captured in a view transition=] before reading the value.
+* Make the {{Document/startViewTransition()}} parameter non-nullable. See <a href="https://github.com/w3c/csswg-drafts/issues/9460">issue 9460</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -333,20 +333,22 @@ The <dfn attribute for=RevealEvent>viewTransition</dfn> [=getter steps=] are to 
 
 		partial interface Document {
 
-			ViewTransition startViewTransition((UpdateCallback or StartViewTransitionOptions?) callbackOptionsOrNull);
+			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions);
 		};
 	</xmp>
 
 ### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}
 
 	<div algorithm="start-vt-with-options">
-		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptionsOrNull|)</dfn> are as follows:
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
 
-		1. If |callbackOptionsOrNull| is an {{UpdateCallback}} or null, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptionsOrNull| and return the result.
+		1. If |callbackOptions| is not provided, then run the [=method steps=] for {{Document/startViewTransition()}} and return the result.
 
-		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptionsOrNull|'s {{StartViewTransitionOptions/update}}.
+		1. If |callbackOptions| is an {{UpdateCallback}}, then run the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptions| and return the result.
 
-		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOptionsOrNull|'s {{StartViewTransitionOptions/types}}.
+		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptions|'s {{StartViewTransitionOptions/update}}.
+
+		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOptions|'s {{StartViewTransitionOptions/types}}.
 
 		1. Return |viewTransition|.
 	</div>


### PR DESCRIPTION
[css-view-transitions] Make the startViewTransition non-nullable

Fixes #9460

