### PR TITLE
[css-contain-3] No query container for unknown features (#7551)

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -612,7 +612,9 @@ Container Queries: the ''@container'' rule</h3>
 	is selected from among the element’s ancestor [=query containers=]
 	that are established as a valid [=query container=]
 	for all the [=container features=]
-	in the <<container-query>>.
+	in the <<container-query>>. If the <<container-query>> contains unknown
+	or unsupported [=container feature=]s, no [=query container=] will be
+	selected.
 	The optional <<container-name>>
 	filters the set of [=query containers=] considered
 	to just those with a matching [=query container name=].


### PR DESCRIPTION
From [1]: "RESOLVED: No container is valid for unknown queries"

[1] https://github.com/w3c/csswg-drafts/issues/7551#issuecomment-1854385652
