### PR TITLE
[css-images-4] Allow a single color stop with two positions

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1828,18 +1828,18 @@ Color Stop Lists</h4>
 
 	<a>Color stops</a> and [=transition hints=] are specified
 	in a <dfn export>color stop list</dfn>,
-	which is a list of two or more [=color stops=]
+	which is a list of one or more [=color stops=]
 	interleaved with optional [=transition hints=]:
 
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
-			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
+			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#?
 		<dfn>&lt;linear-color-stop></dfn> = <<color>> <<color-stop-length>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 		<dfn>&lt;color-stop-length></dfn> = <<length-percentage>>{1,2}
 
 		<dfn>&lt;angular-color-stop-list></dfn> =
-			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
+			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#?
 		<dfn>&lt;angular-color-stop></dfn> = <<color>> <<color-stop-angle>>?
 		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>>
 		<dfn>&lt;color-stop-angle></dfn> = <<angle-percentage>>{1,2}

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1833,20 +1833,16 @@ Color Stop Lists</h4>
 
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
-			  <<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
-			| <<single-linear-color-stop>>
+			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
 		<dfn>&lt;linear-color-stop></dfn> = <<color>> <<color-stop-length>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 		<dfn>&lt;color-stop-length></dfn> = <<length-percentage>>{1,2}
-		<dfn>&lt;single-linear-color-stop></dfn> = <<color>> <<length-percentage>>{2}
 
 		<dfn>&lt;angular-color-stop-list></dfn> =
-			  <<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
-			| <<single-angular-color-stop>>
+			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
 		<dfn>&lt;angular-color-stop></dfn> = <<color>> <<color-stop-angle>>?
 		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>>
 		<dfn>&lt;color-stop-angle></dfn> = <<angle-percentage>>{1,2}
-		<dfn>&lt;single-angular-color-stop></dfn> = <<color>> <<angle-percentage>>{2}
 
 		<dfn>&lt;color-stop></dfn> = <<color-stop-length>> | <<color-stop-angle>>
 	</pre>

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1833,16 +1833,20 @@ Color Stop Lists</h4>
 
 	<pre class=prod>
 		<dfn>&lt;color-stop-list></dfn> =
-			<<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
+			  <<linear-color-stop>> , [ <<linear-color-hint>>? , <<linear-color-stop>> ]#
+			| <<single-linear-color-stop>>
 		<dfn>&lt;linear-color-stop></dfn> = <<color>> <<color-stop-length>>?
 		<dfn>&lt;linear-color-hint></dfn> = <<length-percentage>>
 		<dfn>&lt;color-stop-length></dfn> = <<length-percentage>>{1,2}
+		<dfn>&lt;single-linear-color-stop></dfn> = <<color>> <<length-percentage>>{2}
 
 		<dfn>&lt;angular-color-stop-list></dfn> =
-			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
+			  <<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#
+			| <<single-angular-color-stop>>
 		<dfn>&lt;angular-color-stop></dfn> = <<color>> <<color-stop-angle>>?
 		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>>
 		<dfn>&lt;color-stop-angle></dfn> = <<angle-percentage>>{1,2}
+		<dfn>&lt;single-angular-color-stop></dfn> = <<color>> <<angle-percentage>>{2}
 
 		<dfn>&lt;color-stop></dfn> = <<color-stop-length>> | <<color-stop-angle>>
 	</pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/10092.

  > Also, the value definition of `<color-stop-list>` does not allow a single color stop implicitly representing two color stops

  > it needs a variant production that allows a single doubled stop

I am not sure this remains an editorial change. I assume a single color stop defined with two positions was supposed to become valid at the time the syntax of (more than one) color stop defined with two positions was specified.

Chrome and FF (at least) supports this syntax, but it is not [tested](https://github.com/web-platform-tests/wpt/blob/6f39f52d77d922d9e38aadd249caddb93b3d20d5/css/css-images/gradient/color-stops-parsing.html).

Maybe this sentence should also be updated:

  > [Color stops](https://drafts.csswg.org/css-images-4/#color-stop) and [transition hints](https://drafts.csswg.org/css-images-4/#color-transition-hint) are specified in a color stop list, which is a list of **two** or more color stops interleaved with optional transition hints: