### PR TITLE
[css-images-4] Allow omitting resolution/type in image-set()

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -189,7 +189,7 @@ Resolution/Type Negotiation: the ''image-set()'' notation {#image-set-notation}
 	<pre class='prod'>
 	<<image-set()>> = image-set( <<image-set-option>># )
 	<dfn>&lt;image-set-option></dfn> = [ <<image>> | <<string>> ]
-	                     [ <<resolution>> || type(<<string>>) ]
+	                     [ <<resolution>> || type(<<string>>) ]?
 	</pre>
 
 	Issue: We should add "w" and "h" dimensions as a possibility


### PR DESCRIPTION
Editorial.

  > Each `<image-set-option>` defines a possible image [...] composed of three parts:
  >
  > - An image reference (required) [...]
  > - A `<resolution>` **(optional)** [...]
  > - A `type( <string> )` function **(optional)** [...]

But currently optional parts are not optionals:

  > `<image-set-option> = [ <image> | <string> ] [ <resolution> || type(<string>) ]`