### PR TITLE
[css-counter-styles-3][editorial] Add the preferred name for Oriya

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -1438,7 +1438,7 @@ Numeric: ''decimal'', ''decimal-leading-zero'', ''arabic-indic'', ''armenian'', 
 
 		<dt><dfn>oriya</dfn>
 		<dd>
-			Oriya numbering
+			Oriya (Odia) numbering
 			(e.g., ୧, ୨, ୩, ..., ୯୮, ୯୯, ୧୦୦).
 
 		<dt><dfn>persian</dfn>


### PR DESCRIPTION
Odia is now the preferred name in English.

Ref:

* https://www.omniglot.com/writing/oriya.htm
* https://www.unicode.org/L2/L2012/12380-odia-naming.pdf
* https://en.wikipedia.org/wiki/Odia_language