### PR TITLE
[css-view-transitions-2] Skip cross-document view-transitions when hidden or not-yet-revealed

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -49,6 +49,7 @@ spec:html
 	text: run the animation frame callbacks; type: dfn;
 	text: unload; type: dfn;
 	text: pagereveal; type: dfn; for: Window;
+	text: has been revealed; type: dfn;
 spec:infra; type:dfn; text:list
 </pre>
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -613,6 +613,9 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 	<div algorithm>
 		To get the <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
 
+		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
+			then return "<code>skip transition</code>".
+
 		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
 
 		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
@@ -654,6 +657,8 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 		a {{Document}} |newDocument|, and |proceedWithNavigation|, which is an algorithm accepting nothing:
 
 		1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
+
+		1. If |oldDocument|'s [=has been revealed=] is false, then return null.
 
 		1. Let |resolvedRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
 


### PR DESCRIPTION
This handles the cases where
- A cross document transition starts from a hidden document
- A hidden document receives a cross-document transition
- A cross-document transition starts from a document that hasn't yet rendered
Closes #9822
See also #9543

Resolutions:
https://github.com/w3c/csswg-drafts/issues/9822#issuecomment-1939374784
https://github.com/w3c/csswg-drafts/issues/9543#issuecomment-1939242246