### PR TITLE
[css-fonts-4] Set dfn type for legacy "font-stretch" property dfn

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -1025,7 +1025,7 @@ Font width: the 'font-width!!property' property</h3>
 		Font width: the 'font-stretch!!property' legacy name alias</h4>
 
 	For historical reasons,
-	a <dfn>font-stretch</dfn> property exists
+	a <dfn property>font-stretch</dfn> property exists
 	which is a [=legacy name alias=]
 	and functions in the identical way to 
 	the 'font-width!!property'.


### PR DESCRIPTION
The `font-stretch` property was not properly defined as a "property". This made links to it from the rest of the spec actually target the definition of the property in the /TR version of the spec.
