### PR TITLE
[css-view-transitions-2] Editorial: fix document variable usage

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -456,7 +456,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 			Note: this means that any running transition would be skipped when the document is ready
 			to unload.
 
-		1. Set |document|'s [=auto-skip view transitions=] to true.
+		1. Set |oldDocument|'s [=auto-skip view transitions=] to true.
 
 			Note: this means that calling {{Document/startViewTransition()}} while capturing the old document for a cross-document view-transition would run the callback but skip the animation.
 
@@ -474,7 +474,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 				Note: The ViewTransition object on the old Document should be destroyed after its state has been copied to the new Document below.
 					We explicitly clear it here since the old Document may be cached by the UA.
 
-			1. Set |document|'s [=auto-skip view transitions=] to false.
+			1. Set |oldDocument|'s [=auto-skip view transitions=] to false.
 
 			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=],
 				to perform the following steps:
@@ -491,7 +491,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 				1. Call |onReady|.
 
 				1. At any given time, the UA may decide to skip |inboundTransition|, e.g. after an [=implementation-defined=] timeout.
-					To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
+					To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following step:
 						If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
 
 			Note: |outboundTransition| is not exposed to JavaScript, it is used only for capturing


### PR DESCRIPTION
`document` is used without being declared - it's ambiguous as the surrounding steps have `oldDocument` and `newDocument`. Update to use the (hopefully) correct one.