### PR TITLE
[cssom-1] Simplify setting MediaList.mediaText

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -568,7 +568,6 @@ The <dfn attribute for=MediaList>mediaText</dfn> attribute, on getting, must ret
 Setting the {{MediaList/mediaText}} attribute must run these steps:
 <ol>
  <li>Empty the <a>collection of media queries</a>.
- <li>If the given value is the empty string, then return.
  <li>Append all the media queries as a result of <a lt="parse a media query list">parsing</a> the given
  value to the <a>collection of media queries</a>.
 </ol>


### PR DESCRIPTION
This PR removes step 2 for [setting `MediaList.mediaText`](https://drafts.csswg.org/cssom-1/#dom-medialist-mediatext) with empty string since step 3 (parsing) produces the same outcome:

  > 3. Append all the media queries as a result of [parsing](https://drafts.csswg.org/cssom-1/#parse-a-media-query-list) the given value to the collection of media queries.

*Parsing* links to [parse a media query list](https://drafts.csswg.org/cssom-1/#parse-a-media-query-list) which redirects to [`<media-query-list>`](https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list):

  > To parse a `<media-query-list>` production, parse a comma-separated list of component values, then parse each entry in the returned list as a `<media-query>`.
  >
  > Note: This definition of `<media-query-list>` parsing intentionally accepts an empty list.