### PR TITLE
[css-box-4][css-backgrounds-4][css-shapes-1] Cleanup <*-box> definitions

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -160,7 +160,7 @@ Painting Area: the 'background-clip' property</h3>
 	The syntax of the property is given with
 
 	<pre class=prod>
-	<dfn>&lt;bg-clip></dfn> = <<box>> | border | text
+	<dfn>&lt;bg-clip></dfn> = <<visual-box>> | border | text
 	</pre>
 
 	Issue: Or should this be defining the <css>-webkit-background-clip</css> property,
@@ -168,7 +168,7 @@ Painting Area: the 'background-clip' property</h3>
 	with this additional ''text'' value?
 
 	<dl dfn-type=value dfn-for="background-clip, <bg-clip>">
-		<dt><dfn><<box>></dfn>
+		<dt><dfn><<visual-box>></dfn>
 		<dd>
 			The background is painted within (clipped to)
 			the specified box of the element.

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -215,36 +215,36 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<visual-box>,<shape-box>,<geometry-box>" dfn-type=value>
+	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
 		<dt><dfn>content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
-				(In an SVG context, treated as ''<visual-box>/fill-box''.)
+				(In an SVG context, treated as ''<box>/fill-box''.)
 
 		<dt><dfn>padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
-				(In an SVG context, treated as ''<visual-box>/fill-box''.)
+				(In an SVG context, treated as ''<box>/fill-box''.)
 
 		<dt><dfn>border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
-				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
+				(In an SVG context, treated as ''<box>/stroke-box''.)
 
 		<dt><dfn>margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
-				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
+				(In an SVG context, treated as ''<box>/stroke-box''.)
 
 		<dt><dfn>fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
-				(In a CSS box context, treated as ''<visual-box>/content-box''.)
+				(In a CSS box context, treated as ''<box>/content-box''.)
 
 		<dt><dfn>stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
-				(In a CSS box context, treated as ''<visual-box>/border-box''.)
+				(In a CSS box context, treated as ''<box>/border-box''.)
 
 		<dt><dfn>view-box</dfn>
 			<dd>
@@ -255,7 +255,7 @@ Box-edge Keywords {#keywords}
 				established by the <{svg/viewBox}> attribute for that element,
 				positioned such that its top left corner is anchored
 				at the coordinate system origin.
-				(In a CSS box context, treated as ''<visual-box>/border-box''.)
+				(In a CSS box context, treated as ''<box>/border-box''.)
 
 				Note: When the <{svg/viewBox}>
 				includes non-zero <var ignore>min-x</var> or <var ignore>min-y</var> offsets,

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -215,38 +215,38 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
-		<dt><dfn>content-box</dfn>
+	<dl dfn-type=value>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn>padding-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn>border-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn>margin-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn>fill-box</dfn>
+		<dt><dfn dfn-for="<box>,<paint-box>">fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/content-box''.)
 
-		<dt><dfn>stroke-box</dfn>
+		<dt><dfn dfn-for="<box>,<paint-box>">stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/border-box''.)
 
-		<dt><dfn>view-box</dfn>
+		<dt><dfn dfn-for="<box>,<coord-box>">view-box</dfn>
 			<dd>
 				Refers to the nearest [=SVG viewport=] element’s
 				<dfn dfn lt="SVG viewport origin box" local-lt="origin box">origin box</dfn>,
