### PR TITLE
[cssom-1][css-color-4][css-color-5][css-color-6] Describe CSSOM serialization in terms of declared values rather than specified values, fix #9993

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -5694,7 +5694,7 @@ Resolving sRGB values</h3>
 
 	If the sRGB color was explicitly specified by the author as a [=named color=],
 	or as a [=system color=],
-	the [=specified value=] is that named or system color, converted to 
+	the [=declared value=] is that named or system color, converted to 
 	<a href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a>.
 	The computed and used value
 	is the corresponding sRGB color,
@@ -5703,7 +5703,7 @@ Resolving sRGB values</h3>
 	and defaulting to opaque if unspecified).
 
 	<div class="example" id="ex-named-case">
-			<p>The author-provided mixed-case form below has a specified value in all lowercase.</p>
+			<p>The author-provided mixed-case form below has a declared value in all lowercase.</p>
 			<pre class="lang-css"><span class="swatch" style="--color: purple"></span> pUrPlE
 
 			<span class="swatch" style="--color: purple"></span> purple</pre>
@@ -5722,12 +5722,12 @@ Resolving sRGB values</h3>
 	
 	<!-- While the function names and named colors
 		are <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>,
-		the [=specified value=]
+		the [=declared value=]
 		does not preserve any mixed casing
 		and is treated as being all lowercase. -->
 
 	
-	Otherwise, the specified, computed and used value
+	Otherwise, the declared, computed and used value
 	is the corresponding sRGB color,
 	paired with the specified alpha channel
 	(after clamping to [0, 1])
@@ -5735,12 +5735,12 @@ Resolving sRGB values</h3>
 
 	For historical reasons, when ''calc()'' in sRGB colors 
 	resolves to a single value, 
-	the specified value serialises without the "calc(" ")" wrapper.
+	the declared value serialises without the "calc(" ")" wrapper.
 
 	<div class="example" id="ex-srgb-calc-specified">
 		For example, if a color is given as
 		<span class="swatch" style="--color: rgb(128 127 255)"></span>  rgb(calc(64 * 2) 127 255)
-		the specified value will be
+		the declared value will be
 		rgb(128 127 255)
 		and not
 		rgb(calc(128) 127 255).
@@ -5749,7 +5749,7 @@ Resolving sRGB values</h3>
 	<div class="example" id="ex-srgb-hsl-calc-specified">
 		For example, if a color is given as
 		<span class="swatch" style="--color: rgb(255 165.2 0)"></span>  hsl(38.82 calc(2 * 50%) 50%)
-		the specified value will be
+		the declared value will be
 		rgb(255 165.2 0)
 		because the ''calc()'' is lost
 		during HSL to RGB conversion.
@@ -5762,7 +5762,7 @@ Resolving sRGB values</h3>
 	<div class="example" id="ex-srgb-clamped-calc-specified">
 		For example, if a color is given as
 		<span class="swatch" style="--color: rgb(255 127 0)"></span>  rgb(calc(100 * 4) 127 calc(20 - 35))
-		the specified value will be
+		the declared value will be
 		rgb(255 127 0)
 		and not
 		rgb(calc(400) 127 calc(-15)).
@@ -5789,7 +5789,7 @@ Resolving Lab and LCH values</h3>
 
 	This applies to ''lab()'' and ''lch()'' values.
 
-		The specified, computed and used value
+		The declared, computed and used value
 		is the corresponding CIE Lab or LCH color
 		(after clamping of L, C and H)
 		paired with the specified alpha channel
@@ -5808,7 +5808,7 @@ Resolving Oklab and Oklch values</h3>
 
 	This applies to ''oklab()'' and ''oklch()'' values.
 
-		The specified, computed and used value
+		The declared, computed and used value
 		is the corresponding Oklab or Oklch color
 		(after clamping of L, C and H)
 		paired with the specified alpha channel
@@ -5825,7 +5825,7 @@ Resolving Oklab and Oklch values</h3>
 <h3 id="resolving-color-function-values">
 Resolving values of the ''color()'' function</h3>
 
