### PR TITLE
[css-contain-3] Fix style query example

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -468,7 +468,7 @@ Creating Query Containers: the 'container-type' property</h3>
 		  container-type: style;
 		}
 
-		@container (--cards: small) {
+		@container style(--cards: small) {
 		  article {
 		    border: thin solid silver;
 		    border-radius: 0.5em;


### PR DESCRIPTION
The style query example is missing `style()` around the `<style-query>`. Oops!
