### PR TITLE
[css-color-4] Fix LCH alpha interpolation example

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4867,7 +4867,7 @@ Interpolating with Alpha</h3>
 		along the ''shorter'' hue arc (the default) would be
 		[29.4365% 40.563 31.82]
 		which, with an alpha value of 0.5,
-		is <span class="swatch" style="--color: rgb(83.918% 44.583% 0% / 0.5)"></span>  lch(58.873% 81.126 31.82) / 0.5)
+		is <span class="swatch" style="--color: rgb(99.344% 28.029% 28.277% / 0.5)"></span>  lch(58.873% 81.126 31.82) / 0.5)
 		when premultiplication is undone.
 
 	</div>

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4867,7 +4867,7 @@ Interpolating with Alpha</h3>
 		along the ''shorter'' hue arc (the default) would be
 		[29.4365% 40.563 31.82]
 		which, with an alpha value of 0.5,
-		is <span class="swatch" style="--color: rgb(83.918% 44.583% 0% / 0.5)"></span>  lch(58.873% 81.126 63.64) / 0.5)
+		is <span class="swatch" style="--color: rgb(83.918% 44.583% 0% / 0.5)"></span>  lch(58.873% 81.126 31.82) / 0.5)
 		when premultiplication is undone.
 
 	</div>


### PR DESCRIPTION
The example LCH interpolation with premultiplied alpha at https://www.w3.org/TR/css-color-4/#ex-premultiplied-lch un-premultiplies the hue component, which I believe is wrong according to:

> To obtain a color value from a premultipled color value ... each component which had been premultiplied is divided by the interpolated alpha value.