### PR TITLE
[css-view-transitions-2] Fix "<pt-class-selector>" syntax

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -353,7 +353,7 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	<<pt-class-selector>> has the following syntax definition:
 
 	<pre class=prod>
-		<dfn>&lt;pt-class-selector></dfn> = ('.' <<custom-ident>>)*
+		<dfn>&lt;pt-class-selector></dfn> = ['.' <<custom-ident>>]*
 	</pre>
 
 	A [=named view transition pseudo-element=] [=selector=] which has one or more <<custom-ident>> values


### PR DESCRIPTION
The syntax used parentheses for grouping, instead of brackets, see: https://drafts.csswg.org/css-values-4/#component-combinators

(Buggy syntax introduced in #9773)