### PR TITLE
[css-view-transitions-2] Specify 'view-transition-class' and corresponding algorithms

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1225,6 +1225,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	Note: These are used to update, and later remove styles
 	from a [=/document=]'s [=document/dynamic view transition style sheet=].
 
+	Other specs can supply <dfn>additional capture steps</dfn>, which is an algorithm that acepts a [=captured element=] and an [=element=].
+
 ## [=Perform pending transition operations=] ## {#perform-pending-transition-operations-algorithm}
 
 	<div algorithm>
@@ -1398,6 +1400,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Set |namedElements|[|transitionName|] to |capture|.
 
+			1. Perform [=additional capture steps=] given |capture| and |element|.
+
 		1. [=list/For each=] |element| in |captureElements|:
 
 			1. Set |element|'s [=captured in a view transition=] to false.
@@ -1439,6 +1443,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					This might not be the right layering for all cases. See <a href="https://github.com/w3c/csswg-drafts/issues/8941">issue 8941</a>.
 
 			1. Set |namedElements|[|transitionName|]'s [=new element=] to |element|.
+
+			1. Perform [=additional capture steps=] given |namedElements|[|transitionName|] and |element|.
 	</div>
 
 ### [=Setup transition pseudo-elements=] ### {#setup-transition-pseudo-elements-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1225,8 +1225,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	Note: These are used to update, and later remove styles
 	from a [=/document=]'s [=document/dynamic view transition style sheet=].
 
-	Other specs can supply <dfn>additional capture steps</dfn>, which is an algorithm that acepts a [=captured element=] and an [=element=].
-
 ## [=Perform pending transition operations=] ## {#perform-pending-transition-operations-algorithm}
 
 	<div algorithm>
@@ -1400,8 +1398,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Set |namedElements|[|transitionName|] to |capture|.
 
-			1. Perform [=additional capture steps=] given |capture| and |element|.
-
 		1. [=list/For each=] |element| in |captureElements|:
 
 			1. Set |element|'s [=captured in a view transition=] to false.
@@ -1443,8 +1439,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					This might not be the right layering for all cases. See <a href="https://github.com/w3c/csswg-drafts/issues/8941">issue 8941</a>.
 
 			1. Set |namedElements|[|transitionName|]'s [=new element=] to |element|.
-
-			1. Perform [=additional capture steps=] given |namedElements|[|transitionName|] and |element|.
 	</div>
 
 ### [=Setup transition pseudo-elements=] ### {#setup-transition-pseudo-elements-algorithm}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1168,7 +1168,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 ### [=Captured elements=] ### {#captured-elements}
 
-	A <dfn>captured element</dfn> is a [=struct=] with the following:
+	A <dfn export>captured element</dfn> is a [=struct=] with the following:
 
 	<dl dfn-for="captured element">
 		: <dfn>old image</dfn>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1168,7 +1168,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 ### [=Captured elements=] ### {#captured-elements}
 
-	A <dfn export>captured element</dfn> is a [=struct=] with the following:
+	A <dfn>captured element</dfn> is a [=struct=] with the following:
 
 	<dl dfn-for="captured element">
 		: <dfn>old image</dfn>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -269,7 +269,7 @@ for multiple elements without having to replicate the corresponding pseudo-eleme
 
 	<dl dfn-type=value dfn-for=view-transition-class>
 		: <dfn>none</dfn>
-		:: No class would apply to the [=/element=], and pseudo-elements would have to match its 'view-transition-name'.
+		:: No class would apply to the [=named view-transition pseudo-elements=] generated for this element.
 
 		: <dfn><<custom-ident>>*</dfn>
 		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) apply as classes for the [=/element=].

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -209,7 +209,7 @@ spec:infra; type:dfn; text:list
 ### 'view-transition-class' ### {#vt-class-example}
 
 view-transition-class provides a way to use the same style
-for multiple elements without having to replicate the corresponding pseudo-elements.
+for multiple view transition pseudo elements without having to replicate the corresponding pseudo-elements.
 
 	<div class="example">
 	This example creates a transition with each box participating under its own name, while applying

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -208,7 +208,7 @@ spec:infra; type:dfn; text:list
 
 ### 'view-transition-class' ### {#vt-class-example}
 
