### PR TITLE
[css-view-transitions-1] More precisely define snapshot containing block in subframes #9786

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -41,6 +41,7 @@ spec:css22; type:dfn; text:element
 spec:css-break-4; type:dfn; text:fragment
 spec:css-viewport; type:dfn; text:interactive-widget;
 spec:css-display-4; type: dfn; text:invisible;
+spec:css2; type:dfn; text:viewport
 </pre>
 
 <pre class=anchors>
@@ -768,7 +769,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	(and is therefore consistent regardless of root scrollbars or [=interactive-widget|interactive widgets=]).
 	This makes it likely to be consistent for the [=document element=]'s [=captured element/old image=] and [=captured element/new element=].
 
-	For iframes, the [=snapshot containing block=] corresponds to its [=initial containing block=].
+	Within a [=child navigable=], the [=snapshot containing block=] is the union of the navigable's [=viewport=] with any [=scrollbar gutters=].
 
 	<figure>
 		<img src="diagrams/phone-browser.svg" width="200" height="335" alt="A diagram of a phone screen, including a top status bar, a browser URL bar, web-content area with a floating scrollbar, a virtual keyboard, and a bottom bar with an OS back button">


### PR DESCRIPTION
[css-view-transitions-1] More precisely define snapshot containing block in subframes #9786

The intent of the current definition is that the snapshot containing block in a child frame should be a rect at the origin, the same size as the frame, including any scrollbars.

Initial containing block is misleading in 2 ways - it doesn't include scrollbars in its size and its position changes as the page scrolls so a strict reading would make the snapshot containing block's position dependent on the scroll offset.

I think [viewport](https://www.w3.org/TR/CSS22/visuren.html#viewport) is the better definition here but I believe that excludes scrollbars as well so we explicitly union it with [scrollbar gutters](https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property).

Also, refer to [child navigable](https://html.spec.whatwg.org/multipage/document-sequences.html#child-navigable) rather than iframes since there's no need to limit this to just iframes (e.g. `<fencedframes>`? `<frame>`?)