### PR TITLE
Revert "[css-backgrounds-3] #8649 Specify ink overflow extent for box-shadow"

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -2097,7 +2097,7 @@ they apply to the top, right, bottom, and left, respectively.
 <p>Portions of the border-image that are rendered outside the border
 box do not trigger scrolling. Also such portions are invisible to mouse
 events and do not capture such events on behalf of the element, but
-but they are included in the [=ink overflow area=] of the element.</p>
+they are included in the [=ink overflow area=] of the element.</p>
 
 <p class=note>Note that, even though they never cause a scrolling
 mechanism, outset images may still be clipped by an ancestor or by the

--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -2096,7 +2096,7 @@ they apply to the top, right, bottom, and left, respectively.
 
 <p>Portions of the border-image that are rendered outside the border
 box do not trigger scrolling. Also such portions are invisible to mouse
-events and do not capture such events on behalf of the element,
+events and do not capture such events on behalf of the element, but
 but they are included in the [=ink overflow area=] of the element.</p>
 
 <p class=note>Note that, even though they never cause a scrolling

--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -31,7 +31,6 @@ spec:css2; type:value; text:visible
 spec:css-break-4; type:dfn; text:fragment
 spec:css-color-4; type:property; text:color
 spec:css-color-4; type:value; text:transparent
-spec:css-overflow-3; type:dfn; text:ink overflow area 
 spec:selectors-3; type:selector; text: ::first-letter
 spec:selectors-3; type:selector; text: ::first-line
 spec:css-values-3; type:type; text:<position>
@@ -2096,8 +2095,7 @@ they apply to the top, right, bottom, and left, respectively.
 
 <p>Portions of the border-image that are rendered outside the border
 box do not trigger scrolling. Also such portions are invisible to mouse
-events and do not capture such events on behalf of the element, but
-they are included in the [=ink overflow area=] of the element.</p>
+events and do not capture such events on behalf of the element.</p>
 
 <p class=note>Note that, even though they never cause a scrolling
 mechanism, outset images may still be clipped by an ancestor or by the
@@ -2353,14 +2351,6 @@ Animation type: by computed value,
                 which is visibly apparent for 24px centered along the edge of the shadow.">
     </p>
   </div>
-
-  <p>If the ''box-shadow/inset'' keyword is not present,
-  the [=ink overflow area=] of a box shadow is defined by the
-  extent of the [=box-shadow/horizontal offset=], [=box-shadow/vertical offset=],
-  and [=box-shadow/spread distance=] values beyond the element's border-box,
-  plus the ink overflow contributed by the [=box-shadow/blur radius=]
-  as described for the
-  <a class="css" data-link-type="maybe" href="https://drafts.fxtf.org/filter-effects-1/#funcdef-filter-blur" id="ref-for-funcdef-filter-blur">blur()</a> filter function.</p>
 
 <h4 id="shadow-shape">
 Shadow Shape, Spread, and Knockout</h4>


### PR DESCRIPTION
Reverts w3c/csswg-drafts#9823 which afaict isn't an editorial clarification, wasn't approved by an editor, and doesn't have a WG resolution...