-view-transition-class provides a way to use the same view-transition style
+view-transition-class provides a way to use the same style
 for multiple elements without having to replicate the corresponding pseudo-elements.
 
 	<div class="example">

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -204,7 +204,7 @@ spec:infra; type:dfn; text:list
 
 ### 'view-transition-class' ### {#vt-class-example}
 
-In addition to cross-document view-transitions, this document specifies a way to use the same view-transition style
+view-transition-class provides a way to use the same view-transition style
 for multiple elements without having to replicate the corresponding pseudo-elements.
 
 	<div class="example">

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -32,6 +32,8 @@ spec:css-view-transitions-1;
 	text: call the update callback; type: dfn;
 	text: perform pending transition operations; type: dfn;
 	text: setup view transition; type: dfn;
+	text: additional capture steps; type: dfn;
+	text: named view transition pseudo-element; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
 spec:selectors-4; type:dfn;
@@ -124,6 +126,8 @@ spec:infra; type:dfn; text:list
 	1. From this point forward, the transition continues as if it was a same-document transition, as per [=activate view transition=].
 
 ## Examples ## {#examples}
+
+### Cross-document view-transitions ### {#cross-doc-example}
 
 	<div class=example>
 		To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
@@ -259,20 +263,21 @@ for multiple elements without having to replicate the corresponding pseudo-eleme
 	Animation type: discrete
 	</pre>
 
-	The 'view-transition-class' works alongside 'view-transition-name', and is read at the same time
-	'view-transition-name' is read. But unlike 'view-transition-name', 'view-transition-class' doesn't
-	have to be unique - an element can have several view-transition classes, and the same 'view-transition-class'
-	can apply to multiple elements. While 'view-transition-name' is used to match between the element
-	in the old state with its corresponding element in the new state, 'view-transition-class' is used
+	The 'view-transition-class' can be used to apply the same style rule to multiple [=named view transition pseudo-elements=] which may have a different 'view-transition-name'.
+	While 'view-transition-name' is used to match between the element in the old state with its corresponding element in the new state, 'view-transition-class' is used
 	only to apply styles using the view-transition pseudo-elements
 	(''::view-transition-group()'', ''::view-transition-image-pair()'', ''::view-transition-old()'', ''::view-transition-new()'').
 
+	Note that 'view-transition-class' by itself doesn't mark an element for capturing, it is only used as an additional
+	way to style an element that already has a 'view-transition-name'.
+
 	<dl dfn-type=value dfn-for=view-transition-class>
 		: <dfn>none</dfn>
-		:: No class would apply to the [=named view-transition pseudo-elements=] generated for this element.
+		:: No class would apply to the [=named view transition pseudo-elements=] generated for this element.
 
 		: <dfn><<custom-ident>>*</dfn>
-		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) apply as classes for the [=/element=].
+		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
+			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with other <<custom-ident>>s.
 
 			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
 			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view-transitions:
