### PR TITLE
[css-view-transitions-1] Treat `auto` as an invalid value for `view-transition-name`

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1943,7 +1943,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Copy `color-scheme` from DOM element to ''::view-transition-group()''. See <a href="https://github.com/w3c/csswg-drafts/issues/9276">issue 9276</a>.
 * Expose [=auto-skip view transition=] for a {{Document}}, to allow having outbound cross-document transitions preceed programmatic view transiitons. see <a href="https://github.com/w3c/csswg-drafts/issues/9512">issue 9512</a>.
 * Add a note about why 'view-transition-name' should be animatable.
-* `view-transition-name: auto` should be an invalid value.
+* `view-transition-name: auto` should be an invalid value. See <a href="https://github.com/w3c/csswg-drafts/issues/9639">issue 9639</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -535,7 +535,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		:: The [=/element=] will not participate independently in a view transition.
 
 		: <dfn>auto</dfn>
-		:: This should be treated as an invalid value, despite being a valid <<custom-ident>>.
+		:: This should be treated as an invalid value, despite being a valid <<custom-ident>>. The property value remains unchanged.
 
 		: <dfn><<custom-ident>></dfn>
 		:: The [=/element=] participates independently in a view transition--

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -511,7 +511,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<pre class=propdef>
 	Name: view-transition-name
-	Value: none | <<custom-ident>>
+	Value: none | auto | <<custom-ident>>
 	Initial: none
 	Inherited: no
 	Percentages: n/a
@@ -533,6 +533,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<dl dfn-type=value dfn-for=view-transition-name>
 		: <dfn>none</dfn>
 		:: The [=/element=] will not participate independently in a view transition.
+
+		: <dfn>auto</dfn>
+		:: This should be treated as an invalid value, despite being a valid <<custom-ident>>.
 
 		: <dfn><<custom-ident>></dfn>
 		:: The [=/element=] participates independently in a view transition--
@@ -1940,6 +1943,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Copy `color-scheme` from DOM element to ''::view-transition-group()''. See <a href="https://github.com/w3c/csswg-drafts/issues/9276">issue 9276</a>.
 * Expose [=auto-skip view transition=] for a {{Document}}, to allow having outbound cross-document transitions preceed programmatic view transiitons. see <a href="https://github.com/w3c/csswg-drafts/issues/9512">issue 9512</a>.
 * Add a note about why 'view-transition-name' should be animatable.
+* `view-transition-name: auto` should be an invalid value.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>


### PR DESCRIPTION
Keeping `auto` as reserved for future purposes, so for now it is not a valid ident for `view-transition-name`.

Closes #9639
