### PR TITLE
[css-view-transitions-2] Refactor based on topics

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -149,17 +149,19 @@ In this way, the author can use the the <code data-x="">blocking</code> attribut
 </div>
 
 ### Customization ### {#customizing-cross-document-view-transitions}
-While in same-document view transition the author handles a single {{ViewTransition}} object returned from the {{Document/startViewTransition}} call,
-in the cross-document case, the view transition is divided to two {{ViewTransition}} objects, one in the old document and one in the new document.
+The {{ViewTransition}} object enables customizing the transition in script.
+Same-document view transitions use a single {{ViewTransition}} object returned from the {{Document/startViewTransition}} call for the entire lifecycle.
+Cross-document view transitions have two {{ViewTransition}} objects, one in the old document and one in the new document.
 
-### Handling the view transition in the old document ### {#old-doc-event}
+#### Handling the view transition in the old document #### {#old-doc-event}
 
 The {{Window/pageswap}} event is fired at the last moment before a document is about to be unloaded and swapped by another document.
 It can be used to find out whether a view transition is about to take place, customize it using {{ViewTransition/types}}, make last minute changes to the captured elements, or skip it if necessary.
 The {{PageSwapEvent}} interface has a {{PageSwapEvent/viewTransition}} object, which would be non-null when the navigation is eligible to a view transition,
 and a {{PageSwapEvent/activation}} object, providing handy information about the navigation, like the URL after redirects.
+The transition's {{ViewTransition/finished}} promise can be used for cleaning up after the transition, in case the document is later restored from BFCache.
 
-### Handling the view transition in the new document ### {#new-doc-event}
+#### Handling the view transition in the new document #### {#new-doc-event}
 
 The {{Window/pagereveal}} event is fired right before presenting the first frame of the new document.
 It can be used to find out if the view transition is still valid, by querying the {{PageRevealEvent/viewTransition}} attribute.
@@ -353,9 +355,6 @@ Similar to a same-document view transition, the author can now select different 
 The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
 should setup and activate a {{ViewTransition}}.
 
-Note: To take effect, it must be present in the old document
-when unloading, and in the new document when the {{Window/pagereveal}} is fired.
-
 The ''@view-transition'' rule has the following syntax:
 
 <pre class=prod>
@@ -373,7 +372,7 @@ When the ''@view-transition'' rule changes for {{Document}} |document|, the user
 
 Note: this needs to be cached in the boolean because the result needs to be read [=in parallel=], when navigating.
 
-#### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
+### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
 
 	<pre class='descdef'>
 	Name: navigation
@@ -400,7 +399,6 @@ Note: this needs to be cached in the boolean because the result needs to be read
 	</dl>
 
 ### Accessing the ''@view-transition'' rule using CSSOM ### {#cssom}
-#### Extensions to the <code>CSSRule</code> interface</h3> #### {#extensions-to-cssrule-interface}
 
 The <code>CSSRule</code> interface is extended as follows:
 
@@ -410,249 +408,22 @@ partial interface CSSRule {
 };
 </pre>
 
-#### The <code>CSSViewTransitionRule</code> interface</h3> #### {#navgation-behavior-rule-interface}
-
 The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 <xmp class=idl>
 		enum ViewTransitionNavigation { "auto", "none" };
 
 		[Exposed=Window]
-		interface ReadonlyViewTransitionTypeSet {
+		interface CSSViewTransitionTypeSet {
 			readonly setlike<CSSOMString>;
 		};
 
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			attribute ViewTransitionNavigation navigation;
-			attribute ReadonlyViewTransitionTypeSet types;
+			attribute CSSViewTransitionTypeSet types;
 		};
 </xmp>
-
-### Resolving the ''@view-transition'' rule ### {#vt-rule-algo}
-	<div algorithm>
-		To <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
-
-		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
-			then return "<code>skip transition</code>".
-
-		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
-
-		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
-
-		1. If |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/none'', then return "<code>skip transition</code>".
-
-		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
-
-		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/types=] descriptor.
-
-		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
-
-		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
-	</div>
-
-## Setting up the view transition in the old {{Document}} ## {#setup-old-document-vt}
-
-### Check eligibility for outbound cross-document view transition ### {#check-eligibility}
-<div algorithm>
-	To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
-	a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
-
-		Note: this is called during navigation, potentially [=in parallel=].
-
-	1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
-		the user agent may ignore the author-defined view transition. If that is the case, return false.
-
-	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return false.
-
-	1. If |navigationType| is {{NavigationType/reload}}, then return false.
-
-	1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
-
-	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
-
-	1. If |isBrowserUINavigation| is true, then return false.
-
-	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
-
-	1. Return true.
-</div>
-
-### Setup the outbound transition when ready to swap pages ### {#setup-outbound-transition}
-<div algorithm>
-	To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-	a {{Document}} |newDocument|, and |proceedWithNavigation|, which is an algorithm accepting nothing:
-
-	1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
-
-	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return null.
-
-	1. Let |transitionTypesFromRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
-
-	1. [=Assert=]: |transitionTypesFromRule| is not "<code>skip transition</code>".
-
-		Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
-		We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
-
-	1. If |oldDocument|'s [=active view transition=] is not null,
-		then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
-		with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
-
-		Note: this means that any running transition would be skipped when the document is ready
-		to unload.
-
-	1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
-
-	1. Set |outboundTransition|'s [=ViewTransition/active types=] to |transitionTypesFromRule|.
-
-		Note: the [=ViewTransition/active types=] are not shared between documents.
-		Manipulating the {{ViewTransition/types}} in the new document does not affect the types in the new document,
-		which would be read from the [=@view-transition/types=] descriptor once the document is revealed.
-
-		Note: the {{ViewTransition}} is skipped once the old document is hidden.
-
-	1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
-		1. Set |newDocument|'s [=inbound view transition params=] to |params|.
-
-			Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
-
-		1. Call |proceedWithNavigation|.
-
-	1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
-
-		Note: The process continues in [=perform pending transition operations=].
-
-	1. The user agent should display the currently displayed frame until either:
-		* The {{Window/pagereveal}} event is fired.
-		* its [=active view transition=]'s [=ViewTransition/phase=] is "`done`".
-
-		Note: this is to ensure that there are no unintended flashes between displaying the old and new state, to keep the transition smooth.
-
-	1. Return |outboundTransition|.
-</div>
-
-### Update the opt-in flag to reflect the current state ### {#update-opt-in}
-<div algorithm="update-opt-in-for-outbound">
-To <dfn>update the opt-in state for outbound transitions</dfn> for a {{Document}} |document|:
-	1. If |document| [=has been revealed=], and the result of [=resolve @view-transition rule|resolving the @view-transition rule=] is not "<code>skip transition</code>",
-		then set |document|'s [=can initiate outbound view transition=] to true.
-	1. Otherwise, set |document|'s [=can initiate outbound view transition=] to false.
-</div>
-
-### Proceed with navigation if view transition is skipped ### {#proceed-if-skipped}
-<div algorithm="additional skip steps">
-	Append the following steps to [=skip the view transition=] given a {{ViewTransition}} |transition|:
-		1. If |transition|'s [=outbound post-capture steps=] is not null, then run |transition|'s [=outbound post-capture steps=] with null.
-
-	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
-</div>
-
-### Proceed with cross-document view transition after capturing the old state ### {#cross-doc-after-capture}
-<div algorithm="additional transition operation">
-Prepend the following step to the [=Perform pending transition operations=] algorithm given a {{Document}} |document|:
-	1. If |document|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null, then:
-
-		1. Assert: |document|'s [=active view transition=]'s  [=ViewTransition/phase=] is "`pending-capture`".
-
-		1. Let |viewTransitionParams| be null;
-
-		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
-
-			Issue: though [=capture the old state=] appears here as a synchronous step, it is in fact an asynchronous step
-			as rendering an element into an image cannot be done synchronously. This should be more explicit in the L1 spec.
-
-		1. [=Capture the old state=] for |transition|.
-
-		1. If this succeeded, then set |viewTransitionParams| to a new [=view transition params=] whose
-			[=view transition params/named elements=] is a [=map/clone=] of |transition|'s [=ViewTransition/named elements=],
-			and whose [=view transition params/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=].
-
-		1. Set |document|'s [=document/rendering suppression for view transitions=] to false.
-
-		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
-
-	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
-</div>
-
-## Activating the view transition in the new {{Document}} ## {#access-view-transition-in-new-doc}
-
-<div algorithm>
-	To <dfn export>resolve inbound cross-document view-transition</dfn> for {{Document}} |document|:
-
-	1. [=Assert=]: |document| is [=fully active=].
-
-	1. [=Assert=]: |document| [=has been revealed=] is true.
-
-	1. [=Update the opt-in state for outbound transitions=] for |document|.
-
-	1. Let |inboundViewTransitionParams| be |document|'s [=inbound view transition params=].
-
-	1. If |inboundViewTransitionParams| is null, then return null.
-
-	1. Set |document|'s [=inbound view transition params=] to null.
-
-	1. If |document|'s [=active view transition=] is not null, then return null.
-
-		Note: this means that starting a same-document transition before revealing the document would cancel a pending cross-document transition.
-
-	1. [=Resolve @view-transition rule=] for |document| and let |resolvedRule| be the result.
-
-	1. If |resolvedRule| is "<code>skip transition</code>", then return null.
-
-	1. Let |transition| be a new {{ViewTransition}} in |document|'s [=relevant Realm=],
-		whose [=ViewTransition/named elements=] is |inboundViewTransitionParams|'s [=view transition params/named elements=],
-		and [=ViewTransition/initial snapshot containing block size=] is |inboundViewTransitionParams|'s [=view transition params/initial snapshot containing block size=].
-
-	1. Set |document|'s [=active view transition=] to |transition|.
-
-	1. [=Resolve=] |transition|’s [=ViewTransition/update callback done promise=] with undefined.
-
-	1. Set |transition|’s [=ViewTransition/phase=] to "`update-callback-called`".
-
-	1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
-
-	1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
-		To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
-			If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
-
-	1. Return |transition|.
-</div>
-
-## Data structures ## {#cross-doc-data-structures}
-
-### Additions to {{Document}} ### {#cross-doc-data-structure-document}
-A {{Document}} additionaly has:
-
-<dl dfn-for=document>
-	: <dfn>inbound view transition params</dfn>
-	:: a [=view transition params=], or null.
-		Initially null.
-
-	: <dfn>can initiate outbound view transition</dfn>
-	:: a boolean.
-		Initially false.
-
-		Note: this value can be read [=in parallel=] while navigating.
-</dl>
-
-### Additions to {{ViewTransition}} ### {#cross-doc-data-structure-vt}
-A {{ViewTransition}} additionally has:
-<dl dfn-for=ViewTransition>
-	: <dfn>outbound post-capture steps</dfn>
-	:: Null or a set of steps, initially null.
-</dl>
-
-### Serializable [=view transition params=] ### {#cross-doc-data-structure-serialization}
-A <dfn>view transition params</dfn> is a [=struct=] whose purpose is to serialize view transition information across documents.
-It has the following [=struct/items=]:
-
-<dl dfn-for="view transition params">
-	: <dfn>named elements</dfn>
-	:: a [=/map=], whose keys are strings and whose values are [=captured elements=].
-
-	: <dfn>initial snapshot containing block size</dfn>
-	:: a [=tuple=] of two numbers (width and height).
-</dl>
 
 # Selective view transitions # {#selective-vt}
 
