### PR TITLE
[css-scrollbars] Remove example about IE

### DIFF
--- a/css-scrollbars-1/Overview.bs
+++ b/css-scrollbars-1/Overview.bs
@@ -292,20 +292,6 @@ Value Definitions</h3>
 	Note: When a user interacts with a scrollbar (e.g. hovering or activating),
 	implementations may alter which scrollbar colors apply to which scrollbar parts.
 
-	<div class="example">
-		<p>
-		The following example
-		(derived from
-		<a href="https://www.w3.org/Style/Examples/007/scrollbars.en.html">https://www.w3.org/Style/Examples/007/scrollbars.en.html</a>)
-		resets scrollbar colors in IE.
-
-		<pre><code highlight="css">
-		html {
-			scrollbar-color: ThreeDFace Scrollbar;
-		}
-		</code></pre>
-	</div>
-
 <h3 id=color-compat>
 Interaction with non-standard features</h3>
 


### PR DESCRIPTION
While the example isn't inherently wrong, it's of little relevance to present-day authors, as Internet Explorer hasn't been supported for years, and barely has any usage anymore.
