### PR TITLE
[css-view-transitions-1] Add a note to explain how the named elements are cleaned up

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1044,6 +1044,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		: <dfn>named elements</dfn>
 		:: a [=/map=], whose keys are [=view transition names=] and whose values are [=captured elements=].
 			Initially a new [=map=].
+			Note: Since this is associated to the {{ViewTransition}}, it will be cleaned up when [=Clear view transition=] is called.
 
 		: <dfn>phase</dfn>
 		:: One of the following ordered phases, initially "`pending-capture`":
@@ -1949,6 +1950,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add a note about why 'view-transition-name' should be animatable.
 * `view-transition-name: auto` should be an invalid value. See <a href="https://github.com/w3c/csswg-drafts/issues/9639">issue 9639</a>.
 * Add note to explain paint order for entry animations. See <a href="https://github.com/w3c/csswg-drafts/issues/9672">issue 9672</a>.
+* Add note to explain how the named elements are cleaned up. See <a href="https://github.com/w3c/csswg-drafts/issues/9669">issue 9669</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>


### PR DESCRIPTION
Fixes #9669