@@ -712,8 +483,8 @@ document.startViewTransition({update: updateTheDOMSomehow});
 ```
 </div>
 
-## Pseudo-classes ## {#pseudo-classes-for-selective-vt}
-### '':active-view-transition'' ### {#the-active-view-transition-pseudo}
+## Selecting based on the active view transition ## {#pseudo-classes-for-selective-vt}
+### The '':active-view-transition'' pseudo-class ### {#the-active-view-transition-pseudo}
 
 The <dfn id='active-view-transition-pseudo'>:active-view-transition</dfn> pseudo-class applies to the root element of the document, if it has an [=active view transition=].
 
@@ -721,7 +492,7 @@ The [=specificity=] of an '':active-view-transition'' is one pseudo-class select
 
 An '':active-view-transition'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=].
 
-### '':active-view-transition-type()'' ### {#the-active-view-transition-type-pseudo}
+### The '':active-view-transition-type()'' pseudo-class ### {#the-active-view-transition-type-pseudo}
 
 The <dfn id='active-view-transition-type-pseudo'>:active-view-transition-type()</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
 It has the following syntax definition:
@@ -735,48 +506,7 @@ The [=specificity=] of an '':active-view-transition-type()'' is one pseudo-class
 An '':active-view-transition-type()'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=],
 whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> arguments.
 
-## Activating the transition type using JavaScript ## {#types-js}
-
-### Extending {{Document/startViewTransition|document.startViewTransition()}} ### {#extend-document-types}
-	<xmp class=idl>
-		dictionary StartViewTransitionOptions {
-			UpdateCallback? update = null;
-			sequence<DOMString>? types = null;
-		};
-
-		partial interface Document {
-
-			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
-		};
-	</xmp>
-
-
-	<div algorithm="start-vt-with-options">
-		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
-
-		1. Let |updateCallback| be null.
-
-		1. If |callbackOptions| is an an {{UpdateCallback}}, set |updateCallback| to |callbackOptions|.
-
-		1. Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |updateCallback| to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
-
-		1. If |this|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null,
-			then:
-
-			1. Let |preSkippedTransition| be a new {{ViewTransition}} in |this|'s [=relevant realm=] whose [=ViewTransition/update callback=] is |updateCallback|.
-
-			1. [=Skip the view transition|Skip=] |preSkippedTransition| with an "{{InvalidStateError}}" {{DOMException}}.
-
-			1. Return |preSkippedTransition|.
-
-		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
-
-		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=] to a [=list/clone=] of {{StartViewTransitionOptions/types}} as a [=/set=].
-
-		1. Return |viewTransition|.
-	</div>
-
-### Extending the {{ViewTransition}} interface ### {#view-transitions-extension}
+## Changing the types of an ongoing view transition ## {#view-transitions-extension-types}
 
 The {{ViewTransition}} interface is extended as follows:
 
@@ -793,15 +523,9 @@ partial interface ViewTransition {
 
 The {{ViewTransition/types}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
 
-A {{ViewTransition}} additionally has:
-<dl dfn-for=ViewTransition>
-	: <dfn>active types</dfn>
-	:: A [=/set] of strings, initially empty.
-</dl>
-
 ## Activating the transition type for cross-document view transitions ## {#types-cross-doc}
 
-### The [=@view-transition/types=] descriptor ### {#view-transition-type-descriptor}
+The [=@view-transition/types=] descriptor
 
 	<pre class='descdef'>
 	Name: type
@@ -933,13 +657,289 @@ div.box {
 	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
 	with a ''*'' argument and with an empty <<pt-class-selector>> is zero.
 
-## Capturing the 'view-transition-class' ## {#vt-class-algorithms}
+# Extending {{Document/startViewTransition|document.startViewTransition()}} # {#extend-document-types}
+	<xmp class=idl>
+		dictionary StartViewTransitionOptions {
+			UpdateCallback? update = null;
+			sequence<DOMString>? types = null;
+		};
 
+		partial interface Document {
+
+			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+		};
+	</xmp>
+
+
+	<div algorithm="start-vt-with-options">
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
+
+		1. Let |updateCallback| be null.
+
+		1. If |callbackOptions| is an an {{UpdateCallback}}, set |updateCallback| to |callbackOptions|.
+
+		1. Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |updateCallback| to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
+
+		1. If |this|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null,
+			then:
+
+			1. Let |preSkippedTransition| be a new {{ViewTransition}} in |this|'s [=relevant realm=] whose [=ViewTransition/update callback=] is |updateCallback|.
+
+			1. [=Skip the view transition|Skip=] |preSkippedTransition| with an "{{InvalidStateError}}" {{DOMException}}.
+
+			1. Return |preSkippedTransition|.
+
+			Note: This ensures that a same-document transition that started after firing {{Window/pageswap}} is skipped.
+
+		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
+
+		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=] to a [=list/clone=] of {{StartViewTransitionOptions/types}} as a [=/set=].
+
+		1. Return |viewTransition|.
+	</div>
+
+# Algorithms # {#algorithms}
+
+## Data structures ## {#cross-doc-data-structures}
+
+### Additions to {{Document}} ### {#cross-doc-data-structure-document}
+A {{Document}} additionaly has:
+
+<dl dfn-for=document>
+	: <dfn>inbound view transition params</dfn>
+	:: a [=view transition params=], or null.
+		Initially null.
+
+	: <dfn>can initiate outbound view transition</dfn>
+	:: a boolean.
+		Initially false.
+
+		Note: this value can be read [=in parallel=] while navigating.
+</dl>
+
+### Additions to {{ViewTransition}} ### {#cross-doc-data-structure-vt}
+A {{ViewTransition}} additionally has:
+<dl dfn-for=ViewTransition>
+	: <dfn>active types</dfn>
+	:: A [=/set=] of strings, initially empty.
+
+	: <dfn>outbound post-capture steps</dfn>
+	:: Null or a set of steps, initially null.
+</dl>
+
+### Serializable [=view transition params=] ### {#cross-doc-data-structure-serialization}
+A <dfn>view transition params</dfn> is a [=struct=] whose purpose is to serialize view transition information across documents.
+It has the following [=struct/items=]:
+
+<dl dfn-for="view transition params">
+	: <dfn>named elements</dfn>
+	:: a [=/map=], whose keys are strings and whose values are [=captured elements=].
+
+	: <dfn>initial snapshot containing block size</dfn>
+	:: a [=tuple=] of two numbers (width and height).
+</dl>
+
+### Captured elements extension ### {#capture-classes-data-structure}
 The [=captured element=] struct should contain these fields, in addition to the existing ones:
 	<dl>
 		: <dfn for="captured element">class list</dfn>
 		:: a [=/list=] of strings, initially empty.
 	</dl>
+
+## Resolving the ''@view-transition'' rule ## {#vt-rule-algo}
+	<div algorithm>
+		To <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
+
+		Note: this is called in both the old and new document.
+
+		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
+			then return "<code>skip transition</code>".
+
+		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
+
+		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
+
+		1. If |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/none'', then return "<code>skip transition</code>".
+
+		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
+
+		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/types=] descriptor.
+
+		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
+
+		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
+	</div>
+
+## Setting up the view transition in the old {{Document}} ## {#setup-old-document-vt}
+
+### Check eligibility for outbound cross-document view transition ### {#check-eligibility}
+<div algorithm>
+	To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
+	a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+
+		Note: this is called during navigation, potentially [=in parallel=].
+
+	1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
+		the user agent may ignore the author-defined view transition. If that is the case, return false.
+
+	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return false.
+
+	1. If |navigationType| is {{NavigationType/reload}}, then return false.
+
+	1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
+
+	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
+
+	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
+
+	1. If |isBrowserUINavigation| is true, then return false.
+
+	1. Return true.
+</div>
+
+### Setup the outbound transition when ready to swap pages ### {#setup-outbound-transition}
+<div algorithm>
+	To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
+	a {{Document}} |newDocument|, and |proceedWithNavigation|, which is an algorithm accepting nothing:
+
+	Note: This is called from the HTML spec.
+
+	1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
+
+	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return null.
+
+	1. Let |transitionTypesFromRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
+
+	1. [=Assert=]: |transitionTypesFromRule| is not "<code>skip transition</code>".
+
+		Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
+		We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
+
+	1. If |oldDocument|'s [=active view transition=] is not null,
+		then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
+		with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
+
+		Note: this means that any running transition would be skipped when the document is ready
+		to unload.
+
+	1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+
+	1. Set |outboundTransition|'s [=ViewTransition/active types=] to |transitionTypesFromRule|.
+
+		Note: the [=ViewTransition/active types=] are not shared between documents.
+		Manipulating the {{ViewTransition/types}} in the new document does not affect the types in |newDocument|,
+		which would be read from the [=@view-transition/types=] descriptor once |newDocument| is revealed.
+
+		Note: the {{ViewTransition}} is skipped once the old document is hidden.
+
+	1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
+		1. Set |newDocument|'s [=inbound view transition params=] to |params|.
+
+			Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
+
+		1. Call |proceedWithNavigation|.
+
+	1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
+
+		Note: The process continues in [=perform pending transition operations=].
+
+	1. The user agent should display the currently displayed frame until either:
+		* The {{Window/pagereveal}} event is fired.
+		* its [=active view transition=]'s [=ViewTransition/phase=] is "`done`".
+
+		Note: this is to ensure that there are no unintended flashes between displaying the old and new state, to keep the transition smooth.
+
+	1. Return |outboundTransition|.
+</div>
+
+### Update the opt-in flag to reflect the current state ### {#update-opt-in}
+<div algorithm="update-opt-in-for-outbound">
+To <dfn>update the opt-in state for outbound transitions</dfn> for a {{Document}} |document|:
+	1. If |document| [=has been revealed=], and the result of [=resolve @view-transition rule|resolving the @view-transition rule=] is not "<code>skip transition</code>",
+		then set |document|'s [=can initiate outbound view transition=] to true.
+	1. Otherwise, set |document|'s [=can initiate outbound view transition=] to false.
+</div>
+
+### Proceed with navigation if view transition is skipped ### {#proceed-if-skipped}
+<div algorithm="additional skip steps">
+	Append the following steps to [=skip the view transition=] given a {{ViewTransition}} |transition|:
+		1. If |transition|'s [=outbound post-capture steps=] is not null, then run |transition|'s [=outbound post-capture steps=] with null.
+
+	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
+</div>
+
+### Proceed with cross-document view transition after capturing the old state ### {#cross-doc-after-capture}
+<div algorithm="additional transition operation">
+Prepend the following step to the [=Perform pending transition operations=] algorithm given a {{Document}} |document|:
+	1. If |document|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null, then:
+
+		1. Assert: |document|'s [=active view transition=]'s  [=ViewTransition/phase=] is "`pending-capture`".
+
+		1. Let |viewTransitionParams| be null;
+
+		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
+
+			Issue: Though [=capture the old state=] appears here as a synchronous step, it is in fact an asynchronous step
+			as rendering an element into an image cannot be done synchronously. This should be more explicit in the L1 spec.
+
+		1. [=Capture the old state=] for |transition|.
+
+		1. If this succeeded, then set |viewTransitionParams| to a new [=view transition params=] whose
+			[=view transition params/named elements=] is a [=map/clone=] of |transition|'s [=ViewTransition/named elements=],
+			and whose [=view transition params/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=].
+
+		1. Set |document|'s [=document/rendering suppression for view transitions=] to false.
+
+		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
+
+	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
+</div>
+
+## Activating the view transition in the new {{Document}} ## {#access-view-transition-in-new-doc}
+
+<div algorithm>
+	To <dfn export>resolve inbound cross-document view-transition</dfn> for {{Document}} |document|:
+
+	1. [=Assert=]: |document| is [=fully active=].
+
+	1. [=Assert=]: |document| [=has been revealed=] is true.
+
+	1. [=Update the opt-in state for outbound transitions=] for |document|.
+
+	1. Let |inboundViewTransitionParams| be |document|'s [=inbound view transition params=].
+
+	1. If |inboundViewTransitionParams| is null, then return null.
+
+	1. Set |document|'s [=inbound view transition params=] to null.
+
+	1. If |document|'s [=active view transition=] is not null, then return null.
+
+		Note: this means that starting a same-document transition before revealing the document would cancel a pending cross-document transition.
+
+	1. [=Resolve @view-transition rule=] for |document| and let |resolvedRule| be the result.
+
+	1. If |resolvedRule| is "<code>skip transition</code>", then return null.
+
+	1. Let |transition| be a new {{ViewTransition}} in |document|'s [=relevant Realm=],
+		whose [=ViewTransition/named elements=] is |inboundViewTransitionParams|'s [=view transition params/named elements=],
+		and [=ViewTransition/initial snapshot containing block size=] is |inboundViewTransitionParams|'s [=view transition params/initial snapshot containing block size=].
+
+	1. Set |document|'s [=active view transition=] to |transition|.
+
+	1. [=Resolve=] |transition|’s [=ViewTransition/update callback done promise=] with undefined.
+
+	1. Set |transition|’s [=ViewTransition/phase=] to "`update-callback-called`".
+
+	1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
+
+	1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
+		To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
+			If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+
+	1. Return |transition|.
+</div>
+
+## Capturing the 'view-transition-class' ## {#vt-class-algorithms}
 
 <div algorithm="additional capture steps">
 When capturing the old or new state for an element, perform the following steps given a [=captured element=] |capture| and an [=element=] |element|:

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -685,6 +685,8 @@ div.box {
 
 			1. Let |preSkippedTransition| be a new {{ViewTransition}} in |this|'s [=relevant realm=] whose [=ViewTransition/update callback=] is |updateCallback|.
 
+				Note: The |preSkippedTransition|'s {{ViewTransition/types}} are ignored here because the transition is never activated.
+
 			1. [=Skip the view transition|Skip=] |preSkippedTransition| with an "{{InvalidStateError}}" {{DOMException}}.
 
 			1. Return |preSkippedTransition|.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -416,10 +416,16 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 <xmp class=idl>
 		enum ViewTransitionNavigation { "auto", "none" };
+
+		[Exposed=Window]
+		interface ReadonlyViewTransitionTypeList {
+			readonly setlike<CSSOMString>;
+		};
+
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			attribute ViewTransitionNavigation navigation;
-			attribute FrozenArray<CSSOMString> types;
+			attribute ReadonlyViewTransitionTypeList types;
 		};
 </xmp>
 
@@ -774,13 +780,16 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 
 The {{ViewTransition}} interface is extended as follows:
 
-<pre class='idl'>
+<xmp class='idl'>
+interface ViewTransitionTypeList {
+	setlike<DOMString>;
+};
 
 [Exposed=Window]
 partial interface ViewTransition {
-	attribute DOMTokenList types;
+	attribute ViewTransitionTypeList types;
 };
-</pre>
+</xmp>
 
 The {{ViewTransition/types}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -418,14 +418,14 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		enum ViewTransitionNavigation { "auto", "none" };
 
 		[Exposed=Window]
-		interface ReadonlyViewTransitionTypeList {
+		interface ReadonlyViewTransitionTypeSet {
 			readonly setlike<CSSOMString>;
 		};
 
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			attribute ViewTransitionNavigation navigation;
-			attribute ReadonlyViewTransitionTypeList types;
+			attribute ReadonlyViewTransitionTypeSet types;
 		};
 </xmp>
 
@@ -781,13 +781,13 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 The {{ViewTransition}} interface is extended as follows:
 
 <xmp class='idl'>
-interface ViewTransitionTypeList {
+interface ViewTransitionTypeSet {
 	setlike<DOMString>;
 };
 
 [Exposed=Window]
 partial interface ViewTransition {
-	attribute ViewTransitionTypeList types;
+	attribute ViewTransitionTypeSet types;
 };
 </xmp>
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -143,7 +143,7 @@ Since cross-document view transitions are declarative, there is no such explicit
 In this way, the author can use the the <code data-x="">blocking</code> attribute, to delay the transition until:
 	* All expected scripts are executed, by using the script's {{HTMLScriptElement/blocking}} attribute on required scripts.
 	* All expected styles are executed, by using the style or link's {{HTMLStyleElement/blocking}} attribute on required styles.
-	* All expected HTML elements are seen by the parser, using an [^link/rel/expect^] {{HTMLLinkElement}} element.
+	* All expected HTML elements are seen by the parser, using an <{link/rel/expect}> {{HTMLLinkElement}} element.
 
 <div class="example">
 </div>
@@ -617,7 +617,7 @@ div.box {
 
 		: <dfn><<custom-ident>>+</dfn>
 		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
-			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with other <<custom-ident>>s.
+			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with another <<custom-ident>>.
 
 			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
 			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view transitions:

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -419,7 +419,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			attribute ViewTransitionNavigation navigation;
-			attribute FrozenArray<DOMString> types;
+			attribute FrozenArray<CSSOMString> types;
 		};
 </xmp>
 
@@ -497,7 +497,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 	1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
 
-	1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |transitionTypesFromRule|.
+	1. Set |outboundTransition|'s [=ViewTransition/active types=] to |transitionTypesFromRule|.
 
 		Note: the [=ViewTransition/active types=] are not shared between documents.
 		Manipulating the {{ViewTransition/types}} in the new document does not affect the types in the new document,
@@ -603,7 +603,7 @@ Prepend the following step to the [=Perform pending transition operations=] algo
 
 	1. Set |transition|’s [=ViewTransition/phase=] to "`update-callback-called`".
 
-	1. Set |transition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |resolvedRule|.
+	1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
 
 	1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
 		To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
@@ -765,7 +765,7 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 
 		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
 
-		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to a [=list/clone=] of {{StartViewTransitionOptions/types}} as a [=/set=].
+		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=] to a [=list/clone=] of {{StartViewTransitionOptions/types}} as a [=/set=].
 
 		1. Return |viewTransition|.
 	</div>
@@ -775,8 +775,10 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 The {{ViewTransition}} interface is extended as follows:
 
 <pre class='idl'>
+
+[Exposed=Window]
 partial interface ViewTransition {
-	readonly attribute DOMTokenList types;
+	attribute DOMTokenList types;
 };
 </pre>
 
@@ -785,7 +787,7 @@ The {{ViewTransition/types}} [=getter steps=] are to return [=this=]'s [=ViewTra
 A {{ViewTransition}} additionally has:
 <dl dfn-for=ViewTransition>
 	: <dfn>active types</dfn>
-	:: A {{DOMTokenList}}, initially a new {{DOMTokenList}}.
+	:: A [=/set] of strings, initially empty.
 </dl>
 
 ## Activating the transition type for cross-document view transitions ## {#types-cross-doc}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -261,7 +261,7 @@ The ''@view-transition'' rule accepts the [=@view-transition/navigation=] and [=
 Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
 [=conditional group rule=] such as ''@media'' or ''@supports''.
 
-### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
+#### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
 
 	<pre class='descdef'>
 	Name: navigation

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -318,7 +318,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 ### Resolving the ''@view-transition'' rule ### {#vt-rule-algo}
 	<div algorithm>
-		To get the <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
+		To <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
 
 		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
 			then return "<code>skip transition</code>".

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -19,6 +19,7 @@ Markup Shorthands: css yes, markdown yes
 <pre class=link-defaults>
 spec:css-view-transitions-1;
 	text: active view transition; type: dfn;
+	text: capture the new state; type: dfn;
 	text: capture the old state; type: dfn;
 	text: activate view transition; type: dfn;
 	text: skip the view transition; type: dfn;
@@ -46,7 +47,7 @@ spec:html
 	text: latest entry; type: dfn;
 	text: was created via cross-origin redirects; type: dfn;
 	text: run the animation frame callbacks; type: dfn;
-	text: unload; type: dfn;
+	text: deactivate a document for a cross-document navigation; type: dfn;
 	text: pagereveal; type: dfn; for: Window;
 	text: has been revealed; type: dfn;
 spec:infra; type:dfn; text:list
@@ -105,8 +106,102 @@ spec:infra; type:dfn; text:list
 	to create animated transitions between visual states of the [=/document=].
 
 	Level 2 extends that specification, by adding the necessary API and lifecycle to enable
-	transitions across a same-origin cross-document navigation.
+	transitions across a same-origin cross-document navigation, as well as a few additions that
+	make it easier to author pages with richer view transitions.
 
+	Level 2 defines the following:
+
+		* <a href="#cross-document-view-transitions">Cross-document view transitions</a>, including the ''@view-transition'' rule and the algorithms
+			that enable the cross-document view transition lifecycle.
+		* <a href="#selective-vt">Selective view transitions</a>, a way to match styles based on the existence of an [=active view transition=],
+			and more specifically based on the active view transition being of a certain type.
+		* <a href="#shared-style-with-vt-classes">Sharing styles between view transition pseudo-elements</a>, a way to declare a style once,
+			and use it for multiple view transition pseudo-elements. This includes the 'view-transition-class' property, and <a href="#pseudo-element-class-additions">additions to named pseudo-elements</a>
+
+# Cross-document view transitions # {#cross-document-view-transitions}
+
+## Overview ## {#cross-doc-overview}
+
+*This section is non-normative.*
+
+## Examples ## {#cross-doc-examples}
+
+<div class=example>
+	To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
+	but across documents, we don't need JavaScript.
+
+	Instead, we opt in to triggering view-transitions on navigation in both page 1 and page 2:
+
+	```css
+	// in both documents:
+	@view-transition {
+		navigation: auto;
+	}
+	```
+
+	A link from page 1 to or from page 2 would generate a crossfade transition for example 1.
+	To achieve the effect examples 2, 3 & 4, simply put the CSS for the pseudo-elements in both
+	documents.
+</div>
+
+<div class="example">
+	To achieve the effect in [[css-view-transitions-1#examples|example 5]], we have to do several
+	things:
+
+	- Opt-in to navigation-triggered view-transitions in both pages.
+	- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
+	- Intercept the {{ViewTransition}} object in the new document, using the {{Window/pagereveal}} event.
+
+	In both pages:
+	```css
+	@view-transition {
+		navigation: auto;
+	}
+
+	```
+
+	In the old page:
+	```js
+	addEventListener('click', event => {
+		sessionStorage.setItem("lastClickX", event.clientX);
+		sessionStorage.setItem("lastClickY", event.clientY);
+	});
+	```
+
+	In the new page:
+	```js
+	// This would run both on initial load and on reactivation from BFCache.
+	addEventListener("pagereveal", async event => {
+		if (!event.viewTransition)
+			return;
+
+		const x = sessionStorage.getItem("lastClickX") ?? innerWidth / 2;
+		const y = sessionStorage.getItem("lastClickY") ?? innerHeight / 2;
+
+		const endRadius = Math.hypot(
+			Math.max(x, innerWidth - x),
+			Math.max(y, innerHeight - y)
+		);
+
+		await event.viewTransition.ready;
+
+		// Animate the new document's view
+		document.documentElement.animate(
+			{
+				clipPath: [
+					`circle(0 at ${x}px ${y}px)`,
+					`circle(${endRadius}px at ${x}px ${y}px)`,
+				],
+			},
+			{
+				duration: 500,
+				easing: 'ease-in',
+				pseudoElement: '::view-transition-new(root)'
+			}
+		);
+	})
+	```
+</div>
 
 ## Lifecycle ## {#lifecycle}
 
@@ -114,208 +209,359 @@ spec:infra; type:dfn; text:list
 
 	A successful cross-document view transition goes through the following phases:
 
-	1. The user navigates, by clicking a link, submitting a form, traversing history using the
-		browser UI, etc.
+	1. In the old {{Document}}:
 
-	1. Once it's time to [=unload=] the old document, if the navigation is [=same origin=]
-		and the old {{Document}} has opted in to cross-document view-transitions, the old state is captured.
+		1. The user initiates a navigation, by clicking a link, submitting a form, pressing the browser's back button, etc.
 
-	1. An event named {{Window/pagereveal}} is fired on the new {{Document}}, with a `viewTransition` property,
-		which is a {{ViewTransition}} object. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> is already resolved,
-		and its [=captured elements=] are populated from the old {{Document}}.
+			Note: some navigations do not trigger a view-transition, e.g. typing a new address in the URL bar.
 
-	1. Right before the new {{Document}} has the first [=rendering opportunity=], its state is captured as
-		the "new" state.
+		1. When the new {{Document}} is ready to be activated, the {{Window/pageswap}} event is fired.
 
-	1. From this point forward, the transition continues as if it was a same-document transition, as per [=activate view transition=].
+		1. If the navigation is [=same origin=], has no cross-origin redirects,
+			and the old {{Document}} has <a href="#cross-doc-opt-in">opted in to cross-document view transitions</a>, the event's {{PageSwapEvent/viewTransition}} attribute would be
+			a {{ViewTransition}} object.
 
-## Examples ## {#examples}
+		1. The author can now customize the transition, e.g. by mutating its {{ViewTransition/typeList}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
 
-### Cross-document view-transitions ### {#cross-doc-example}
+		1. If the {{ViewTransition}} is not skipped, the state of the old document is [=capture the old state|captured=].
 
-	<div class=example>
-		To generate the same cross-fade as in the first example [[css-view-transitions-1#examples]],
-		but across documents, we don't need JavaScript.
+		1. The navigation proceeds: the old {{Document}} is unloaded, and the new {{Document}} is now active.
 
-		Instead, we opt in to triggering view-transitions on navigation in both page 1 and page 2:
+	1. Then, in the new {{Document}}:
 
-		```css
-		// in both documents:
-		@view-transition {
-			navigation: auto;
-		}
-		```
+		1. When the new {{Document}} is ready for its first [=rendering opportunity=], an event named {{Window/pagereveal}} is fired on the new {{Document}}, with a {{PageRevealEvent/viewTransition}} attribute.
 
-		A link from page 1 to or from page 2 would generate a crossfade transition for example 1.
-		To achieve the effect examples 2, 3 & 4, simply put the CSS for the pseudo-elements in both
-		documents.
-	</div>
+		1. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> promise is already resolved,
+			and its [=captured elements=] are populated from the old {{Document}}.
 
-	<div class="example">
-		To achieve the effect in [[css-view-transitions-1#examples|example 5]], we have to do several
-		things:
+		1. This is another opportunity for the author customize the transition, e.g. by mutating its {{ViewTransition/typeList}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
 
-		- Opt-in to navigation-triggered view-transitions in both pages.
-		- Pass the click location to the new document, e.g. via {{WindowSessionStorage/sessionStorage}}.
-		- Intercept the {{ViewTransition}} object in the new document, using the {{Window/pagereveal}} event.
+		1. The state of the new document is [=capture the new state|captured=] as the "new" state of the transition.
 
-		In both pages:
-		```css
-		@view-transition {
-			navigation: auto;
-		}
+		1. From this point forward, the transition continues in a similar fashion to a same-document transition, as per [=activate view transition=].
 
