### PR TITLE
[css-view-transitions-2] Resolve outbound transition promises after document unloads

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -20,7 +20,6 @@ Markup Shorthands: css yes, markdown yes
 spec:css-view-transitions-1;
 	text: active view transition; type: dfn;
 	text: capture the old state; type: dfn;
-	text: clear view transition; type: dfn;
 	text: activate view transition; type: dfn;
 	text: skip the view transition; type: dfn;
 	text: ViewTransition; type: interface;
@@ -582,13 +581,28 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 			[=view transition params/named elements=] is a [=map/clone=] of |transition|'s [=ViewTransition/named elements=],
 			and whose [=view transition params/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=].
 
-		1. [=Clear view transition=] |transition|.
-
-			Note: The ViewTransition object on the old Document should be destroyed after its state has been copied to the new Document below.
-				We explicitly clear it here since the old Document may be cached by the UA.
-
 		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
 
+## Modifications to page-visibility change steps ## {#additions-to-page-visibility-change-steps}
+	<div algorithm="amended page-visibility change steps">
+	The <dfn export>amended view transition page-visibility change steps</dfn> given {{Document}} |document| are:
+
+	1. Let |transition| be |document|'s [=active view transition=].
+
+	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>", then:
+
+		1. If |transition| is null, then return.
+
+		1. If |transition|'s [=outbound post-capture steps=] are null, then [=skip the view transition|skip=] |transition|.
+
+		1. Otherwise, [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to [=skip the view transition|skip=] |transition|.
+
+			Note: this ensures that the promises are resolved if and when the document is restored from BFCache.
+
+	1. Otherwise, [=assert=]: |transition| is null.
+
+	Note: this is called from the HTML spec, and replaces the [=page visibility change steps=] from L1.
+	</div>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
@@ -677,6 +691,9 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
 			whose [=ViewTransition/active types=] is |resolvedRule|.
+
+			Note: the {{ViewTransition}} object is skipped when the old page is hidden, and the promises resolve
+			if it is restored from BFCache.
 
 		1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
 			1. Set |newDocument|'s [=inbound view transition params=] to |params|.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -583,26 +583,6 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
 
-## Modifications to page-visibility change steps ## {#additions-to-page-visibility-change-steps}
-	<div algorithm="amended page-visibility change steps">
-	The <dfn export>amended view transition page-visibility change steps</dfn> given {{Document}} |document| are:
-
-	1. Let |transition| be |document|'s [=active view transition=].
-
-	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>", then:
-
-		1. If |transition| is null, then return.
-
-		1. If |transition|'s [=outbound post-capture steps=] are null, then [=skip the view transition|skip=] |transition|.
-
-		1. Otherwise, [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to [=skip the view transition|skip=] |transition|.
-
-			Note: this ensures that the promises are resolved if and when the document is restored from BFCache.
-
-	1. Otherwise, [=assert=]: |transition| is null.
-
-	Note: this is called from the HTML spec, and replaces the [=page visibility change steps=] from L1.
-	</div>
 
 ## Monkey patches to HTML ## {#monkey-patch-to-html}
 
@@ -692,8 +672,7 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=],
 			whose [=ViewTransition/active types=] is |resolvedRule|.
 
-			Note: the {{ViewTransition}} object is skipped when the old page is hidden, and the promises resolve
-			if it is restored from BFCache.
+			Note: the {{ViewTransition}} is skipped once the old document is hidden.
 
 		1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
 			1. Set |newDocument|'s [=inbound view transition params=] to |params|.


### PR DESCRIPTION
See [this resolution](https://github.com/w3c/csswg-drafts/issues/9888#issuecomment-1939367607)
Closes #9888
