### PR TITLE
[scroll-animations] Abstract should say CSS properties instead of markup

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -14,7 +14,7 @@ Level: 1
 Group: CSSWG
 TR: https://www.w3.org/TR/scroll-animations-1/
 ED: https://drafts.csswg.org/scroll-animations-1/
-Abstract: Defines an API and markup for creating animations that are tied to
+Abstract: Defines CSS properties and an API for creating animations that are tied to
           the scroll offset of a scroll container.
 Editor: Brian Birtles, Invited Expert, brian@birchill.co.jp, w3cid 43194
 Editor: Botond Ballo, Mozilla, botond@mozilla.com, w3cid 94018


### PR DESCRIPTION
As suggested by @tantek in https://github.com/mozilla/standards-positions/pull/978#pullrequestreview-1852888403