-		```
+## Opting in to cross-document view transitions ## {#cross-doc-opt-in}
 
-		In the old page:
-		```js
-		addEventListener('click', event => {
-			sessionStorage.setItem("lastClickX", event.clientX);
-			sessionStorage.setItem("lastClickY", event.clientY);
-		});
-		```
+### The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ### {#view-transition-rule}
 
-		In the new page:
-		```js
-		// This would run both on initial load and on reactivation from BFCache.
-		addEventListener("pagereveal", async event => {
-			if (!event.viewTransition)
-				return;
+The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
+should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
+when unloading, and in the new document when the {{Window/pagereveal}} is fired.
 
-			const x = sessionStorage.getItem("lastClickX") ?? innerWidth / 2;
-			const y = sessionStorage.getItem("lastClickY") ?? innerHeight / 2;
+The ''@view-transition'' rule has the following syntax:
 
-			const endRadius = Math.hypot(
-				Math.max(x, innerWidth - x),
-				Math.max(y, innerHeight - y)
-			);
-
-			await event.viewTransition.ready;
-
-			// Animate the new document's view
-			document.documentElement.animate(
-				{
-					clipPath: [
-						`circle(0 at ${x}px ${y}px)`,
-						`circle(${endRadius}px at ${x}px ${y}px)`,
-					],
-				},
-				{
-					duration: 500,
-					easing: 'ease-in',
-					pseudoElement: '::view-transition-new(root)'
-				}
-			);
-		})
-		```
-	</div>
-
-### 'view-transition-class' ### {#vt-class-example}
-
-view-transition-class provides a way to use the same style
-for multiple view transition pseudo elements without having to replicate the corresponding pseudo-elements.
-
-	<div class="example">
-	This example creates a transition with each box participating under its own name, while applying
-	a 1-second duration to the animation of all the boxes:
-
-	```html
-	<div class="box" id="red-box"></div>
-	<div class="box" id="green-box"></div>
-	<div class="box" id="yellow-box"></div>
-	```
-
-	```css
-	div.box {
-		view-transition-class: any-box;
-		width: 100px;
-		height: 100px;
+<pre class=prod>
+	@view-transition {
+		<<declaration-list>>
 	}
-	#red-box {
-		view-transition-name: red-box;
-		background: red;
-	}
-	#green-box {
-		view-transition-name: green-box;
-		background: green;
-	}
-	#yellow-box {
-		view-transition-name: yellow-box;
-		background: yellow;
-	}
+</pre>
 