-		The specified, computed and used value
+		The declared, computed and used value
 		is the color in the specified [=color space=],
 		paired with the specified alpha channel
 		(as a <<number>>, not a <<percentage>>;
@@ -5857,7 +5857,7 @@ Resolving values of the ''color()'' function</h3>
 	''transparent'',
 	and ''color>/currentcolor''.
 
-	The specified value for each <<system-color>> keyword
+	The declared value for each <<system-color>> keyword
 	and <<deprecated-color>> keyword
 	is itself.
 	The computed value
@@ -5870,12 +5870,12 @@ Resolving values of the ''color()'' function</h3>
 
 		<pre class="lang-html">&lt;button style="color: <span class="swatch" style="--color: ButtonText"></span> ButtonText; background: <span class="swatch" style="--color: ButtonFace"></span> ButtonFace">&lt;/button></pre>
 
-		The specified value of the color property is "ButtonText" 
+		The declared value of the color property is "ButtonText" 
 		while the computed value could be, for example, 
 		<span class="swatch" style="--color: #FFF"></span> rgb(0, 0, 0).
 	</div>
 
-	The specified value of ''transparent'' is "transparent" 
+	The declared value of ''transparent'' is "transparent" 
 	while the computed and used value  is [=transparent black=].
 
 	The ''currentcolor'' keyword computes to itself.
@@ -6084,7 +6084,7 @@ Serializing alpha values</h3>
 	</div>
 
 	Because <<alpha-value>>s which were specified outside the valid range
-	are clamped at parse time, the specified value will be clamped.
+	are clamped at parse time, the declared value will be clamped.
 	However, per [[css-values-4#calc-range]], <<alpha-value>>s
 	specified using calc() are not clamped when the specified form is serialized;
 	but the computed values are clamped.
@@ -6093,7 +6093,7 @@ Serializing alpha values</h3>
 		<p>For example an alpha value which was specified directly as 120%
 			would be serialized as the string "1".
 			However, if it was specified as calc(2*60%)
-			the specified value would be serialized as the string "calc(1.2)".
+			the declared value would be serialized as the string "calc(1.2)".
 		</p>
 	</div>
 
@@ -6116,14 +6116,14 @@ Serializing sRGB values</h3>
 		https://github.com/w3c/csswg-drafts/issues/8312
 	-->
 
-	is derived from the [=specified value=].
+	is derived from the [=declared value=].
 	
 	When serializing the value of a property 
 	which was set by the author to a CSS [=named color=], 
 	a [=system color=],
 	a <a href="#deprecated-system-colors">deprecated-color</a>,
 	or ''transparent''
-	therefore, for the [=specified value=],
+	therefore, for the [=declared value=],
 	the <a href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a>  
 	keyword value is retained.
 	For the computed and used value,
@@ -6133,11 +6133,11 @@ Serializing sRGB values</h3>
 		system-color-compute.html
 	</wpt>
 
-	Thus, the serialized specified value of ''transparent'' is the string "transparent",
+	Thus, the serialized declared value of ''transparent'' is the string "transparent",
 	while the serialized computed value of ''transparent'' is the string "rgba(0, 0, 0, 0)".
 
 	For all other sRGB values,
-	the specified, computed and used value
+	the declared, computed and used value
 	is the corresponding sRGB value.
 
 	Corresponding sRGB values use either the ''rgb()'' or ''rgba()'' form

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2773,7 +2773,7 @@ an implicit value of 1 (fully opaque) is the default.
 	Serializing color-mix()
 </h3>
 
-The serialization of the specified value of a ''color-mix()'' function
+The serialization of the declared value of a ''color-mix()'' function
 is the string "color-mix(in ",
 followed by the specified <<color-space>> in all-lowercase,
 followed by ", ",
@@ -2791,15 +2791,15 @@ the second percentage is typically omitted,
 even if explicitly specified.
 
 <div class="example" id="ex-serial-specified-mix">
-	For example, the serialized specified value of
+	For example, the serialized declared value of
 	<pre>color-mix(in oklab, teal, peru 40%)</pre>
 	would be the string "color-mix(in oklab, teal 60%, peru)".
 
-	The serialized specified value of
+	The serialized declared value of
 	<pre>color-mix(in oklab, teal 50%, peru 50%)</pre>
 	would be the string "color-mix(in oklab, teal, peru)".
 
-	The serialized specified value of
+	The serialized declared value of
 	<pre>color-mix(in oklab, teal 70%, peru 70%)</pre>
 	would be the string "color-mix(in oklab, teal 70%, peru 70%)"
 	because the fact that these normalize to 50% each
@@ -2808,7 +2808,7 @@ even if explicitly specified.
 
 The serialization of the result of a ''color-mix()'' function
 depends on whether the keyword ''currentColor'' is used in the mix.
-If so, the result is serialized as the specified value.
+If so, the result is serialized as the declared value.
 This allows the correct mixture to be used
 on child elements whose ''color'' property has a different value.
 Otherwise, it
@@ -2899,16 +2899,16 @@ is the same as that specified in
 	Serializing Relative Color Functions
 </h3>
 
-The serialization of the specified value of a relative color function
+The serialization of the declared value of a relative color function
 is a string identifying the color function in all-lowercase,
 followed by "(from ",
-followed by the serialization of the specified value of the origin color,
+followed by the serialization of the declared value of the origin color,
 followed by a single space,
 followed by a singly-space-separated list of the arguments to the color function,
 followed by ")".
 
 <div class="example" id="ex-serial-rcs-specified-simple">
-	For example, the result of serializing the specified value
+	For example, the result of serializing the declared value
 
 	<pre class="lang-css">OkLcH(from peru  l    c  h)</pre>
 
@@ -2919,7 +2919,7 @@ followed by ")".
 
 The serialization of the result of a relative color function
 depends on whether the keyword ''currentColor'' is the [=origin color=].
-If so, the result is serialized as the specified value.
+If so, the result is serialized as the declared value.
 This allows the correct value to be used
 on child elements whose ''color'' property has a different value.
 Otherwise, it

--- a/css-color-6/Overview.bs
+++ b/css-color-6/Overview.bs
@@ -379,7 +379,7 @@ results of the
 Serializing contrast-color() {#serial-contrast-color}
 -----------------------------------------------------
 
-The [=specified value=] of the ''contrast-color()'' function
+The [=declared value=] of the ''contrast-color()'' function
 is serialized with each keyword value as specified
 and each component in canonical order.
 

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2802,7 +2802,7 @@ depends on the component, as follows:
  <dd>
   The &lt;number> component serialized as per &lt;number> followed by the unit in canonical form as defined in its respective specification.
 
-  Issue: Probably should distinguish between specified and computed / resolved values.
+  Issue: Probably should distinguish between declared and computed / resolved values.
 
  <dt><<color>>
  <dd>
@@ -2811,7 +2811,7 @@ depends on the component, as follows:
  If &lt;color&gt; is a component of a computed value, see [[css-color-4#serializing-color-values]].
 
 
- If <<color>> is a component of a specified value, then
+ If <<color>> is a component of a declared value, then
 for sRGB values, see
 [[css-color-4#resolving-sRGB-values]].
 For other color functions, see 
@@ -2842,7 +2842,7 @@ For other color functions, see
  <dd>
   The &lt;number> component serialized as per &lt;number> followed by the unit in its canonical form as defined in its respective specification.
 
-  Issue: Probably should distinguish between specified and computed / resolved values.
+  Issue: Probably should distinguish between declared and computed / resolved values.
 
  <dt><<identifier>>
  <dd>The identifier
@@ -2857,7 +2857,7 @@ For other color functions, see
  <dd>
   The &lt;number> component serialized as per &lt;number> followed by the unit in its canonical form as defined in its respective specification.
 
-  Issue: Probably should distinguish between specified and computed / resolved values.
+  Issue: Probably should distinguish between declared and computed / resolved values.
 
  <dt><<number>>
  <dd>
@@ -2908,7 +2908,7 @@ For other color functions, see
  <dd>The <a>absolute-URL string</a>
  <a lt="serialize a URL">serialized as URL</a>.
 
- Issue: This should differentiate specified and computed <<url>> values, see <a href="https://github.com/w3c/csswg-drafts/issues/3195">#3195</a>.
+ Issue: This should differentiate declared and computed <<url>> values, see <a href="https://github.com/w3c/csswg-drafts/issues/3195">#3195</a>.
 </dl>
 
 
@@ -2934,7 +2934,7 @@ define the CSS components.
 
 #### Examples #### {#serializing-css-values-examples}
 
-Here are some examples of before and after results on specified values.
+Here are some examples of before and after results on declared values.
 The before column could be what the author wrote in a style sheet, while
 the after column shows what querying the DOM would return.
 


### PR DESCRIPTION
This PR rephrases `specified value` as `declared value`, where it involves CSSOM value serialization. Fixes #9993.

The fact that the CSS-wide keywords are kept as-is is already [covered in serialize-values tests](https://github.com/web-platform-tests/wpt/blob/f57f833daf407ab46840ec52c0a8de8ee02e319a/css/cssom/serialize-values.html#L369-L372).