### PR TITLE
[css-view-transitions-2] Use the right data types for `types`

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -414,14 +414,9 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		enum ViewTransitionNavigation { "auto", "none" };
 
 		[Exposed=Window]
-		interface CSSViewTransitionTypeSet {
-			readonly setlike<CSSOMString>;
-		};
-
-		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			readonly attribute ViewTransitionNavigation navigation;
-			readonly attribute CSSViewTransitionTypeSet types;
+			readonly attribute FrozenArray<CSSOMString> types;
 		};
 </xmp>
 
@@ -520,6 +515,11 @@ partial interface ViewTransition {
 	attribute ViewTransitionTypeSet types;
 };
 </xmp>
+
+The {{ViewTransitionTypeSet}} object represents a [=/set=] of strings, without special semantics.
+
+Note: a {{ViewTransitionTypeSet}} can contain strings that are invalid for '':active-view-transition-type'', e.g.
+strings that are not a <<custom-ident>>.
 
 The {{ViewTransition/types}} [=getter steps=] are to return [=this=]'s [=ViewTransition/active types=].
 
@@ -724,7 +724,7 @@ A {{Document}} additionaly has:
 A {{ViewTransition}} additionally has:
 <dl dfn-for=ViewTransition>
 	: <dfn>active types</dfn>
-	:: A [=/set=] of strings, initially empty.
+	:: A {{ViewTransitionTypeSet}}, initially empty.
 
 	: <dfn>outbound post-capture steps</dfn>
 	:: Null or a set of steps, initially null.


### PR DESCRIPTION
Based on CSSWG resolution:
https://github.com/w3c/csswg-drafts/issues/10114#issuecomment-2023217450

Closes #10114