### PR TITLE
[css-view-transitions-1] Exclude auto as custom ident for view-transition-name

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -542,7 +542,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			as either an old or new [=/element=]--
 			with the specified [=view transition name=].
 
-			The value <css>none</css> is excluded from <<custom-ident>> here.
+			The values <css>none</css> and <css>auto</css> are excluded from <<custom-ident>> here.
 
 			Note: If this name is not unique
 			(i.e. if two elements simultaneously specify the same [=view transition name=])

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -511,7 +511,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<pre class=propdef>
 	Name: view-transition-name
-	Value: none | auto | <<custom-ident>>
+	Value: none | <<custom-ident>>
 	Initial: none
 	Inherited: no
 	Percentages: n/a
@@ -533,9 +533,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<dl dfn-type=value dfn-for=view-transition-name>
 		: <dfn>none</dfn>
 		:: The [=/element=] will not participate independently in a view transition.
-
-		: <dfn>auto</dfn>
-		:: This should be treated as an invalid value, despite being a valid <<custom-ident>>. The property value remains unchanged.
 
 		: <dfn><<custom-ident>></dfn>
 		:: The [=/element=] participates independently in a view transition--


### PR DESCRIPTION
Currently, below `view-transition-name`, defined with `none | auto | <custom-ident>`:

  > `<custom-ident>`: [...] The value `none` is excluded from `<custom-ident>` here.

https://drafts.csswg.org/css-view-transitions-1/#valdef-view-transition-name-custom-ident

This PR adds `auto` as an excluded `<custom-ident>` value.