-	/* The following style would apply to all the boxes, thanks to 'view-transition-class' */
-	::view-transition-group(*.any-box) {
-		animation-duration: 1s;
-	}
-	```
+The ''@view-transition'' rule accepts the [=@view-transition/navigation=] and [=@view-transition/type=] descriptors.
 
-	</div>
+Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
+[=conditional group rule=] such as ''@media'' or ''@supports''.
 
+### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
 
-# CSS Properties # {#css-properties}
-
-## Applying the same style to multiple participating elements: the 'view-transition-class' property ## {#view-transition-class-prop}
-
-	<pre class=propdef>
-	Name: view-transition-class
-	Value: none | <<custom-ident>>+
+	<pre class='descdef'>
+	Name: navigation
+	For: @view-transition
+	Value: auto | none
 	Initial: none
-	Inherited: no
-	Percentages: n/a
-	Computed Value: as specified
-	Animation type: discrete
 	</pre>
 
-	The 'view-transition-class' can be used to apply the same style rule to multiple [=named view transition pseudo-elements=] which may have a different 'view-transition-name'.
-	While 'view-transition-name' is used to match between the element in the old state with its corresponding element in the new state, 'view-transition-class' is used
-	only to apply styles using the view-transition pseudo-elements
-	(''::view-transition-group()'', ''::view-transition-image-pair()'', ''::view-transition-old()'', ''::view-transition-new()'').
+	The '<dfn for="@view-transition">navigation</dfn>' descriptor opts in to automatically starting a view transition when performing a navigation of a certain type.
+	Must be present on both the old and new document.
 
-	Note that 'view-transition-class' by itself doesn't mark an element for capturing, it is only used as an additional
-	way to style an element that already has a 'view-transition-name'.
-
-	<dl dfn-type=value dfn-for=view-transition-class>
+	<dl dfn-type=value dfn-for="@view-transition/navigation">
 		: <dfn>none</dfn>
-		:: No class would apply to the [=named view transition pseudo-elements=] generated for this element.
+		:: There will be no transition.
 
-		: <dfn><<custom-ident>>+</dfn>
-		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
-			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with other <<custom-ident>>s.
+		: <dfn>auto</dfn>
+		:: The transition will be enabled if the navigation is same-origin, without cross-origin
+			redirects, and whose {{NavigationType}} is
+			* {{NavigationType/traverse}}, or
+			* {{NavigationType/push}} or {{NavigationType/replace}}, with <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> not equal to `"browser UI"`.
 
-			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
-			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view-transitions:
-			classes from the old document would only apply if their corresponding 'view-transition-name' was not specified in the new document.
+			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
+			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
+
 	</dl>
 
-# Pseudo-classes # {#pseudo-classes}
+### Responding to changes in the ''@view-transition'' rule ### {#respond-to-rule-changes}
 
-## Active View Transition Pseudo-class '':active-view-transition()'' ## {#the-active-view-transition-pseudo}
+When the ''@view-transition'' rule changes for {{Document}} |document|, the user agent must [=update the opt-in state for outbound transitions=] given |document|.
 
-The <dfn id='active-view-transition-pseudo'>:active-view-transition</dfn> pseudo-class applies to the root element of the document, if it has an [=active view transition=].
-It has the following syntax definition:
+### Accessing the ''@view-transition'' rule using CSSOM ### {#cssom}
+#### Extensions to the <code>CSSRule</code> interface</h3> #### {#extensions-to-cssrule-interface}
 
-<pre class=prod>
-	:active-view-transition
+The <code>CSSRule</code> interface is extended as follows:
+
+<pre class='idl'>
+partial interface CSSRule {
+	const unsigned short VIEW_TRANSITION_RULE = 15;
+};
 </pre>
 
-The [=specificity=] of an '':active-view-transition'' is one pseudo-class selector.
+#### The <code>CSSViewTransitionRule</code> interface</h3> #### {#navgation-behavior-rule-interface}
 
-An '':active-view-transition'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=].
+The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
-## Active View Transition Type Pseudo-class '':active-view-transition-type()'' ## {#the-active-view-transition-type-pseudo}
+<xmp class=idl>
+		enum ViewTransitionNavigation { "auto", "none" };
+		[Exposed=Window]
+		interface CSSViewTransitionRule : CSSRule {
+			attribute ViewTransitionNavigation navigation;
+			attribute DOMTokenList typeList;
+		};
+</xmp>
 
-The <dfn id='active-view-transition-type-pseudo'>:active-view-transition-type()</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
-It has the following syntax definition:
+### Resolving the ''@view-transition'' rule ### {#vt-rule-algo}
+	<div algorithm>
+		To get the <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
 
-<pre class=prod>
-	:active-view-transition-type(<<custom-ident>>#)
-</pre>
+		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
+			then return "<code>skip transition</code>".
 
-The [=specificity=] of an '':active-view-transition-type()'' is two pseudo-class selectors.
+		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
 
-An '':active-view-transition-type()'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=],
-whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> arguments.
+		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
+
+		1. If |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/none'', then return "<code>skip transition</code>".
+
+		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
+
+		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/type=] descriptor.
+
+		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
+
+		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
+	</div>
+
+## Setting up the view transition in the old {{Document}} ## {#setup-old-document-vt}
+
+### Check eligibility for outbound cross-document view transition ### {#check-eligibility}
+<div algorithm>
+	To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
+	a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
+
+		Note: this is called during navigation, potentially [=in parallel=].
+
+	1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
+		the user agent may ignore the author-defined view transition. If that is the case, return false.
+
+	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return false.
+
+	1. If |navigationType| is {{NavigationType/reload}}, then return false.
+
+	1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
+
+	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
+
+	1. If |isBrowserUINavigation| is true, then return false.
+
+	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
+
+	1. Return true.
+</div>
+
+### Setup the outbound transition when ready to swap pages ### {#setup-outbound-transition}
+<div algorithm>
+	To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
+	a {{Document}} |newDocument|, and |proceedWithNavigation|, which is an algorithm accepting nothing:
+
+	1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
+
+	1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return null.
+
+	1. Let |transitionTypesFromRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
+
+	1. [=Assert=]: |transitionTypesFromRule| is not "<code>skip transition</code>".
+
+		Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
+		We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
+
+	1. If |oldDocument|'s [=active view transition=] is not null,
+		then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
+		with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
+
+		Note: this means that any running transition would be skipped when the document is ready
+		to unload.
+
+	1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
+
+	1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |transitionTypesFromRule|.
+
+		Note: the [=ViewTransition/active types=] are not shared between documents.
+		Manipulating the {{ViewTransition/typeList}} in the new document does not affect the types in the new document,
+		which would be read from the [=@view-transition/type=] descriptor once the document is revealed.
+
+		Note: the {{ViewTransition}} is skipped once the old document is hidden.
+
+	1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
+		1. Set |newDocument|'s [=inbound view transition params=] to |params|.
+
+			Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
+
+		1. Call |proceedWithNavigation|.
+
+	1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
+
+		Note: The process continues in [=perform pending transition operations=].
+
+	1. The user agent should display the currently displayed frame until either:
+		* The {{Window/pagereveal}} event is fired.
+		* its [=active view transition=]'s [=ViewTransition/phase=] is "`done`".
+
+		Note: this is to ensure that there are no unintended flashes between displaying the old and new state, to keep the transition smooth.
+
+	1. Return |outboundTransition|.
+</div>
+
+### Update the opt-in flag to reflect the current state ### {#update-opt-in}
+<div algorithm="update-opt-in-for-outbound">
+To <dfn>update the opt-in state for outbound transitions</dfn> for a {{Document}} |document|:
+	1. If |document| [=has been revealed=], and the result of [=resolve @view-transition rule|resolving the @view-transition rule=] is not "<code>skip transition</code>",
+		then set |document|'s [=can initiate outbound view transition=] to true.
+	1. Otherwise, set |document|'s [=can initiate outbound view transition=] to false.
+</div>
+
+### Proceed with navigation if view transition is skipped ### {#proceed-if-skipped}
+<div algorithm="additional skip steps">
+	Append the following steps to [=skip the view transition=] given a {{ViewTransition}} |transition|:
+		1. If |transition|'s [=outbound post-capture steps=] is not null, then run |transition|'s [=outbound post-capture steps=] with null.
+
+	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
+</div>
+
+### Proceed with cross-document view transition after capturing the old state ### {#cross-doc-after-capture}
+<div algorithm="additional transition operation">
+Prepend the following step to the [=Perform pending transition operations=] algorithm given a {{Document}} |document|:
+	1. If |document|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null, then:
+
+		1. Assert: |document|'s [=active view transition=]'s  [=ViewTransition/phase=] is "`pending-capture`".
+
+		1. Let |viewTransitionParams| be null;
+
+		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
+
+			Issue: though [=capture the old state=] appears here as a synchronous step, it is in fact an asynchronous step
+			as rendering an element into an image cannot be done synchronously. This should be more explicit in the L1 spec.
+
+		1. [=Capture the old state=] for |transition|.
+
+		1. If this succeeded, then set |viewTransitionParams| to a new [=view transition params=] whose
+			[=view transition params/named elements=] is a [=map/clone=] of |transition|'s [=ViewTransition/named elements=],
+			and whose [=view transition params/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=].
+
+		1. Set |document|'s [=document/rendering suppression for view transitions=] to false.
+
+		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
+
+	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
+</div>
+
+## Activating the view transition in the new {{Document}} ## {#access-view-transition-in-new-doc}
+
+<div algorithm>
+	To <dfn export>resolve inbound cross-document view-transition</dfn> for {{Document}} |document|:
+
+	1. [=Assert=]: |document| is [=fully active=].
+
+	1. [=Assert=]: |document| [=has been revealed=] is true.
+
+	1. [=Update the opt-in state for outbound transitions=] for |document|.
+
+	1. Let |inboundViewTransitionParams| be |document|'s [=inbound view transition params=].
+
+	1. If |inboundViewTransitionParams| is null, then return null.
+
+	1. Set |document|'s [=inbound view transition params=] to null.
+
+	1. If |document|'s [=active view transition=] is not null, then return null.
+
+		Note: this means that starting a same-document transition before revealing the document would cancel a pending cross-document transition.
+
+	1. [=Resolve @view-transition rule=] for |document| and let |resolvedRule| be the result.
+
+	1. If |resolvedRule| is "<code>skip transition</code>", then return null.
+
+	1. Let |transition| be a new {{ViewTransition}} in |document|'s [=relevant Realm=],
+		whose [=ViewTransition/named elements=] is |inboundViewTransitionParams|'s [=view transition params/named elements=],
+		and [=ViewTransition/initial snapshot containing block size=] is |inboundViewTransitionParams|'s [=view transition params/initial snapshot containing block size=].
+
+	1. Set |document|'s [=active view transition=] to |transition|.
+
+	1. [=Resolve=] |transition|’s [=ViewTransition/update callback done promise=] with undefined.
+
+	1. Set |transition|’s [=ViewTransition/phase=] to "`update-callback-called`".
+
+	1. Set |transition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |resolvedRule|.
+
+	1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
+		To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
+			If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+
+	1. Return |transition|.
+</div>
+
+## Data structures ## {#cross-doc-data-structures}
+
+### Additions to {{Document}} ### {#cross-doc-data-structure-document}
+A {{Document}} additionaly has:
+
+<dl dfn-for=document>
+	: <dfn>inbound view transition params</dfn>
+	:: a [=view transition params=], or null.
+		Initially null.
+
+	: <dfn>can initiate outbound view transition</dfn>
+	:: a boolean.
+		Initially false.
+
+		Note: this value can be read [=in parallel=] while navigating.
+</dl>
+
+### Additions to {{ViewTransition}} ### {#cross-doc-data-structure-vt}
+A {{ViewTransition}} additionally has:
+<dl dfn-for=ViewTransition>
+	: <dfn>outbound post-capture steps</dfn>
+	:: Null or a set of steps, initially null.
+</dl>
+
+### Serializable [=view transition params=] ### {#cross-doc-data-structure-serialization}
+A <dfn>view transition params</dfn> is a [=struct=] whose purpose is to serialize view transition information across documents.
+It has the following [=struct/items=]:
+
+<dl dfn-for="view transition params">
+	: <dfn>named elements</dfn>
+	:: a [=/map=], whose keys are strings and whose values are [=captured elements=].
+
+	: <dfn>initial snapshot containing block size</dfn>
+	:: a [=tuple=] of two numbers (width and height).
+</dl>
+
+# Selective view transitions # {#selective-vt}
+
+## Overview ## {#selective-vt-overview}
+
+*This section is non-normative.*
+
+For simple pages, with a single view transition, setting the ''view-transition-name'' property on participating elements should be sufficient.
+However, in more complex scenarios, the author might want to declare various view transitions, and only run one of them simultaneously.
+For example, sliding the whole page when clicking on the navigation bar, and sorting a list when one if its items is dragged.
+
+To make sure each view transition only captures what it needs to, and different transitions don't interfere with each other,
+this spec introduces the concept of [=active types=], alongside the '':active-view-transition'' and '':active-view-transition-type()'' pseudo-classes.
+
+'':active-view-transition'' matches the [=document element=] when it has an [=active view transition=], and '':active-view-transition-type()''
+matches the [=document element=] if the types in the selectors match the [=active view transition=]'s [=ViewTransition/active types=].
+
+The {{ViewTransition}}'s [=active types=] are populated in one of the following ways:
+
+	1. Passed as part of the arguments to {{Document/startViewTransition(callbackOptions)}}
+	1. Mutated at any time, using the transition's {{ViewTransition/typeList}}
+	1. Declared for a cross-document view transition, using the [=@view-transition/type=] descriptor.
 
 ## Examples ## {#active-view-transition-pseudo-examples}
 
@@ -325,7 +571,7 @@ For example, the developer might start a transition in the following manner:
 document.startViewTransition({update: updateTheDOMSomehow, type: ["slide-in", "reverse"]});
 ```
 
