### PR TITLE
[css-values-4] Define function names as case-insensitive

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2902,6 +2902,7 @@ Functional Notations</h2>
 	(i.e. a <<function-token>>)
 	followed by the argument(s) to the notation
 	followed by a right parenthesis.
+	Like keywords, function names are [=ASCII case-insensitive=].
 	<a href="https://www.w3.org/TR/css-syntax/#whitespace">White space</a> is allowed, but optional,
 	immediately inside the parentheses.
 	Functions can take multiple arguments,


### PR DESCRIPTION
As far as I know, all function names are case-insensitive, but there is no specification that requires it.