### PR TITLE
[css-view-transitions-1] Export an algorithm to skip a transition in a hidden document

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1662,6 +1662,17 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			then |transition|'s [=ViewTransition/finished promise=] will reject with the same reason.
 	</div>
 
+## View transition page-visibility change steps ## {#page-visibility-change-steps}
+	<div algorithm>
+	The <dfn export>view transition page-visibility change steps</dfn> given {{Document}} |document| are:
+
+	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
+		and |document|'s [=active view transition=] is not null,
+		then [=skip the view transition|skip=] |document|'s [=active view transition=].
+
+	Note: this is called from the HTML spec.
+	</div>
+
 ## [=Capture the image=] ## {#capture-the-image-algorithm}
 
 	<div algorithm>
@@ -1939,6 +1950,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Add animation-delay inherit to UA stylesheet rules for (::view-transition) -image-pair, -old, and -new. See <a href="https://github.com/w3c/csswg-drafts/issues/9817">issue 9817</a>.
 * Auto-skip animation when document is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
 * Remove references to cross-document view-transitions, to keep the L1 spec clean. See <a href="https://github.com/w3c/csswg-drafts/issues/9886">Issue 9886</a>.
+* Export an algorithm to skip the active transition when the page is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1666,9 +1666,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<div algorithm>
 	The <dfn export>view transition page-visibility change steps</dfn> given {{Document}} |document| are:
 
-	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
-		and |document|'s [=active view transition=] is not null,
-		then [=skip the view transition|skip=] |document|'s [=active view transition=].
+	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>", then:
+
+		1. If |document|'s [=active view transition=] is not null, then [=skip the view transition|skip=] |document|'s [=active view transition=].
+
+	1. Otherwise, [=assert=]: [=active view transition=] is null.
 
 	Note: this is called from the HTML spec.
 	</div>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -588,6 +588,7 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
 
+
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
 	<div algorithm="monkey patch to apply the history step">

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -588,7 +588,6 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
 
-
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
 	<div algorithm="monkey patch to apply the history step">


### PR DESCRIPTION
Together with https://github.com/whatwg/html/pull/10137
See #9543
