### PR TITLE
[cssom-1] Fix false assumption that all rules are style rules

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1884,7 +1884,7 @@ To <dfn export>remove a CSS rule</dfn> from a CSS rule list <var>list</var> at i
 
 ### The {{CSSRuleList}} Interface ### {#the-cssrulelist-interface}
 
-The {{CSSRuleList}} interface represents an ordered collection of CSS style rules.
+The {{CSSRuleList}} interface represents an ordered collection of [=CSS rules=].
 
 <pre class=idl>
 [Exposed=Window]
@@ -1906,8 +1906,8 @@ collection.
 
 ### The {{CSSRule}} Interface ### {#the-cssrule-interface}
 
-The {{CSSRule}} interface represents an abstract, base CSS style rule. Each
-distinct CSS style rule type is represented by a distinct interface that
+The {{CSSRule}} interface represents an abstract, base [=CSS rule=]. Each
+distinct CSS rule type is represented by a distinct interface that
 inherits from this interface.
 
 <pre class=idl>


### PR DESCRIPTION
`CSSRuleList` is currently defined as *"a collection of CSS **style** rules"*.

`CSSRule` is currently defined as *"representing a CSS **style** rule"*.

I do not know if this is a remnant of an older version of the spec, or if this somewhat matches browser implementations. In the second case, I assume it is better to make the spec more abstract.