### PR TITLE
[multi][editorial] Rewrite syntax with implicitly optional comma

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -970,7 +970,7 @@ layer.
 
 <pre class="propdef">
 Name: background
-Value: [<<bg-layer>># ,]? <<final-bg-layer>>
+Value: <<bg-layer>>#? , <<final-bg-layer>>
 Initial: see individual properties
 Applies to: all elements
 Inherited: no

--- a/css-easing-1/Overview.bs
+++ b/css-easing-1/Overview.bs
@@ -249,8 +249,8 @@ It has following syntax:
 <div class="prod">
   <dfn type>&lt;step-easing-function&gt;</dfn> =
   ''step-start'' | ''step-end'' |
-  <span class="atom"><a lt="steps()" function>steps</a>(<<integer>>[,
-    <<step-position>>]?)</span>
+  <span class="atom"><a lt="steps()" function>steps</a>(<<integer>> ,
+    <<step-position>>?)</span>
 
   <dfn type>&lt;step-position&gt;</dfn> =
     ''jump-start'' | ''jump-end'' |

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -563,8 +563,8 @@ It has following syntax:
 <div class="prod">
   <dfn type>&lt;step-easing-function&gt;</dfn> =
   ''step-start'' | ''step-end'' |
-  <span class="atom"><a lt="steps()" function>steps</a>(<<integer>>[,
-    <<step-position>>]?)</span>
+  <span class="atom"><a lt="steps()" function>steps</a>(<<integer>> ,
+    <<step-position>>?)</span>
 
   <dfn type>&lt;step-position&gt;</dfn> =
     ''jump-start'' | ''jump-end'' |

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -497,7 +497,7 @@ Supported Shapes</h3>
 
 		</dd>
 		<dt><dfn>path()</dfn> = 
-			path( [<<'fill-rule'>>,]? <<string>> )
+			path( <<'fill-rule'>>? , <<string>> )
 		</dt>
 		<dd dfn-type=value dfn-for="path()">
 			<ul>


### PR DESCRIPTION
Eg. rewrite `[<foo>,]? <bar>` as `<foo>? , <bar>`.

In case there is any doubt for `[<bg-layer># ,]? <final-bg-layer>`.

  > the `#` and `?` multipliers may be stacked as `#?`

https://drafts.csswg.org/css-values-4/#component-multipliers

---

**edit**

Hmm, actually there is currently a mismatch between...:

  > `<step-easing-function> = step-start | step-end | steps(<integer>[, <step-position>]?)`

... and:

  > **`steps(<integer>, <step-position>?)`:** The first parameter specifies the number of intervals [...]

This confuses `w3c/reffy`, which [extracts](https://github.com/w3c/webref/blob/4390fd492ed7ee4c100895c123ada1757f9568d9/ed/css/css-easing.json#L103) the latter whereas some contextual definitions like the latter may use an abstract syntax, eg. `pow(A, B)` instead of the formal syntax `pow(<calc-sum>, <calc-sum>)`.

Do you mind if I replace `steps(<integer>[, <step-position>]?)` with `<steps()>` in this PR or another one?