### PR TITLE
[css-view-transitions-2] Separte MPA transition start from check

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -434,43 +434,34 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 ### Setting up the view-transition in the old {{Document}} ###  {#setup-old-document-vt}
 
 	<div algorithm>
-		To check if a <dfn export>should navigation trigger a cross-document view-transition?</dfn> given
-		an [=origin=] |oldOrigin|, an [=origin=] |newOrigin|, a boolean |newDocumentWasCreatedWithCrossOriginRedirects|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+		To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
+		an [=origin=] |oldOrigin|, an [=origin=] |newOrigin|, a boolean |navigationHasCrossOriginRedirects|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+
+			Note: this is called during navigation, potentially [=in parallel=], for documents that have opted-in to view-transitions using the ''@view-transition'' rule.
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
 			the user agent may ignore the author-defined view transition. If that is the case, return false.
 
 		1. If |navigationType| is {{NavigationType/reload}}, then return false.
 
-		1. If ||newDocumentWasCreatedWithCrossOriginRedirects|, then return false.
-
 		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return false.
 
 		1. If |oldOrigin| is not [=same origin=] as |newOrigin| then return false.
 
-		1. If |newDocument| [=was created via cross-origin redirects=] is true
-			and |newDocument|'s [=latest entry=] is null, then return false.
-
-			Note: A document with a non-null [=latest entry=]
-			is being [=Document/reactivated=], in which case we don't need to check for cross-origin redirects.
+		1. If |navigationHasCrossOriginRedirects| is true, then return false.
 
 		1. Return true.
 	</div>
 	<div algorithm>
 		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
+		a {{Document}} |newDocument|, and |onReady|, which is an algorithm accepting nothing:
 
-		1. [=Resolve @view-transition rule=] for |oldDocument| and let |resolvedRule| be the result.
+		1. Let |resolvedRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
 
-		1. If |resolvedRule| is "<code>skip transition</code>", then return false.
+		1. If |resolvedRule| is "<code>skip transition</code>", then return null.
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
-
-		1. If the result of calling [=should navigation trigger cross-document view-transition?=]
-			given |oldDocument|'s [=Document/origin=], |newDocument|'s [=Document/origin=],
-			|newDocument|'s [=was created via cross-origin redirects=], |navigationType|, and |isBrowserUINavigation| is false,
-			then return.
 
 		1. If |oldDocument|'s [=active view transition=] is not null,
 			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
@@ -479,7 +470,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 			Note: this means that any running transition would be skipped when the document is ready
 			to unload.
 
-		1. Set |document|'s [=auto-skip view transitions=] to true.
+		1. Set |oldDocument|'s [=auto-skip view transitions=] to true.
 
 			Note: this means that calling {{Document/startViewTransition()}} while capturing the old document for a cross-document view-transition would run the callback but skip the animation.
 
@@ -497,7 +488,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 				Note: The ViewTransition object on the old Document should be destroyed after its state has been copied to the new Document below.
 					We explicitly clear it here since the old Document may be cached by the UA.
 
-			1. Set |document|'s [=auto-skip view transitions=] to false.
+			1. Set |oldDocument|'s [=auto-skip view transitions=] to false.
 
 			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
 				to perform the following steps:
@@ -529,6 +520,8 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 			* its [=active view transition=]'s [=ViewTransition/phase=] is "`done`".
 
 			Note: this is to ensure that there are no unintended flashes between displaying the old and new state, to keep the transition smooth.
+
+		1. Return |outboundTransition|.
 	</div>
 
 ### Accessing the view-transition in the new {{Document}} ### {#access-view-transition-in-new-doc}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -434,31 +434,41 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 ### Setting up the view-transition in the old {{Document}} ###  {#setup-old-document-vt}
 
 	<div algorithm>
-		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
+		To check if a <dfn export>should navigation trigger cross-document view-transition?</dfn> given
+		a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
-			the user agent may ignore the author-defined view transition. If that is the case, return.
+			the user agent may ignore the author-defined view transition. If that is the case, return false.
 
