### PR TITLE
[web-animations-1] Fix typo `invaid` → `invalid`

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -5635,7 +5635,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
       after applying the following exceptions:
 
       * If the provided value is not `null`
-          and is an [=invalid selector|invaid=] <<pseudo-element-selector>>,
+          and is an [=invalid selector|invalid=] <<pseudo-element-selector>>,
           the user agent must [=throw=] a {{DOMException}}
           with error name "{{SyntaxError}}" and leave the
           [=target pseudo-selector=] of this [=animation effect=] unchanged.


### PR DESCRIPTION
Sorry, but I didn’t open an issue for such a small typographic error.