### PR TITLE
[css-color-4] ActiveCaption is a background.

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -6567,7 +6567,7 @@ Appendix A: Deprecated CSS System Colors</h2>
 		<dd>Active window border. Same as ''ButtonBorder''.
 
 		<dt><dfn>ActiveCaption</dfn>
-		<dd>Active window caption. Same as ''CanvasText''.
+		<dd>Active window caption. Same as ''Canvas''.
 
 		<dt><dfn>AppWorkspace</dfn>
 		<dd>Background color of multiple document interface. Same as ''Canvas''.


### PR DESCRIPTION
And thus shouldn't match CanvasText, but Canvas.