### PR TITLE
[css-backgrounds-4] Fixed logical background-position-* longhands syntaxes

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -119,7 +119,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 
 	<pre class="propdef">
 		Name: background-position-inline
-		Value: [ center | [ start | end ]? <<length-percentage>>? ]#
+		Value: [ center | [ [ start | end ]? <<length-percentage>>? ]! ]#
 		Initial: 0%
 		Inherited: no
 		Logical property group: background-position
@@ -133,7 +133,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 
 	<pre class="propdef">
 		Name: background-position-block
-		Value: [ center | [ start | end ]? <<length-percentage>>? ]#
+		Value: [ center | [ [ start | end ]? <<length-percentage>>? ]! ]#
 		Initial: 0%
 		Inherited: no
 		Logical property group: background-position


### PR DESCRIPTION
Added the exclamation point to the syntaxes of `background-position-block` and `background-position-inline` like there is already for the physical longhands to make it clear that the combination of `start` or `end` keyword with a `<length-percentage>` must produce a value.

Sebastian