### PR TITLE
[css-view-transitions-2] Tighten view-transition rule resolving

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -305,8 +305,8 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 	<pre class='descdef'>
 	Name: type
 	For: @view-transition
-	Value: <<custom-ident>>*
-	Initial: an empty list
+	Value: none | <<custom-ident>>*
+	Initial: none
 	</pre>
 
 	The '<dfn for="@view-transition">type</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
@@ -453,11 +453,19 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 	<div algorithm>
 		To get the <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
 
-		1. Let |matchingRule| be the last ''@view-transition'' rule in |document| which has a ''@view-transition/navigation'' descriptor whose [=computed value=] is ''@view-transition/navigation/auto''.
+		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
 
-		1. If |matchingRule| is not found, then return "<code>not found</code>".
+		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
 
-		1. Return a [=list=] of strings corresponding to that descriptor's [=computed value=].
+		1. If |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/none'', then return "<code>skip transition</code>".
+
+		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
+
+		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/type=] descriptor.
+
+		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return an [=empty list=].
+
+		1. Return a [=list=] of strings corresponding to |typesDescriptor|'s [=computed value=].
 	</div>
 
 ### Setting up the view-transition in the old {{Document}}
@@ -482,7 +490,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. [=Resolve @view-transition rule=] for |oldDocument| and let |resolvedRule| be the result.
 
-		1. If |resolvedRule| is "<code>not found</code>", then call |onReady| and return.
+		1. If |resolvedRule| is "<code>skip transition</code>", then call |onReady| and return.
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when it is [=reveal=].
@@ -549,7 +557,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. [=Resolve @view-transition rule=] for |document| and let |resolvedRule| be the result.
 
-		1. If |resolvedRule| is "<code>not found</code>", then [=skip the view transition|skip=] |transition| and return null.
+		1. If |resolvedRule| is "<code>skip transition</code>", then [=skip the view transition|skip=] |transition| and return null.
 
 		1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
 


### PR DESCRIPTION
- `types: none` should resolve to having no types
- `navigation: none` should always skip transition.

Closes #9534
