### PR TITLE
[mediaqueries-5] Add picture-in-picture display mode | issue #9260

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -1301,7 +1301,7 @@ Display Modes: the ''display-mode'' media feature </h3>
 
 	<pre class='descdef mq'>
 	Name: display-mode
-	Value: fullscreen | standalone | minimal-ui | browser
+	Value: fullscreen | standalone | minimal-ui | browser | picture-in-picture
 	For: @media
 	Type: discrete
 	</pre>
@@ -1350,6 +1350,16 @@ Display Modes: the ''display-mode'' media feature </h3>
 			The web application is displayed using the platform-specific convention
 			for opening hyperlinks in the user agent
 			(e.g., in a browser tab or a new window).
+
+		<dt><dfn>picture-in-picture</dfn>
+		<dd>
+			This mode allows users to continue consuming media while they interact
+			with other sites or applications on their device.
+			The web application is displayed in a floating and always-on-top window.
+			A user agent may include other platform specific UI elements,
+			such as "back-to-tab" and "site information" buttons
+			or whatever is customary on the platform and user agent.
+
 	</dl>
 
 	<details class="note">


### PR DESCRIPTION
This CL adds the `picture-in-picture` display mode to mediaqueries-5 spec as discussed in https://github.com/w3c/csswg-drafts/issues/9260