### PR TITLE
[css-display-4] drafting reading-order-items issue #8589

### DIFF
--- a/css-display-4/Overview.bs
+++ b/css-display-4/Overview.bs
@@ -966,121 +966,38 @@ Toggling Box Generation: the 'display-or-not' property</h2>
  ███████  ██     ██ ████████  ████████ ██     ██
 -->
 
-<h2 id='display-order'>
-Display Order</h2>
+<h2 id='order-property'>
+Display Order: the 'order' property</h2>
 
-	The 'layout-order' and 'reading-order' properties and their 'order' [=shorthand=]
-	allow creating deliberate divergence
-	between spatial arrangement on the 2D visual canvas,
-	the reading and document navigation order,
-	and the underlying order of elements in the source document
-	<em>in order to improve the accessibility of the document</em>
-	while creating interesting visual layouts.
-	They are not intended (and should not be used)
-	to apply semantic reordering operations.
-
-	Advisement: Author-facing documentation such as tutorials and references
-	should adequately address the accessibility impacts
-	of 'order', 'layout-order', and 'reading-order'
-	and discourage their misuse by authors and authoring tools.
-
-	<details class="note">
-		<summary>Design Considerations and Background</summary>
-
-		Some of the considerations that went into the design
-		of 'order', 'reading-order', and 'layout-order' are:
-
-		* There are clear use cases for disconnecting
-			the [=reading and navigation order=] from the box layout order,
-			the most fundamental of which is to make sure
-			the [=reading and navigation order=] matches the <strong>visual perception order</strong>
-			when it is not the same as the box layout order.
-			(Visual perception is non-linear, and is influenced by things like
-				the size, color contrast, and spacing of a visual element,
-				not just its spatial coordinates on the page.)
-		* It is a <a href="https://www.w3.org/TR/webarch/#pci">core principle of Web platform architecture</a>,
-			in order to allow content to be accessible to the widest possible audience
-			across devices that exist now and in the future,
-			for the underlying document to be sensical independent of CSS.
-			Therefore the underlying document order
-			should represent a logical ordering of its elements
-			regardless of its visual presentation.
-		* For components of a page that do not have a strong inherent order,
-			a document can have multiple visual presentations with different layouts,
-			all conveying the same semantic information.
-			It should be possible for all of these presentations to have good accessibility.
-		* Linear navigation, focus sequencing order, and screen-reader order
-			should always match, because there are users who use them together.
-		* Each component or hierarchical level of a page
-			can have different requirements for reordering,
-			so CSS reordering controls should not lend themselves
-			too easily to blanket use
-			(like 'box-sizing')
-			rather than tailored use
-			(like <a href="https://www.w3.org/TR/css-logical/">flow-relative vs. physical properties and values</a>).
-	</details>
-
-	ISSUE(7387): DOM needs a convenient reordering function
-	so that authors (even authors who don't usually write JS)
-	can easily perform source order reordering when necessary
-	instead of misusing 'order'.
-
-<h3 id='order-property'>
-Display Order Shorthand: the 'order' property</h3>
-
-	<pre class='propdef shorthand'>
+	<pre class='propdef'>
 	Name: order
-	Value: [ <<'layout-order'>> <<'reading-order'>>? ] |
-	       [ [ reading || layout ] && <<integer>> ]
+	Value: <<integer>>
+	Initial: 0
 	Applies to: [=flex items=] and [=grid items=]
 	Inherited: no
+	Computed value: specified integer
+	Animation type: by computed value type
 	</pre>
+
+	<wpt pathprefix="css/css-flexbox/">
+		flexible-order.html
+	</wpt>
 
 	Boxes are generally displayed and laid out
 	in the same order as they appear in the source document.
-	The 'order' property and its [=longhands=]
-	can be used to rearrange the order of boxes
+	In some [=formatting contexts=],
+	the 'order' property can be used to rearrange the order of boxes
 	to deliberately create a divergence
-	of the underlying order of elements
-	and their speech and navigation order
-	and/or their spatial arrangement on the 2D visual canvas.
+	of the logical order of elements
+	and their spatial arrangement on the 2D visual canvas.
+	(See [[#order-accessibility]].)
 
-	Advisement: The 'order' property is not a replacement for correct source ordering.
-	The ordering of content within conformant documents must be sensical without CSS.
-	Authoring tools and documents that use 'order' or its [=longhands=]
-	as a lazy way of reordering the document
-	are non-conformant.
-
-	The 'order' property sets both 'layout-order' and 'reading-order'
-	in a single declaration.
-	Values have the following meanings:
-
-	<dl dfn-for=order dfn-type=value>
-		<dt><dfn><<integer>></dfn>
-		<dd>
-			If one integer and no keyword is specified,
-			then sets 'layout-order' to the specified integer,
-			and sets 'reading-order' to its [=initial value=].
-			If two integers are specified,
-			the first sets 'layout-order' and the second sets 'reading-order'.
-			Otherwise sets the appropriate [=longhand=](s) to the specified integer(s).
-
-		<dt><dfn>layout</dfn>
-		<dd>
-			Indicates setting 'layout-order' to the specified integer.
-			If ''reading'' is not specified,
-			'reading-order' is set to its [=initial value=].
-
-		<dt><dfn>reading</dfn>
-		<dd>
-			Indicates setting 'reading-order' to the specified integer.
-			If ''layout'' is not specified,
-			'layout-order' is set to its [=initial value=].
-	</dl>
-
-	Note: The single-integer syntax sets only 'layout-order',
-	in order to enable rearranging layout for better visual display
-	without changing the underlying reading order.
+	Specifically,
+	the 'order' property controls the order in which
+	[=flex items=] or [=grid items=] appear within their container,
+	by assigning them to ordinal groups.
+	It takes a single <dfn value for=order><<integer>></dfn> value,
+	which specifies which ordinal group the item belongs to.
 
 	<div class='example'>
 		Here's an example of a catalog item card
@@ -1160,98 +1077,15 @@ Display Order Shorthand: the 'order' property</h3>
 		</style>
 	</div>
 
-<h3 id='reading-order'>
-Reading Order: the 'reading-order' property</h3>
-
-	<pre class='propdef'>
-	Name: reading-order
-	Value: <<integer>>
-	Initial: 0
-	Applies to: all elements
-	Inherited: no
-	Computed value: specified integer
-	Animation type: by computed value type
-	</pre>
-
-	The 'reading-order' property controls the order in which
-	elements are rendered to speech
-	or are navigated to when using (linear) sequential navigation methods.
-	It takes a single <dfn value for=reading-order><<integer>></dfn> value,
-	which specifies which ordinal group the item belongs to.
-	Sibling elements are ordered starting from the lowest numbered ordinal group and going up;
-	elements with the same ordinal group are keep the order they appear in the source document.
-
-	The 'reading-order' property affects neither layout nor painting order
-	and therefore has no effect on rendering to the visual [=canvas=].
-
-	Advisement: The source document should express
-	the underlying logical order of elements.
-	The 'reading-order' property exists for cases where a given document
-	can have multiple reading orders depending on layout changes,
-	e.g. in response to [=media queries=].
-	In such cases, the most common or most fundamental reading order
-	should be encoded in the source order
-	so that the document is sensical without CSS.
-
-	If the host language defines features for explicitly controlling
-	the reading or navigation order
-	(such as <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"><code>tabindex</code></a> [[HTML]]),
-	these take precedence over 'reading-order':
-	the modified document order created by 'reading-order'
-	essentially replaces the underlying source order
-	for the purpose of such features.
-
-	ISSUE: Is this the most appropriate interaction with with <code>tabindex</code>?
-
-<h3 id='layout-order'>
-Box Order: the 'layout-order' property</h3>
-
-	<pre class='propdef'>
-	Name: layout-order
-	Value: <<integer>>
-	Initial: 0
-	Applies to: [=flex items=] and [=grid items=]
-	Inherited: no
-	Computed value: specified integer
-	Animation type: by computed value type
-	</pre>
-
-	<wpt pathprefix="css/css-flexbox/">
-		flexible-order.html
-	</wpt>
-
-	By allowing the layout to be rearranged
-	without affecting the underlying document source order,
-	the 'layout-order' property lets authors keep
-	a document’s reading and interaction order matched to the visual perception order
-	in cases where it does not match the layout order.
-
-	Specifically, the 'layout-order' property controls the order in which
-	[=flex items=] or [=grid items=] appear within their container
-	by assigning them to the ordinal groups,
-	as specified by its <dfn value for=layout-order><<integer>></dfn> value.
-
-	[=flex container|Flex=] and [=grid containers=] then lay out their contents
+	[=flex container|Flex=] and [=grid containers=] lay out their contents
 	in <dfn export>order-modified document order</dfn>,
 	starting from the lowest numbered ordinal group and going up.
 	Items with the same ordinal group are laid out in the order they appear in the source document.
-
 	This also affects the <a href="https://www.w3.org/TR/CSS2/zindex.html">painting order</a> [[!CSS2]],
 	exactly as if the [=flex item|flex=]/[=grid items=] were reordered in the source document.
 	Absolutely-positioned children of a [=flex container|flex=]/[=grid container=]
 	are treated as having ''order: 0''
 	for the purpose of determining their painting order relative to [=flex item|flex=]/[=grid items=].
-
-	Advisement: Authors should generally use the 'order' [=shorthand=]
-	(which overrides prior values of 'reading-order')
-	rather than 'layout-order'.
-	This prevents inappropriate values of 'reading-order'
-	declared elsewhere in the [=cascade=]
-	from combining with 'layout-order'
-	to create incomprehensible layouts.
-
-	Note: Since it was introduced in <a href="https://www.w3.org/TR/css-display-3/">Level 3</a>,
-	'order' also has broader support than the 'layout-order' longhand.
 
 	Unless otherwise specified by a future specification,
 	this property has no effect on boxes that are not [=flex items=] or [=grid items=].
@@ -1259,20 +1093,20 @@ Box Order: the 'layout-order' property</h3>
 <h3 id="order-accessibility">
 Reordering and Accessibility</h3>
 
-	The 'layout-order' property <em>does not</em> affect ordering in non-visual media
+	The 'order' property <em>does not</em> affect ordering in non-visual media
 	(such as <a href="https://www.w3.org/TR/css-speech-1/">speech</a>).
-	Likewise, 'layout-order' does not affect
+	Likewise, 'order' does not affect
 	the default traversal order of sequential navigation modes
 	(such as cycling through links, see e.g. <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"><code>tabindex</code></a> [[HTML]]).
 
 	Advisement:
-	Authors <em>must</em> use 'layout-order' only for spatial, not logical, reordering of content.
-	Style sheets that use 'layout-order' to perform logical reordering are non-conforming.
+	Authors <em>must</em> use 'order' only for spatial, not logical, reordering of content.
+	Style sheets that use 'order' to perform logical reordering are non-conforming.
 
 	Note: This is so that non-visual media and non-CSS UAs,
 	which typically present content linearly,
 	can rely on a logical source order,
-	while 'layout-order' is used to tailor the layout order.
+	while 'order' is used to tailor the layout order.
 	(Since visual perception is two-dimensional and non-linear,
 	the desired layout order is not always logical.)
 
@@ -1280,7 +1114,7 @@ Reordering and Accessibility</h3>
 	authoring tools--
 	including WYSIWYG editors as well as Web-based authoring aids--
 	must reorder the underlying document source
-	and not use 'layout-order' to perform reordering
+	and not use 'order' to perform reordering
 	unless the author has explicitly indicated that
 	the spatial order should be <em>out-of-sync</em> with
 	the underlying document order (which determines speech and navigation order).
@@ -1306,14 +1140,218 @@ Reordering and Accessibility</h3>
 
 	Note: User agents, including browsers, accessible technology, and extensions,
 	may offer spatial navigation features.
-	This section does not preclude respecting the 'layout-order' property
+	This section does not preclude respecting the 'order' property
 	when determining element ordering in such spatial navigation modes;
 	indeed it would need to be considered for such a feature to work.
-	But 'layout-order' is not the only (or even the primary) CSS property
+	But 'order' is not the only (or even the primary) CSS property
 	that would need to be considered for such a spatial navigation feature.
 	A well-implemented spatial navigation feature would need to consider
 	all the layout features of CSS that modify spatial relationships.
 
+<h2 id='reading-order-items'>
+Reading Order: the 'reading-order-items' property</h2>
+
+	<pre class='propdef'>
+	Name: reading-order-items
+	Value: normal from-order? | flex [ visual | flow ] | grid [ rows | columns ]
+	Initial: normal
+	Applies to: flex and grid containers
+	Inherited: no
+	Computed value: as specified
+	Animation type: not animatable
+	</pre>
+
+	The 'reading-order-items' property controls the order in which
+	elements in a flex or grid layout are rendered to speech
+	or are navigated to when using (linear) sequential navigation methods.
+
+	It takes one or more keyword values. Values are defined as follows:
+
+	<dl dfn-for=reading-order-items dfn-type=value>
+		<dt><dfn>normal</dfn>
+		<dd>
+			Follow the order of elements in the DOM.
+		<dt><dfn>normal from-order</dfn>
+		<dd>
+			Follows the [=order-modified document order=].
+			Therefore, as 'normal' unless the 'order'
+			property has been used to change the order of items.
+		<dt><dfn>flex visual</dfn>
+		<dd>
+			Only takes effect on flex containers. 
+			Follows the visual reading order of flex items,
+			taking the writing mode into account.
+			Therefore, a document in English, with a 'flex-direction' of 'row-reverse'
+			and 'reading-order-items' of 'flex visual'
+			would have a reading order of left to right.
+		<dt><dfn>flex flow</dfn>
+		<dd>
+			Only takes effect on flex containers.
+			Follows the 'flex-flow' direction.
+		<dt><dfn>grid rows</dfn>
+		<dd>
+			Only takes effect on grid containers.
+			Follows the visual order of grid items by row,
+			taking the writing mode into account.
+		<dt><dfn>grid columns</dfn>
+		<dd>
+			Only takes effect on grid containers.
+			Follows the visual order of grid items by column,
+			taking the writing mode into account.
+	</dl>
+
+	ISSUE: <a href="https://github.com/w3c/csswg-drafts/issues/8589#issuecomment-1690330738">As raised in a comment by fantasai</a>,
+	do we need the multiple keywords, or should we hyphenate?
+
+	<div class='example'>
+		In this example, there are three flex items displayed as a row,
+		The 'reading-order-items' property has a value of 'flex visual'.
+		The 'flex-direction' property is 'row-reverse'.
+		The reading order of these items is therefore
+		"Item 3", "Item 2", "Item 1", reading from left to right.
+		
+		<pre class="lang-markup">
+		&lt;div class="wrapper"&gt;
+        	&lt;a href="#"&gt;Item 1&lt;/a&gt;
+        	&lt;a href="#"&gt;Item 2&lt;/a&gt;
+        	&lt;a href="#"&gt;Item 3&lt;/a&gt;
+    	&lt;/div&gt;
+		</pre>
+
+		<pre class="lang-css">
+        .wrapper {
+            display: flex;
+            flex-direction: row-reverse;
+            reading-order-items: flex visual;
+        }
+		</pre>
+	</div>
+
+	<div class='example'>
+		In this example there are four grid items,
+		placed on a grid and displayed visually out of DOM order.
+		The 'reading-order-items' property has a value of 'grid rows',
+		and the document is in English.
+		The reading order of these items is therefore
+		"Item 4", "Item 2", "Item 3", "Item 1".
+
+		<pre class="lang-markup">
+		&lt;div class="wrapper"&gt;
+        	&lt;a class="a" href="#"&gt;Item 1&lt;/a&gt;
+        	&lt;a class="b" href="#"&gt;Item 2&lt;/a&gt;
+        	&lt;a class="c" href="#"&gt;Item 3&lt;/a&gt;
+			&lt;a class="d" href="#"&gt;Item 4&lt;/a&gt;
+    	&lt;/div&gt;
+		</pre>
+
+		<pre class="lang-css">
+		.wrapper {
+            display: grid;
+            grid-template-columns: repeat(3, 150px);
+            grid-template-areas: "d b b"
+                                 "c c a";  
+            reading-order-items: grid rows;
+        }
+
+        .a { grid-area: a; }
+        .b { grid-area: b; }
+        .c { grid-area: c; }
+        .d { grid-area: d; }
+		</pre>
+	</div>
+
+	The 'reading-order-items' property affects neither layout nor painting order
+	and therefore has no effect on rendering to the visual [=canvas=].
+
+	When using a 'flex' or 'grid' keyword value,
+	the 'order' property is taken into account.
+
+	<div class='example'>
+		In this example, there are three flex items displayed as a row,
+		The 'reading-order-items' property has a value of 'flex flow'.
+		The third item in the DOM has 'order=-1'.
+		The reading order of these items is therefore
+		"Item 3", "Item 1", "Item 2".
+		
+		<pre class="lang-markup">
+		&lt;div class="wrapper"&gt;
+        	&lt;a href="#"&gt;Item 1&lt;/a&gt;
+        	&lt;a href="#"&gt;Item 2&lt;/a&gt;
+        	&lt;a href="#"&gt;Item 3&lt;/a&gt;
+    	&lt;/div&gt;
+		</pre>
+
+		<pre class="lang-css">
+		.wrapper a:nth-child(3) {
+            order: -1;
+        }
+
+        .wrapper {
+            display: flex;
+            reading-order-items: flex flow;
+        }
+		</pre>
+	</div>
+
+	Advisement: The source document should express
+	the underlying logical order of elements.
+	The 'reading-order-items' property exists for cases where a given document
+	can have multiple reading orders depending on layout changes,
+	e.g. in response to [=media queries=].
+	In such cases, the most common or most fundamental reading order
+	should be encoded in the source order
+	so that the document is sensical without CSS.
+
+	If the host language defines features for explicitly controlling
+	the reading or navigation order
+	(such as <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex"><code>tabindex</code></a> [[HTML]]),
+	these take precedence over 'reading-order-items':
+	the modified document order created by 'reading-order-items'
+	essentially replaces the underlying source order
+	for the purpose of such features.
+
+	ISSUE: Is this the most appropriate interaction with with <code>tabindex</code>?
+
+	<details class="note">
+		<summary>Design Considerations and Background</summary>
+
+		Some of the considerations that went into the design
+		of 'reading-order-items' are:
+
+		* There are clear use cases for disconnecting
+			the [=reading and navigation order=] from the box layout order,
+			the most fundamental of which is to make sure
+			the [=reading and navigation order=] matches the <strong>visual perception order</strong>
+			when it is not the same as the box layout order.
+			(Visual perception is non-linear, and is influenced by things like
+				the size, color contrast, and spacing of a visual element,
+				not just its spatial coordinates on the page.)
+		* It is a <a href="https://www.w3.org/TR/webarch/#pci">core principle of Web platform architecture</a>,
+			in order to allow content to be accessible to the widest possible audience
+			across devices that exist now and in the future,
+			for the underlying document to be sensical independent of CSS.
+			Therefore the underlying document order
+			should represent a logical ordering of its elements
+			regardless of its visual presentation.
+		* For components of a page that do not have a strong inherent order,
+			a document can have multiple visual presentations with different layouts,
+			all conveying the same semantic information.
+			It should be possible for all of these presentations to have good accessibility.
+		* Linear navigation, focus sequencing order, and screen-reader order
+			should always match, because there are users who use them together.
+		* Each component or hierarchical level of a page
+			can have different requirements for reordering,
+			so CSS reordering controls should not lend themselves
+			too easily to blanket use
+			(like 'box-sizing')
+			rather than tailored use
+			(like <a href="https://www.w3.org/TR/css-logical/">flow-relative vs. physical properties and values</a>).
+	</details>
+
+	ISSUE(7387): DOM needs a convenient reordering function
+	so that authors (even authors who don't usually write JS)
+	can easily perform source order reordering when necessary
+	instead of misusing 'order' or 'reading-order-items'.
 
 <!--
 ██     ██ ████  ██████  ████ ████████


### PR DESCRIPTION
Work on a draft for the `reading-order-items` property.

I have:

1. Put `order` back as in CSS Display 3, as the previous draft changed the `order` property and this does not.
2. Kept relevant sections from the original reading order draft, including design considerations, as it is still valid with some small updates.
3. Drafted `reading-order-items` with some examples. Worked examples can be found [here](https://github.com/rachelandrew/reading-order-items-examples).

An initial question, is that there is a section on order and accessibility in the specification. The details there are mostly relevant to `order` and `reading-order-items`, should this be updated to include both? (Could be done as a separate PR).
