### PR TITLE
[css-anchor-position-1] Re-create `anchor()` function definition

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -565,7 +565,7 @@ The ''anchor()'' Function {#anchor-pos}
 ---------------------------------------------------
 
 An [=absolutely-positioned=] element
-can use the ''anchor()'' function
+can use the <dfn>anchor()</dfn> function
 as a value in its [=inset properties=]
 to refer to the position of one or more [=anchor elements=].
 The ''anchor()'' function resolves to a <<length>>.


### PR DESCRIPTION
The definition was inadvertently dropped in:
https://github.com/w3c/csswg-drafts/commit/471d90fc0d0063bc267540266bb7adacbf013df2

Without the definition, Bikeshed links to the definition in the TR version of the spec, but that definition will disappear next time the spec is updated.
