### PR TITLE
[css-color-5] fix typo

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -961,7 +961,7 @@ if the destination color space is capable of representing them.
 
 	<pre highlight=css>
 		--vivid-yellow: <span class="swatch oog" style="--color: color(display-p3 1 1 0)"></span> color(display-p3 1 1 0); 
-		--paler-yellow: <span class="swatch" style="--color: rgb(100% 100% 15.37%)"></span> srgb(from var(--vivid-yellow) r g calc(b + 50%));
+		--paler-yellow: <span class="swatch" style="--color: rgb(100% 100% 15.37%)"></span> color(from var(--vivid-yellow) srgb r g calc(b + 0.5));
 	</pre>
 
 	Here --vivid-yellow, once converted to sRGB, 

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -979,7 +979,7 @@ alpha channels <em>are</em> clamped to the reference range.
 	results in an alpha in the result of 1, not 1.4.
 
 	<pre highlight=css>
-		--tan: <span class="swatch" style="--color: rgb(80.93% 70% 55.27% / 70%)"></span> oklch(78% 0.06 75) / 0.7;
+		--tan: <span class="swatch" style="--color: rgb(80.93% 70% 55.27% / 70%)"></span> oklch(78% 0.06 75 / 0.7);
 		--deeper-tan: <span class="swatch" style="--color: rgb(80.93% 70% 55.27%)"></span> oklch(from var(--tan) l c h / calc(alpha * 2));
 	</pre>
 </div>


### PR DESCRIPTION
[css-color-5] : some fixes after: https://github.com/w3c/csswg-drafts/commit/4429f5f511be30214d2202670f927aeaea264cea
