### PR TITLE
[css-view-transitions-2] Make some syntax clarifications

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -416,7 +416,7 @@ The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
 			readonly attribute ViewTransitionNavigation navigation;
-			readonly attribute FrozenArray<CSSOMString> types;
+			[SameObject] readonly attribute FrozenArray<CSSOMString> types;
 		};
 </xmp>
 
@@ -641,9 +641,14 @@ div.box {
 	<<pt-name-and-class-selector>> has the following syntax definition:
 
 	<pre class=prod>
-		<dfn>&lt;pt-name-and-class-selector></dfn> = <<pt-name-selector>><<pt-class-selector>>? | <<pt-class-selector>>
+		<dfn>&lt;pt-name-and-class-selector></dfn> = <<pt-name-selector>> <<pt-class-selector>>? | <<pt-class-selector>>
 		<dfn>&lt;pt-class-selector></dfn> = ['.' <<custom-ident>>]+
 	</pre>
+
+	When interpreting the above grammar, white space is forbidden:
+
+		* Between <<pt-name-selector>> and <<pt-class-selector>>
+		* Between any of the components of <<pt-class-selector>>.
 
 	A [=named view transition pseudo-element=] [=selector=] which has one or more <<custom-ident>> values
 	in its <<pt-class-selector>> would only match an element if the [=captured element/class list=] value in


### PR DESCRIPTION
- Add [SameObject] to CSSOM
- Clarify that classes can't include white space
