### PR TITLE
[css-view-transitions-2] Add note about UA transitions

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -466,6 +466,9 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
 		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and |onReady|, which is an algorithm accepting nothing:
 
+		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
+			the user agent may ignore the author-defined view transition. If that is the case, return.
+
 		1. If |navigationType| is {{NavigationType/reload}}, then return.
 
 		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as


### PR DESCRIPTION
As per the resolution, UAs may skip author view-transition if the UA provides its own transition or other navigation experience.

Closes #8953 