### PR TITLE
[css-view-transitions-2] Only accept declarations in `@view-transitions`

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -379,7 +379,7 @@ The ''@view-transition'' rule has the following syntax:
 
 <pre class=prod>
 	@view-transition {
-		<<declaration-rule-list>>
+		<<declaration-list>>
 	}
 </pre>
 


### PR DESCRIPTION
In #9383, which introduced `@view-transitions`, I do not see examples with `@view-transitions` (or with the other rule names) containing nested rules, so I assume this is not planned in the future, and that the basic syntax of its block contents can be defined with `<declaration-list>` instead of `<declaration-rule-list>`.

https://drafts.csswg.org/css-view-transitions-2/#view-transition-grammar