### PR TITLE
[css-view-transitions-1] Auto-skip a view-transition if document is hidden

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -956,8 +956,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
 
+		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
+			then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
+			and return.
+
 		1. If |document|'s [=auto-skip view transitions=] is true,
-			then [=skip the view transition=] for |transition| with "{{InvalidStateError}}" {{DOMException}},
+			then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}},
 			and return.
 
 		1. If |document|'s [=active view transition=] is not null,
@@ -1955,7 +1959,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add note to explain how the named elements are cleaned up. See <a href="https://github.com/w3c/csswg-drafts/issues/9669">issue 9669</a>.
 * Refactor algorithm to clarify timing, especially of `updateCallbackDone. See <a href="https://github.com/w3c/csswg-drafts/issues/9762">issue 9762</a>.
 * Add animation-delay inherit to UA stylesheet rules for (::view-transition) -image-pair, -old, and -new. See <a href="https://github.com/w3c/csswg-drafts/issues/9817">issue 9817</a>.
-
+* Auto-skip animation when document is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>
 </h3>


### PR DESCRIPTION
See [resolution](https://github.com/w3c/csswg-drafts/issues/9543#issuecomment-1939242246).

Note: this only covers [css-view-transitions-1], will follow up on cross-document view transitions.