### PR TITLE
[mediaqueries] Lift <media-feature> parens to <media-in-parens> (#6806)

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -405,7 +405,6 @@ Media Features</h3>
 	or in range form with a comparison operator.
 
 	<pre class='railroad'>
-	T: (
 	Choice:
 		And:
 			N: feature name
@@ -415,7 +414,6 @@ Media Features</h3>
 		And:
 			N: range form
 			C: (see below)
-	T: )
 	</pre>
 
 	There are, however, several important differences between properties and media features:

--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -411,7 +411,6 @@ Media Features</h3>
 	or in range form with a comparison operator.
 
 	<pre class='railroad'>
-	T: (
 	Choice:
 		And:
 			N: feature name
@@ -421,7 +420,6 @@ Media Features</h3>
 		And:
 			N: range form
 			C: (see below)
-	T: )
 	</pre>
 
 	There are, however, several important differences between properties and media features:
@@ -853,9 +851,9 @@ Syntax</h2>
 	<dfn>&lt;media-not></dfn> = not <<media-in-parens>>
 	<dfn>&lt;media-and></dfn> = and <<media-in-parens>>
 	<dfn>&lt;media-or></dfn> = or <<media-in-parens>>
-	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | <<media-feature>> | <<general-enclosed>>
+	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | ( <<media-feature>> ) | <<general-enclosed>>
 
-	<dfn>&lt;media-feature></dfn> = ( [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ] )
+	<dfn>&lt;media-feature></dfn> = [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ]
 	<dfn>&lt;mf-plain></dfn> = <<mf-name>> : <<mf-value>>
 	<dfn>&lt;mf-boolean></dfn> = <<mf-name>>
 	<dfn>&lt;mf-range></dfn> = <<mf-name>> <<mf-comparison>> <<mf-value>>


### PR DESCRIPTION
This PR applies https://github.com/w3c/csswg-drafts/commit/1af56e0fe072307489875cd6456d3c409953bcb0 to MediaQueries 5. This commit was made 3 years ago, after [initiating](https://github.com/w3c/csswg-drafts/commit/2e34611e661fe3a7cb6ce70491ecf44676c6685e) from MediaQueries 4.

Also, the railroad diagram of the updated syntax was not updated accordingly. This PR updates it in both levels of the spec.

---

Without this change, a container size query will match `<general-enclosed>` and evaluate to `unknown`, unless it is specified in two `()`-blocks, because `<query-in-parens>` ([CSS Contain](https://drafts.csswg.org/css-contain-3/#typedef-query-in-parens)) produces `( <size-feature> )`, and `<size-feature>` is defined as *"the same as for a media feature: a feature name, a comparator, and a value"*. (*Note that you do not always have a comparator, eg. `orientation: portrait`*.)

Besides, I assume that [`media-progress(<media-feature>, ...)`](https://drafts.csswg.org/css-values-5/#typedef-media-progress) and [`container-progress(<size-feature>, ...)`](https://drafts.csswg.org/css-values-5/#typedef-container-progress) are supposed to accept/take a query without using a `()`-block.