@@ -332,11 +337,11 @@ document.startViewTransition({update: updateTheDOMSomehow});
 ```
 </div>
 
-# Additions to view-transition pseudo-elements # {#pseudo-element-additions}
+# Additions to named view-transition pseudo-elements # {#pseudo-element-additions}
 
-	The <dfn>named view transition pseudo-elements</dfn>
+	The [=named view transition pseudo-elements=]
 	(''view-transition-group()'', ''view-transition-image-pair()'', ''view-transition-old()'', ''view-transition-new()'')
-	are extended to support the following syntax for each |pseudo|:
+	are extended to support the following syntax:
 
 	<pre class=prod>
 		::view-transition-group(<<pt-name-selector>><<pt-class-selector>>)
@@ -353,8 +358,8 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	</pre>
 
 	A [=named view transition pseudo-element=] [=selector=] which has one or more <<custom-ident>> values
-	in its <<pt-class-selector>> would only match an element if the element's [=captured element/class list=]
-	[=list/contains=] all of those values.
+	in its <<pt-class-selector>> would only match an element if the [=captured element/class list=] value in
+	[=ViewTransition/named elements=] for the pseudo-element's 'view-transition-name' [=list/contains=] all of those values.
 
 	The specificity of a [=named view transition pseudo-element=] [=selector=]
 	with a <<pt-class-selector>>
@@ -495,23 +500,18 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 ## Additions to [=captured element=] struct ## {#additions-to-captured-element-struct}
 
+The [=captured element=] struct should contain these fields, in addition to the existing ones:
+
 	<dl>
 		: <dfn for="captured element">class list</dfn>
 		:: a [=/list=] of strings, initially empty.
 	</dl>
 
-## Additions to capture algorithms: ## {#additions-to-capture-algorithms}
-<div algorithm="capture old classes">
-When capturing the old state of the view transition, perform the following step when iterating on |captureElements| given |element| and |capture|:
+## Algorithms to capture 'view-transition-class': ## {#vt-class-algorithms}
+<div algorithm="additional capture steps">
+This spec provides the following [=additional capture steps=] given a [=captured element=] |capture| and an [=element=] |element|:
 
 	1. Set |capture|'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
-
-</div>
-
-<div algorithm="capture new classes">
-When capturing the new state of the view transition, perform the following step when iterating on |captureElements| given |element| and |namedElements|:
-
-	1. Set |namedElement|[|transitionName|]'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
 </div>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -34,6 +34,9 @@ spec:css-view-transitions-1;
 	text: setup view transition; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
+spec:selectors-4; type:dfn;
+	text:selector
+	text:type selector
 spec:html
 	text: latest entry; type: dfn;
 	text: was created via cross-origin redirects; type: dfn;
@@ -199,6 +202,83 @@ spec:infra; type:dfn; text:list
 		```
 	</div>
 
+### Example of using 'view-transition-class' ### {#vt-class-example}
+
+In addition to cross-document view-transitions, this document specifies a way to use the same view-transition style
+for multiple elements without having to replicate the corresponding pseudo-elements.
+
+	<div class="example">
+	This example creates a transition with each box participating under its own name, while applying
+	a 1-second duration to the animation of all the boxes:
+
+	```html
+	<div class="box" id="red-box"></div>
+	<div class="box" id="green-box"></div>
+	<div class="box" id="yellow-box"></div>
+	```
+
+	```css
+	div.box {
+		view-transition-class: any-box;
+		width: 100px;
+		height: 100px;
+	}
+	#red-box {
+		view-transition-name: red-box;
+		background: red;
+	}
+	#green-box {
+		view-transition-name: green-box;
+		background: green;
+	}
+	#yellow-box {
+		view-transition-name: yellow-box;
+		background: yellow;
+	}
+
+	/* The following style would apply to all the boxes, thanks to 'view-transition-class' */
+	::view-transition-group(*.any-box) {
+		animation-duration: 1s;
+	}
+	```
+
+	</div>
+
+
+# CSS Properties # {#css-properties}
+
+## Applying the same style to multiple participating elements: the 'view-transition-class' property ## {#view-transition-class-prop}
+
+	<pre class=propdef>
+	Name: view-transition-class
+	Value: none | <<custom-ident>>*
+	Initial: none
+	Inherited: no
+	Percentages: n/a
+	Computed Value: as specified
+	Animation type: discrete
+	</pre>
+
+	The 'view-transition-class' works alongside 'view-transition-name', and is read at the same time
+	'view-transition-name' is read. But unlike 'view-transition-name', 'view-transition-class' doesn't
+	have to be unique - an element can have several view-transition classes, and the same 'view-transition-class'
+	can apply to multiple elements. While 'view-transition-name' is used to match between the element
+	in the old state with its corresponding element in the new state, 'view-transition-class' is used
+	only to apply styles using the view-transition pseudo-elements
+	(''::view-transition-group()'', ''::view-transition-image-pair()'', ''::view-transition-old()'', ''::view-transition-new()'').
+
+	<dl dfn-type=value dfn-for=view-transition-class>
+		: <dfn>none</dfn>
+		:: No class would apply to the [=/element=], and pseudo-elements would have to match its 'view-transition-name'.
+
+		: <dfn><<custom-ident>>*</dfn>
+		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) apply as classes for the [=/element=].
+
+			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
+			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view-transitions:
+			classes from the old document would only apply if their corresponding 'view-transition-name' was not specified in the new document.
+	</dl>
+
 # Pseudo-classes # {#pseudo-classes}
 
 ## Active View Transition Pseudo-class '':active-view-transition()''' ## {#the-active-view-transition-pseudo}
@@ -251,6 +331,34 @@ document.startViewTransition({update: updateTheDOMSomehow});
 :root:active-view-transition(any-type-at-all-except-star) {}
 ```
 </div>
+
+# Additions to view-transition pseudo-elements # {#pseudo-element-additions}
+
+	The <dfn>named view transition pseudo-elements</dfn>
+	(''view-transition-group()'', ''view-transition-image-pair()'', ''view-transition-old()'', ''view-transition-new()'')
+	are extended to support the following syntax for each |pseudo|:
+
+	<pre class=prod>
+		::view-transition-group(<<pt-name-selector>><<pt-class-selector>>)
+		::view-transition-image-pair(<<pt-name-selector>><<pt-class-selector>>)
+		::view-transition-old(<<pt-name-selector>><<pt-class-selector>>)
+		::view-transition-new(<<pt-name-selector>><<pt-class-selector>>)
+	</pre>
+
+	where <<pt-name-selector>> works as previously defined, and
+	<<pt-class-selector>> has the following syntax definition:
+
+	<pre class=prod>
+		<dfn>&lt;pt-class-selector></dfn> = ('.' <<custom-ident>>)*
+	</pre>
+
+	A [=named view transition pseudo-element=] [=selector=] which has one or more <<custom-ident>> values
+	in its <<pt-class-selector>> would only match an element if the element's [=captured element/class list=]
+	[=list/contains=] all of those values.
+
+	The specificity of a [=named view transition pseudo-element=] [=selector=]
+	with a <<pt-class-selector>>
+	is equivalent to a [=class selector=] with the equivalent number of classes.
 
 # CSS rules # {#css-rules}
 
@@ -384,6 +492,27 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		: <dfn>active types</dfn>
 		:: Null or a [=list=] of strings, initially null.
 	</dl>
+
+## Additions to [=captured element=] struct ## {#additions-to-captured-element-struct}
+
+	<dl>
+		: <dfn for="captured element">class list</dfn>
+		:: a [=/list=] of strings, initially empty.
+	</dl>
+
+## Additions to capture algorithms: ## {#additions-to-capture-algorithms}
+<div algorithm="capture old classes">
+When capturing the old state of the view transition, perform the following step when iterating on |captureElements| given |element| and |capture|:
+
+	1. Set |capture|'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
+
+</div>
+
+<div algorithm="capture new classes">
+When capturing the new state of the view transition, perform the following step when iterating on |captureElements| given |element| and |namedElements|:
+
+	1. Set |namedElement|[|transitionName|]'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
+</div>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -32,7 +32,6 @@ spec:css-view-transitions-1;
 	text: call the update callback; type: dfn;
 	text: perform pending transition operations; type: dfn;
 	text: setup view transition; type: dfn;
-	text: additional capture steps; type: dfn;
 	text: named view transition pseudo-element; type: dfn;
 spec:dom; type:dfn; text:document
 spec:css22; type:dfn; text:element
@@ -509,9 +508,11 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 ## Algorithms to capture 'view-transition-class': ## {#vt-class-algorithms}
 <div algorithm="additional capture steps">
-This spec provides the following [=additional capture steps=] given a [=captured element=] |capture| and an [=element=] |element|:
+When capturing the old or new state for an element, perform the following steps given a [=captured element=] |capture| and an [=element=] |element|:
 
 	1. Set |capture|'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
+
+	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
 </div>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -202,7 +202,7 @@ spec:infra; type:dfn; text:list
 		```
 	</div>
 
-### Example of using 'view-transition-class' ### {#vt-class-example}
+### 'view-transition-class' ### {#vt-class-example}
 
 In addition to cross-document view-transitions, this document specifies a way to use the same view-transition style
 for multiple elements without having to replicate the corresponding pseudo-elements.


### PR DESCRIPTION
A `view-transition-class` property allows specifying view-transition pseudo-elements that apply to multiple participating elements without having to replicate them.

In this PR:
- Specifying `view-transition-class`
- Extending the pseudo-element syntax to support `::view-transition-foo(name.class)`
- Extending the capture algorithms and data structure to capture the classes
- Added a simple example for using classes

Based on [this resolution](https://github.com/w3c/csswg-drafts/issues/8319#issuecomment-1876155920).
Closes #8319

