### PR TITLE
[css-view-transitions-1] Use snapshot containing block for new root

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1847,7 +1847,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					Note: Other rendering constraints are enforced via |capturedElement|'s [=new element=] being [=captured in a view transition=].
 
 				1. Let |newRect| be [=snapshot containing block=] if |capturedElement| is the [=document element=],
-					otherwise, |capturedElement's [=border box=].
+					otherwise, |capturedElement|'s [=border box=].
 
 				1. Set |width| to the current width of |newRect|.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1846,11 +1846,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 					Note: Other rendering constraints are enforced via |capturedElement|'s [=new element=] being [=captured in a view transition=].
 
-				1. Set |width| to the current width of |capturedElement|'s [=new element=]'s [=border box=].
+				1. Let |newRect| be [=snapshot containing block=] if |capturedElement| is the [=document element=],
+					otherwise, |capturedElement's [=border box=].
 
-				1. Set |height| to the current height of |capturedElement|'s [=new element=]'s [=border box=].
+				1. Set |width| to the current width of |newRect|.
 
-				1. Set |transform| to a transform that would map |capturedElement|'s [=new element=]'s [=border box=] from the [=snapshot containing block origin=] to its current visual position.
+				1. Set |height| to the current height of |newRect|.
+
+				1. Set |transform| to a transform that would map |newRect| from the [=snapshot containing block origin=] to its current visual position.
 
 				1. Set |writingMode| to the [=computed value=] of 'writing-mode' on |capturedElement|'s [=new element=].
 
@@ -1959,6 +1962,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Auto-skip animation when document is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
 * Remove references to cross-document view-transitions, to keep the L1 spec clean. See <a href="https://github.com/w3c/csswg-drafts/issues/9886">Issue 9886</a>.
 * Export an algorithm to skip the active transition when the page is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
+* Use snapshot containing block when capturing new state for document element. See <a href="https://github.com/w3c/csswg-drafts/issues/10177">issue #10177</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>


### PR DESCRIPTION
This aligns with current behavior, but was overlooked in the spec.

Closes #10177

