### PR TITLE
[css-2023] Possible errata in four specification names

### DIFF
--- a/css-2023/Overview.bs
+++ b/css-2023/Overview.bs
@@ -463,7 +463,7 @@ Modules with Rough Interoperability</h3>
 	We hope to incorporate them into the [[#css-official|official definition of CSS]] in a future snapshot.
 
 	<dl>
-		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions</a>
+		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>
 		[[CSS-TRANSITIONS-1]]
 		and <a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
 		[[CSS-ANIMATIONS-1]].

--- a/css-2023/Overview.bs
+++ b/css-2023/Overview.bs
@@ -307,7 +307,7 @@ Classification of CSS Specifications</h2>
 		<dd>
 			Introduces a flexible linear layout model for CSS.
 
-		<dt><a href="https://www.w3.org/TR/css-ui-3/">CSS User Interface Module Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-ui-3/">CSS Basic User Interface Module Level 3</a>
 		[[!CSS-UI-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;18.1 and CSS2&sect;18.4,
@@ -414,7 +414,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 
-		<dt><a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Module Level 3</a>
 		[[CSS-TEXT-DECOR-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;16.3,
@@ -422,7 +422,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 			and adding the ability to specify text emphasis marks
 			and text shadows.
 
-		<dt><a href="https://www.w3.org/TR/css-masking-1/">CSS Masking Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-masking-1/">CSS Masking Module Level 1</a>
 		[[CSS-MASKING-1]]
 		<dd>
 			Replaces CSS2&sect;11.1.2
@@ -463,7 +463,7 @@ Modules with Rough Interoperability</h3>
 	We hope to incorporate them into the [[#css-official|official definition of CSS]] in a future snapshot.
 
 	<dl>
-		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions</a>
 		[[CSS-TRANSITIONS-1]]
 		and <a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
 		[[CSS-ANIMATIONS-1]].


### PR DESCRIPTION
In [CSS 2023](https://www.w3.org/TR/css-2023/) sections 2.1, 2.2 and 2.3 the names of four specifications do not match with the name that appear in the specifications themselves. 
- CSS User Interface Module Level 3 -> CSS Basic User Interface Module Level 3 
- CSS Text Decoration Level 3 -> CSS Text Decoration Module Level 3 
- CSS Masking Level 1 -> CSS Masking Module Level 1
- CSS Transitions Level 1 -> CSS Transitions