@@ -268,9 +268,9 @@ Box-edge Keywords {#keywords}
 	For convenience, the following value types are defined:
 	<pre class="prod">
 		<dfn><<visual-box>></dfn> = content-box | padding-box | border-box
-		<dfn><<layout-box>></dfn> = content-box | padding-box | border-box | margin-box
-		<dfn><<paint-box>></dfn> = content-box | padding-box | border-box | fill-box | stroke-box
-		<dfn><<coord-box>></dfn> = content-box | padding-box | border-box | fill-box | stroke-box | view-box
+		<dfn><<layout-box>></dfn> = <<visual-box>> | margin-box
+		<dfn><<paint-box>></dfn> = <<visual-box>> | fill-box | stroke-box
+		<dfn><<coord-box>></dfn> = <<paint-box>> | view-box
 	</pre>
 
 Margins {#margins}

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -211,7 +211,7 @@ The CSS Box Model {#box-model}
 Box-edge Keywords {#keywords}
 -----------------
 
-	The following <dfn>&lt;box></dfn> CSS keywords are defined for use
+	The following <dfn noexport>&lt;box></dfn> CSS keywords are defined for use
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -215,36 +215,36 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
+	<dl dfn-for="<visual-box>,<shape-box>,<geometry-box>" dfn-type=value>
 		<dt><dfn>content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
-				(In an SVG context, treated as ''<box>/fill-box''.)
+				(In an SVG context, treated as ''<visual-box>/fill-box''.)
 
 		<dt><dfn>padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
-				(In an SVG context, treated as ''<box>/fill-box''.)
+				(In an SVG context, treated as ''<visual-box>/fill-box''.)
 
 		<dt><dfn>border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
-				(In an SVG context, treated as ''<box>/stroke-box''.)
+				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
 
 		<dt><dfn>margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
-				(In an SVG context, treated as ''<box>/stroke-box''.)
+				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
 
 		<dt><dfn>fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
-				(In a CSS box context, treated as ''<box>/content-box''.)
+				(In a CSS box context, treated as ''<visual-box>/content-box''.)
 
 		<dt><dfn>stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
-				(In a CSS box context, treated as ''<box>/border-box''.)
+				(In a CSS box context, treated as ''<visual-box>/border-box''.)
 
 		<dt><dfn>view-box</dfn>
 			<dd>
@@ -255,7 +255,7 @@ Box-edge Keywords {#keywords}
 				established by the <{svg/viewBox}> attribute for that element,
 				positioned such that its top left corner is anchored
 				at the coordinate system origin.
-				(In a CSS box context, treated as ''<box>/border-box''.)
+				(In a CSS box context, treated as ''<visual-box>/border-box''.)
 
 				Note: When the <{svg/viewBox}>
 				includes non-zero <var ignore>min-x</var> or <var ignore>min-y</var> offsets,

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -216,37 +216,37 @@ Box-edge Keywords {#keywords}
 	that need to refer to various box edges:
 
 	<dl dfn-type=value>
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">content-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">padding-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">border-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">margin-box</dfn>
+		<dt><dfn dfn-for="<box>,<layout-box>,<shape-box>,<geometry-box>">margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn dfn-for="<box>,<paint-box>">fill-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<paint-box>,<coord-box>">fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/content-box''.)
 
-		<dt><dfn dfn-for="<box>,<paint-box>">stroke-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<paint-box>,<coord-box>">stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/border-box''.)
 
-		<dt><dfn dfn-for="<box>,<coord-box>">view-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<coord-box>">view-box</dfn>
 			<dd>
 				Refers to the nearest [=SVG viewport=] element’s
 				<dfn dfn lt="SVG viewport origin box" local-lt="origin box">origin box</dfn>,

--- a/css-box-3/Overview.bs
+++ b/css-box-3/Overview.bs
@@ -211,7 +211,7 @@ The CSS Box Model {#box-model}
 Box-edge Keywords {#keywords}
 -----------------
 
-	The following CSS keywords are defined for use
+	The following <dfn>&lt;box></dfn> CSS keywords are defined for use
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -201,36 +201,36 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<visual-box>,<shape-box>,<geometry-box>" dfn-type=value>
+	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
 		<dt><dfn>content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
-				(In an SVG context, treated as ''<visual-box>/fill-box''.)
+				(In an SVG context, treated as ''<box>/fill-box''.)
 
 		<dt><dfn>padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
-				(In an SVG context, treated as ''<visual-box>/fill-box''.)
+				(In an SVG context, treated as ''<box>/fill-box''.)
 
 		<dt><dfn>border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
-				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
+				(In an SVG context, treated as ''<box>/stroke-box''.)
 
 		<dt><dfn>margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
-				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
+				(In an SVG context, treated as ''<box>/stroke-box''.)
 
 		<dt><dfn>fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
-				(In a CSS box context, treated as ''<visual-box>/content-box''.)
+				(In a CSS box context, treated as ''<box>/content-box''.)
 
 		<dt><dfn>stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
-				(In a CSS box context, treated as ''<visual-box>/border-box''.)
+				(In a CSS box context, treated as ''<box>/border-box''.)
 
 		<dt><dfn>view-box</dfn>
 			<dd>
@@ -240,7 +240,7 @@ Box-edge Keywords {#keywords}
 				of the [=SVG viewport=],
 				positioned such that its top left corner is anchored
 				at the coordinate system origin.
-				(In a CSS box context, treated as ''<visual-box>/border-box''.)
+				(In a CSS box context, treated as ''<box>/border-box''.)
 
 				Note: When the [=SVG viewport=]
 				is not itself anchored at the origin,

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -201,36 +201,36 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
+	<dl dfn-for="<visual-box>,<shape-box>,<geometry-box>" dfn-type=value>
 		<dt><dfn>content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
-				(In an SVG context, treated as ''<box>/fill-box''.)
+				(In an SVG context, treated as ''<visual-box>/fill-box''.)
 
 		<dt><dfn>padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
-				(In an SVG context, treated as ''<box>/fill-box''.)
+				(In an SVG context, treated as ''<visual-box>/fill-box''.)
 
 		<dt><dfn>border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
-				(In an SVG context, treated as ''<box>/stroke-box''.)
+				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
 
 		<dt><dfn>margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
-				(In an SVG context, treated as ''<box>/stroke-box''.)
+				(In an SVG context, treated as ''<visual-box>/stroke-box''.)
 
 		<dt><dfn>fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
-				(In a CSS box context, treated as ''<box>/content-box''.)
+				(In a CSS box context, treated as ''<visual-box>/content-box''.)
 
 		<dt><dfn>stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
-				(In a CSS box context, treated as ''<box>/border-box''.)
+				(In a CSS box context, treated as ''<visual-box>/border-box''.)
 
 		<dt><dfn>view-box</dfn>
 			<dd>
@@ -240,7 +240,7 @@ Box-edge Keywords {#keywords}
 				of the [=SVG viewport=],
 				positioned such that its top left corner is anchored
 				at the coordinate system origin.
-				(In a CSS box context, treated as ''<box>/border-box''.)
+				(In a CSS box context, treated as ''<visual-box>/border-box''.)
 
 				Note: When the [=SVG viewport=]
 				is not itself anchored at the origin,

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -197,7 +197,7 @@ The CSS Box Model {#box-model}
 Box-edge Keywords {#keywords}
 -----------------
 
-	The following <dfn>&lt;box></dfn> CSS keywords are defined for use
+	The following <dfn noexport>&lt;box></dfn> CSS keywords are defined for use
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -197,7 +197,7 @@ The CSS Box Model {#box-model}
 Box-edge Keywords {#keywords}
 -----------------
 
-	The following CSS keywords are defined for use
+	The following <dfn>&lt;box></dfn> CSS keywords are defined for use
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -202,37 +202,37 @@ Box-edge Keywords {#keywords}
 	that need to refer to various box edges:
 
 	<dl dfn-type=value>
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">content-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">padding-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">border-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<layout-box>,<shape-box>,<geometry-box>,<paint-box>,<coord-box>">border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">margin-box</dfn>
+		<dt><dfn dfn-for="<box>,<layout-box>,<shape-box>,<geometry-box>">margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn dfn-for="<box>,<paint-box>">fill-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<paint-box>,<coord-box>">fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/content-box''.)
 
-		<dt><dfn dfn-for="<box>,<paint-box>">stroke-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<paint-box>,<coord-box>">stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/border-box''.)
 
-		<dt><dfn dfn-for="<box>,<coord-box>">view-box</dfn>
+		<dt><dfn dfn-for="<box>,<geometry-box>,<coord-box>">view-box</dfn>
 			<dd>
 				Refers to the nearest [=SVG viewport=]’s
 				<dfn dfn lt="SVG viewport origin box" local-lt="origin box">origin box</dfn>,

--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -201,38 +201,38 @@ Box-edge Keywords {#keywords}
 	in properties (such as 'transform-box' and 'background-clip')
 	that need to refer to various box edges:
 
-	<dl dfn-for="<box>,<shape-box>,<geometry-box>" dfn-type=value>
-		<dt><dfn>content-box</dfn>
+	<dl dfn-type=value>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">content-box</dfn>
 			<dd>
 				Refers to the [=content box=] or [=content edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn>padding-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">padding-box</dfn>
 			<dd>
 				Refers to the [=padding box=] or [=padding edge=].
 				(In an SVG context, treated as ''<box>/fill-box''.)
 
-		<dt><dfn>border-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">border-box</dfn>
 			<dd>
 				Refers to the [=border box=] or [=border edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn>margin-box</dfn>
+		<dt><dfn dfn-for="<box>,<visual-box>,<shape-box>,<geometry-box>">margin-box</dfn>
 			<dd>
 				Refers to the [=margin box=] or [=margin edge=].
 				(In an SVG context, treated as ''<box>/stroke-box''.)
 
-		<dt><dfn>fill-box</dfn>
+		<dt><dfn dfn-for="<box>,<paint-box>">fill-box</dfn>
 			<dd>
 				Refers to the [=object bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/content-box''.)
 
-		<dt><dfn>stroke-box</dfn>
+		<dt><dfn dfn-for="<box>,<paint-box>">stroke-box</dfn>
 			<dd>
 				Refers to the [=stroke bounding box=] or its edges.
 				(In a CSS box context, treated as ''<box>/border-box''.)
 
-		<dt><dfn>view-box</dfn>
+		<dt><dfn dfn-for="<box>,<coord-box>">view-box</dfn>
 			<dd>
 				Refers to the nearest [=SVG viewport=]’s
 				<dfn dfn lt="SVG viewport origin box" local-lt="origin box">origin box</dfn>,
@@ -253,9 +253,9 @@ Box-edge Keywords {#keywords}
 	For convenience, the following value types are defined:
 	<pre class="prod">
 		<dfn><<visual-box>></dfn> = content-box | padding-box | border-box
-		<dfn><<layout-box>></dfn> = content-box | padding-box | border-box | margin-box
-		<dfn><<paint-box>></dfn> = content-box | padding-box | border-box | fill-box | stroke-box
-		<dfn><<coord-box>></dfn> = content-box | padding-box | border-box | fill-box | stroke-box | view-box
+		<dfn><<layout-box>></dfn> = <<visual-box>> | margin-box
+		<dfn><<paint-box>></dfn> = <<visual-box>> | fill-box | stroke-box
+		<dfn><<coord-box>></dfn> = <<paint-box>> | view-box
 	</pre>
 
 Margins {#margins}

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -807,12 +807,12 @@ Shapes from Box Values</h2>
 	These edges include
 	<a href="https://www.w3.org/TR/css3-background/#corner-shaping">border-radius curvature</a> [[!CSS3BG]]
 	from the used border-radius values.
-	The <<shape-box>> value extends the <<box>> value
+	The <<shape-box>> value extends the <<visual-box>> value
 	to include ''margin-box''.
 	Its syntax is:
 
 	<pre class="prod">
-		<dfn><<shape-box>></dfn> = <<box>> | ''margin-box''
+		<dfn><<shape-box>></dfn> = <<visual-box>> | ''margin-box''
 	</pre>
 
 	The definitions of the values are:


### PR DESCRIPTION
Follow-up on https://github.com/w3c/csswg-drafts/commit/7dc439c83df8bd34885f74689f8cbc7dff77b5e0, fixing https://github.com/speced/bikeshed/issues/2679.

The commit [removed the `<box>` production](https://github.com/w3c/csswg-drafts/commit/7dc439c83df8bd34885f74689f8cbc7dff77b5e0#diff-529e03c120f8bdf7db93b9f4dd1007bce16c44b6f73a45c0da5c4366c4e567a0L678) (which became undefined) and replaced `<box>` references with `<visual-box>`, but some `<box>` references remained in other specs (including CSS Box, which defines `<visual-box>`).