### PR TITLE
[css-position-3] Fix broken refs to property value ranges

### DIFF
--- a/css-position-3/Overview.bs
+++ b/css-position-3/Overview.bs
@@ -540,7 +540,7 @@ Box Insets Shorthands: the 'inset-block', 'inset-inline', and 'inset' properties
 
 	<pre class="propdef">
 	Name: inset-block, inset-inline
-	Value: <'top'>{1,2}
+	Value: <<'top'>>{1,2}
 	Initial: auto
 	Applies to: positioned elements
 	Inherited: no
@@ -560,7 +560,7 @@ Box Insets Shorthands: the 'inset-block', 'inset-inline', and 'inset' properties
 
 	<pre class="propdef">
 	Name: inset
-	Value: <'top'>{1,4}
+	Value: <<'top'>>{1,4}
 	Initial: auto
 	Applies to: positioned elements
 	Inherited: no


### PR DESCRIPTION
Editorial. 

`<'top'>` in source produces `<top>` (CSS type) instead of `<'top'>` (CSS property value range) in output, so it should be `<<'top'>>` in source.