### PR TITLE
[css-view-transitions-2] Nit: remove extra leading colon before active-view-transition() pseudo class

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -297,7 +297,7 @@ It has the following syntax definition:
 
 The [=specificity=] of an '':active-view-transition()'' is one pseudo-class selector if it has value is ''*'', and two if it has any other value.
 
-An ''::active-view-transition()'' pseudo-class matches the [=document element=] when it has an non-null [=active view transition=] |viewTransition|, for which any of the following are true:
+An '':active-view-transition()'' pseudo-class matches the [=document element=] when it has an non-null [=active view transition=] |viewTransition|, for which any of the following are true:
 
 * The <<vt-type-selector>> is ''*''
 * |viewTransition|'s [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> values of the <<vt-type-selector>>.
@@ -308,7 +308,7 @@ For example, the developer might start a transition in the following manner:
 document.startViewTransition({update: updateTheDOMSomehow, types: ["slide-in", "reverse"]});
 ```
 
-This will activate any of the following '::active-view-transition()'' selectors:
+This will activate any of the following ':active-view-transition()'' selectors:
 ```css
 :root:active-view-transition(slide-in) {}
 :root:active-view-transition(reverse) {}
@@ -317,7 +317,7 @@ This will activate any of the following '::active-view-transition()'' selectors:
 :root:active-view-transition(*) {}
 ```
 
-While starting a transition without selecting transition types, would only activate '::active-view-transition()'' with ''*'':
+While starting a transition without selecting transition types, would only activate ':active-view-transition()'' with ''*'':
 
 ```js
 document.startViewTransition(updateTheDOMSomehow);


### PR DESCRIPTION
Pseudo classes start with a single colon. Pseudo elements start with two.
