### PR TITLE
[css-values-5] Minor syntax fixes

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -596,7 +596,9 @@ Toggling Between Values: ''toggle()''</h3>
 
 	The syntax of the ''toggle()'' expression is:
 
-	<pre>toggle( <<whole-value>> [ ';' <<whole-value>> ]+ )</pre>
+	<pre class=prod>
+		<dfn><<toggle()>></dfn> = toggle( <<whole-value>> [ ';' <<whole-value>> ]+ )
+	</pre>
 
 	Note: This [=functional notation=] uses semicolons to separate arguments
 	rather than the more typical comma
@@ -980,7 +982,7 @@ Generating a Random Numeric Value: the ''random()'' function</h3>
 	optionally limiting the possible values to a step between those limits:
 
 	<pre class=prod>
-	&lt;random()> = random( <<random-caching-options>>? , <<calc-sum>>, <<calc-sum>>, [by <<calc-sum>>]? );
+	&lt;random()> = random( <<random-caching-options>>? , <<calc-sum>>, <<calc-sum>>, [by <<calc-sum>>]? )
 
 	<dfn><<random-caching-options>></dfn> = <<dashed-ident>> || per-element
 	</pre>
@@ -1142,7 +1144,7 @@ Picking a Random Item From a List: the ''random-item()'' function</h3>
 	from among its list of items.
 
 	<pre class=prod>
-	&lt;random-item()> = random-item( <<random-caching-options>> ';' <<any-value>> [ ';' <<any-value>> ]* )
+	&lt;random-item()> = random-item( <<random-caching-options>> ';' <<declaration-value>>? [ ';' <<declaration-value>>? ]* )
 	</pre>
 
 	The <em>required</em> <<random-caching-options>>
@@ -1178,7 +1180,7 @@ Picking a Random Item From a List: the ''random-item()'' function</h3>
 	but optional in ''random()'',
 	both for parsing reasons
 	(it's impossible to tell whether ''random-item(--foo; --bar; --baz)''
-	has three <<any-value>> arguments
+	has three <<declaration-value>> arguments
 	or two and a <<random-caching-options>> argument),
 	and because accidentally associating the random generation of ''random-item()'' functions together
 	is much easier to do accidentally,


### PR DESCRIPTION
Fixes #8384.

- defines `toggle()` in a production rule
- removes the trailing semicolon in `random()` production
- replaces `<any-value> ; ...`/`<declaration-value> ; ...` with `<declaration-value>? ; ...` since `<any-value>` eats semicolons, and custom properties accept empty inputs