### PR TITLE
[cssom-view] Add 'onmove' event handler for the Window object

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -732,7 +732,6 @@ The <dfn attribute for=Window caniuse=devicepixelratio>devicePixelRatio</dfn> at
 1. Let <var>device pixel size</var> be the vertical size of a device pixel of the output device.
 1. Return the result of dividing <var>CSS pixel size</var> by <var>device pixel size</var>.
 
-
 <h3 id=the-features-argument-to-the-open()-method>The <var ignore>features</var> argument to the {{Window/open()}} method</h3>
 
 HTML defines the {{Window/open()}} method. This section defines behavior for position and size given
@@ -1003,6 +1002,16 @@ Note: The {{colorDepth}} and {{pixelDepth}} attributes return the same value for
 compatibility reasons.
 
 Note: Some non-conforming implementations are known to return 32 instead of 24.
+
+<h2 id=extensions-to-the-windoweventhandlers-interface>Extensions to the {{WindowEventHandlers}} Interface</h3>
+
+<pre class=idl>
+partial interface WindowEventHandlers {
+    attribute EventHandler onmove;
+};
+</pre>
+
+<dfn attribute for=Window>onmove</dfn> is the <a>event handler IDL attribute</a> for the <a event>move</a> event.
 
 
 <h2 id=extensions-to-the-document-interface>Extensions to the {{Document}} Interface</h2>
@@ -1933,6 +1942,22 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scrollend event targets</a>.
 
+<h3 id=moving-viewports>Moving viewports</h3>
+
+This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
+
+When <a for=/>updating the rendering</a>, after running the scroll steps:
+
+1. For each fully active Document in docs, <dfn export for=Document>run the move steps</dfn> for that Document.
+
+When asked to <a>run the move steps</a> for a {{Document}} <var>doc</var>, run these steps:
+
+1. If <var>doc</var>'s client window has had its position relative to the <a>Web-exposed screen area</a> changed
+    (e.g. as a result of the user moving the browser window)
+    since the last time these steps were run,
+    <a>fire an event</a> named <a event>move</a>
+    at the {{Window}} object associated with <var>doc</var>.
+
 <h3 id=event-summary>Event summary</h3>
 
 <i>This section is non-normative.</i>
@@ -1963,6 +1988,12 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
    <td>Fired at the {{VisualViewport}}, {{Document}}, or element when a scroll is <a lt="scroll completed">completed</a>: the
       {{VisualViewport}}, <a>viewport</a>, or element has been scrolled, the scroll sequence has ended and any scroll offset changes have
       been applied.
+  <tr>
+   <td><dfn event for="Window">move</dfn>
+   <td>{{Event}}
+   <td>{{Window}}
+   <td>Fired at the {{Window}} when the client window is moved relative to the <a>Web-exposed screen area</a>.
+  <tr>
 </table>
 
 


### PR DESCRIPTION
Define a partial interface WindowEventHandller to integrate the changes that would eventually be moved to the html spec. A new element 'onmove' is added to this interface. 

See cssom-view [issue 7693](https://github.com/w3c/csswg-drafts/issues/7693) for details.