### PR TITLE
[css-view-transitions-2] cross-document transition preceeds startViewTransition on outgoing page

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1947,7 +1947,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * The [=view transition tree=] is not exposed to accessibility tree. See <a href="https://github.com/w3c/csswg-drafts/issues/9365">issue 9365</a>.
 * Animate back-drop filter similar to transform/size. See <a href="https://github.com/w3c/csswg-drafts/issues/9358">issue 9358</a>.
 * Copy `color-scheme` from DOM element to ''::view-transition-group()''. See <a href="https://github.com/w3c/csswg-drafts/issues/9276">issue 9276</a>.
-
+* Expose [=auto-skip view transition=] for a {{Document}}, to allow having outbound cross-document transitions preceed programmatic view transiitons. see <a href="https://github.com/w3c/csswg-drafts/issues/9512">issue 9512</a>.
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>
 </h3>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -949,6 +949,23 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
+		1. If |document|'s [=auto-skip view transitions=] is true, then:
+
+		1. [=Queue a global task=] on the [=DOM manipulation task source=],
+			given |transition|'s [=relevant global object=],
+			to execute the following steps:
+
+			1. [=Call the update callback=] for |transition|.
+
+			1. [=Reject=] |transition|'s [=ViewTransition/ready promise=] with an "{{InvalidStateError}}" {{DOMException}}.
+
+			1. [=Mark as handled=] |transition|'s [=ViewTransition/ready promise=].
+
+			1. [=Resolve=] |transition|'s [=ViewTransition/finished promise=].
+
+			1. Return |transition|.
+
+
 		1. If |document|'s [=active view transition=] is not null,
 			then [=skip the view transition|skip that view transition=]
 			with an "{{AbortError}}" {{DOMException}} in [=this's=] [=relevant Realm=].
@@ -1142,6 +1159,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			with [=this=]'s [=document element=] is its [=originating element=].
 
 			Note: The position of the [=ViewTransition/transition root pseudo-element=] within the [=document element=] does not matter, as the [=ViewTransition/transition root pseudo-element=]'s [=containing block=] is the [=snapshot containing block=].
+
+		: <dfn export>auto-skip view transitions</dfn>
+		:: A boolean. Initially false.
 	</dl>
 
 ### Additions to Elements ### {#elements-concept}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -504,7 +504,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. Set |document|'s [=auto-skip view transitions=] to true.
 
-			Note: this means that calling {{Document/startViewTransition()}} while capturing the old document for a cross-document view-transition would fail.
+			Note: this means that calling {{Document/startViewTransition()}} while capturing the old document for a cross-document view-transition would run the callback but skip the animation.
 
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
 			whose [=ViewTransition/active types=] is |resolvedRule|, and whose [=ViewTransition/process old state captured=] is set to the following steps:

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -502,6 +502,10 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 			Note: this means that any running transition would be skipped when the document is ready
 			to unload.
 
+		1. Set |document|'s [=auto-skip view transitions=] to true.
+
+			Note: this means that calling {{Document/startViewTransition()}} while capturing the old document for a cross-document view-transition would fail.
+
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
 			whose [=ViewTransition/active types=] is |resolvedRule|, and whose [=ViewTransition/process old state captured=] is set to the following steps:
 
@@ -515,6 +519,8 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 				Note: The ViewTransition object on the old Document should be destroyed after its state has been copied to the new Document below.
 					We explicitly clear it here since the old Document may be cached by the UA.
+
+			1. Set |document|'s [=auto-skip view transitions=] to false.
 
 			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
 				to perform the following step:


### PR DESCRIPTION
When starting a transition in an old page and there's a capture ongoing for a cross-document view transition, the programatically-created transition is automatically skipped, calling its callback and resolving the promises on the next task. The `ready` promise is rejected.

As per resolution.
Closes #9512