### PR TITLE
 [css-transforms-2] Fix a typo.

### DIFF
--- a/css-transforms-2/Overview.bs
+++ b/css-transforms-2/Overview.bs
@@ -240,7 +240,7 @@ The transform is a 50&deg; rotation about the vertical, Y axis. Note how this ma
 
 ### Perspective ### {#perspective}
 
-Perspective can be used to add a feeling of depth to a scene by making elements higher on the Z axis (closer to the viewer) appear larger, and those further away to appear smaller. The scaling is proportional to <var>d</var>/(<var>d</var> &minus; <var>Z</var>) where <var>d</var>, the value of 'perspective', is the distance from the drawing plane to the assumed position of the viewer's eye.
+Perspective can be used to add a feeling of depth to a scene by making elements higher on the Z axis (closer to the viewer) appear larger, and those further away appear smaller. The scaling is proportional to <var>d</var>/(<var>d</var> &minus; <var>Z</var>) where <var>d</var>, the value of 'perspective', is the distance from the drawing plane to the assumed position of the viewer's eye.
 
 The appearance of perspective can be applied to a 3d-transformed element in two ways. First, the element's 'transform function list' can contain the ''perspective()'' function which computes into the element's 'current transformation matrix'.
 


### PR DESCRIPTION
It should've been "making elements [...] further away appear smaller", not "making elements [...] further away to appear smaller".

I have not opened an issue for this or discussed with anyone, given how minor of a change it is.