### PR TITLE
[css-scroll-snap-2] Fix typo in CSS `scroll-snap` overview

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -320,7 +320,7 @@ Snap Events {#snap-events}
 	<dl>
 		<dt><code>SnapEvent . target</code></dt>
 		<dd>
-			This is the scroll container of the the snapped-to element.
+			This is the scroll container of the snapped-to element.
 		</dd>
 		<dt><code>SnapEvent . snappedTargets</code></dt>
 		<dd>
@@ -358,7 +358,7 @@ Snap Events {#snap-events}
 		<tr><th>Composed</th><td>Yes</td></tr>
 		<tr><th>Default action</th><td>None</td></tr>
 		<tr><th>Context<br/>(trusted events)</th><td><ul>
-													 <li>{{Event}}.{{Event/target}} : scroll container of the the snapped-to element</li>
+													 <li>{{Event}}.{{Event/target}} : scroll container of the snapped-to element</li>
 													 <li>{{SnapEvent}}.{{snappedTargets}} : an object with 2 keys for each axis, each key returns an array of snapped targets</li>
 													 <li>{{SnapEvent}}.{{snapTargets}} : an object with 2 keys for each axis, each key returns an array of the aggregated snap children</li>
 													 <li>{{SnapEvent}}.{{invokedProgrammatically}} : a boolean informing developers if a user or script invoked scroll that caused <a>snapChanged</a></li>
@@ -380,7 +380,7 @@ Snap Events {#snap-events}
 		<tr><th>Composed</th><td>Yes</td></tr>
 		<tr><th>Default action</th><td>None</td></tr>
 		<tr><th>Context<br/>(trusted events)</th><td><ul>
-													 <li>{{Event}}.{{Event/target}} : scroll container of the the snapped-to element.</li>
+													 <li>{{Event}}.{{Event/target}} : scroll container of the snapped-to element.</li>
 													 <li>{{SnapEvent}}.{{snappedTargets}}
 													 <li>{{SnapEvent}}.{{snapTargets}} : an object with 2 keys for each axis, each key returns an array of the aggregated snap children.</li>
 													 <li>{{SnapEvent}}.{{invokedProgrammatically}} : a boolean informing developers if a user or script invoked scroll that caused <a>snapChanged.</a></li>


### PR DESCRIPTION
This contribution replaces all occurrences of “the the” by “the”.