### PR TITLE
[css-view-transitions-2] UA may apply implementation-defined timeout o cross-document view transition

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -517,16 +517,24 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 					We explicitly clear it here since the old Document may be cached by the UA.
 
 			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
-				to perform the following step:
+				to perform the following steps:
 
-				1. Let |newDocument|'s [=active view transition=] be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
+				1. Let |inboundTransition| be a new {{ViewTransition}} in |newDocument|'s [=relevant Realm=],
 					whose [=ViewTransition/named elements=] is |outboundTransition|'s [=ViewTransition/named elements=],
 					[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
 					and whose [=ViewTransition/is inbound cross-document transition=] is true.
 
-				1. [=Call the update callback=] for |newDocument|'s [=active view transition=].
+				1. Let |newDocument|'s [=active view transition=] be |inboundTransition|.
+
+				1. [=Call the update callback=] for |inboundTransition|.
 
 				1. Call |onReady|.
+
+				1. At any given time, the UA may decide to skip |inboundTransition|, e.g. after an implementation-defined timeout, by running the following steps:
+
+					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
+
+					1. [=Skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
 			Note: |outboundTransition| is not exposed to JavaScript, it is used only for capturing
 			the state of the old document.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -530,11 +530,9 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 				1. Call |onReady|.
 
-				1. At any given time, the UA may decide to skip |inboundTransition|, e.g. after an implementation-defined timeout, by running the following steps:
-
-					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
-
-					1. [=Skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+				1. At any given time, the UA may decide to skip |inboundTransition|, e.g. after an [=implementation-defined=] timeout.
+					To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
+						If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
 			Note: |outboundTransition| is not exposed to JavaScript, it is used only for capturing
 			the state of the old document.


### PR DESCRIPTION
As per CSSWG resolution.
Closes #9155
