### PR TITLE
[css-viewport-1] Hardcode numeric range in syntax

### DIFF
--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -398,7 +398,7 @@ Note: 'zoom' does not affect or prevent 'transform' scaling.
 
 <pre class="propdef">
 	Name: zoom
-	Value: <<number>> || <<percentage>>
+	Value: <<number [0,∞]>> || <<percentage [0,∞]>>
 	Initial: 1
 	Applies to: all <<length>> property values of all elements
 	Inherited: no


### PR DESCRIPTION
  > Negative values for [zoom](https://drafts.csswg.org/css-viewport-1/#propdef-zoom) are illegal.

This PR encodes this requirement in its value definition, following the [range notation syntax](https://drafts.csswg.org/css-values-4/#numeric-ranges).