-This will activate any of the following ':active-view-transition-type()'' selectors:
+This will activate any of the following selectors:
 ```css
 :root:active-view-transition-type(slide-in) {}
 :root:active-view-transition-type(reverse) {}
@@ -353,7 +599,190 @@ document.startViewTransition({update: updateTheDOMSomehow});
 ```
 </div>
 
-# Additions to named view-transition pseudo-elements # {#pseudo-element-additions}
+## Pseudo-classes ## {#pseudo-classes-for-selective-vt}
+### '':active-view-transition'' ### {#the-active-view-transition-pseudo}
+
+The <dfn id='active-view-transition-pseudo'>:active-view-transition</dfn> pseudo-class applies to the root element of the document, if it has an [=active view transition=].
+
+The [=specificity=] of an '':active-view-transition'' is one pseudo-class selector.
+
+An '':active-view-transition'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=].
+
+### '':active-view-transition-type()'' ### {#the-active-view-transition-type-pseudo}
+
+The <dfn id='active-view-transition-type-pseudo'>:active-view-transition-type()</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
+It has the following syntax definition:
+
+<pre class=prod>
+	:active-view-transition-type(<<custom-ident>>#)
+</pre>
+
+The [=specificity=] of an '':active-view-transition-type()'' is one pseudo-class selector.
+
+An '':active-view-transition-type()'' pseudo-class matches the [=document element=] when its [=node document=] has an non-null [=active view transition=],
+whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<custom-ident>> arguments.
+
+## Activating the transition type using JavaScript ## {#types-js}
+
+### Extending {{Document/startViewTransition|document.startViewTransition()}} ### {#extend-document-types}
+	<xmp class=idl>
+		dictionary StartViewTransitionOptions {
+			UpdateCallback? update = null;
+			sequence<DOMString>? type = null;
+		};
+
+		partial interface Document {
+
+			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+		};
+	</xmp>
+
+
+	<div algorithm="start-vt-with-options">
+		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
+
+		1. Let |updateCallback| be null.
+
+		1. If |callbackOptions| is an an {{UpdateCallback}}, set |updateCallback| to |callbackOptions|.
+
+		1. Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |updateCallback| to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
+
+		1. If |this|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null,
+			then:
+
+			1. Let |preSkippedTransition| be a new {{ViewTransition}} in |this|'s [=relevant realm=] whose [=ViewTransition/update callback=] is |updateCallback|.
+
+			1. [=Skip the view transition|Skip=] |preSkippedTransition| with an "{{InvalidStateError}}" {{DOMException}}.
+
+			1. Return |preSkippedTransition|.
+
+		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
+
+		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to a [=list/clone=] of {{StartViewTransitionOptions/type}} as a [=/set=].
+
+		1. Return |viewTransition|.
+	</div>
+
+### Extending the {{ViewTransition}} interface ### {#view-transitions-extension}
+
+The {{ViewTransition}} interface is extended as follows:
+
+<pre class='idl'>
+partial interface ViewTransition {
+	readonly attribute DOMTokenList typeList;
+};
+</pre>
+
+The {{ViewTransition/typeList}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
+
+A {{ViewTransition}} additionally has:
+<dl dfn-for=ViewTransition>
+	: <dfn>active types</dfn>
+	:: A {{DOMTokenList}}, initially a new {{DOMTokenList}}.
+</dl>
+
+## Activating the transition type for cross-document view transitions ## {#types-cross-doc}
+
+### The [=@view-transition/type=] descriptor ### {#view-transition-type-descriptor}
+
+	<pre class='descdef'>
+	Name: type
+	For: @view-transition
+	Value: none | <<custom-ident>>+
+	Initial: none
+	</pre>
+
+	The '<dfn for="@view-transition">type</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
+	when capturing or performing the transition, equivalent to calling {{Document/startViewTransition(callbackOptions)}} with that {{StartViewTransitionOptions/type}}.
+
+	Note: the [=@view-transition/type=] descriptor only applies to the {{Document}} in which it is defined.
+	The author is responsible for using their chosen set of types in both documents.
+
+# Sharing styles between view transition pseudo-elements # {#shared-style-with-vt-classes}
+
+## Overview ## {#shared-style-overview}
+
+*This section is non-normative.*
+
+When styling multiple elements in the DOM in a similar way, it is common to use the [=Element/class=] attribute:
+setting a name that's shared across multiple elements, and then using the [=class selector=] to declare the shared style.
+
+[=Named view transition pseudo-elements|The view transition pseudo-elements=] (e.g. ''view-transition-group()'') are not defined in the DOM, but rather by using the ''view-transition-name'' property.
+For that purpose, the ''view-transition-class''' CSS property provides view transitions with the equivalent of HTML [=Element/class|classes=].
+When an element with a ''view-transition-name'' also has a ''view-transition-class'' value, that class would be selectable by the pseudo-elements, as per the <a href="#vt-class-example">examples</a>.
+
+## Examples ## {#vt-class-example}
+
+<div class="example">
+This example creates a transition with each box participating under its own name, while applying
+a 1-second duration to the animation of all the boxes:
+
+```html
+<div class="box" id="red-box"></div>
+<div class="box" id="green-box"></div>
+<div class="box" id="yellow-box"></div>
+```
+
+```css
+div.box {
+	view-transition-class: any-box;
+	width: 100px;
+	height: 100px;
+}
+#red-box {
+	view-transition-name: red-box;
+	background: red;
+}
+#green-box {
+	view-transition-name: green-box;
+	background: green;
+}
+#yellow-box {
+	view-transition-name: yellow-box;
+	background: yellow;
+}
+
+/* The following style would apply to all the boxes, thanks to 'view-transition-class' */
+::view-transition-group(*.any-box) {
+	animation-duration: 1s;
+}
+```
+</div>
+
+## The 'view-transition-class' property ## {#view-transition-class-prop}
+
+	<pre class=propdef>
+	Name: view-transition-class
+	Value: none | <<custom-ident>>+
+	Initial: none
+	Inherited: no
+	Percentages: n/a
+	Computed Value: as specified
+	Animation type: discrete
+	</pre>
+
+	The 'view-transition-class' can be used to apply the same style rule to multiple [=named view transition pseudo-elements=] which may have a different 'view-transition-name'.
+	While 'view-transition-name' is used to match between the element in the old state with its corresponding element in the new state, 'view-transition-class' is used
+	only to apply styles using the view transitionpseudo-elements
+	(''::view-transition-group()'', ''::view-transition-image-pair()'', ''::view-transition-old()'', ''::view-transition-new()'').
+
+	Note that 'view-transition-class' by itself doesn't mark an element for capturing, it is only used as an additional
+	way to style an element that already has a 'view-transition-name'.
+
+	<dl dfn-type=value dfn-for=view-transition-class>
+		: <dfn>none</dfn>
+		:: No class would apply to the [=named view transition pseudo-elements=] generated for this element.
+
+		: <dfn><<custom-ident>>+</dfn>
+		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
+			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with other <<custom-ident>>s.
+
+			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
+			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view transitions:
+			classes from the old document would only apply if their corresponding 'view-transition-name' was not specified in the new document.
+	</dl>
+
+## Additions to named view transition pseudo-elements ## {#pseudo-element-class-additions}
 
 	The [=named view transition pseudo-elements=]
 	(''view-transition-group()'', ''view-transition-image-pair()'', ''view-transition-old()'', ''view-transition-new()'')
@@ -386,204 +815,14 @@ document.startViewTransition({update: updateTheDOMSomehow});
 	The [=specificity=] of a [=named view transition pseudo-element=] [=selector=]
 	with a ''*'' argument and with an empty <<pt-class-selector>> is zero.
 
-# CSS rules # {#css-rules}
-
-## The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ## {#view-transition-rule}
-
-The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
-should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
-when unloading, and in the new document when the {{Window/pagereveal}} is fired.
-
-
-## @view-transition rule grammar ## {#view-transition-grammar}
-
-The ''@view-transition'' rule has the following syntax:
-
-<pre class=prod>
-	@view-transition {
-		<<declaration-list>>
-	}
-</pre>
-
-Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
-[=conditional group rule=] such as ''@media'' or ''@supports''.
-
-## The [=@view-transition/navigation=] descriptor ## {#view-transition-navigation-descriptor}
-
-	<pre class='descdef'>
-	Name: navigation
-	For: @view-transition
-	Value: auto | none
-	Initial: none
-	</pre>
-
-	The '<dfn for="@view-transition">navigation</dfn>' descriptor opts in to automatically starting a view transition when performing a navigation of a certain type.
-	It needs to be enabled both in the old document (when unloading) and in the new document (when reveal).
-
-	<dl dfn-type=value dfn-for="@view-transition/navigation">
-		: <dfn>none</dfn>
-		:: There will be no transition.
-
-		: <dfn>auto</dfn>
-		:: The transition will be enabled if the navigation is same-origin, without cross-origin
-			redirects, and whoes {{NavigationType}} is
-			* {{NavigationType/traverse}} or
-			* {{NavigationType/push}} or {{NavigationType/replace}} with <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> not equal to `"browser UI"`.
-
-			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
-			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
-
-	</dl>
-
-## The [=@view-transition/type=] descriptor ## {#view-transition-type-descriptor}
-
-	<pre class='descdef'>
-	Name: type
-	For: @view-transition
-	Value: none | <<custom-ident>>+
-	Initial: none
-	</pre>
-
-	The '<dfn for="@view-transition">type</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
-	when capturing and performing the transition, equivalent to calling {{Document/startViewTransition(callbackOptions)}} with that {{StartViewTransitionOptions/type}}.
-
-	Note: the [=@view-transition/type=] descriptor only applies to the {{Document}} in which it is defined.
-	The author is responsible for using their chosen set of types in both documents.
-
-## Responding to changes in the ''@view-transition'' rule ## {#respond-to-rule-changes}
-
-When the ''@view-transition'' rule changes for {{Document}} |document|, [=update the opt-in state for outbound transitions=] given |document|.
-
-
-# API # {#api}
-
-## Additions to {{Document}} ## {#additions-to-document-api}
-
-	<xmp class=idl>
-		dictionary StartViewTransitionOptions {
-			UpdateCallback? update = null;
-			sequence<DOMString>? type = null;
-		};
-
-		partial interface Document {
-
-			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
-		};
-	</xmp>
-
-### {{Document/startViewTransition(callbackOptions)}} Method Steps ### {#ViewTransition-start-with-options}
-
-	<div algorithm="start-vt-with-options">
-		The [=method steps=] for <dfn method for=Document>startViewTransition(|callbackOptions|)</dfn> are as follows:
-
-		1. Let |updateCallback| be null.
-
-		1. If |callbackOptions| is an an {{UpdateCallback}}, set |updateCallback| to |callbackOptions|.
-
-		1. Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |updateCallback| to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
-
-		1. If |this|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null,
-			then:
-
-			1. Let |preSkippedTransition| be a new {{ViewTransition}} in |this|'s [=relevant realm=] whose [=ViewTransition/update callback=] is |updateCallback|.
-
-			1. [=Skip the view transition|Skip=] |preSkippedTransition| with an "{{InvalidStateError}}" {{DOMException}}.
-
-			1. Return |preSkippedTransition|.
-
-		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
-
-		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to a [=list/clone=] of {{StartViewTransitionOptions/type}} as a [=/set=].
-
-		1. Return |viewTransition|.
-	</div>
-
-## Extensions to the <code>CSSRule</code> interface</h3> ## {#extensions-to-cssrule-interface}
-
-The <code>CSSRule</code> interface is extended as follows:
-
-<pre class='idl'>
-partial interface CSSRule {
-	const unsigned short VIEW_TRANSITION_RULE = 15;
-};
-</pre>
-
-## The <code>CSSViewTransitionRule</code> interface</h3> ## {#navgation-behavior-rule-interface}
-
-The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
-
-<xmp class=idl>
-		enum ViewTransitionNavigation { "auto", "none" };
-		[Exposed=Window]
-		interface CSSViewTransitionRule : CSSRule {
-			attribute ViewTransitionNavigation navigation;
-			attribute DOMTokenList typeList;
-		};
-</xmp>
-
-
-# Algorithms # {#algorithms}
-## Data Structures ## {#concepts}
-
-### Additions to {{Document}} ### {#additions-to-document}
-	A {{Document}} additionaly has:
-
-	<dl dfn-for=document>
-		: <dfn>inbound view transition params</dfn>
-		:: a [=view transition params=], or null.
-			Initially null.
-
-		: <dfn>can initiate outbound view transition</dfn>
-		:: a boolean.
-			Initially false.
-
-			Note: this value can be read [=in parallel=] while navigating.
-	</dl>
-
-### The View transition params struct ### {#view-transition-params-struct}
-
-	A <dfn>view transition params</dfn> is a [=struct=] whose purpose is to serialize view transition information across documents.
-	It has the following [=struct/items=]:
-
-	<dl dfn-for="view transition params">
-		: <dfn>named elements</dfn>
-		:: a [=/map=], whose keys are strings and whose values are [=captured elements=].
-
-		: <dfn>initial snapshot containing block size</dfn>
-		:: a [=tuple=] of two numbers (width and height).
-	</dl>
-
-### Additions to {{ViewTransition}} ### {#view-transitions-extension}
-
-	The {{ViewTransition}} interface is extended as follows:
-
-<pre class='idl'>
-partial interface ViewTransition {
-	readonly attribute DOMTokenList typeList;
-};
-</pre>
-
-	The {{ViewTransition/typeList}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
-
-	A {{ViewTransition}} additionally has:
-	<dl dfn-for=ViewTransition>
-		: <dfn>outbound post-capture steps</dfn>
-		:: Null or a set of steps, initially null.
-
-		: <dfn>active types</dfn>
-		:: A {{DOMTokenList}}, initially a new {{DOMTokenList}}.
-	</dl>
-
-### Additions to [=captured element=] struct ### {#additions-to-captured-element-struct}
+## Capturing the 'view-transition-class' ## {#vt-class-algorithms}
 
 The [=captured element=] struct should contain these fields, in addition to the existing ones:
-
 	<dl>
 		: <dfn for="captured element">class list</dfn>
 		:: a [=/list=] of strings, initially empty.
 	</dl>
 
-## Algorithm to capture 'view-transition-class': ## {#vt-class-algorithms}
 <div algorithm="additional capture steps">
 When capturing the old or new state for an element, perform the following steps given a [=captured element=] |capture| and an [=element=] |element|:
 
@@ -591,211 +830,6 @@ When capturing the old or new state for an element, perform the following steps 
 
 	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
 </div>
-
-## Additions to skip steps: ## {#additional-skip-steps}
-<div algorithm="additional skip steps">
-Append the following steps to [=skip the view transition=] given a {{ViewTransition}} |transition|:
-	1. If |transition|'s [=outbound post-capture steps=] is not null, then run |transition|'s [=outbound post-capture steps=] with null.
-
-	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
-</div>
-
-## Addition to pending transition operations ## {#additions-to-pending-transition-operation}
-
-Prepend this to the [=Perform pending transition operations=] algorithm given a {{Document}} |document|:
-	1. If |document|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null, then:
-
-		1. Assert: |document|'s [=active view transition=]'s  [=ViewTransition/phase=] is "`pending-capture`".
-
-		1. Let |viewTransitionParams| be null;
-
-		1. Set |document|'s [=document/rendering suppression for view transitions=] to true.
-
-			Issue: though [=capture the old state=] appears here as a synchronous step, it is in fact an asynchronous step
-			as rendering an element into an image cannot be done synchronously. This should be more explicit in the L1 spec.
-
-		1. [=Capture the old state=] for |transition|.
-
-		1. Set |document|'s [=document/rendering suppression for view transitions=] to false.
-
-		1. If this succeeded, then set |viewTransitionParams| to a new [=view transition params=] whose
-			[=view transition params/named elements=] is a [=map/clone=] of |transition|'s [=ViewTransition/named elements=],
-			and whose [=view transition params/initial snapshot containing block size=] is |transition|'s [=ViewTransition/initial snapshot containing block size=].
-
-		1. Call |transition|'s [=outbound post-capture steps=] given |viewTransitionParams|.
-
-
-## Monkey patches to HTML ## {#monkey-patch-to-html}
-
-	<div algorithm="monkey patch to apply the history step">
-		Prepend these steps at the beginning of the task [=queue a global task|queued=] on |navigable|'s [=active window=]
-		when <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step">applying the history step</a> (14.11.1, <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-traversable:queue-a-global-task-3">here</a>):
-
-		This monkey-patch step assumes a boolean |changingNavigationContinuation|, a [=/navigable=] |navigable|, a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|,
-		and a <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement">user navigation involvement</a> |userInvolvementForNavigateEvents|.
-
-		1. Let |isBrowserUINavigation| be true if |userInvolvementForNavigateEvents| is `"browser UI"`, otherwise false.
-
-		1. If |changingNavigationContinuation| update-only is false, then [=setup cross-document view-transition=] given |oldDocument|, |newDocument|, |navigationType|, |isBrowserUINavigation|, and the remaining steps and return from these steps.
-
-		Note: This would wait until a transition is captured or skipped before proceeding to unloading the old document and activating the new one.
-	</div>
-
-
-## Setting up and activating the cross-document view transition ## {#setting-up-and-activating-the-cross-document-view-transition}
-
-### Resolving the ''@view-transition''' rule ### {#resolve-view-transition-rule-algo}
-
-	<div algorithm>
-		To get the <dfn>resolve @view-transition rule</dfn> for a {{Document}} |document|:
-
-		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>",
-			then return "<code>skip transition</code>".
-
-		1. Let |matchingRule| be the last ''@view-transition'' rule in |document|.
-
-		1. If |matchingRule| is not found, then return "<code>skip transition</code>".
-
-		1. If |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/none'', then return "<code>skip transition</code>".
-
-		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
-
-		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/type=] descriptor.
-
-		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
-
-		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
-	</div>
-
-### Setting up the view-transition in the old {{Document}} ###  {#setup-old-document-vt}
-
-	<div algorithm>
-		To check if a <dfn export>navigation can trigger a cross-document view-transition?</dfn> given
-		a {{Document}} |oldDocument|, a {{Document}} |newDocument|, a {{NavigationType}} |navigationType|, and a boolean |isBrowserUINavigation|:
-
-			Note: this is called during navigation, potentially [=in parallel=].
-
-		1. If the user agent decides to display an [=implementation-defined=] navigation experience, e.g. a gesture-based transition for a back navigation,
-			the user agent may ignore the author-defined view transition. If that is the case, return false.
-
-		1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return false.
-
-		1. If |navigationType| is {{NavigationType/reload}}, then return false.
-
-		1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
-
-		1. If |navigationType| is {{NavigationType/traverse}}, then return true.
-
-		1. If |isBrowserUINavigation| is true, then return false.
-
-		1. If |newDocument| [=was created via cross-origin redirects=], then return false.
-
-		1. Return true.
-	</div>
-	<div algorithm>
-		To <dfn export>setup cross-document view-transition</dfn> given a {{Document}} |oldDocument|,
-		a {{Document}} |newDocument|, and |proceedWithNavigation|, which is an algorithm accepting nothing:
-
-		1. [=Assert=]: These steps are running as part of a [=task=] queued on |oldDocument|.
-
-		1. If |oldDocument|'s [=can initiate outbound view transition=] is false, then return null.
-
-		1. Let |transitionTypesFromRule| be the result of [=Resolve @view-transition rule|resolving the @view-transition rule=] for |oldDocument|.
-
-		1. [=Assert=]: |transitionTypesFromRule| is not "<code>skip transition</code>".
-
-			Note: We don't know yet if |newDocument| has opted in, as it might not be parsed yet.
-			We check the opt-in for |newDocument| when we fire the {{Window/pagereveal}} event.
-
-		1. If |oldDocument|'s [=active view transition=] is not null,
-			then [=skip the view transition|skip=] |oldDocument|'s [=active view transition=]
-			with an "{{AbortError}}" {{DOMException}} in |oldDocument|'s [=relevant Realm=].
-
-			Note: this means that any running transition would be skipped when the document is ready
-			to unload.
-
-		1. Let |outboundTransition| be a new {{ViewTransition}} object in |oldDocument|'s [=relevant Realm=].
-
-		1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |transitionTypesFromRule|.
-
-			Note: the [=ViewTransition/active types=] are not shared between documents.
-			Manipulating the {{ViewTransition/typeList}} in the new document does not affect the types in the new document,
-			which would be read from the [=@view-transition/type=] descriptor once the document is revealed.
-
-			Note: the {{ViewTransition}} is skipped once the old document is hidden.
-
-		1. Set |outboundTransition|'s [=outbound post-capture steps=] to the following steps given a [=view transition params=]-or-null |params|:
-			1. Set |newDocument|'s [=inbound view transition params=] to |params|.
-
-				Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
-
-			1. Call |proceedWithNavigation|.
-
-		1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
-
-			Note: The process continues in [=perform pending transition operations=].
-
-		1. The user agent should display the currently displayed frame until either:
-			* The {{Window/pagereveal}} event is fired.
-			* its [=active view transition=]'s [=ViewTransition/phase=] is "`done`".
-
-			Note: this is to ensure that there are no unintended flashes between displaying the old and new state, to keep the transition smooth.
-
-		1. Return |outboundTransition|.
-	</div>
-
-### Accessing the view-transition in the new {{Document}} ### {#access-view-transition-in-new-doc}
-
-	<div algorithm>
-		To <dfn export>resolve inbound cross-document view-transition</dfn> for {{Document}} |document|:
-
-		1. [=Assert=]: |document| is [=fully active=].
-
-		1. [=Assert=]: |document| [=has been revealed=] is true.
-
-		1. [=Update the opt-in state for outbound transitions=] for |document|.
-
-		1. Let |inboundViewTransitionParams| be |document|'s [=inbound view transition params=].
-
-		1. If |inboundViewTransitionParams| is null, then return null.
-
-		1. Set |document|'s [=inbound view transition params=] to null.
-
-		1. If |document|'s [=active view transition=] is not null, then return null.
-
-			Note: this means that starting a same-document transition before revealing the document would cancel a pending cross-document transition.
-
-		1. [=Resolve @view-transition rule=] for |document| and let |resolvedRule| be the result.
-
-		1. If |resolvedRule| is "<code>skip transition</code>", then return null.
-
-		1. Let |transition| be a new {{ViewTransition}} in |document|'s [=relevant Realm=],
-			whose [=ViewTransition/named elements=] is |inboundViewTransitionParams|'s [=view transition params/named elements=],
-			and [=ViewTransition/initial snapshot containing block size=] is |inboundViewTransitionParams|'s [=view transition params/initial snapshot containing block size=].
-
-		1. Set |document|'s [=active view transition=] to |transition|.
-
-		1. [=Resolve=] |transition|’s [=ViewTransition/update callback done promise=] with undefined.
-
-		1. Set |transition|’s [=ViewTransition/phase=] to "`update-callback-called`".
-
-		1. Set |transition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |resolvedRule|.
-
-		1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
-			To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
-				If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
-
-		1. Return |transition|.
-	</div>
-
-### Updating the opt-in state for outbound view transitions ### {#update-opt-in-state-for-outbound}
-
-<div algorithm="update-opt-in-for-outbound">
-To <dfn>update the opt-in state for outbound transitions</dfn> for a {{Document}} |document|:
-	1. If |document| [=has been revealed=], and the result of [=resolve @view-transition rule|resolving the @view-transition rule=] is not "<code>skip transition</code>",
-		then set |document|'s [=can initiate outbound view transition=] to true.
-	1. Otherwise, set |document|'s [=can initiate outbound view transition=] to false.
-
 
 <h2 id="priv" class="no-num">Privacy Considerations</h2>
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -50,6 +50,7 @@ spec:html
 	text: deactivate a document for a cross-document navigation; type: dfn;
 	text: pagereveal; type: dfn; for: Window;
 	text: has been revealed; type: dfn;
+	text: render-blocking mechanism; type: dfn;
 spec:infra; type:dfn; text:list
 </pre>
 
@@ -124,6 +125,83 @@ spec:infra; type:dfn; text:list
 
 *This section is non-normative.*
 
+### Activation ### {#activating-cross-document-view-transition}
+With same-document view transitions, the author starts a view transition using JavaScript, by calling {{Document/startViewTransition}}.
+In cross-document view transition, what triggers a view transition is a navigation between two documents, as long as the following conditions are met:
+
+	* Both documents are of the [=same origin=];
+	* The page is visible throughout the entire course of the navigatiion;
+	* the navigation is initiated by the page, e.g. by clicking a link or submitting a form, or is a {{NavigationType/traverse}} navigation (back/forward). This excludes, for example, navigations initiated by the URL bar;
+	* the navigation didn't include cross-origin redirects; and
+	* both documents opted in to cross-document view transitions, using the ''@view-transition'' rule.
+
+See the <a href="#lifecycle">lifecycle</a> section for more details.
+
+### Waiting for the new state to stabilize ### {#waiting-for-stable-state}
+In same-document view transitions, the author can indicate when the new state of the transition is in a stable state by using the callback passed to {{Document/startViewTransition}}.
+Since cross-document view transitions are declarative, there is no such explicit promise. Instead, the user agent relies on the [=render-blocking mechanism=] to decide when the stable state is ready.
+In this way, the author can use the the <code data-x="">blocking</code> attribute, to delay the transition until:
+	* All expected scripts are executed, by using the script's {{HTMLScriptElement/blocking}} attribute on required scripts.
+	* All expected styles are executed, by using the style or link's {{HTMLStyleElement/blocking}} attribute on required styles.
+	* All expected HTML elements are seen by the parser, using an [^link/rel/expect^] {{HTMLLinkElement}} element.
+
+<div class="example">
+</div>
+
+### Customization ### {#customizing-cross-document-view-transitions}
+While in same-document view transition the author handles a single {{ViewTransition}} object returned from the {{Document/startViewTransition}} call,
+in the cross-document case, the view transition is divided to two {{ViewTransition}} objects, one in the old document and one in the new document.
+
+### Handling the view transition in the old document ### {#old-doc-event}
+
+The {{Window/pageswap}} event is fired at the last moment before a document is about to be unloaded and swapped by another document.
+It can be used to find out whether a view transition is about to take place, customize it using {{ViewTransition/types}}, make last minute changes to the captured elements, or skip it if necessary.
+The {{PageSwapEvent}} interface has a {{PageSwapEvent/viewTransition}} object, which would be non-null when the navigation is eligible to a view transition,
+and a {{PageSwapEvent/activation}} object, providing handy information about the navigation, like the URL after redirects.
+
+### Handling the view transition in the new document ### {#new-doc-event}
+
+The {{Window/pagereveal}} event is fired right before presenting the first frame of the new document.
+It can be used to find out if the view transition is still valid, by querying the {{PageRevealEvent/viewTransition}} attribute.
+Similar to a same-document view transition, the author can now select different {{ViewTransition/types}}, make last minute changes to the captured elements, wait for the transition to be {{ViewTransition/ready}} in order to animate it, or skip it altogether.
+
+### Lifecycle ### {#lifecycle}
+
+	*This section is non-normative.*
+
+	A successful cross-document view transition goes through the following phases:
+
+	1. In the old {{Document}}:
+
+		1. The user initiates a navigation, by clicking a link, submitting a form, pressing the browser's back button, etc.
+
+			Note: some navigations do not trigger a view-transition, e.g. typing a new address in the URL bar.
+
+		1. When the new {{Document}} is ready to be activated, the {{Window/pageswap}} event is fired.
+
+		1. If the navigation is [=same origin=], has no cross-origin redirects,
+			and the old {{Document}} has <a href="#cross-doc-opt-in">opted in to cross-document view transitions</a>, the event's {{PageSwapEvent/viewTransition}} attribute would be
+			a {{ViewTransition}} object.
+
+		1. The author can now customize the transition, e.g. by mutating its {{ViewTransition/types}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
+
+		1. If the {{ViewTransition}} is not skipped, the state of the old document is [=capture the old state|captured=].
+
+		1. The navigation proceeds: the old {{Document}} is unloaded, and the new {{Document}} is now active.
+
+	1. Then, in the new {{Document}}:
+
+		1. When the new {{Document}} is ready for its first [=rendering opportunity=], an event named {{Window/pagereveal}} is fired on the new {{Document}}, with a {{PageRevealEvent/viewTransition}} attribute.
+
+		1. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> promise is already resolved,
+			and its [=captured elements=] are populated from the old {{Document}}.
+
+		1. This is another opportunity for the author customize the transition, e.g. by mutating its {{ViewTransition/types}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
+
+		1. The state of the new document is [=capture the new state|captured=] as the "new" state of the transition.
+
+		1. From this point forward, the transition continues in a similar fashion to a same-document transition, as per [=activate view transition=].
+
 ## Examples ## {#cross-doc-examples}
 
 <div class=example>
@@ -144,6 +222,21 @@ spec:infra; type:dfn; text:list
 	documents.
 </div>
 
+<div class=example>
+	Note that the ''@view-transition'' rule can be used together with media queries.
+	For example, this would only perform the transition when the screen width is greater than:
+
+	```css
+	@view-transition {
+		navigation: auto;
+	}
+
+	@media (max-width: 600px) {
+		navigation: none;
+	}
+	```
+</div>
+
 <div class="example">
 	To achieve the effect in [[css-view-transitions-1#examples|example 5]], we have to do several
 	things:
@@ -159,7 +252,6 @@ spec:infra; type:dfn; text:list
 	}
 
 	```
-
 	In the old page:
 	```js
 	addEventListener('click', event => {
@@ -203,49 +295,65 @@ spec:infra; type:dfn; text:list
 	```
 </div>
 
-## Lifecycle ## {#lifecycle}
+<div class="example">
+	To choose which elements are captured based on properties of the navigation, and whether certain images are loaded:
 
-	*This section is non-normative.*
+	In the old page:
+	```js
+		window.addEventListener("pageswap", event => {
+			// For example, the page was hidden, or the navigation is cross-document.
+			if (!event.viewTransition)
+				return;
 
-	A successful cross-document view transition goes through the following phases:
+			// If you don't want view transition for back/forward navigations...
+			if (event.activation.navigationType === "traverse") {
+				event.viewTransition.skipTransition();
+			}
 
-	1. In the old {{Document}}:
+			const newURL = new URL(event.activation.entry.url);
+			if (newURL.pathname === "/details" && thumbnail.complete) {
+				thumbnail.classList.add("transition-to-hero");
 
-		1. The user initiates a navigation, by clicking a link, submitting a form, pressing the browser's back button, etc.
+				// This will cleanup the state if the page is restored from BFCache.
+				event.viewTransition.finished.then(() => {
+					thumbnail.classList.remove("transition-to-hero");
+				});
+			}
 
-			Note: some navigations do not trigger a view-transition, e.g. typing a new address in the URL bar.
+		});
+	```
 
-		1. When the new {{Document}} is ready to be activated, the {{Window/pageswap}} event is fired.
+	In the new page:
+	```js
+		window.addEventListener("pagereveal", event => {
+			// For example, the page was hidden, the navigation is cross-document, or the transition was skipped in the old document.
+			if (!event.viewTransition)
+				return;
 
-		1. If the navigation is [=same origin=], has no cross-origin redirects,
-			and the old {{Document}} has <a href="#cross-doc-opt-in">opted in to cross-document view transitions</a>, the event's {{PageSwapEvent/viewTransition}} attribute would be
-			a {{ViewTransition}} object.
+			const oldURL = new URL(navigation.activation.from.url);
+			if (newURL.pathname === "/list") {
+				event.viewTransition.types.add("coming-from-list");
 
-		1. The author can now customize the transition, e.g. by mutating its {{ViewTransition/typeList}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
-
-		1. If the {{ViewTransition}} is not skipped, the state of the old document is [=capture the old state|captured=].
-
-		1. The navigation proceeds: the old {{Document}} is unloaded, and the new {{Document}} is now active.
-
-	1. Then, in the new {{Document}}:
-
-		1. When the new {{Document}} is ready for its first [=rendering opportunity=], an event named {{Window/pagereveal}} is fired on the new {{Document}}, with a {{PageRevealEvent/viewTransition}} attribute.
-
-		1. This {{ViewTransition}}'s <code>{{ViewTransition/updateCallbackDone}}</code> promise is already resolved,
-			and its [=captured elements=] are populated from the old {{Document}}.
-
-		1. This is another opportunity for the author customize the transition, e.g. by mutating its {{ViewTransition/typeList}}, or {{ViewTransition/skipTransition()|skip}} it altogether.
-
-		1. The state of the new document is [=capture the new state|captured=] as the "new" state of the transition.
-
-		1. From this point forward, the transition continues in a similar fashion to a same-document transition, as per [=activate view transition=].
+				// This will show the thumbnail until the view transition is finished.
+				if (!hero.complete) {
+					setToThumbnail(hero);
+					event.viewTransition.finished.then(() => {
+						setToFullResolution(hero);
+					})
+				}
+			}
+		});
+	```
+</div>
 
 ## Opting in to cross-document view transitions ## {#cross-doc-opt-in}
 
 ### The <dfn id="at-view-transition-rule">''@view-transition''</dfn> rule ### {#view-transition-rule}
 
 The ''@view-transition'' rule is used by a document to indicate that cross-document navigations
-should setup and activate a {{ViewTransition}}. To take effect, it must be present in the old document
+should setup and activate a {{ViewTransition}}.
+
+Note: To take effect, it must be present in the old document
 when unloading, and in the new document when the {{Window/pagereveal}} is fired.
 
 The ''@view-transition'' rule has the following syntax:
@@ -256,10 +364,14 @@ The ''@view-transition'' rule has the following syntax:
 	}
 </pre>
 
-The ''@view-transition'' rule accepts the [=@view-transition/navigation=] and [=@view-transition/type=] descriptors.
+The ''@view-transition'' rule accepts the [=@view-transition/navigation=] and [=@view-transition/types=] descriptors.
 
 Note: as per default behavior, the ''@view-transition'' rule can be nested inside a
 [=conditional group rule=] such as ''@media'' or ''@supports''.
+
+When the ''@view-transition'' rule changes for {{Document}} |document|, the user agent must [=update the opt-in state for outbound transitions=] given |document|.
+
+Note: this needs to be cached in the boolean because the result needs to be read [=in parallel=], when navigating.
 
 #### The [=@view-transition/navigation=] descriptor ### {#view-transition-navigation-descriptor}
 
@@ -285,12 +397,7 @@ Note: as per default behavior, the ''@view-transition'' rule can be nested insid
 
 			Note: Navigations excluded from ''@view-transition/navigation/auto'' are for example, navigating
 			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
-
 	</dl>
-
-### Responding to changes in the ''@view-transition'' rule ### {#respond-to-rule-changes}
-
-When the ''@view-transition'' rule changes for {{Document}} |document|, the user agent must [=update the opt-in state for outbound transitions=] given |document|.
 
 ### Accessing the ''@view-transition'' rule using CSSOM ### {#cssom}
 #### Extensions to the <code>CSSRule</code> interface</h3> #### {#extensions-to-cssrule-interface}
@@ -312,7 +419,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			attribute ViewTransitionNavigation navigation;
-			attribute DOMTokenList typeList;
+			attribute FrozenArray<DOMString> types;
 		};
 </xmp>
 
@@ -331,7 +438,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 		1. Assert: |matchingRule|'s [=@view-transition/navigation=] descriptor's [=computed value=] is ''@view-transition/navigation/auto''.
 
-		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/type=] descriptor.
+		1. Let |typesDescriptor| be |matchingRule|'s [=@view-transition/types=] descriptor.
 
 		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
 
@@ -393,8 +500,8 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 	1. Set |outboundTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to |transitionTypesFromRule|.
 
 		Note: the [=ViewTransition/active types=] are not shared between documents.
-		Manipulating the {{ViewTransition/typeList}} in the new document does not affect the types in the new document,
-		which would be read from the [=@view-transition/type=] descriptor once the document is revealed.
+		Manipulating the {{ViewTransition/types}} in the new document does not affect the types in the new document,
+		which would be read from the [=@view-transition/types=] descriptor once the document is revealed.
 
 		Note: the {{ViewTransition}} is skipped once the old document is hidden.
 
@@ -560,8 +667,8 @@ matches the [=document element=] if the types in the selectors match the [=activ
 The {{ViewTransition}}'s [=active types=] are populated in one of the following ways:
 
 	1. Passed as part of the arguments to {{Document/startViewTransition(callbackOptions)}}
-	1. Mutated at any time, using the transition's {{ViewTransition/typeList}}
-	1. Declared for a cross-document view transition, using the [=@view-transition/type=] descriptor.
+	1. Mutated at any time, using the transition's {{ViewTransition/types}}
+	1. Declared for a cross-document view transition, using the [=@view-transition/types=] descriptor.
 
 ## Examples ## {#active-view-transition-pseudo-examples}
 
@@ -628,7 +735,7 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 	<xmp class=idl>
 		dictionary StartViewTransitionOptions {
 			UpdateCallback? update = null;
-			sequence<DOMString>? type = null;
+			sequence<DOMString>? types = null;
 		};
 
 		partial interface Document {
@@ -658,7 +765,7 @@ whose [=ViewTransition/active types=] [=list/contains=] at least one of the <<cu
 
 		1. Let |viewTransition| be the result of running the [=method steps=] for {{Document/startViewTransition(updateCallback)}} given |updateCallback|.
 
-		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to a [=list/clone=] of {{StartViewTransitionOptions/type}} as a [=/set=].
+		1. If |callbackOptions| is a {{StartViewTransitionOptions}}, set |viewTransition|'s [=ViewTransition/active types=]'s [=DOMTokenList/token set=] to a [=list/clone=] of {{StartViewTransitionOptions/types}} as a [=/set=].
 
 		1. Return |viewTransition|.
 	</div>
@@ -669,11 +776,11 @@ The {{ViewTransition}} interface is extended as follows:
 
 <pre class='idl'>
 partial interface ViewTransition {
-	readonly attribute DOMTokenList typeList;
+	readonly attribute DOMTokenList types;
 };
 </pre>
 
-The {{ViewTransition/typeList}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
+The {{ViewTransition/types}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
 
 A {{ViewTransition}} additionally has:
 <dl dfn-for=ViewTransition>
@@ -683,7 +790,7 @@ A {{ViewTransition}} additionally has:
 
 ## Activating the transition type for cross-document view transitions ## {#types-cross-doc}
 
-### The [=@view-transition/type=] descriptor ### {#view-transition-type-descriptor}
+### The [=@view-transition/types=] descriptor ### {#view-transition-type-descriptor}
 
 	<pre class='descdef'>
 	Name: type
@@ -692,10 +799,10 @@ A {{ViewTransition}} additionally has:
 	Initial: none
 	</pre>
 
-	The '<dfn for="@view-transition">type</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
-	when capturing or performing the transition, equivalent to calling {{Document/startViewTransition(callbackOptions)}} with that {{StartViewTransitionOptions/type}}.
+	The '<dfn for="@view-transition">types</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
+	when capturing or performing the transition, equivalent to calling {{Document/startViewTransition(callbackOptions)}} with that {{StartViewTransitionOptions/types}}.
 
-	Note: the [=@view-transition/type=] descriptor only applies to the {{Document}} in which it is defined.
+	Note: the [=@view-transition/types=] descriptor only applies to the {{Document}} in which it is defined.
 	The author is responsible for using their chosen set of types in both documents.
 
 # Sharing styles between view transition pseudo-elements # {#shared-style-with-vt-classes}


### PR DESCRIPTION
- Divided the spec to have feature-based sections rather than by type of addition.
- Added overviews and examples, enhanced intro to introduce all new features.
- Applied resolutions regarding types:
    * https://github.com/w3c/csswg-drafts/issues/10070#issuecomment-2009980134
    * https://github.com/w3c/csswg-drafts/issues/10011#issuecomment-2009951924
    * https://github.com/w3c/csswg-drafts/issues/10071#issuecomment-2005363808

Closes #10011 
Closes #10070
Closes #10071