### PR TITLE
[cssom-1] Avoid validating declarations twice

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2233,19 +2233,8 @@ the DOM a <a>CSS declaration block</a> is a
  the <a for="CSSStyleDeclaration">owner node</a>'s <code>style</code> attribute.
 </dl>
 
-To <dfn export>parse a CSS declaration block</dfn> from a string <var>string</var>, follow these steps:
-
-<ol>
- <li>Let <var>declarations</var> be the returned declarations from invoking <a>parse a block's contents</a> with <var>string</var>.
- <li>Let <var>parsed declarations</var> be a new empty list.
- <li>For each item <var>declaration</var> in <var>declarations</var>, follow these substeps:
-  <ol>
-   <li>Let <var>parsed declaration</var> be the result of parsing <var>declaration</var> according to the appropriate CSS specifications, dropping parts that
-   are said to be ignored. If the whole declaration is dropped, let <var>parsed declaration</var> be null.
-   <li>If <var>parsed declaration</var> is not null, append it to <var>parsed declarations</var>.
-  </ol>
- <li>Return <var>parsed declarations</var>.
-</ol>
+To <dfn export>parse a CSS declaration block</dfn> from a string <var>string</var>,
+return the declarations from invoking <a>parse a block's contents</a> with <var>string</var>.
 
 To <dfn export>serialize a CSS declaration</dfn> with property name <var>property</var>, value <var>value</var> and optionally an <i>important</i> flag set, follow
 these steps:


### PR DESCRIPTION
[Consume a block's contents](https://drafts.csswg.org/css-syntax-3/#consume-a-blocks-contents) (CSS Syntax) now filters invalid declarations in the context, so it does not need to be performed in [*parse a CSS declaration block*](https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block) anymore.

Related: #9821