### PR TITLE
[css-anchor-position-1] Fixed anchor-size() syntax

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -921,7 +921,7 @@ The ''anchor-size()'' Function {#anchor-size-fn}
 ------------------------------
 
 <pre class=prod>
-anchor-size() = anchor( <<anchor-element>>? <<anchor-size>>, <<length-percentage>>? )
+anchor-size() = anchor-size( <<anchor-element>>? <<anchor-size>>, <<length-percentage>>? )
 <dfn><<anchor-size>></dfn> = width | height | block | inline | self-block | self-inline
 </pre>
 


### PR DESCRIPTION
The syntax for `anchor-size()` got corrected to actually define `anchor-size()` instead of just `anchor()`.

Sebastian