### PR TITLE
[css-view-transitions-1] Inherit to the UA stylesheet rules for animation-delay in vt pseudo-elements

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -858,6 +858,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		animation-duration: inherit;
 		animation-fill-mode: inherit;
+		animation-delay: inherit;
 	}
 
 	:root::view-transition-old(*),
@@ -869,6 +870,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		animation-duration: inherit;
 		animation-fill-mode: inherit;
+		animation-delay: inherit;
 	}
 
 	/* Default cross-fade transition */
@@ -1952,6 +1954,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add note to explain paint order for entry animations. See <a href="https://github.com/w3c/csswg-drafts/issues/9672">issue 9672</a>.
 * Add note to explain how the named elements are cleaned up. See <a href="https://github.com/w3c/csswg-drafts/issues/9669">issue 9669</a>.
 * Refactor algorithm to clarify timing, especially of `updateCallbackDone. See <a href="https://github.com/w3c/csswg-drafts/issues/9762">issue 9762</a>.
+* inherit to the UA stylesheet rules for (::view-transition) -image-pair, -old, and -new
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1954,7 +1954,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add note to explain paint order for entry animations. See <a href="https://github.com/w3c/csswg-drafts/issues/9672">issue 9672</a>.
 * Add note to explain how the named elements are cleaned up. See <a href="https://github.com/w3c/csswg-drafts/issues/9669">issue 9669</a>.
 * Refactor algorithm to clarify timing, especially of `updateCallbackDone. See <a href="https://github.com/w3c/csswg-drafts/issues/9762">issue 9762</a>.
-* inherit to the UA stylesheet rules for (::view-transition) -image-pair, -old, and -new
+* Add animation-delay inherit to UA stylesheet rules for (::view-transition) -image-pair, -old, and -new. See <a href="https://github.com/w3c/csswg-drafts/issues/9817">issue 9817</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>


### PR DESCRIPTION

Closes #9817
See [resolution](https://github.com/w3c/csswg-drafts/issues/9817#issuecomment-1933113926).
