### PR TITLE
[css-view-transitions-2] Update the algorithm to check opt-in on outbound transition

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -450,6 +450,11 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 	Note: the [=@view-transition/type=] descriptor only applies to the {{Document}} in which it is defined.
 	The author is responsible for using their chosen set of types in both documents.
 
+## Responding to changes in the ''@view-transition'' rule ## {#respond-to-rule-changes}
+
+When the ''@view-transition'' rule changes for {{Document}} |document|, [=update the opt-in state for outbound transitions=] given |document|.
+
+
 # API # {#api}
 
 ## Additions to {{Document}} ## {#additions-to-document-api}
@@ -527,6 +532,12 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		: <dfn>inbound view transition params</dfn>
 		:: a [=view transition params=], or null.
 			Initially null.
+
+		: <dfn export>can initiate outbound view transition</dfn>
+		:: a boolean.
+			Initially false.
+
+			Note: this value can be read [=in parallel=] while navigating.
 	</dl>
 
 ### The View transition params struct ### {#view-transition-params-struct}
@@ -736,6 +747,10 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. [=Assert=]: |document| is [=fully active=].
 
+		1. [=Assert=]: |document| [=has been revealed=] is true.
+
+		1. [=Update the opt-in state for outbound transitions=] for |document|.
+
 		1. Let |inboundViewTransitionParams| be |document|'s [=inbound view transition params=].
 
 		1. If |inboundViewTransitionParams| is null, then return null.
@@ -768,6 +783,14 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Return |transition|.
 	</div>
+
+### Updating the opt-in state for outbound view transitions ### {#update-opt-in-state-for-outbound}
+
+<div algorithm="update-opt-in-for-outbound">
+To <dfn>update the opt-in state for outbound transitions</dfn> for a {{Document}} |document|:
+	1. If |document| [=has been revealed=], and the result of [=resolve @view-transition rule|resolving the @view-transition rule=] is not "<code>skip transition</code>",
+		then set |document|'s [=can initiate outbound view transition=] to true.
+	1. Otherwise, set |document|'s [=can initiate outbound view transition=] to false.
 
 
 <h2 id="priv" class="no-num">Privacy Considerations</h2>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -533,7 +533,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		:: a [=view transition params=], or null.
 			Initially null.
 
-		: <dfn export>can initiate outbound view transition</dfn>
+		: <dfn>can initiate outbound view transition</dfn>
 		:: a boolean.
 			Initially false.
 
@@ -671,20 +671,24 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 	<div algorithm>
 		To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
-		an [=/origin=] |oldOrigin|, an [=/origin=] |newOrigin|, a boolean |navigationHasCrossOriginRedirects|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+		a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
 
-			Note: this is called during navigation, potentially [=in parallel=], for documents that have opted-in to view-transitions using the ''@view-transition'' rule.
+			Note: this is called during navigation, potentially [=in parallel=].
 
 		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
 			the user agent may ignore the author-defined view transition. If that is the case, return false.
 
+		1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return false.
+
 		1. If |navigationType| is {{NavigationType/reload}}, then return false.
 
-		1. If |isBrowserUINavigation| is true, and |navigationType| is {{NavigationType/push}} or {{NavigationType/replace}}, then return false.
+		1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
 
-		1. If |oldOrigin| is not [=same origin=] as |newOrigin| then return false.
+		1. If |navigationType| is {{NavigationType/traverse}}, then return true.
 
-		1. If |navigationHasCrossOriginRedirects| is true, then return false.
+		1. If |isBrowserUINavigation| is true, then return false.
+
+		1. If |newDocument| [=was created via cross-origin redirects=], then return false.
 
 		1. Return true.
 	</div>
@@ -694,11 +698,11 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
 
-		1. If |oldDocument|'s [=has been revealed=] is false, then return null.
+		1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return null.
 
-		1. Let |resolvedRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
+		1. Let |transitionTypesFromRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
 
-		1. If |resolvedRule| is "<code>skip transition</code>", then return null.
+		1. [=Assert=]: |transitionTypesFromRule| is not "<code>skip transition</code>".
 
 			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
 			We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
@@ -712,7 +716,7 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 
 		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
 
-		1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |resolvedRule|.
+		1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |transitionTypesFromRule|.
 
 			Note: the [=ViewTransition/active types=] are not shared between documents.
 			Manipulating the {{ViewTransition/typeList}} in the new document does not affect the types in the new document,
@@ -743,7 +747,7 @@ Prepend this to the [=Perform pending transition operations=] algorithm given a 
 ### Accessing the view-transition in the new {{Document}} ### {#access-view-transition-in-new-doc}
 
 	<div algorithm>
-		To <dfn export>resolve cross-document view-transition</dfn> for {{Document}} |document|:
+		To <dfn export>resolve inbound cross-document view-transition</dfn> for {{Document}} |document|:
 
 		1. [=Assert=]: |document| is [=fully active=].
 


### PR DESCRIPTION


Instead of relying on the source snapshot params in HTML, we update a flag every time something relevant changes, and HTML can read that flag.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
