### PR TITLE
[css-view-transitions-1] Refactor timings of `updateCallbackDone` and related

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1611,7 +1611,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		1. Let |fulfillSteps| be to following steps:
 			1. [=Activate view transition|Activate=] |transition|.
 
-			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then [=resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
+			1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
+
+				Note: This would be a no-op if the previous step already resolved the promise.
 
 		1. Let |rejectSteps| be the following steps given |reason|:
 			1. [=Reject=] |transition|'s [=ViewTransition/update callback done promise=] with |reason|.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1264,14 +1264,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			given |transition|'s [=relevant global object=],
 			to perform the following steps:
 
+				Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
+					although the render steps in the HTML spec act as if it's synchronous.
+
 			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
 
 				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
 			1. [=call the update callback=].
-
-				Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
-					although the render steps in the HTML spec act as if it's synchronous.
 	</div>
 
 	<div algorithm>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1262,7 +1262,13 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Queue a global task=] on the [=DOM manipulation task source=],
 			given |transition|'s [=relevant global object=],
-			to [=call the update callback=].
+			to perform the following steps:
+
+			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
+
+				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
+
+			1. [=call the update callback=].
 
 				Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
 					although the render steps in the HTML spec act as if it's synchronous.

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1262,43 +1262,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Queue a global task=] on the [=DOM manipulation task source=],
 			given |transition|'s [=relevant global object=],
-			to execute the following steps:
+			to [=call the update callback=].
 
 				Note: A task is queued here because the texture read back in [=capturing the image=] may be async,
 					although the render steps in the HTML spec act as if it's synchronous.
-
-			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then abort these steps.
-
-				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
-					The [=skip the view transition=] steps [=call the update callback=],
-					ensuring the |transition|'s [=ViewTransition/update callback=] is always called.
-
-			1. [=Call the update callback=] of |transition|.
-
-			1. [=promise/React=] to |transition|'s [=ViewTransition/update callback done promise=]:
-
-				* If the promise does not settle within an implementation-defined timeout, then:
-
-					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
-
-						Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
-
-					1. [=Skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
-
-				* If the promise was rejected with reason |reason|, then:
-
-					1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
-
-						Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
-
-					1. [=Mark as handled=] |transition|'s [=ViewTransition/ready promise=].
-
-						Note: |transition|'s [=ViewTransition/update callback done promise=] will provide the {{unhandledrejection}}.
-						This step avoids a duplicate.
-
-					1. [=Skip the view transition=] |transition| with |reason|.
-
-				* If the promise was fulfilled, then [=activate view transition|activate=] |transition|.
 	</div>
 
 	<div algorithm>
@@ -1318,6 +1285,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
+
+		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 
@@ -1633,13 +1602,39 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
 
-		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=]
-			with the result of [=reacting=] to |callbackPromise|:
+		1. Let |fulfillSteps| be to following steps:
+			1. [=Activate view transition|Activate=] |transition|.
 
-			- If the promise was fulfilled, then return undefined.
+			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then [=resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
 
-			Note: Since the rejection of |callbackPromise| isn't explicitly handled here,
-			if |callbackPromise| rejects, then |transition|'s [=ViewTransition/update callback done promise=] will reject with the same reason.
+		1. Let |rejectSteps| be the following steps given |reason|:
+			1. [=Reject=] |transition|'s [=ViewTransition/update callback done promise=] with |reason|.
+
+			1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
+
+				Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
+
+			1. [=Mark as handled=] |transition|'s [=ViewTransition/ready promise=].
+
+				Note: |transition|'s [=ViewTransition/update callback done promise=] will provide the {{unhandledrejection}}.
+				This step avoids a duplicate.
+
+			1. [=Skip the view transition=] |transition| with |reason|.
+
+		1. [=React=] to |callbackPromise| with |fulfillSteps| and |rejectSteps|.
+
+		1. To skip a transition after a timeout, the user agent may perform the following steps [=in parallel=]:
+			1. Wait for an implementation-defined [=duration=].
+
+			1. [=Queue a global task=] on the [=DOM manipulation task source=],
+				given |transition|'s [=relevant global object=], to perform the following steps:
+
+				1. If |transition|'s [=ViewTransition/phase=] is "`done`", then return.
+
+					Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
+
+				1. [=skip the view transition|Skip=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+
 	</div>
 
 ## [=Skip the view transition=] ## {#skip-the-view-transition-algorithm}
@@ -1951,6 +1946,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * `view-transition-name: auto` should be an invalid value. See <a href="https://github.com/w3c/csswg-drafts/issues/9639">issue 9639</a>.
 * Add note to explain paint order for entry animations. See <a href="https://github.com/w3c/csswg-drafts/issues/9672">issue 9672</a>.
 * Add note to explain how the named elements are cleaned up. See <a href="https://github.com/w3c/csswg-drafts/issues/9669">issue 9669</a>.
+* Refactor algorithm to clarify timing, especially of `updateCallbackDone. See <a href="https://github.com/w3c/csswg-drafts/issues/9762">issue 9762</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>


### PR DESCRIPTION
Note: this change is not a behavior change, but rather a clarification of existing expected behavior.

- Instead of reacting to the update callback's promise in several places, we react to it once with fulfill/reject steps and continue based on the state, all inside the "call the update callback" algorithm.
- Clarify that in the successful case, `updateCallbackDone` is always resolved after the new state capture but before the `ready` promise. (This is current behavior, but not explicit in the current spec).
- Fix a bug where we were resolving a promise with the result of reacting to a different promise, which is wrong use of those operations.
- Use normative language for user-agent transition timeout
- Remove redundant early returns for `done` phase.

Closes #9762