### PR TITLE
[css-scroll-snap-2] Add SnapEvent definition

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -474,14 +474,6 @@ Snap Events {#snap-events}
 	1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
 
 
-	<h4>Dispatching Pending Snap Events</h4>
-	When asked to <dfn export>dispatch pending snap events</dfn> for a {{Document}},
-	|doc|, run these steps:
-
-	1. Run the steps to <a>dispatch pending snapchanging events</a> for |doc|.
-	1. Run the steps to <a>dispatch pending snapchanged events</a> for |doc|.
-
-
 SnapEvent interface
 -------------------
 

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -322,7 +322,7 @@ Snap Events {#snap-events}
 	</li>
 	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the element to
 		which a snap container is snapped to changes, regardless of whether there is
-		a change in scroll position	after the layout change.
+		a change in scroll position after the layout change.
 	</li>
 	</ol>
 
@@ -335,9 +335,10 @@ Snap Events {#snap-events}
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
-	one <dfn export>snapchangedTargetBlock</dfn> (which is either null or an
-	{{Element}}) and one <dfn export>snapchangedTargetInline</dfn> (which is either
-	null or an {{Element}}) in the block and inline axes respectively.
+	one <dfn export>snapchangedTargetBlock</dfn> and one
+	<dfn export>snapchangedTargetInline</dfn> in the block and inline axes
+	respectively, each of which can either be null if the container is not
+	snapped in that axis or the {{Element}} to which the container is snapped.
 
 	When asked to <dfn export for=Document>update snapchanged targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -423,9 +424,10 @@ Snap Events {#snap-events}
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
-	one <dfn>snapchangingTargetBlock</dfn> (which is either null or an {{Element}})
-	and one <dfn>snapchangingTargetInline</dfn> (which is either null or an
-	{{Element}}) in the block and inline axes respectively.
+	one <dfn>snapchangingTargetBlock</dfn> 
+	and one <dfn>snapchangingTargetInline</dfn>in the block and inline axes
+	respectively, each of which can either be null if the container is not
+	snapping in that axis or the {{Element}} to which the container is snapping.
 
 	When asked to <dfn export for=Document>update snapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -326,9 +326,6 @@ Snap Events {#snap-events}
 	</li>
 	</ol>
 
-	Although, snapping occurs when a snap container is first laid out, {{snapchanged}}
-	should not be triggered by this initial layout.
-
 	Scrolling operations always lead to {{scrollend}} events being fired. If a
 	scrolling operation also results in a {{snapchanged}} event being fired, the
 	{{snapchanged}} event should be fired before the {{scrollend}} event.
@@ -351,51 +348,61 @@ Snap Events {#snap-events}
 		associated with |snapcontainer|.
 	1. Let <var>inlineSnapchangingTarget</var> be the
 		<a>snapchangingTargetInline</a> associated with |snapcontainer|.
-	1. If <var>blockTarget</var> is not the same element as
-		<var>blockSnapchangingTarget</var>:
+	1. If <var>blockTarget</var> is not the same element as <var>blockSnapchangingTarget</var> or
+			<var>inlineTarget</var> is not the same element as <var>inlineSnapchangingTarget</var>:
 		1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
 			<var>blockSnapchangingTarget</var>.
-		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
-			1. Append |snapcontainer| to <var>doc</var>'s
-				<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
-	1. If <var>inlineTarget</var> is not the same element as
-			<var>inlineSnapchangingTarget</var>:
 		1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
 			<var>inlineSnapchangingTarget</var>.
-		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
-			1. Append |snapcontainer| to <var>doc</var>'s
-				<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanged}} at <var>target</var>
+			 and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+			 {{SnapEvent/snapTargetInline}} attributes be the <a>snapchangedTargetBlock</a> and the
+			 <a>snapchangedTargetInline</a>, respectively, that are associated with <var>target</var>.
 
-<h4 id="snapchanging"> snapchanging </h4>
-	{{snapchanging}} is dispatched when the element to which a
-	snap container would snap (in either axis) during a scrolling operation changes.
+	Note: When snapping occurs on a scroller (either due to a layout change or a
+	 scrolling operation) the <a>snapchangingTargetBlock</a> and <a>snapchangingTargetInline</a>
+	 associated with that scroller are updated and represent the current snap targets
+	 of that scroller. This allows the <a>update snapchanged targets</a> algorithm
+	 to use these elements to determine whether a {{snapchanged}} event should be fired.
+
+	<h4 id="snapchanging"> snapchanging </h4>
+	{{snapchanging}} is dispatched:
+	* during a scrolling operation, if the element to which a
+		 <a spec=css-scroll-snap lt="scroll snap container">snap container</a> would
+		 <a spec="css-scroll-snap-1" lt="scroll snap">snap</a> (in either axis) changes, or
+	* if a [[css-scroll-snap-1#re-snap|layout change]] occurs such that a {{snapchanged}} event
+		 is to be dispatched. In this case, as with the scrolling case, the {{snapchanging}} event
+		 should be dispatched before the {{snapchanged}} event.
+
 	A scrolling operation may animate towards a particular position (e.g.
 	scrollbar arrow clicks, arrow key presses, "behavior: smooth" programmatic
 	scrolls) or may directly track a user's input (e.g. touch scrolling, scrollbar
-	dragging).
-	* In the former case, the user agent should evaluate whether snapchanging is
-		occurring based on the
-		<a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
-		that will eventually be snapped to after the scroll animation's target offset
-		is reached.
-	* In the latter case, the user agent should evaluate whether snapchanging
-		should be triggered based on the
-		<a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a> that
-		would be snapped to if the scroll is ended at the current scroll position
-		(determined by the user's input).
+	dragging). In either case, the user agent [[css-scroll-snap-1#choosing|chooses]] an
+	<dfn>eventual snap target</dfn> in each axis to which the scroller will
+	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> after the scrolling operation
+	reaches its intended scroll position.
+	* In the former case, the intended scroll position is the scroll animation's
+		 target scroll offset.
+	* In the latter case, the intended scroll position is the current scroll offset as
+		 determined by the user's input.
 
 	{{snapchanging}} aims to let the web page know, as early as possible,
 	that the scrolling operation will result in a change in the element the snap
-	container is snapped to.
-
-	{{snapchanging}} events should fire before {{scroll}} events.
+	container is snapped to. The user agent should evaluate whether to trigger
+	{{snapchanging}} based on the	<a>eventual snap target</a> to which the scroller would
+	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> were the scrolling operation
+	to reach its intended scroll position.
 
 	Note: Since snapchanging gives the web page hints about future snapping,
 	the snapping hinted at by a snapchanging event may not materialize since it
 	will be	possible for subsequent scrolling input to further alter the snap
-	container's scroll position and result in a different eventual snap position.
+	container's scroll position and result in a different eventual snap target.
+
+
+	{{snapchanging}} events should fire before {{scroll}} events.
+
+	Each {{Document}} has an associated list of
+	<dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
@@ -407,35 +414,52 @@ Snap Events {#snap-events}
 	|snapcontainer|, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-	1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
-		all pending scroll updates to |snapcontainer|.
 	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
 		associated with |snapcontainer|.
 	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
 		associated with |snapcontainer|.
-	1. Let <var>newBlockTarget</var> be the element that the UA would snap
-		|snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
-		to any element) along the block axis.
-	1. Let <var>newInlineTarget</var> be the element that the UA would snap
-		|snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
-		to any element) along the inline axis.
-	1. If <var>newBlockTarget</var> is not the same element as
-		<var>blockTarget</var>:
+	1. Let <var>newBlockTarget</var> be the <a>eventual snap target</a> that |snapcontainer| will snap
+		to along the block axis or null if it would not snap to any element.
+	1. Let <var>newInlineTarget</var> be the <a>eventual snap target</a> that |snapcontainer| will snap
+		to along the inline axis or null if it would not snap to any element.
+	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
 		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
 			<var>newBlockTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>,
+			<a>pending snapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
-				<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>
-	1. If <var>newInlineTarget</var> is not the same element as
-		<var>inlineTarget</var>:
+				<a>pending snapchanging event targets</a>
+	1. If <var>newInlineTarget</var> is not the same element as <var>inlineTarget</var>:
 		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
 			<var>newInlineTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>,
+			<a>pending snapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
-				<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>.
+				<a>pending snapchanging event targets</a>.
 
+
+	<h4 id="snap-events-on-layout-changes"> Snap Events due to Layout Changes </h4>
+	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+	|snapcontainer|, [[css-scroll-snap-1#re-snap|re-snaps]], run these steps:
+
+	1. Let <var>newBlockTarget</var> be the element that |snapcontainer| has
+		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a>  to
+		 in the block axis or null if it did not snap to any element.
+	1. Let <var>newInlineTarget</var> be the element that |snapcontainer| has
+		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
+		 in the inline axis or null if it did not snap to any element.
+	1. Let <var>snapchangingBlock</var> be the <a>snapchangingTargetBlock</a> associated
+		with |snapcontainer|.
+	1. Let <var>snapchangingInline</var> be the <a>snapchangingTargetInline</a> associated
+		with |snapcontainer|.
+	1. If <var>newBlockTarget</var> is not the same element as <var>snapchangingBlock</var> or
+		 <var>newInlineTarget</var> is not the same element as <var>snapchangingInline</var>:
+		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to <var>newBlockTarget</var>.
+		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to <var>newInlineTarget</var>.
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at |snapcontainer| and let
+			 |snapevent|'s {{SnapEvent/snapTargetBlock}} and {{SnapEvent/snapTargetInline}}
+			 attributes be <var>newBlockTarget</var> and <var>newInlineTarget</var>, respectively.
+		1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
 
 SnapEvent interface
 -------------------

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -330,6 +330,9 @@ Snap Events {#snap-events}
 	scrolling operation also results in a {{snapchanged}} event being fired, the
 	{{snapchanged}} event should be fired before the {{scrollend}} event.
 
+	Each {{Document}} has an associated list of
+	<dfn export for=Document>pending snapchanged event targets</dfn>, initially empty.
+
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
 	associated with at most one <dfn export>snapchangedTargetBlock</dfn> and at most one
@@ -358,16 +361,25 @@ Snap Events {#snap-events}
 			<var>inlineSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
 	1. If <var>snap targets changed</var> is true:
-		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanged}} at <var>target</var>
-			 and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			 {{SnapEvent/snapTargetInline}} attributes be the <a>snapchangedTargetBlock</a> and the
-			 <a>snapchangedTargetInline</a>, respectively, that are associated with <var>target</var>.
+		1. If |snapcontainer| is not already in <var>doc</var>'s
+			<a>pending snapchanged event targets</a>:
+			1. Append |snapcontainer| to <var>doc</var>'s
+				<a>pending snapchanged event targets</a>.
 
 	Note: When snapping occurs on a scroller (either due to a layout change or a
 	 scrolling operation) the <a>snapchangingTargetBlock</a> and <a>snapchangingTargetInline</a>
 	 associated with that scroller are updated and represent the current snap targets
 	 of that scroller. This allows the <a>update snapchanged targets</a> algorithm
 	 to use these elements to determine whether a {{snapchanged}} event should be fired.
+
+	When asked to <dfn>dispatch pending snapchanged events</dfn> for a {{Document}},
+		<var>doc</var>, run these steps:
+	1. For each item <var>target</var> in |doc|'s <a>pending snapchanged event targets</a>:
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanged}} at <var>target</var>
+			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangedTargetBlock</a> and the
+			<a>snapchangedTargetInline</a>, respectively, that are associated with <var>target</var>.
+	1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
 
 	<h4 id="snapchanging"> snapchanging </h4>
 	{{snapchanging}} is dispatched:
@@ -415,17 +427,14 @@ Snap Events {#snap-events}
 
 	When asked to <dfn export for=Document>update snapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-	|snapcontainer|, run these steps:
+	|snapcontainer|, given an {{Element}} newBlockTarget and an {{Element}}
+	newInlineTarget, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
 	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
 		associated with |snapcontainer|.
 	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
 		associated with |snapcontainer|.
-	1. Let <var>newBlockTarget</var> be the <a>eventual snap target</a> that |snapcontainer| will snap
-		to along the block axis or null if it would not snap to any element.
-	1. Let <var>newInlineTarget</var> be the <a>eventual snap target</a> that |snapcontainer| will snap
-		to along the inline axis or null if it would not snap to any element.
 	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
 		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
 			<var>newBlockTarget</var>.
@@ -441,8 +450,16 @@ Snap Events {#snap-events}
 			1. Append |snapcontainer| to <var>doc</var>'s
 				<a>pending snapchanging event targets</a>.
 
+	When asked to <dfn>dispatch pending snapchanging events</dfn> for a {{Document}},
+		<var>doc</var>, run these steps:
+	1. For each item <var>target</var> in |doc|'s <a>pending snapchanging event targets</a>:
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at <var>target</var>
+			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangingTargetBlock</a> and the
+			<a>snapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
+  1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 
-	<h4 id="snap-events-on-layout-changes"> Snap Events due to Layout Changes </h4>
+	<h4 id="snap-events-on-layout-changes">Snap Events due to Layout Changes </h4>
 	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
 	|snapcontainer|, [[css-scroll-snap-1#re-snap|re-snaps]], run these steps:
 
@@ -452,25 +469,18 @@ Snap Events {#snap-events}
 	1. Let <var>newInlineTarget</var> be the element that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
 		 in the inline axis or null if it did not snap to any element.
-	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> associated
-		with |snapcontainer|.
-	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> associated
-		with |snapcontainer|.
-	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
-	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
-		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
-			<var>newBlockTarget</var>.
-		1. Set <var>snap targets changed</var> to true.
-	1. If <var>newInlineTarget</var> is not the same element as <var>inlineTarget</var>:
-		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
-			<var>newInlineTarget</var>.
-		1. Set <var>snap targets changed</var> to true.
-	1. If <var>snap targets changed</var> is true:
-		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at <var>target</var>
-			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangingTargetBlock</a> and the
-			<a>snapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
-		1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
+	1. Run the steps to <a>update snapchanging targets</a> with <var>newBlockTarget</var>
+		 as newBlockTarget and <var>newInlineTarget</var> as newInlineTarget.
+	1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
+
+
+	<h4>Dispatching Pending Snap Events</h4>
+	When asked to <dfn export>dispatch pending snap events</dfn> for a {{Document}},
+	|doc|, run these steps:
+
+	1. Run the steps to <a>dispatch pending snapchanging events</a> for |doc|.
+	1. Run the steps to <a>dispatch pending snapchanged events</a> for |doc|.
+
 
 SnapEvent interface
 -------------------

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -441,10 +441,16 @@ SnapEvent interface
 -------------------
 
 <pre class="idl">
+			dictionary SnapEventInit : EventInit {
+				Node? snapTargetBlock;
+				Node? snapTargetInline;
+			};
+
 			[Exposed=Window]
 			interface SnapEvent : Event {
-				readonly attribute Node snapTargetBlock;
-				readonly attribute Node snapTargetInline;
+				constructor(DOMString type, optional SnapEventInit eventInitDict = {});
+				readonly attribute Node? snapTargetBlock;
+				readonly attribute Node? snapTargetInline;
 			};
 </pre>
 

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -369,10 +369,10 @@ Snap Events {#snap-events}
 				<a>pending snapchanged event targets</a>.
 
 	Note: When snapping occurs on a scroller (either due to a layout change or a
-	 scrolling operation) the <a>snapchangingTargetBlock</a> and <a>snapchangingTargetInline</a>
-	 associated with that scroller are updated and represent the current snap targets
-	 of that scroller. This allows the <a>update snapchanged targets</a> algorithm
-	 to use these elements to determine whether a {{snapchanged}} event should be fired.
+	scrolling operation) the <a>snapchangingTargetBlock</a> and <a>snapchangingTargetInline</a>
+	associated with that scroller are updated and represent the current snap targets
+	of that scroller. This allows the <a>update snapchanged targets</a> algorithm
+	to use these elements to determine whether a {{snapchanged}} event should be fired.
 
 	When asked to <dfn>dispatch pending snapchanged events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -392,9 +392,9 @@ Snap Events {#snap-events}
 		 is to be dispatched. In this case, as with the scrolling case, the {{snapchanging}} event
 		 should be dispatched before the {{snapchanged}} event.
 
-	A scrolling operation may animate towards a particular position (e.g.
+	A scrolling operation might animate towards a particular position (e.g.
 	scrollbar arrow clicks, arrow key presses, "behavior: smooth" programmatic
-	scrolls) or may directly track a user's input (e.g. touch scrolling, scrollbar
+	scrolls) or might directly track a user's input (e.g. touch scrolling, scrollbar
 	dragging). In either case, the user agent [[css-scroll-snap-1#choosing|chooses]] an
 	<dfn>eventual snap target</dfn> in each axis to which the scroller will
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> after the scrolling operation

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -295,8 +295,8 @@ Snap Events {#snap-events}
 				<td>{{SnapEvent}}</td>
 				<td>scroll containers</td>
 				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll}} event),
-					if the scrolling would lead to a change in the
-					element that the scrolling element or Document is snapped to.</td>
+					if the element that the scrolling would cause the scroller to snap to is
+					different from the target reported by the last snapchanging event that was fired.</td>
 			</tr>
 		</tbody>
 	</table>
@@ -360,7 +360,7 @@ Snap Events {#snap-events}
 	Note: Since snapchanging gives the web page hints about future snapping,
 	the snapping hinted at by a snapchanging event may not materialize since it
 	will be	possible for subsequent scrolling input to further alter the snap
-	container's	scroll position and result in a different eventual snap position.
+	container's scroll position and result in a different eventual snap position.
 
 
 SnapEvent interface
@@ -391,7 +391,7 @@ SnapEvent interface
 			</div>
 
 		For {{snapchanged}} events, the snap position is the position already
-		realized by	the snap container after a scroll snap. For {{snapchanging}}
+		realized by the snap container after a scroll snap. For {{snapchanging}}
 		events it is the snap position that the snap container will eventually
 		snap to when the scrolling operation ends.
 
@@ -488,100 +488,117 @@ This appendix describes the algorithm UAs should follow to dispatch {{snapchange
 and {{snapchanging}} events in response to a scrolling operation on a
 <a spec=css-scroll-snap lt="scroll snap container">snap container</a>.
 
+This is a patch to the [[cssom-view#scrolling-events|scrolling events]] where
+the steps to update the document's
+<a spec=cssom-view lt="pending snapchanging event targets">snapchanging event targets</a> and
+<a spec=cssom-view lt="pending snapchanged event targets">snapchanged event targets
+targets are to run before the steps updating the document's
+<a spec=cssom-view lt="pending scroll event targets">scroll event targets</a> and
+<a spec=cssom-view lt="pending scrollend event targets">scrollend event targets</a>
+respectively. Also, the steps to fire {{snapchanging}} and {{snapchanged}}
+events are to run before the steps to fire {{scroll}} and {{scrollend}} events
+respectively.
+
 Each {{Document}} has an associated list of
 <dfn export for=Document>pending snapchanging event targets</dfn>, initially
 empty.
 
-Each {{Document}} associates each of its
-<a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
-with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
+Each
+<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
 <dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
 
-When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-scrolled, run these steps:
+When asked to <dfn export for=Document>update snapchanging targets</dfn>
+for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+|snapcontainer|, run these steps:
 
-0. Let <var>doc</var> be the
-	 <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
-	 associated {{Document}}.
+1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
 1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
-	 all pending scroll updates to the snap container.
-2. Let <var>blockTarget</var> be the
-	 <a>snapchangingTargetBlock</a> that <var>doc</var> associates with the snap
-	 container.
-3. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that
-	 <var>doc</var> associates with the snap container.
-4. Let <var>newBlockTarget</var> be the element that the UA would snap the snap
-	 container to from <var>scrollPosition</var> (or null if it would not snap to
-	 any element) along the block axis.
-5. Let <var>newInlineTarget</var> be the element that the UA would snap the snap
-	 container to from <var>scrollPosition</var> (or null if it would not snap to
-	 any element) along the inline axis.
-6. If <var>newBlockTarget</var> is not the same element as
+	 all pending scroll updates to |snapcontainer|.
+1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
+	 associated with |snapcontainer|.
+1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
+	 associated with |snapcontainer|.
+1. Let <var>newBlockTarget</var> be the element that the UA would snap
+   |snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
+	 to any element) along the block axis.
+1. Let <var>newInlineTarget</var> be the element that the UA would snap
+  |snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
+	to any element) along the inline axis.
+1. If <var>newBlockTarget</var> is not the same element as
 	 <var>blockTarget</var>:
-	
-	1. Set <var>doc</var>'s <a>snapchangingTargetBlock</a> for the snap container
-		 to <var>newBlockTarget</var>.
-	2. Append the snap container to <var>doc</var>'s
-		 <a>pending snapchanging event targets</a> 
-7. If <var>newInlineTarget</var> is not the same element as
+
+	1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
+		 <var>newBlockTarget</var>.
+	1. If |snapcontainer| is not already in <var>doc</var>'s
+		<a>pending snapchanging event targets</a>,
+		1. Append |snapcontainer| to <var>doc</var>'s
+			<a>pending snapchanging event targets</a>
+1. If <var>newInlineTarget</var> is not the same element as
 	 <var>inlineTarget</var>:
 
-	1. Set <var>doc</var>'s <a>snapchangingTargetInline</a> for the snap container
-		 to <var>newInlineTarget</var>.
-	2. Append the snap container to <var>doc</var>'s pending snapchanging event
-		 targets.
+	1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
+		 <var>newInlineTarget</var>.
+	1. If |snapcontainer| is not already in <var>doc</var>'s
+		<a>pending snapchanging event targets</a>,
+		1. Append |snapcontainer| to <var>doc</var>'s
+			<a>pending snapchanging event targets</a>.
 
 When the <a spec=cssom-view lt="run the scroll steps">scroll steps</a> are run
-for a {{Document}} <var>doc</var>, run these steps:
+for a {{Document}}, <var>doc</var>, run these steps before the steps which fire
+{{scroll}} events:
 
 1. For each item <var>target</target> in <var>doc</var>'s
 	 <a>pending snapchanging event targets</a>:
 
 	1. Fire a {{SnapEvent}} named snapchanging whose {{snapTargetBlock}} and
 		 {{snapTargetInline}} are the <a>snapchangingTargetBlock</a> and the
-		 <a>snapchangingTargetInline</a>, respectively, that <var>doc</var>
-		 associates with <var>target</var>.
-2. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
+		 <a>snapchangingTargetInline</a>, respectively, that are associated with
+		 <var>target</var>.
+1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 
 Each {{Document}} has an associated list of
 <dfn export for=Document>pending snapchanged event targets</dfn>, initially
 empty.
 
-Each {{Document}} associates each of its
-<a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
-with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
+Each
+<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+associated with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
 <dfn>snapchangedTargetInline</dfn> in the block and inline axes respectively.
 
-When the scroll on a snap container is
-<a spec="cssom-view" lt="scroll completed"> completed</a>, run these steps:
+When asked to <dfn export for=Document>update snapchanged targets</dfn>
+for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+|snapcontainer|, run these steps:
 
-0. Let <var>doc</var> be the
-	 <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
-	 associated {{Document}}.
-1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> that
-	 <var>doc</var> associates with the snap container.
-2. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> that
-	 <var>doc</var> associates	with the snap container.
-3. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
-	 that <var>doc</var> associates  with the snap container.
-4. Let <var>inlineSnapchangingTarget</var> be the
-	 <a>snapchangingTargetInline</a> that <var>doc</var> associates with the snap
-	 container.
-5. If <var>blockTarget</var> is not the same element as
+1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
+1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
+	 with |snapcontainer|.
+1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
+	 with |snapcontainer|.
+1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
+	 associated with |snapcontainer|.
+1. Let <var>inlineSnapchangingTarget</var> be the
+	 <a>snapchangingTargetInline</a> associated with |snapcontainer|.
+1. If <var>blockTarget</var> is not the same element as
 	 <var>blockSnapchangingTarget</var>:
-	1. Set <var>doc</var>'s <a>snapchangedTargetBlock</a> for the snap container
-		 to <var>blockSnapchangingTarget</var>.
-	2. Append the snap container to <var>doc</var>'s
+	1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
+		 <var>blockSnapchangingTarget</var>.
+	1. If |snapcontainer| is not already in <var>doc</var>'s
 		 <a>pending snapchanged event targets</a>.
-6. If <var>inlineTarget</var> is not the same element as
+		1. Append |snapcontainer| to <var>doc</var>'s
+			<a>pending snapchanged event targets</a>.
+1. If <var>inlineTarget</var> is not the same element as
 		 <var>inlineSnapchangingTarget</var>:
-	1. Set <var>doc</var>'s <a>snapchangedTargetInline</a> for the snap container
-		 to <var>inlineSnapchangingTarget</var>.
-	2. Append the snap container to <var>doc</var>'s
+	1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
+		 <var>inlineSnapchangingTarget</var>.
+	1. If |snapcontainer| is not already in <var>doc</var>'s
 		 <a>pending snapchanged event targets</a>.
+		1. Append |snapcontainer| to <var>doc</var>'s
+			<a>pending snapchanged event targets</a>.
 
-When the <a spec=cssom-view lt="run the scroll steps">scroll steps</a> are run
-for a {{Document}} <var>doc</var>, run these steps:
+Whenever scrolling is
+<a spec="cssom-view" lt="scroll completed"> completed</a>, run these steps
+before the steps which fire {{scrollend}} events:
 
 1. For each item <var>target</var> in <var>doc</var>'s
 	 <a>pending snapchanged event targets</a>:
@@ -590,4 +607,4 @@ for a {{Document}} <var>doc</var>, run these steps:
 		 {{snapTargetInline}} are the <a>snapchangedTargetBlock</a> and the
 		 <a>snapchangedTargetInline</a>, respectively, that <var>doc</var>
 		 associates with <var>target</var>.
-2. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
+1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -413,7 +413,7 @@ Snap Events {#snap-events}
 
 	Note: Since snapchanging gives the web page hints about future snapping,
 	the snapping hinted at by a snapchanging event might not materialize since it
-	will be	possible for subsequent scrolling input to further alter the snap
+	will be possible for subsequent scrolling input to further alter the snap
 	container's scroll position and result in a different eventual snap target.
 
 

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -412,7 +412,7 @@ Snap Events {#snap-events}
 	to reach its intended scroll position.
 
 	Note: Since snapchanging gives the web page hints about future snapping,
-	the snapping hinted at by a snapchanging event may not materialize since it
+	the snapping hinted at by a snapchanging event might not materialize since it
 	will be	possible for subsequent scrolling input to further alter the snap
 	container's scroll position and result in a different eventual snap target.
 

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -262,7 +262,7 @@ Snap Events {#snap-events}
 ████████    ███    ████████ ██    ██    ██     ██████
 -->
 
-{{snapChanged}} and {{snapChanging}} {#snapchanged-and-snapchanging}
+{{snapchanged}} and {{snapchanging}} {#snapchanged-and-snapchanging}
 --------------------------------------------
 
 	CSS scroll snap points are often used as a mechanism to
@@ -275,119 +275,129 @@ Snap Events {#snap-events}
 	<table class="data" id="eventhandlers">
 		<thead>
 			<tr>
-				<th>Event handler
-				<th>Event handler event type
+				<th>Event</th>
+				<th>Interface</th>
+				<th>Targets</th>
+				<th>Description</th>
+			</tr>
+		</thead>
 		<tbody>
 			<tr>
-				<th><dfn event>snapChanged</dfn>
-				<td>{{scroll!!event}}
+				<th><dfn for="snapchanged" event>snapchanged</dfn></th>
+				<td>{{SnapEvent}}</td>
+				<td>scroll containers</td>
+				<td>Fired at the scrolling element or {{Document}} at the end of a scroll (before a {{scrollend}} event)
+					or after a <a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">layout snap</a>
+					if the element that the scrolling element or Document is snapped to changed.</td>
+			</tr>
 			<tr>
-				<th><dfn event>snapChanging</dfn>
-				<td>{{scroll!!event}}
+				<th><dfn for="snapchanging" event>snapchanging</dfn></th>
+				<td>{{SnapEvent}}</td>
+				<td>scroll containers</td>
+				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll}} event),
+					if the scrolling would lead to a change in the
+					element that the scrolling element or Document is snapped to.</td>
+			</tr>
+		</tbody>
 	</table>
-	<h4>SnapEvents</h4>
-	<pre class="idl">
+
+	<h4 for="snapchanged" id="snapchanged"> snapchanged </h4>
+	{{snapchanged}} indicates that the snap area to which a snap container is snapped along either axis has changed.
+	{{snapchanged}} should be dispatched:
+
+	<ol>
+	<li>
+		when a scrolling operation is <a spec="cssom-view-1" lt="scroll completed">completed</a>
+		if, for either the block or inline axis, the
+		element which the snap container is snapped to is different from the element
+		it most recently snapped to in that axis. For snap containers with
+		''scroll-snap-type/proximity'' strictness, the scroll may result in the snap
+		container no longer being snapped to any element.	[[css-scroll-snap-1#choosing]]
+		describes the method a UA follows when choosing	between elements which are
+		<a spec="css-scroll-snap-1" lt="scroll snap area">snap areas</a>.
+	</li>
+	<li> if there is a change to a snap container's style such that it goes from
+		having a non-'none' value for [[css-scroll-snap-1#scroll-snap-type|scroll-snap-type]]
+		to having a 'none' value or vice versa.
+	</li>
+	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the element to
+		which a snap container is	snapped to changes, regardless of whether there is
+		a change in scroll position	after the layout change.
+	</li>
+	</ol>
+
+	Although, snapping occurs when a snap container is first laid out, {{snapchanged}}
+	should not be triggered by this initial layout.
+
+	Scrolling operations always lead to {{scrollend}} events being fired. If a
+	scrolling operation also results in a {{snapchanged}} event being fired, the
+	{{snapchanged}} event should be fired before the {{scrollend}} event.
+
+<h4 id="snapchanging"> snapchanging </h4>
+	{{snapchanging}} is dispatched when the element to which a
+	snap container would snap (in either axis) during a scrolling operation changes.
+	A scrolling operation may animate towards a particular position (e.g.
+	scrollbar arrow clicks, arrow key presses, "behavior: smooth" programmatic
+	scrolls) or may directly track a user's input (e.g. touch scrolling, scrollbar
+	dragging).
+	* In the former case, the user agent should evaluate whether snapchanging is
+		occurring based on the
+		<a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
+		that will eventually be snapped to after the scroll animation's target offset
+		is reached.
+	* In the latter case, the user agent should evaluate whether snapchanging
+		should be triggered based on the
+		<a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a> that
+		would be snapped to if the scroll is ended at the current scroll position
+		(determined by the user's input).
+
+	{{snapchanging}} aims to let the web page know, as early as possible,
+	that the scrolling operation will result in a change in the element the snap
+	container is snapped to.
+
+	{{snapchanging}} events should fire before {{scroll}} events.
+
+	Note: Since snapchanging gives the web page hints about future snapping,
+	the snapping hinted at by a snapchanging event may not materialize since it
+	will be	possible for subsequent scrolling input to further alter the snap
+	container's	scroll position and result in a different eventual snap position.
+
+
+SnapEvent interface
+-------------------
+
+<pre class="idl">
 			[Exposed=Window]
 			interface SnapEvent : Event {
-				constructor(DOMString type, optional SnapEventInit eventInitDict = {});
-				readonly attribute EventTarget? target;
-				readonly attribute SnapTargetList snappedTargets;
-				readonly attribute SnapTargetList snapTargets;
-				readonly attribute boolean invokedProgrammatically;
-				readonly attribute boolean smoothlyScrolled;
+				readonly attribute Node snapTargetBlock;
+				readonly attribute Node snapTargetInline;
 			};
+</pre>
 
-			[Exposed=Window]
-			interface SnapTargetList {
-			    readonly attribute SnapTargetArray x;
-			    readonly attribute SnapTargetArray y;
-			};
+<dl>
+			<div dfn-type=attribute class=attributes dfn-for="SnapEvent">
+		: <dfn>snapTargetBlock</dfn>
+		::
+			The element that the snap container is snapped to in the block axis
+			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
+			for the associated snap event.
+			</div>
+			<div dfn-type=attribute class=attributes dfn-for="SnapEvent">
+		: <dfn>snapTargetInline</dfn>
+		::
+			The element that the snap container is snapped to in the inline axis
+			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
+			for the associated snap event.
+			</div>
 
-			[Exposed=Window]
-			interface SnapTargetArray {
-			    readonly attribute unsigned long length;
-			    getter EventTarget? item (unsigned long index);
-			};
+		For {{snapchanged}} events, the snap position is the position already
+		realized by	the snap container after a scroll snap. For {{snapchanging}}
+		events it is the snap position that the snap container will eventually
+		snap to when the scrolling operation ends.
 
-			dictionary SnapEventInit : EventModifierInit {
-			    sequence&lt;EventTarget> snappedTargetsX = [];
-			    sequence&lt;EventTarget> snappedTargetsY = [];
-			    sequence&lt;EventTarget> snapTargetsListX = [];
-			    sequence&lt;EventTarget> snapTargetsListY = [];
-			};
-	</pre>
-
-	<dl>
-		<dt><code>SnapEvent . target</code></dt>
-		<dd>
-			This is the scroll container of the snapped-to element.
-		</dd>
-		<dt><code>SnapEvent . snappedTargets</code></dt>
-		<dd>
-			An object with 2 keys for each axis, each key returns an array of snapped targets.
-		</dd>
-		<dt><code>SnapEvent . snapTargets</code></dt>
-		<dd>
-			An object with 2 keys for each axis, each key returns an array of the aggregated snap children.
-		</dd>
-		<dt><code>SnapEvent . invokedProgrammatically</code></dt>
-		<dd>
-			A boolean informing developers if a user or script invoked scroll that caused <a>snapChanged</a>.
-		</dd>
-		<dt><code>SnapEvent . smoothlyScrolled</code></dt>
-		<dd>
-			A boolean informing developers if the snap change was instant or interpolated.
-		</dd>
 	</dl>
 
-	<h4> snapChanged </h4>
-
-		The event is dispatched when a new snap target has been snapped to, providing what caused it.
-		It should be dispatched:
-
-		*	if user scroll interaction has ended and a new item has been rested on. If a user is still touching the screen or the touchpad, this event should not fire, even if the scroll position is exactly at a snapped element's position.
-		*	if animations or transitions change the snapped style of the container or children, IF they have in fact changed the snap target.
-
-		<table>
-		<tr><th>Type</th><td><strong><code>snapChanged</code></strong></td></tr>
-		<tr><th>Interface</th><td>{{SnapEvent}}</td></tr>
-		<tr><th>Sync / Async</th><td>Async</td></tr>
-		<tr><th>Bubbles</th><td>Yes</td></tr>
-		<tr><th>Trusted Targets</th><td><code>Element</code></td></tr>
-		<tr><th>Cancelable</th><td>No</td></tr>
-		<tr><th>Composed</th><td>Yes</td></tr>
-		<tr><th>Default action</th><td>None</td></tr>
-		<tr><th>Context<br/>(trusted events)</th><td><ul>
-													 <li>{{Event}}.{{Event/target}} : scroll container of the snapped-to element</li>
-													 <li>{{SnapEvent}}.{{snappedTargets}} : an object with 2 keys for each axis, each key returns an array of snapped targets</li>
-													 <li>{{SnapEvent}}.{{snapTargets}} : an object with 2 keys for each axis, each key returns an array of the aggregated snap children</li>
-													 <li>{{SnapEvent}}.{{invokedProgrammatically}} : a boolean informing developers if a user or script invoked scroll that caused <a>snapChanged</a></li>
-													 <li>{{SnapEvent}}.{{smoothlyScrolled}} : a boolean informing developers if the snap change was instant or interpolated</li>
-													 </ul></td></tr>
-		</table>
-
-	<h4> snapChanging </h4>
-
-		Should fire every time, and as soon as, the UA has determined a new snap child until the new child is snapped to.
-
-		<table>
-		<tr><th>Type</th><td><strong><code>snapChanging</code></strong></td></tr>
-		<tr><th>Interface</th><td>{{SnapEvent}}</td></tr>
-		<tr><th>Sync / Async</th><td>Async</td></tr>
-		<tr><th>Bubbles</th><td>Yes</td></tr>
-		<tr><th>Trusted Targets</th><td><code>Element</code></td></tr>
-		<tr><th>Cancelable</th><td>No</td></tr>
-		<tr><th>Composed</th><td>Yes</td></tr>
-		<tr><th>Default action</th><td>None</td></tr>
-		<tr><th>Context<br/>(trusted events)</th><td><ul>
-													 <li>{{Event}}.{{Event/target}} : scroll container of the snapped-to element.</li>
-													 <li>{{SnapEvent}}.{{snappedTargets}}
-													 <li>{{SnapEvent}}.{{snapTargets}} : an object with 2 keys for each axis, each key returns an array of the aggregated snap children.</li>
-													 <li>{{SnapEvent}}.{{invokedProgrammatically}} : a boolean informing developers if a user or script invoked scroll that caused <a>snapChanged.</a></li>
-													 <li>{{SnapEvent}}.{{smoothlyScrolled}} : a boolean informing developers if the snap change was instant or interpolated.</li>
-													 </ul></td></tr>
-		</table>
-
+	A {{SnapEvent}} should not bubble and should not be cancellable.
 <!--
 ██        ███████  ██    ██  ██████   ██     ██    ███    ██    ██ ████████   ██████
 ██       ██     ██ ███   ██ ██    ██  ██     ██   ██ ██   ███   ██ ██     ██ ██    ██
@@ -470,3 +480,114 @@ Physical Longhands for 'scroll-start-target' {#scroll-start-target-longhands-phy
 	</pre>
 
 	...
+
+Appendix B: Snap Events Timing {#snap-events-timing}
+==================================
+
+This appendix describes the algorithm UAs should follow to dispatch {{snapchanged}}
+and {{snapchanging}} events in response to a scrolling operation on a
+<a spec=css-scroll-snap lt="scroll snap container">snap container</a>.
+
+Each {{Document}} has an associated list of
+<dfn export for=Document>pending snapchanging event targets</dfn>, initially
+empty.
+
+Each {{Document}} associates each of its
+<a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
+with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
+<dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
+
+When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+scrolled, run these steps:
+
+0. Let <var>doc</var> be the
+	 <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
+	 associated {{Document}}.
+1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
+	 all pending scroll updates to the snap container.
+2. Let <var>blockTarget</var> be the
+	 <a>snapchangingTargetBlock</a> that <var>doc</var> associates with the snap
+	 container.
+3. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that
+	 <var>doc</var> associates with the snap container.
+4. Let <var>newBlockTarget</var> be the element that the UA would snap the snap
+	 container to from <var>scrollPosition</var> (or null if it would not snap to
+	 any element) along the block axis.
+5. Let <var>newInlineTarget</var> be the element that the UA would snap the snap
+	 container to from <var>scrollPosition</var> (or null if it would not snap to
+	 any element) along the inline axis.
+6. If <var>newBlockTarget</var> is not the same element as
+	 <var>blockTarget</var>:
+	
+	1. Set <var>doc</var>'s <a>snapchangingTargetBlock</a> for the snap container
+		 to <var>newBlockTarget</var>.
+	2. Append the snap container to <var>doc</var>'s
+		 <a>pending snapchanging event targets</a> 
+7. If <var>newInlineTarget</var> is not the same element as
+	 <var>inlineTarget</var>:
+
+	1. Set <var>doc</var>'s <a>snapchangingTargetInline</a> for the snap container
+		 to <var>newInlineTarget</var>.
+	2. Append the snap container to <var>doc</var>'s pending snapchanging event
+		 targets.
+
+When the <a spec=cssom-view lt="run the scroll steps">scroll steps</a> are run
+for a {{Document}} <var>doc</var>, run these steps:
+
+1. For each item <var>target</target> in <var>doc</var>'s
+	 <a>pending snapchanging event targets</a>:
+
+	1. Fire a {{SnapEvent}} named snapchanging whose {{snapTargetBlock}} and
+		 {{snapTargetInline}} are the <a>snapchangingTargetBlock</a> and the
+		 <a>snapchangingTargetInline</a>, respectively, that <var>doc</var>
+		 associates with <var>target</var>.
+2. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
+
+Each {{Document}} has an associated list of
+<dfn export for=Document>pending snapchanged event targets</dfn>, initially
+empty.
+
+Each {{Document}} associates each of its
+<a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
+with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
+<dfn>snapchangedTargetInline</dfn> in the block and inline axes respectively.
+
+When the scroll on a snap container is
+<a spec="cssom-view" lt="scroll completed"> completed</a>, run these steps:
+
+0. Let <var>doc</var> be the
+	 <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
+	 associated {{Document}}.
+1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> that
+	 <var>doc</var> associates with the snap container.
+2. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> that
+	 <var>doc</var> associates	with the snap container.
+3. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
+	 that <var>doc</var> associates  with the snap container.
+4. Let <var>inlineSnapchangingTarget</var> be the
+	 <a>snapchangingTargetInline</a> that <var>doc</var> associates with the snap
+	 container.
+5. If <var>blockTarget</var> is not the same element as
+	 <var>blockSnapchangingTarget</var>:
+	1. Set <var>doc</var>'s <a>snapchangedTargetBlock</a> for the snap container
+		 to <var>blockSnapchangingTarget</var>.
+	2. Append the snap container to <var>doc</var>'s
+		 <a>pending snapchanged event targets</a>.
+6. If <var>inlineTarget</var> is not the same element as
+		 <var>inlineSnapchangingTarget</var>:
+	1. Set <var>doc</var>'s <a>snapchangedTargetInline</a> for the snap container
+		 to <var>inlineSnapchangingTarget</var>.
+	2. Append the snap container to <var>doc</var>'s
+		 <a>pending snapchanged event targets</a>.
+
+When the <a spec=cssom-view lt="run the scroll steps">scroll steps</a> are run
+for a {{Document}} <var>doc</var>, run these steps:
+
+1. For each item <var>target</var> in <var>doc</var>'s
+	 <a>pending snapchanged event targets</a>:
+
+	1. Fire a {{SnapEvent}} named snapchanged whose {{snapTargetBlock}} and
+		 {{snapTargetInline}} are the <a>snapchangedTargetBlock</a> and the
+		 <a>snapchangedTargetInline</a>, respectively, that <var>doc</var>
+		 associates with <var>target</var>.
+2. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -312,7 +312,7 @@ Snap Events {#snap-events}
 		element which the snap container is snapped to is different from the element
 		it most recently snapped to in that axis. For snap containers with
 		''scroll-snap-type/proximity'' strictness, the scroll may result in the snap
-		container no longer being snapped to any element.	[[css-scroll-snap-1#choosing]]
+		container no longer being snapped to any element. [[css-scroll-snap-1#choosing]]
 		describes the method a UA follows when choosing	between elements which are
 		<a spec="css-scroll-snap-1" lt="scroll snap area">snap areas</a>.
 	</li>

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -333,6 +333,41 @@ Snap Events {#snap-events}
 	scrolling operation also results in a {{snapchanged}} event being fired, the
 	{{snapchanged}} event should be fired before the {{scrollend}} event.
 
+	Each
+	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+	associated with at most one <dfn export>snapchangedTargetBlock</dfn> and at most one
+	<dfn export>snapchangedTargetInline</dfn> in the block and inline axes respectively.
+
+	When asked to <dfn export for=Document>update snapchanged targets</dfn>
+	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+	|snapcontainer|, run these steps:
+
+	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
+	1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
+		with |snapcontainer|.
+	1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
+		with |snapcontainer|.
+	1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
+		associated with |snapcontainer|.
+	1. Let <var>inlineSnapchangingTarget</var> be the
+		<a>snapchangingTargetInline</a> associated with |snapcontainer|.
+	1. If <var>blockTarget</var> is not the same element as
+		<var>blockSnapchangingTarget</var>:
+		1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
+			<var>blockSnapchangingTarget</var>.
+		1. If |snapcontainer| is not already in <var>doc</var>'s
+			<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
+			1. Append |snapcontainer| to <var>doc</var>'s
+				<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
+	1. If <var>inlineTarget</var> is not the same element as
+			<var>inlineSnapchangingTarget</var>:
+		1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
+			<var>inlineSnapchangingTarget</var>.
+		1. If |snapcontainer| is not already in <var>doc</var>'s
+			<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
+			1. Append |snapcontainer| to <var>doc</var>'s
+				<a spec=cssom-view lt="pending snapchanged event targets">pending snapchanged event targets</a>.
+
 <h4 id="snapchanging"> snapchanging </h4>
 	{{snapchanging}} is dispatched when the element to which a
 	snap container would snap (in either axis) during a scrolling operation changes.
@@ -361,6 +396,45 @@ Snap Events {#snap-events}
 	the snapping hinted at by a snapchanging event may not materialize since it
 	will be	possible for subsequent scrolling input to further alter the snap
 	container's scroll position and result in a different eventual snap position.
+
+	Each
+	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+	associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
+	<dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
+
+	When asked to <dfn export for=Document>update snapchanging targets</dfn>
+	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+	|snapcontainer|, run these steps:
+
+	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
+	1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
+		all pending scroll updates to |snapcontainer|.
+	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
+		associated with |snapcontainer|.
+	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
+		associated with |snapcontainer|.
+	1. Let <var>newBlockTarget</var> be the element that the UA would snap
+		|snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
+		to any element) along the block axis.
+	1. Let <var>newInlineTarget</var> be the element that the UA would snap
+		|snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
+		to any element) along the inline axis.
+	1. If <var>newBlockTarget</var> is not the same element as
+		<var>blockTarget</var>:
+		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
+			<var>newBlockTarget</var>.
+		1. If |snapcontainer| is not already in <var>doc</var>'s
+			<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>,
+			1. Append |snapcontainer| to <var>doc</var>'s
+				<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>
+	1. If <var>newInlineTarget</var> is not the same element as
+		<var>inlineTarget</var>:
+		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
+			<var>newInlineTarget</var>.
+		1. If |snapcontainer| is not already in <var>doc</var>'s
+			<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>,
+			1. Append |snapcontainer| to <var>doc</var>'s
+				<a spec=cssom-view lt="pending snapchanging event targets">pending snapchanging event targets</a>.
 
 
 SnapEvent interface
@@ -480,131 +554,3 @@ Physical Longhands for 'scroll-start-target' {#scroll-start-target-longhands-phy
 	</pre>
 
 	...
-
-Appendix B: Snap Events Timing {#snap-events-timing}
-==================================
-
-This appendix describes the algorithm UAs should follow to dispatch {{snapchanged}}
-and {{snapchanging}} events in response to a scrolling operation on a
-<a spec=css-scroll-snap lt="scroll snap container">snap container</a>.
-
-This is a patch to the [[cssom-view#scrolling-events|scrolling events]] where
-the steps to update the document's
-<a spec=cssom-view lt="pending snapchanging event targets">snapchanging event targets</a> and
-<a spec=cssom-view lt="pending snapchanged event targets">snapchanged event targets
-targets are to run before the steps updating the document's
-<a spec=cssom-view lt="pending scroll event targets">scroll event targets</a> and
-<a spec=cssom-view lt="pending scrollend event targets">scrollend event targets</a>
-respectively. Also, the steps to fire {{snapchanging}} and {{snapchanged}}
-events are to run before the steps to fire {{scroll}} and {{scrollend}} events
-respectively.
-
-Each {{Document}} has an associated list of
-<dfn export for=Document>pending snapchanging event targets</dfn>, initially
-empty.
-
-Each
-<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
-<dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
-
-When asked to <dfn export for=Document>update snapchanging targets</dfn>
-for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-|snapcontainer|, run these steps:
-
-1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
-	 all pending scroll updates to |snapcontainer|.
-1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
-	 associated with |snapcontainer|.
-1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
-	 associated with |snapcontainer|.
-1. Let <var>newBlockTarget</var> be the element that the UA would snap
-   |snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
-	 to any element) along the block axis.
-1. Let <var>newInlineTarget</var> be the element that the UA would snap
-  |snapcontainer| to from <var>scrollPosition</var> (or null if it would not snap
-	to any element) along the inline axis.
-1. If <var>newBlockTarget</var> is not the same element as
-	 <var>blockTarget</var>:
-
-	1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
-		 <var>newBlockTarget</var>.
-	1. If |snapcontainer| is not already in <var>doc</var>'s
-		<a>pending snapchanging event targets</a>,
-		1. Append |snapcontainer| to <var>doc</var>'s
-			<a>pending snapchanging event targets</a>
-1. If <var>newInlineTarget</var> is not the same element as
-	 <var>inlineTarget</var>:
-
-	1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
-		 <var>newInlineTarget</var>.
-	1. If |snapcontainer| is not already in <var>doc</var>'s
-		<a>pending snapchanging event targets</a>,
-		1. Append |snapcontainer| to <var>doc</var>'s
-			<a>pending snapchanging event targets</a>.
-
-When the <a spec=cssom-view lt="run the scroll steps">scroll steps</a> are run
-for a {{Document}}, <var>doc</var>, run these steps before the steps which fire
-{{scroll}} events:
-
-1. For each item <var>target</target> in <var>doc</var>'s
-	 <a>pending snapchanging event targets</a>:
-
-	1. Fire a {{SnapEvent}} named snapchanging whose {{snapTargetBlock}} and
-		 {{snapTargetInline}} are the <a>snapchangingTargetBlock</a> and the
-		 <a>snapchangingTargetInline</a>, respectively, that are associated with
-		 <var>target</var>.
-1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
-
-Each {{Document}} has an associated list of
-<dfn export for=Document>pending snapchanged event targets</dfn>, initially
-empty.
-
-Each
-<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-associated with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
-<dfn>snapchangedTargetInline</dfn> in the block and inline axes respectively.
-
-When asked to <dfn export for=Document>update snapchanged targets</dfn>
-for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-|snapcontainer|, run these steps:
-
-1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
-	 with |snapcontainer|.
-1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
-	 with |snapcontainer|.
-1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
-	 associated with |snapcontainer|.
-1. Let <var>inlineSnapchangingTarget</var> be the
-	 <a>snapchangingTargetInline</a> associated with |snapcontainer|.
-1. If <var>blockTarget</var> is not the same element as
-	 <var>blockSnapchangingTarget</var>:
-	1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
-		 <var>blockSnapchangingTarget</var>.
-	1. If |snapcontainer| is not already in <var>doc</var>'s
-		 <a>pending snapchanged event targets</a>.
-		1. Append |snapcontainer| to <var>doc</var>'s
-			<a>pending snapchanged event targets</a>.
-1. If <var>inlineTarget</var> is not the same element as
-		 <var>inlineSnapchangingTarget</var>:
-	1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
-		 <var>inlineSnapchangingTarget</var>.
-	1. If |snapcontainer| is not already in <var>doc</var>'s
-		 <a>pending snapchanged event targets</a>.
-		1. Append |snapcontainer| to <var>doc</var>'s
-			<a>pending snapchanged event targets</a>.
-
-Whenever scrolling is
-<a spec="cssom-view" lt="scroll completed"> completed</a>, run these steps
-before the steps which fire {{scrollend}} events:
-
-1. For each item <var>target</var> in <var>doc</var>'s
-	 <a>pending snapchanged event targets</a>:
-
-	1. Fire a {{SnapEvent}} named snapchanged whose {{snapTargetBlock}} and
-		 {{snapTargetInline}} are the <a>snapchangedTargetBlock</a> and the
-		 <a>snapchangedTargetInline</a>, respectively, that <var>doc</var>
-		 associates with <var>target</var>.
-1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -348,12 +348,16 @@ Snap Events {#snap-events}
 		associated with |snapcontainer|.
 	1. Let <var>inlineSnapchangingTarget</var> be the
 		<a>snapchangingTargetInline</a> associated with |snapcontainer|.
+	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
 	1. If <var>blockTarget</var> is not the same element as <var>blockSnapchangingTarget</var> or
-			<var>inlineTarget</var> is not the same element as <var>inlineSnapchangingTarget</var>:
 		1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
 			<var>blockSnapchangingTarget</var>.
+		1. Set <var>snap targets changed</var> to true.
+	1. If <var>inlineTarget</var> is not the same element as <var>inlineSnapchangingTarget</var>:
 		1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
 			<var>inlineSnapchangingTarget</var>.
+		1. Set <var>snap targets changed</var> to true.
+	1. If <var>snap targets changed</var> is true:
 		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanged}} at <var>target</var>
 			 and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
 			 {{SnapEvent/snapTargetInline}} attributes be the <a>snapchangedTargetBlock</a> and the
@@ -448,17 +452,24 @@ Snap Events {#snap-events}
 	1. Let <var>newInlineTarget</var> be the element that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
 		 in the inline axis or null if it did not snap to any element.
-	1. Let <var>snapchangingBlock</var> be the <a>snapchangingTargetBlock</a> associated
+	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> associated
 		with |snapcontainer|.
-	1. Let <var>snapchangingInline</var> be the <a>snapchangingTargetInline</a> associated
+	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> associated
 		with |snapcontainer|.
-	1. If <var>newBlockTarget</var> is not the same element as <var>snapchangingBlock</var> or
-		 <var>newInlineTarget</var> is not the same element as <var>snapchangingInline</var>:
-		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to <var>newBlockTarget</var>.
-		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to <var>newInlineTarget</var>.
-		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at |snapcontainer| and let
-			 |snapevent|'s {{SnapEvent/snapTargetBlock}} and {{SnapEvent/snapTargetInline}}
-			 attributes be <var>newBlockTarget</var> and <var>newInlineTarget</var>, respectively.
+	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
+	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
+		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
+			<var>newBlockTarget</var>.
+		1. Set <var>snap targets changed</var> to true.
+	1. If <var>newInlineTarget</var> is not the same element as <var>inlineTarget</var>:
+		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
+			<var>newInlineTarget</var>.
+		1. Set <var>snap targets changed</var> to true.
+	1. If <var>snap targets changed</var> is true:
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at <var>target</var>
+			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangingTargetBlock</a> and the
+			<a>snapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
 		1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
 
 SnapEvent interface

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -303,7 +303,7 @@ Snap Events {#snap-events}
 
 	<h4 for="snapchanged" id="snapchanged"> snapchanged </h4>
 	{{snapchanged}} indicates that the snap area to which a snap container is snapped along either axis has changed.
-	{{snapchanged}} should be dispatched:
+	{{snapchanged}} is dispatched:
 
 	<ol>
 	<li>

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -417,7 +417,7 @@ Snap Events {#snap-events}
 	container's scroll position and result in a different eventual snap target.
 
 
-	{{snapchanging}} events should fire before {{scroll}} events.
+	{{snapchanging}} events are fired before {{scroll}} events.
 
 	Each {{Document}} has an associated list of
 	<dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -321,7 +321,7 @@ Snap Events {#snap-events}
 		to having a 'none' value or vice versa.
 	</li>
 	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the element to
-		which a snap container is	snapped to changes, regardless of whether there is
+		which a snap container is snapped to changes, regardless of whether there is
 		a change in scroll position	after the layout change.
 	</li>
 	</ol>
@@ -334,9 +334,10 @@ Snap Events {#snap-events}
 	<dfn export for=Document>pending snapchanged event targets</dfn>, initially empty.
 
 	Each
-	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-	associated with at most one <dfn export>snapchangedTargetBlock</dfn> and at most one
-	<dfn export>snapchangedTargetInline</dfn> in the block and inline axes respectively.
+	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
+	one <dfn export>snapchangedTargetBlock</dfn> (which is either null or an
+	{{Element}}) and one <dfn export>snapchangedTargetInline</dfn> (which is either
+	null or an {{Element}}) in the block and inline axes respectively.
 
 	When asked to <dfn export for=Document>update snapchanged targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -421,9 +422,10 @@ Snap Events {#snap-events}
 	<dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.
 
 	Each
-	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-	associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
-	<dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
+	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
+	one <dfn>snapchangingTargetBlock</dfn> (which is either null or an {{Element}})
+	and one <dfn>snapchangingTargetInline</dfn> (which is either null or an
+	{{Element}}) in the block and inline axes respectively.
 
 	When asked to <dfn export for=Document>update snapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -457,7 +459,7 @@ Snap Events {#snap-events}
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
 			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangingTargetBlock</a> and the
 			<a>snapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
-  1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
+	1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 
 	<h4 id="snap-events-on-layout-changes">Snap Events due to Layout Changes </h4>
 	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1903,77 +1903,81 @@ When asked to <dfn export for=Document>run the resize steps</dfn> for a {{Docume
 
     This section integrates with the [[#scrolling-events|Scrolling events]].
 
-    Each {{Document}} associates each of its
-    <a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
-    with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
-    <dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
+    Each
+    <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+    associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most
+    one <dfn>snapchangingTargetInline</dfn> in the block and inline axes
+    respectively.
 
-    Each {{Document}} associates each of its
-    <a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
-    with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
-    <dfn>snapchangedTargetInline</dfn> in the block and inline axes respectively.
+    Each
+    <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
+    associated with at most one <dfn>snapchangedTargetBlock</dfn> and at most
+    one <dfn>snapchangedTargetInline</dfn> in the block and inline axes
+    respectively.
 
     When asked to <dfn export for=Document>update snapchanging targets</dfn>
     for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run these steps:
+    |snapcontainer|, run these steps:
 
-    1. Let <var>doc</var> be the snap container's associated {{Document}}.
+    1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
     1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
-        all pending scroll updates to the snap container.
-    1. Let <var>blockTarget</var> be the
-        <a>snapchangingTargetBlock</a> that <var>doc</var> associates with the snap
-        container.
-    1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that
-        <var>doc</var> associates with the snap container.
-    1. Let <var>newBlockTarget</var> be the element that the UA would snap the snap
-        container to from <var>scrollPosition</var> (or null if it would not snap to
-        any element) along the block axis.
-    1. Let <var>newInlineTarget</var> be the element that the UA would snap the snap
-        container to from <var>scrollPosition</var> (or null if it would not snap to
-        any element) along the inline axis.
+        all pending scroll updates to |snapcontainer|.
+    1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
+        associated with |snapcontainer|.
+    1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
+        associated with |snapcontainer|.
+    1. Let <var>newBlockTarget</var> be the element that the UA would snap
+        |snapcontainer| to from <var>scrollPosition</var> (or null if it would not
+        snap to any element) along the block axis.
+    1. Let <var>newInlineTarget</var> be the element that the UA would snap
+        |snapcontainer| to from <var>scrollPosition</var> (or null if it would not
+        snap to any element) along the inline axis.
     1. If <var>newBlockTarget</var> is not the same element as
         <var>blockTarget</var>:
-
-        1. Set <var>doc</var>'s <a>snapchangingTargetBlock</a> for the snap container
-            to <var>newBlockTarget</var>.
-        1. Append the snap container to <var>doc</var>'s
-            <a>pending snapchanging event targets</a>
-
+        1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
+            <var>newBlockTarget</var>.
+        1. If |snapcontainer| is not already in <var>doc</var>'s
+            <a>pending snapchanging event targets</a>,
+            1. Append |snapcontainer| to <var>doc</var>'s
+                <a>pending snapchanging event targets</a>
     1. If <var>newInlineTarget</var> is not the same element as
         <var>inlineTarget</var>:
-        1. Set <var>doc</var>'s <a>snapchangingTargetInline</a> for the snap container
-            to <var>newInlineTarget</var>.
-        1. Append the snap container to <var>doc</var>'s
-            <a>pending snapchanging event targets</a>
+        1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
+            <var>newInlineTarget</var>.
+        1. If |snapcontainer| is not already in <var>doc</var>'s
+            <a>pending snapchanging event targets</a>,
+            1. Append |snapcontainer| to <var>doc</var>'s
+                <a>pending snapchanging event targets</a>.
 
     When asked to <dfn export for=Document>update snapchanged targets</dfn>
     for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run these steps:
+    |snapcontainer|, run these steps:
 
-    1. Let <var>doc</var> be the
-        <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
-        associated {{Document}}.
-    1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> that
-        <var>doc</var> associates with the snap container.
-    1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> that
-        <var>doc</var> associates	with the snap container.
+    1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
+    1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
+         with |snapcontainer|.
+    1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
+         with |snapcontainer|.
     1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
-        that <var>doc</var> associates  with the snap container.
+         associated with |snapcontainer|.
     1. Let <var>inlineSnapchangingTarget</var> be the
-        <a>snapchangingTargetInline</a> that <var>doc</var> associates with the snap
-        container.
+         <a>snapchangingTargetInline</a> associated with |snapcontainer|.
     1. If <var>blockTarget</var> is not the same element as
-        <var>blockSnapchangingTarget</var>:
-        1. Set <var>doc</var>'s <a>snapchangedTargetBlock</a> for the snap container
-            to <var>blockSnapchangingTarget</var>.
-        2. Append the snap container to <var>doc</var>'s
-            <a>pending snapchanged event targets</a>.
+         <var>blockSnapchangingTarget</var>:
+        1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
+             <var>blockSnapchangingTarget</var>.
+        1. If |snapcontainer| is not already in <var>doc</var>'s
+             <a>pending snapchanged event targets</a>.
+            1. Append |snapcontainer| to <var>doc</var>'s
+                <a>pending snapchanged event targets</a>.
     1. If <var>inlineTarget</var> is not the same element as
             <var>inlineSnapchangingTarget</var>:
-        1. Set <var>doc</var>'s <a>snapchangedTargetInline</a> for the snap container
-            to <var>inlineSnapchangingTarget</var>.
-        2. Append the snap container to <var>doc</var>'s
+        1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
+            <var>inlineSnapchangingTarget</var>.
+        1. If |snapcontainer| is not already in <var>doc</var>'s
             <a>pending snapchanged event targets</a>.
+            1. Append |snapcontainer| to <var>doc</var>'s
+                <a>pending snapchanged event targets</a>.
 
 <h3 id=scrolling-events>Scrolling</h3>
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1939,10 +1939,10 @@ When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Docume
 1. For each item <var>target</var> in <var>doc</var>'s
     <a>pending snapchanging event targets</a>:
 
-    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanging|snapchanging]] whose {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} are the <a spec=css-scroll-snap-2 lt="snapchangingTargetBlock">snapchangingTargetBlock</a> and the
-        <a spec=css-scroll-snap-2 lt="snapchangingTargetInline">snapchangingTargetInline</a>, respectively, that <var>doc</var>
-        associates with <var>target</var>.
+    1. Fire a {{SnapEvent}}, |snapevent|, named <a spec=css-scroll-snap-2 event>snapchanging</a> at <var>target</var> and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+        {{SnapEvent/snapTargetInline}} attributes be the <a spec=css-scroll-snap-2 lt="snapchangingTargetBlock">snapchangingTargetBlock</a> and the
+        <a spec=css-scroll-snap-2 lt="snapchangingTargetInline">snapchangingTargetInline</a>, respectively, that are
+        associated with <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
@@ -1964,10 +1964,10 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s
     <a>pending snapchanged event targets</a>:
-    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanged|snapchanged]] whose {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} are the <a spec=css-scroll-snap-2 lt="snapchangedTargetBlock">snapchangedTargetBlock</a> and the
-        <a spec=css-scroll-snap-2 lt="snapchangedTargetInline">snapchangedTargetInline</a>, respectively, that <var>doc</var>
-        associates with <var>target</var>.
+    1. Fire a {{SnapEvent}}, |snapevent|, named <a spec=css-scroll-snap-2 event>snapchanged</a> at <var>target</var> and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+        {{SnapEvent/snapTargetInline}} attributes be the <a spec=css-scroll-snap-2 lt="snapchangedTargetBlock">snapchangedTargetBlock</a> and the
+        <a spec=css-scroll-snap-2 lt="snapchangedTargetInline">snapchangedTargetInline</a>, respectively, that are
+        associated with <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scrollend</a> that bubbles at <var>target</var>.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1938,13 +1938,14 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
-1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snap events</a> for <var>doc</var>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanging events</a> for <var>doc</var>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scroll</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scroll</a> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll event targets</a>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanged events</a> for <var>doc</var>.
 
 Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent must run these steps:
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1907,15 +1907,11 @@ Each {{Document}} has an associated list of <dfn for=Document>pending scroll eve
 
 Each {{Document}} has an associated list of <dfn for=Document>pending scrollend event targets</dfn>, initially empty.
 
-Each {{Document}} has an associated list of <dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.
-
-Each {{Document}} has an associated list of <dfn export for=Document>pending snapchanged event targets</dfn>, initially empty.
-
 Whenever a <a>viewport</a> gets scrolled (whether in response to user interaction or by an API), the user agent must run these steps:
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
 1. If <var>doc</var> is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for <var>doc</var>
+    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for <var>doc</var>.
 1. If <var>doc</var> is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append <var>doc</var> to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1923,7 +1919,7 @@ Whenever an element gets scrolled (whether in response to user interaction or by
 
 1. Let <var>doc</var> be the element's <a>node document</a>.
 1. If the element is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> steps for the element.
+    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for the element.
 1. If the element is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append the element to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1937,13 +1933,13 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
 1. For each item <var>target</var> in <var>doc</var>'s
-    <a>pending snapchanging event targets</a>:
+    <a spec="css-scroll-snap-2" lt="pending snapchanging event targets">pending snapchanging event targets</a>:
 
     1. Fire a {{SnapEvent}}, |snapevent|, named <a spec=css-scroll-snap-2 event>snapchanging</a> at <var>target</var> and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
         {{SnapEvent/snapTargetInline}} attributes be the <a spec=css-scroll-snap-2 lt="snapchangingTargetBlock">snapchangingTargetBlock</a> and the
         <a spec=css-scroll-snap-2 lt="snapchangingTargetInline">snapchangingTargetInline</a>, respectively, that are
         associated with <var>target</var>.
-1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
+1. Empty <var>doc</var>'s <a spec="css-scroll-snap-2" lt="pending snapchanging event targets">pending snapchanging event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
@@ -1962,13 +1958,6 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, |snapcontainer|, run the <a spec=css-scroll-snap-2 lt="update snapchanged targets">update snapchanged targets</a> steps for |snapcontainer|.
     1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
-1. For each item <var>target</var> in <var>doc</var>'s
-    <a>pending snapchanged event targets</a>:
-    1. Fire a {{SnapEvent}}, |snapevent|, named <a spec=css-scroll-snap-2 event>snapchanged</a> at <var>target</var> and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be the <a spec=css-scroll-snap-2 lt="snapchangedTargetBlock">snapchangedTargetBlock</a> and the
-        <a spec=css-scroll-snap-2 lt="snapchangedTargetInline">snapchangedTargetInline</a>, respectively, that are
-        associated with <var>target</var>.
-1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scrollend</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1899,6 +1899,81 @@ When asked to <dfn export for=Document>run the resize steps</dfn> for a {{Docume
     <a attribute for=VisualViewport>width</a>, or <a attribute for=VisualViewport>height</a> properties changed since
     the last time these steps were run, <a>fire an event</a> named <a event>resize</a> at the {{VisualViewport}}.
 
+<h3 id=snap-events>Snap Events</h3>
+
+    This section integrates with the [[#scrolling-events|Scrolling events]].
+
+    Each {{Document}} associates each of its
+    <a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
+    with at most one <dfn>snapchangingTargetBlock</dfn> and at most one
+    <dfn>snapchangingTargetInline</dfn> in the block and inline axes respectively.
+
+    Each {{Document}} associates each of its
+    <a spec=css-scroll-snap lt="scroll snap container">snap containers</a>
+    with at most one <dfn>snapchangedTargetBlock</dfn> and at most one
+    <dfn>snapchangedTargetInline</dfn> in the block and inline axes respectively.
+
+    When asked to <dfn export for=Document>update snapchanging targets</dfn>
+    for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+    run these steps:
+
+    1. Let <var>doc</var> be the snap container's associated {{Document}}.
+    1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
+        all pending scroll updates to the snap container.
+    1. Let <var>blockTarget</var> be the
+        <a>snapchangingTargetBlock</a> that <var>doc</var> associates with the snap
+        container.
+    1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that
+        <var>doc</var> associates with the snap container.
+    1. Let <var>newBlockTarget</var> be the element that the UA would snap the snap
+        container to from <var>scrollPosition</var> (or null if it would not snap to
+        any element) along the block axis.
+    1. Let <var>newInlineTarget</var> be the element that the UA would snap the snap
+        container to from <var>scrollPosition</var> (or null if it would not snap to
+        any element) along the inline axis.
+    1. If <var>newBlockTarget</var> is not the same element as
+        <var>blockTarget</var>:
+
+        1. Set <var>doc</var>'s <a>snapchangingTargetBlock</a> for the snap container
+            to <var>newBlockTarget</var>.
+        1. Append the snap container to <var>doc</var>'s
+            <a>pending snapchanging event targets</a>
+
+    1. If <var>newInlineTarget</var> is not the same element as
+        <var>inlineTarget</var>:
+        1. Set <var>doc</var>'s <a>snapchangingTargetInline</a> for the snap container
+            to <var>newInlineTarget</var>.
+        1. Append the snap container to <var>doc</var>'s
+            <a>pending snapchanging event targets</a>
+
+    When asked to <dfn export for=Document>update snapchanged targets</dfn>
+    for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+    run these steps:
+
+    1. Let <var>doc</var> be the
+        <a spec=css-scroll-snap lt="scroll snap container">snap container</a>'s
+        associated {{Document}}.
+    1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> that
+        <var>doc</var> associates with the snap container.
+    1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> that
+        <var>doc</var> associates	with the snap container.
+    1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
+        that <var>doc</var> associates  with the snap container.
+    1. Let <var>inlineSnapchangingTarget</var> be the
+        <a>snapchangingTargetInline</a> that <var>doc</var> associates with the snap
+        container.
+    1. If <var>blockTarget</var> is not the same element as
+        <var>blockSnapchangingTarget</var>:
+        1. Set <var>doc</var>'s <a>snapchangedTargetBlock</a> for the snap container
+            to <var>blockSnapchangingTarget</var>.
+        2. Append the snap container to <var>doc</var>'s
+            <a>pending snapchanged event targets</a>.
+    1. If <var>inlineTarget</var> is not the same element as
+            <var>inlineSnapchangingTarget</var>:
+        1. Set <var>doc</var>'s <a>snapchangedTargetInline</a> for the snap container
+            to <var>inlineSnapchangingTarget</var>.
+        2. Append the snap container to <var>doc</var>'s
+            <a>pending snapchanged event targets</a>.
 
 <h3 id=scrolling-events>Scrolling</h3>
 
@@ -1908,15 +1983,23 @@ Each {{Document}} has an associated list of <dfn for=Document>pending scroll eve
 
 Each {{Document}} has an associated list of <dfn for=Document>pending scrollend event targets</dfn>, initially empty.
 
+Each {{Document}} has an associated list of <dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.
+
+Each {{Document}} has an associated list of <dfn export for=Document>pending snapchanged event targets</dfn>, initially empty.
+
 Whenever a <a>viewport</a> gets scrolled (whether in response to user interaction or by an API), the user agent must run these steps:
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
+1. If <var>doc</var> is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+    run the <a>update snapchanging targets</a> steps for <var>doc</var>.
 1. If <var>doc</var> is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append <var>doc</var> to <var>doc</var>'s <a>pending scroll event targets</a>.
 
 Whenever an element gets scrolled (whether in response to user interaction or by an API), the user agent must run these steps:
 
 1. Let <var>doc</var> be the element's <a>node document</a>.
+1. If the element is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
+    run the <a>update snapchanging targets</a> steps for the element.
 1. If the element is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append the element to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1929,6 +2012,14 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
+1. For each item <var>target</target> in <var>doc</var>'s
+    <a>pending snapchanging event targets</a>:
+
+    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanging|snapchanging]] whose {{snapTargetBlock}} and
+        {{snapTargetInline}} are the <a>snapchangingTargetBlock</a> and the
+        <a>snapchangingTargetInline</a>, respectively, that <var>doc</var>
+        associates with <var>target</var>.
+1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
@@ -1944,8 +2035,16 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>box</var> belongs to a <a>viewport</a>, let <var>doc</var> be the <a>viewport’s</a> associated {{Document}} and <var>target</var> be the <a>viewport</a>.
         If <var>box</var> belongs to a {{VisualViewport}}, let <var>doc</var> be the {{VisualViewport}}'s <a for=visualviewport>associated document</a> and <var>target</var>
         be the {{VisualViewport}}. Otherwise, <var>box</var> belongs to an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
+    1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, run the <a>update snapchanged targets</a> steps for that snap container.
     1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
+1. For each item <var>target</var> in <var>doc</var>'s
+    <a>pending snapchanged event targets</a>:
+    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanged|snapchanged]] whose {{snapTargetBlock}} and
+        {{snapTargetInline}} are the <a>snapchangedTargetBlock</a> and the
+        <a>snapchangedTargetInline</a>, respectively, that <var>doc</var>
+        associates with <var>target</var>.
+1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scrollend</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1899,86 +1899,6 @@ When asked to <dfn export for=Document>run the resize steps</dfn> for a {{Docume
     <a attribute for=VisualViewport>width</a>, or <a attribute for=VisualViewport>height</a> properties changed since
     the last time these steps were run, <a>fire an event</a> named <a event>resize</a> at the {{VisualViewport}}.
 
-<h3 id=snap-events>Snap Events</h3>
-
-    This section integrates with the [[#scrolling-events|Scrolling events]].
-
-    Each
-    <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-    associated with at most one <dfn>snapchangingTargetBlock</dfn> and at most
-    one <dfn>snapchangingTargetInline</dfn> in the block and inline axes
-    respectively.
-
-    Each
-    <a spec=css-scroll-snap lt="scroll snap container">snap container</a> is
-    associated with at most one <dfn>snapchangedTargetBlock</dfn> and at most
-    one <dfn>snapchangedTargetInline</dfn> in the block and inline axes
-    respectively.
-
-    When asked to <dfn export for=Document>update snapchanging targets</dfn>
-    for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    |snapcontainer|, run these steps:
-
-    1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-    1. Let <var>scrollPosition</var> be the scroll offset resulting from applying
-        all pending scroll updates to |snapcontainer|.
-    1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
-        associated with |snapcontainer|.
-    1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
-        associated with |snapcontainer|.
-    1. Let <var>newBlockTarget</var> be the element that the UA would snap
-        |snapcontainer| to from <var>scrollPosition</var> (or null if it would not
-        snap to any element) along the block axis.
-    1. Let <var>newInlineTarget</var> be the element that the UA would snap
-        |snapcontainer| to from <var>scrollPosition</var> (or null if it would not
-        snap to any element) along the inline axis.
-    1. If <var>newBlockTarget</var> is not the same element as
-        <var>blockTarget</var>:
-        1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
-            <var>newBlockTarget</var>.
-        1. If |snapcontainer| is not already in <var>doc</var>'s
-            <a>pending snapchanging event targets</a>,
-            1. Append |snapcontainer| to <var>doc</var>'s
-                <a>pending snapchanging event targets</a>
-    1. If <var>newInlineTarget</var> is not the same element as
-        <var>inlineTarget</var>:
-        1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
-            <var>newInlineTarget</var>.
-        1. If |snapcontainer| is not already in <var>doc</var>'s
-            <a>pending snapchanging event targets</a>,
-            1. Append |snapcontainer| to <var>doc</var>'s
-                <a>pending snapchanging event targets</a>.
-
-    When asked to <dfn export for=Document>update snapchanged targets</dfn>
-    for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    |snapcontainer|, run these steps:
-
-    1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-    1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
-         with |snapcontainer|.
-    1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
-         with |snapcontainer|.
-    1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
-         associated with |snapcontainer|.
-    1. Let <var>inlineSnapchangingTarget</var> be the
-         <a>snapchangingTargetInline</a> associated with |snapcontainer|.
-    1. If <var>blockTarget</var> is not the same element as
-         <var>blockSnapchangingTarget</var>:
-        1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
-             <var>blockSnapchangingTarget</var>.
-        1. If |snapcontainer| is not already in <var>doc</var>'s
-             <a>pending snapchanged event targets</a>.
-            1. Append |snapcontainer| to <var>doc</var>'s
-                <a>pending snapchanged event targets</a>.
-    1. If <var>inlineTarget</var> is not the same element as
-            <var>inlineSnapchangingTarget</var>:
-        1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
-            <var>inlineSnapchangingTarget</var>.
-        1. If |snapcontainer| is not already in <var>doc</var>'s
-            <a>pending snapchanged event targets</a>.
-            1. Append |snapcontainer| to <var>doc</var>'s
-                <a>pending snapchanged event targets</a>.
-
 <h3 id=scrolling-events>Scrolling</h3>
 
 This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
@@ -1995,7 +1915,7 @@ Whenever a <a>viewport</a> gets scrolled (whether in response to user interactio
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
 1. If <var>doc</var> is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the <a>update snapchanging targets</a> steps for <var>doc</var>.
+    run the <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for <var>doc</var>
 1. If <var>doc</var> is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append <var>doc</var> to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -2003,7 +1923,7 @@ Whenever an element gets scrolled (whether in response to user interaction or by
 
 1. Let <var>doc</var> be the element's <a>node document</a>.
 1. If the element is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the <a>update snapchanging targets</a> steps for the element.
+    run the <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> steps for the element.
 1. If the element is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append the element to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -2016,12 +1936,12 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
-1. For each item <var>target</target> in <var>doc</var>'s
+1. For each item <var>target</var> in <var>doc</var>'s
     <a>pending snapchanging event targets</a>:
 
-    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanging|snapchanging]] whose {{snapTargetBlock}} and
-        {{snapTargetInline}} are the <a>snapchangingTargetBlock</a> and the
-        <a>snapchangingTargetInline</a>, respectively, that <var>doc</var>
+    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanging|snapchanging]] whose {{SnapEvent/snapTargetBlock}} and
+        {{SnapEvent/snapTargetInline}} are the <a spec=css-scroll-snap-2 lt="snapchangingTargetBlock">snapchangingTargetBlock</a> and the
+        <a spec=css-scroll-snap-2 lt="snapchangingTargetInline">snapchangingTargetInline</a>, respectively, that <var>doc</var>
         associates with <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
@@ -2039,14 +1959,14 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>box</var> belongs to a <a>viewport</a>, let <var>doc</var> be the <a>viewport’s</a> associated {{Document}} and <var>target</var> be the <a>viewport</a>.
         If <var>box</var> belongs to a {{VisualViewport}}, let <var>doc</var> be the {{VisualViewport}}'s <a for=visualviewport>associated document</a> and <var>target</var>
         be the {{VisualViewport}}. Otherwise, <var>box</var> belongs to an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
-    1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, run the <a>update snapchanged targets</a> steps for that snap container.
+    1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, |snapcontainer|, run the <a spec=css-scroll-snap-2 lt="update snapchanged targets">update snapchanged targets</a> steps for |snapcontainer|.
     1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s
     <a>pending snapchanged event targets</a>:
-    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanged|snapchanged]] whose {{snapTargetBlock}} and
-        {{snapTargetInline}} are the <a>snapchangedTargetBlock</a> and the
-        <a>snapchangedTargetInline</a>, respectively, that <var>doc</var>
+    1. Fire a {{SnapEvent}} named [[css-scroll-snap-2#snapchanged|snapchanged]] whose {{SnapEvent/snapTargetBlock}} and
+        {{SnapEvent/snapTargetInline}} are the <a spec=css-scroll-snap-2 lt="snapchangedTargetBlock">snapchangedTargetBlock</a> and the
+        <a spec=css-scroll-snap-2 lt="snapchangedTargetInline">snapchangedTargetInline</a>, respectively, that <var>doc</var>
         associates with <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1911,7 +1911,10 @@ Whenever a <a>viewport</a> gets scrolled (whether in response to user interactio
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
 1. If <var>doc</var> is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for <var>doc</var>.
+    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a>
+    for <var>doc</var> with <var>doc</var>'s <a spec="css-scroll-snap-2">eventual snap target</a> in the block axis
+    as newBlockTarget and <var>doc</var>'s <a spec="css-scroll-snap-2">eventual snap target</a> in the inline axis
+    as newInlineTarget.
 1. If <var>doc</var> is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append <var>doc</var> to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1919,7 +1922,10 @@ Whenever an element gets scrolled (whether in response to user interaction or by
 
 1. Let <var>doc</var> be the element's <a>node document</a>.
 1. If the element is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a> for the element.
+    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a>
+    for the element with the element's <a spec="css-scroll-snap-2">eventual snap target</a> in the block axis
+    as newBlockTarget and the element's <a spec="css-scroll-snap-2">eventual snap target</a> in the inline axis
+    as newInlineTarget.
 1. If the element is already in <var>doc</var>'s <a>pending scroll event targets</a>, abort these steps.
 1. Append the element to <var>doc</var>'s <a>pending scroll event targets</a>.
 
@@ -1932,14 +1938,7 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
-1. For each item <var>target</var> in <var>doc</var>'s
-    <a spec="css-scroll-snap-2" lt="pending snapchanging event targets">pending snapchanging event targets</a>:
-
-    1. Fire a {{SnapEvent}}, |snapevent|, named <a spec=css-scroll-snap-2 event>snapchanging</a> at <var>target</var> and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be the <a spec=css-scroll-snap-2 lt="snapchangingTargetBlock">snapchangingTargetBlock</a> and the
-        <a spec=css-scroll-snap-2 lt="snapchangingTargetInline">snapchangingTargetInline</a>, respectively, that are
-        associated with <var>target</var>.
-1. Empty <var>doc</var>'s <a spec="css-scroll-snap-2" lt="pending snapchanging event targets">pending snapchanging event targets</a>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snap events</a> for <var>doc</var>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
@@ -1955,9 +1954,11 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>box</var> belongs to a <a>viewport</a>, let <var>doc</var> be the <a>viewport’s</a> associated {{Document}} and <var>target</var> be the <a>viewport</a>.
         If <var>box</var> belongs to a {{VisualViewport}}, let <var>doc</var> be the {{VisualViewport}}'s <a for=visualviewport>associated document</a> and <var>target</var>
         be the {{VisualViewport}}. Otherwise, <var>box</var> belongs to an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
-    1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, |snapcontainer|, run the <a spec=css-scroll-snap-2 lt="update snapchanged targets">update snapchanged targets</a> steps for |snapcontainer|.
+    1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, |snapcontainer|,
+        run the <a spec=css-scroll-snap-2 lt="update snapchanged targets">update snapchanged targets</a> steps for |snapcontainer|.
     1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanged targets</a> for <var>doc</var>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scrollend</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.


### PR DESCRIPTION
SnapEvent defines the interface of scroll-snap-related JavaScript events, snapchanged and snapchanging.
