### PR TITLE
[css-view-transitions-1] Defer restoring persisted state until after capturing old state

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -47,6 +47,9 @@ spec:css-display-4; type: dfn; text:invisible;
 urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	text: NavigateEvent
 	text: signal; for: NavigateEvent; url: #ref-for-dom-navigateevent-signal①
+urlPrefix: https://html.spec.whatwg.org/multipage/; spec: html; type: dfn;
+	text: restore persisted state; url: #restore-persisted-state
+	text: latest entry; url: #latest-entry
 </pre>
 
 <script async type="module" src="diagrams/resources/scaler.js"></script>
@@ -1094,6 +1097,18 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			Initially null.
 
 			Note: this is used for cross-document view transitions.
+
+		: <dfn>persisted state restoration</dfn>
+		:: One of the following, initially "`defer`":
+
+			1. "`defer`".
+			1. "`pending`".
+			1. "`immediate`".
+
+			Note: this is used to defer automatic restoration of persisted state, e.g. scroll position,
+			to be performed after the old state is captured. When in the "`defer`" mode, persisted state
+			is not yet requested, but should be deferred if requested. When in the "`pending`" mode,
+			persisted state restoration is requested and should be performed once the old state is captured.
 	</dl>
 
 	A {{ViewTransition}} must never have both an [=ViewTransition/update callback=] and a [=ViewTransition/process old state captured=].
@@ -1252,9 +1267,15 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
 
+		1. [=Resolve persisted state restoration=] for |transition|.
+
 		1. If |transition|'s [=ViewTransition/process old state captured=] is not null, then call [=ViewTransition/process old state captured=] and return.
 
 		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
+
+		1. Set |transition|'s [=ViewTransition/persisted state restoration=] to "`immediate`".
+
+			Note: Now that the old state is captured, synchronous restoring persisted state should behave as normal.
 
 		1. [=Queue a global task=] on the [=DOM manipulation task source=],
 			given |transition|'s [=relevant global object=],
@@ -1912,6 +1933,23 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		1. Set |document|'s [=document/active view transition=] to null.
 	</div>
 
+## [=persisted state restoration=] ## {#persisted-state-restoration-algorithm}
+
+	<div algorithm>
+		To <dfn export>request persisted state restoration</dfn> for a {{Document}} |document|:
+
+			1. Let |transition| be |document|'s [=active view transition=].
+			1. If |transition| is null or its [=ViewTransition/persisted state restoration=] is "`immediate`", then return true.
+			1. Set |transition|'s [=ViewTransition/persisted state restoration=] to "`pending`".
+			1. Return false.
+	</div>
+
+	<div algorithm>
+		To <dfn>resolve persisted state restoration</dfn> for a {{ViewTransition}} |transition|:
+			1. If |transition|'s [=ViewTransition/persisted state restoration=] is "`pending`", then
+				[=restore persisted state=] given |transition|'s [=associated document=]'s [=latest entry=].
+			1. Set |transition|'s [=ViewTransition/persisted state restoration=] to "`immediate`".
+	</div>
 <h2 id="priv" class="no-num">Privacy Considerations</h2>
 
 This specification introduces no new privacy considerations.


### PR DESCRIPTION
This fixes an issue that the spec restores the persisted state (e.g. scroll position) too eagerly, e.g. when calling `document.startViewTransition` inside a `popstate` handler, not giving the UA an opportunity to first capture the old state.

This exports an algorithm that should be called from the HTML spec when ready to automatically restore persisted state, e.g. after `popstate`. If the algorithm returns true, proceed as normal, otherwise the state will be restored after capturing the old state.