### PR TITLE
[css-view-transitions-1] Perform the visibility change steps in own task

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1672,11 +1672,15 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	<div algorithm>
 	The <dfn export>view transition page-visibility change steps</dfn> given {{Document}} |document| are:
 
-	1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>", then:
+	1. [=Queue a global task=] on the [=DOM manipulation task source=],
+			given |document|'s [=relevant global object=],
+			to perform the following steps:
 
-		1. If |document|'s [=active view transition=] is not null, then [=skip the view transition|skip=] |document|'s [=active view transition=] with an "{{InvalidStateError}}" {{DOMException}}.
+		1. If |document|'s [=Document/visibility state=] is "<code>hidden</code>", then:
 
-	1. Otherwise, [=assert=]: [=active view transition=] is null.
+			1. If |document|'s [=active view transition=] is not null, then [=skip the view transition|skip=] |document|'s [=active view transition=] with an "{{InvalidStateError}}" {{DOMException}}.
+
+		1. Otherwise, [=assert=]: [=active view transition=] is null.
 
 	Note: this is called from the HTML spec.
 	</div>


### PR DESCRIPTION
This doesn't change observable behavior, but makes the visibility reaction consistent with other similar reactions.

See https://github.com/whatwg/html/pull/10137
