### PR TITLE
[css-cascade-5] page and view-transition at rules should cascade

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1253,6 +1253,11 @@ Cascade Layers</h3>
 	that are defined inside [=cascade layers=]
 	also use the layer order when resolving name collisions.
 
+	Other [=at-rules=] which rely on [=cascading=]
+	such as ''@page'' or ''@view-transition''
+	that are defined inside [=cascade layers=]
+	also use the layer order when determining order and [=specificity=].
+
 	<div class="example">
 		For example,
 		authors could override the animation from a framework,


### PR DESCRIPTION
Mention that `@view-transition` and `@page` at-rules respect CSS layer when computing order/specificity.

Closes #9601