### PR TITLE
[css-fonts-4] Define CSSFontFeatureValuesRule.historicalForms

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -8258,6 +8258,7 @@ interface CSSFontFeatureValuesRule : CSSRule {
 	readonly attribute CSSFontFeatureValuesMap swash;
 	readonly attribute CSSFontFeatureValuesMap characterVariant;
 	readonly attribute CSSFontFeatureValuesMap styleset;
+	readonly attribute CSSFontFeatureValuesMap historicalForms;
 };
 
 [Exposed=Window]


### PR DESCRIPTION
The map interface for [`@historical-forms`](https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-feature-values-historical-forms) declaration values is missing in [`CSSFontFeatureValuesRule`](https://drafts.csswg.org/css-fonts-4/#cssfontfeaturevaluesrule).