-		1. If |navigationType| is {{NavigationType/reload}}, then return.
+		1. If |navigationType| is {{NavigationType/reload}}, then return false.
 
-		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return.
+		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return false.
 
 		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
-			|newDocument|'s [=environment settings object/origin=] then call |onReady| and return.
+			|newDocument|'s [=environment settings object/origin=] then return false.
 
 		1. If |newDocument| [=was created via cross-origin redirects=] is true
-			and |newDocument|'s [=latest entry=] is null, then call |onReady| and return.
+			and |newDocument|'s [=latest entry=] is null, then return false.
 
 			Note: A document with a non-null [=latest entry=]
 			is being [=Document/reactivated=], in which case we don't need to check for cross-origin redirects.
 
 		1. [=Resolve @view-transition rule=] for |oldDocument| and let |resolvedRule| be the result.
 
-		1. If |resolvedRule| is "<code>skip transition</code>", then call |onReady| and return.
+		1. If |resolvedRule| is "<code>skip transition</code>", then return false.
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
+
+		1. Return true.
+	</div>
+	<div algorithm>
+		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
+		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
+
+		1. If the result of calling [=should navigation trigger cross-document view-transition?=]
+			given |oldDocument|, |newDocument|, |navigationType|, and |isBrowserUINavigation| is false,
+			then return.
 
 		1. If |oldDocument|'s [=active view transition=] is not null,
 			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -435,23 +435,30 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 	<div algorithm>
 		To check if a <dfn export>should navigation trigger a cross-document view-transition?</dfn> given
-		a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+		an [=origin=] |oldOrigin|, an [=origin=] |newOrigin|, a boolean |newDocumentWasCreatedWithCrossOriginRedirects|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
 			the user agent may ignore the author-defined view transition. If that is the case, return false.
 
 		1. If |navigationType| is {{NavigationType/reload}}, then return false.
 
+		1. If ||newDocumentWasCreatedWithCrossOriginRedirects|, then return false.
+
 		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return false.
 
-		1. If |oldDocument|'s [=environment settings object/origin=] is not [=same origin=] as
-			|newDocument|'s [=environment settings object/origin=] then return false.
+		1. If |oldOrigin| is not [=same origin=] as |newOrigin| then return false.
 
 		1. If |newDocument| [=was created via cross-origin redirects=] is true
 			and |newDocument|'s [=latest entry=] is null, then return false.
 
 			Note: A document with a non-null [=latest entry=]
 			is being [=Document/reactivated=], in which case we don't need to check for cross-origin redirects.
+
+		1. Return true.
+	</div>
+	<div algorithm>
+		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
+		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
 
 		1. [=Resolve @view-transition rule=] for |oldDocument| and let |resolvedRule| be the result.
 
@@ -460,14 +467,9 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
 
-		1. Return true.
-	</div>
-	<div algorithm>
-		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-		a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, a boolean |isBrowserUINavigation|, and |onReady|, which is an algorithm accepting nothing:
-
 		1. If the result of calling [=should navigation trigger cross-document view-transition?=]
-			given |oldDocument|, |newDocument|, |navigationType|, and |isBrowserUINavigation| is false,
+			given |oldDocument|'s [=Document/origin=], |newDocument|'s [=Document/origin=],
+			|newDocument|'s [=was created via cross-origin redirects=], |navigationType|, and |isBrowserUINavigation| is false,
 			then return.
 
 		1. If |oldDocument|'s [=active view transition=] is not null,

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -434,7 +434,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 ### Setting up the view-transition in the old {{Document}} ###  {#setup-old-document-vt}
 
 	<div algorithm>
-		To check if a <dfn export>should navigation trigger cross-document view-transition?</dfn> given
+		To check if a <dfn export>should navigation trigger a cross-document view-transition?</dfn> given
 		a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,


### PR DESCRIPTION
In prepartion for the HTML integration and the `pageconceal` event, the check for whether cross-document view transition should take place is to be called twice from the HTML spec:
- once when initiating the navigation, to check if a `pageconceal` event should be blocking
- once right before firing `pageconceal`.

So separating the algorithm and exporting the check.