### PR TITLE
[css-overflow-3] Clarify that scripts can also scroll a scroll container

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -321,9 +321,8 @@ Scrollable Overflow</h3>
 Scrolling Overflow</h3>
 
 	A box’s [=overflow=] can be visible or clipped.
-        CSS also allows a box to be a <dfn export>scroll container</dfn>
-	with a <a>scrollable overflow area</a> whose clipped parts can be
-        scrolled into view via user interaction or script.
+	CSS also allows a box to be a <dfn export>scroll container</dfn>
+	that allows clipped parts of its scrollable overflow area to be scrolled into view.
 	The visual viewport of a <a>scroll container</a>
 	(through which the <a>scrollable overflow area</a> can be viewed)
 	coincides with its padding box,

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -321,9 +321,9 @@ Scrollable Overflow</h3>
 Scrolling Overflow</h3>
 
 	A box’s [=overflow=] can be visible or clipped.
-	CSS also allows a box to be <dfn export>scroll container</dfn>
-	that allows the user to scroll clipped parts of its <a>scrollable overflow area</a>
-	into view.
+        CSS also allows a box to be a <dfn export>scroll container</dfn>
+	with a <a>scrollable overflow area</a> whose clipped parts can be
+        scrolled into view via user interaction or script.
 	The visual viewport of a <a>scroll container</a>
 	(through which the <a>scrollable overflow area</a> can be viewed)
 	coincides with its padding box,


### PR DESCRIPTION
This clarification was precipitated by an  [intersection observer issue](https://github.com/w3c/IntersectionObserver/issues/521) in order to avoid confusion over who can scroll the overflow area of a scroll container.

