### PR TITLE
[css-color-4] Update ΔEOK to be even more perceptually uniform

### DIFF
--- a/css-color-4/deltaEOK.js
+++ b/css-color-4/deltaEOK.js
@@ -9,7 +9,7 @@ function deltaEOK (reference, sample) {
     let [L1, a1, b1] = reference;
 	let [L2, a2, b2] = sample;
 	let ΔL = L1 - L2;
-	let Δa = a1 - a2;
-	let Δb = b1 - b2;
+	let Δa = 2 * (a1 - a2);
+	let Δb = 2 * (b1 - b2);
 	return Math.sqrt(ΔL ** 2 + Δa ** 2 + Δb ** 2);
 }


### PR DESCRIPTION
In a discussion with @bottosson, I learned that he considers the scale of the _a_ and _b_ coordinates a mistake in the design of Oklab. Orthogonality between _L_, _a_, and _b_ was a design goal, but the scale of the coordinates was not carefully chosen. They should be roughly doubled to make a change in _a_ or _b_ as noticeable as the same change in _L_.

I don't think this is documented anywhere, so I'm hoping for confirmation here. Perhaps I've also misunderstood.

If correct, then it's too late to change the coordinates, but ΔEOK should probably take this into account. An update to the [preceding prose](https://drafts.csswg.org/css-color-4/#color-difference-OK) would also be needed, but I'm leaving that until the math itself is confirmed to be correct, in case it's not.