### PR TITLE
[css-view-transitions-2] Nit: use 'set' to update variable

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -484,7 +484,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 					[=ViewTransition/initial snapshot containing block size=] is |outboundTransition|'s [=ViewTransition/initial snapshot containing block size=],
 					and whose [=ViewTransition/is inbound cross-document transition=] is true.
 
-				1. Let |newDocument|'s [=active view transition=] be |inboundTransition|.
+				1. Set |newDocument|'s [=active view transition=] to |inboundTransition|.
 
 				1. [=Call the update callback=] for |inboundTransition|.
 


### PR DESCRIPTION
[css-view-transitions-2] Nit: use 'set' to update variable

Small fix to css-view-transitions-2 where we're using 'let' when updating the value of the `Document`'s `active view transition`.