### PR TITLE
[css-view-transitions-2] Fix build errors/warnings

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1068,7 +1068,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			which causes the transition to [=skip the view transition|skip=].
 			[Discussion of this behavior](https://github.com/w3c/csswg-drafts/issues/8045).
 
-		: <dfn>process old state captured</dfn>
+		: <dfn export>process old state captured</dfn>
 		:: An algorithm accepting nothing, or null.
 			Initially null.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -337,7 +337,7 @@ The <dfn attribute for=RevealEvent>viewTransition</dfn> [=getter steps=] are to 
 		};
 	</xmp>
 
-### {{Document/startViewTransition(options)}} Method Steps ### {#ViewTransition-start-with-options}
+### {{Document/startViewTransition(callbackOptions)}} Method Steps ### {#ViewTransition-start-with-options}
 
 	<div algorithm="start-vt-with-options">
 		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
@@ -496,7 +496,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
 
-			Note: The process continues in [=setup view transition=], via [=perform pending transition operations=], which is called in [[css-view-transitions-1#monkey-patch-to-rendering-algorithm]].
+			Note: The process continues in [=setup view transition=], via [=perform pending transition operations=].
 	</div>
 
 	<div algorithm>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -282,7 +282,7 @@ the navigation behavior based on the URL.
 Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
 [=conditional group rule=] such as ''@media'' or ''@supports''.
 
-## The [=@view-transition/view-transition=] property ## {#view-transition-name-prop}
+## The [=@view-transition/trigger=] property ## {#view-transition-trigger-descriptor}
 
 	<pre class='descdef'>
 	Name: trigger
@@ -348,7 +348,7 @@ The <dfn attribute for=RevealEvent>viewTransition</dfn> [=getter steps=] are to 
 
 		1. Let |viewTransition| be the result of running [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |callbackOptions|'s {{StartViewTransitionOptions/update}}.
 
-		1. Set |transition|'s [=ViewTransition/active types=] to |callbackOptions|'s {{StartViewTransitionOptions/types}}.
+		1. Set |viewTransition|'s [=ViewTransition/active types=] to |callbackOptions|'s {{StartViewTransitionOptions/types}}.
 
 		1. Return |viewTransition|.
 	</div>
@@ -359,7 +359,7 @@ The <code>CSSRule</code> interface is extended as follows:
 
 <pre class='idl'>
 partial interface CSSRule {
-    const unsigned short VIEW_TRANSITION_RULE = 15;
+	const unsigned short VIEW_TRANSITION_RULE = 15;
 };
 </pre>
 


### PR DESCRIPTION
Removed and amended some wrong names and refs to css-view-transitions-1.