### PR TITLE
[css-view-transitions-2] Amend specificity of view-transition pseudos with a class

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -365,8 +365,11 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	in its <<pt-class-selector>> would only match an element if the [=captured element/class list=] value in
 	[=ViewTransition/named elements=] for the pseudo-element's 'view-transition-name' [=list/contains=] all of those values.
 
-	The specificity of a [=named view transition pseudo-element=] [=selector=]
-	with a <<pt-class-selector>> is equivalent to a [=type selector=].
+	The specifi[=specificity=]city of a [=named view transition pseudo-element=] [=selector=]
+	with a <<custom-ident>> argument or a or a <<pt-class-selector>> with at least one <<custom-ident>>
+	is equivalent to a [=type selector=].
+	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
+	with a ''*'' argument and with an empty <<pt-class-selector>> is zero.
 
 # CSS rules # {#css-rules}
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -365,9 +365,12 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	in its <<pt-class-selector>> would only match an element if the [=captured element/class list=] value in
 	[=ViewTransition/named elements=] for the pseudo-element's 'view-transition-name' [=list/contains=] all of those values.
 
-	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
-	with a <<custom-ident>> argument or a or a <<pt-class-selector>> with at least one <<custom-ident>>
+	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=] with either:
+		* a <<pt-name-selector>> with a <<custom-ident>>; or
+		* a <<pt-class-selector>> with at least one <<custom-ident>>,
+
 	is equivalent to a [=type selector=].
+
 	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
 	with a ''*'' argument and with an empty <<pt-class-selector>> is zero.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -366,8 +366,7 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	[=ViewTransition/named elements=] for the pseudo-element's 'view-transition-name' [=list/contains=] all of those values.
 
 	The specificity of a [=named view transition pseudo-element=] [=selector=]
-	with a <<pt-class-selector>>
-	is equivalent to a [=class selector=] with the equivalent number of classes.
+	with a <<pt-class-selector>> is equivalent to a [=type selector=].
 
 # CSS rules # {#css-rules}
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -365,7 +365,7 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	in its <<pt-class-selector>> would only match an element if the [=captured element/class list=] value in
 	[=ViewTransition/named elements=] for the pseudo-element's 'view-transition-name' [=list/contains=] all of those values.
 
-	The specifi[=specificity=]city of a [=named view transition pseudo-element=] [=selector=]
+	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
 	with a <<custom-ident>> argument or a or a <<pt-class-selector>> with at least one <<custom-ident>>
 	is equivalent to a [=type selector=].
 	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]


### PR DESCRIPTION
Closes #9887
See [resolution](https://github.com/w3c/csswg-drafts/9887#issuecomment-1939286361)

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
