### PR TITLE
[css-view-transitions-2] Specificity of :active-view-transition()

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -218,6 +218,8 @@ It has the following syntax definition:
 	<dfn>&lt;vt-type-selector></dfn> = '*' | <<custom-ident>>#
 </pre>
 
+The [=specificity=] of an '':active-view-transition()'' is one pseudo-class selector if it has value is ''*'', and two if it has any other value.
+
 An ''::active-view-transition()'' pseudo-class matches the [=document element=] when it has an non-null [=active view transition=] |viewTransition|, for which any of the following are true:
 
 * The <<vt-type-selector>> is ''*''


### PR DESCRIPTION
As per resolution, specificity is 1 pseudo-class (if *) or 2 pseudo-classes (if a type ident)

Closes #9546

