### PR TITLE
[css-logical] Add `block-start` and `block-end` values to `caption-side` property

### DIFF
--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -204,11 +204,11 @@ Logical Values for the 'caption-side' Property</h3>
 
   <pre class="propdef partial">
     Name: caption-side
-    New values: inline-start | inline-end
+    New values: inline-start | inline-end | block-start | block-end
     Computed value: specified keyword
   </pre>
 
-  These two values are added only for implementations that support
+  These two inline values are added only for implementations that support
   ''caption-side/left'' and ''caption-side/right'' values for 'caption-side'.
   The ''caption-side/left'' and ''caption-side/right'' values themselves
   are defined to be <a>line-relative</a>.


### PR DESCRIPTION
While documenting the `caption-side` property on MDN we noticed that the flow-relative `block-start` and `block-end` values are not defined by any spec, although they are mentioned in the spec.

- [Cascading Style Sheets Level 2 Revision 2](https://drafts.csswg.org/css2/#propdef-caption-side) spec defines the `top` | `bottom` | `inherit` values.
- [CSS Logical Properties and Values Level 1](https://drafts.csswg.org/css-logical/#caption-side) spec defines the `inline-start` | `inline-end` values.

The `block-start` and `block-end` values are mentioned but not really defined in the spec.
