### PR TITLE
[css-shapes-1] Replace `<alpha-value>` with `<'opacity'>`

### DIFF
--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -20,7 +20,6 @@ Abstract: CSS Shapes describe geometric shapes for use in CSS. For Level 1, CSS 
 <pre class='link-defaults'>
 spec:css2; type:property; text:margin
 spec:css-backgrounds-3; type:property; text:border-radius
-spec:css-color-4; type:type; for:<color>; text:<alpha-value>
 spec:css-masking-1; type: value
 	text: nonzero
 	text: evenodd
@@ -947,7 +946,7 @@ Choosing Image Pixels: the 'shape-image-threshold' property</h3>
 
 	<pre class='propdef'>
 		Name: shape-image-threshold
-		Value: <<alpha-value>>
+		Value: <<'opacity'>>
 		Initial: 0
 		Applies to: floats
 		Inherited: no


### PR DESCRIPTION
`shape-image-threshold` is defined with `<alpha-value>` but its specified value must be clamped whereas there is interop for clamping the computed value, like for `opacity`.

I suggest to define `shape-image-threshold` with `<'opacity'>`.

Related: https://github.com/w3c/csswg-drafts/issues/8311