### PR TITLE
[css-view-transitions-2] Define the `navigation: auto` descriptor

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -299,8 +299,9 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 
 		: <dfn>auto</dfn>
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
-			redirects, and is either a {{NavigationType/traverse}} navigation or a navigation that's neither
-			a {{NavigationType/reload}} or initiated by browser UI.
+			redirects, and whoes {{NavigationType}} is
+			* {{NavigationType/traverse}} or
+			* {{NavigationType/push}} or {{NavigationType/replace}} with <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> not equal to `"browser UI"`.
 
 			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
 			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}
@@ -398,9 +399,10 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		Prepend these steps at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
 		when <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">applying the history step</a> (14.11.1, <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:queue-a-global-task-3">here</a>):
 
-		This monkey-patch step assumes a boolean |changingNavigationContinuation|, a [=/navigable=] |navigable|, a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and |userInvolvementForNavigateEvents|.
+		This monkey-patch step assumes a boolean |changingNavigationContinuation|, a [=/navigable=] |navigable|, a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|,
+		and a <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> |userInvolvementForNavigateEvents|.
 
-		1. Let |isBrowserUINavigation| be true if |userInvolvementForNavigateEvents| is `"browser UI`", otherwise false.
+		1. Let |isBrowserUINavigation| be true if |userInvolvementForNavigateEvents| is `"browser UI"`, otherwise false.
 
 		1. If |changingNavigationContinuation| update-only is false, then [=setup cross-document view-transition=] given |oldDocument|, |newDocument|, |navigationType|, |isBrowserUINavigation|, and the remaining steps and return from these steps.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -305,7 +305,6 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 
 			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
 			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
-			user or script initiated.
 
 	</dl>
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -304,7 +304,7 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 			* {{NavigationType/push}} or {{NavigationType/replace}} with <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> not equal to `"browser UI"`.
 
 			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
-			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}
+			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
 			user or script initiated.
 
 	</dl>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -303,7 +303,7 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 			a {{NavigationType/reload}} or initiated by browser UI.
 
 			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
-			var the URL address bar or clicking a bookmark, as well as any form of {{NavigationType/reload}},
+			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}
 			user or script initiated.
 
 	</dl>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -299,7 +299,13 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 
 		: <dfn>auto</dfn>
 		:: The transition will be enabled if the navigation is same-origin, without cross-origin
-			redirects, and is not a {{NavigationType/reload}}.
+			redirects, and is either a {{NavigationType/traverse}} navigation or a navigation that's neither
+			a {{NavigationType/reload}} or initiated by browser UI.
+
+			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
+			var the URL address bar or clicking a bookmark, as well as any form of {{NavigationType/reload}},
+			user or script initiated.
+
 	</dl>
 
 ## The [=@view-transition/type=] descriptor ## {#view-transition-type-descriptor}
@@ -389,12 +395,14 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
 	<div algorithm="monkey patch to apply the history step">
-		Prepend a step at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
+		Prepend these steps at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
 		when <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">applying the history step</a> (14.11.1, <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:queue-a-global-task-3">here</a>):
 
-		This monkey-patch step assumes a boolean |changingNavigationContinuation|, a [=/navigable=] |navigable|, a {{Document}} |oldDocument|, a {{Document}} |newDocument|, and a {{NavigationType}} |navigationType|.
+		This monkey-patch step assumes a boolean |changingNavigationContinuation|, a [=/navigable=] |navigable|, a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and |userInvolvementForNavigateEvents|.
 
-		If |changingNavigationContinuation| update-only is false, then [=setup cross-document view-transition=] given |oldDocument|, |newDocument|, |navigationType|, and the remaining steps and return from these steps.
+		1. Let |isBrowserUINavigation| be true if |userInvolvementForNavigateEvents| is `"browser UI`", otherwise false.
+
+		1. If |changingNavigationContinuation| update-only is false, then [=setup cross-document view-transition=] given |oldDocument|, |newDocument|, |navigationType|, |isBrowserUINavigation|, and the remaining steps and return from these steps.
 
 		Note: This would wait until a transition is captured or skipped before proceeding to unloading the old document and activating the new one.
 	</div>
@@ -426,12 +434,14 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 	<div algorithm>
 		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and |onReady|, which is an algorithm accepting nothing:
+		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
 			the user agent may ignore the author-defined view transition. If that is the case, return.
 
 		1. If |navigationType| is {{NavigationType/reload}}, then return.
+
+		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return.
 
 		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
 			|newDocument|'s [=environment settings object/origin=] then call |onReady| and return.


### PR DESCRIPTION
As per [resolution](https://github.com/w3c/csswg-drafts/issues/8783#issuecomment-1885359766), `auto` would match any navigation, except:
- reloads (via script, browser UI, `<meta>`, anythg)..,
- A browser-UI push/replace (e.g. typing in the URL address bar, bookmarks, etc)

Closess #8783 