### PR TITLE
[cssom-view] add `shadowRoots` parameter to `caretPositionFromPoint` API.

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1070,16 +1070,16 @@ result of running these steps:
         <dt><a>caret range</a>
         <dd>null
     </dl>
-1. Otherwise, return a <a>caret position</a> where its properties are set after running these steps:
+1. Otherwise:
 
-    1. Let <a>caret range</a> to be a collapsed {{Range}} object for the position where the text insertion point indicator whould have been inserted when applying
+    1. Let <var>caretRange</var> to be a collapsed {{Range}} object for the position where the text insertion point indicator would have been inserted when applying
         the <a>transforms</a> that apply to the descendants of the <a>viewport</a>.
-    1. Let <var>startNode</var> be the [=range/start node=] of the <a>caret range</a>, and let <var>startOffset</var> be the [=range/start offset=] of the <a>caret range</a>.
+    1. Let <var>startNode</var> be the [=range/start node=] of the <var>caretRange</var>, and let <var>startOffset</var> be the [=range/start offset=] of the <var>caretRange</var>.
     1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:
         1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
         1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
-    1. Set <a>caret node</a> in <a>caret position</a> to <var>startNode</var>, and set <a>caret offset</a> in <a>caret position</a> to <var>startOffset</var>.
-    1. Set <a>caret range</a>'s [=range/start node=] and [=range/end node=] to <var>startNode</var>, and set <a>caret range</a>'s [=range/start offset=] and [=range/end offset=] to <var>startOffset</var>.
+    1. Set <var>caretRange</var>'s [=range/start node=] and [=range/end node=] to <var>startNode</var>, and set <a>caret range</a>'s [=range/start offset=] and [=range/end offset=] to <var>startOffset</var>.
+    1. Return a <a>caret position</a> whose <a>caret node</a> is set to <var>startNode</var>, <a>caret offset</a> is set to <var>startOffset</var>, and <a>caret range</a> is set to <var>caretRange</var>.
 
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1072,14 +1072,16 @@ result of running these steps:
     </dl>
 1. Otherwise:
 
-    1. Let <var>caretRange</var> to be a collapsed [=range=] object for the position where the text insertion point indicator would have been inserted when applying
+    1. Let <var>caretPosition</var> be a <a for=/>tuple</a> consisting of a <var>caretPositionNode</var> (a <a for=/>node</a>) and a <var>caretPositionOffset</var> (a non-negative integer) for the position where the text insertion point indicator would have been inserted when applying
         the <a>transforms</a> that apply to the descendants of the <a>viewport</a>.
-    1. Let <var>startNode</var> be the [=range/start node=] of the <var>caretRange</var>, and let <var>startOffset</var> be the [=range/start offset=] of the <var>caretRange</var>.
+    1. Let <var>startNode</var> be the <var>caretPositionNode</var> of the <var>caretPosition</var>, and let <var>startOffset</var> be the <var>caretPositionOffset</var> of the <var>caretPosition</var>.
     1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:
         1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
         1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
-    1. Set <var>caretRange</var>'s [=range/start node=] and [=range/end node=] to <var>startNode</var>, and set <a>caret range</a>'s [=range/start offset=] and [=range/end offset=] to <var>startOffset</var>.
-    1. Return a <a>caret position</a> whose <a>caret node</a> is set to <var>startNode</var>, <a>caret offset</a> is set to <var>startOffset</var>, and <a>caret range</a> is set to <var>caretRange</var>.
+    1. Return a <a>caret position</a> with its properties set as follows:
+        1. <a>caret node</a> is set to <var>startNode</var>.
+        1. <a>caret offset</a> is set to <var>startOffset</var>.
+        1. <a>caret range</a> is set to a collapsed {{Range}} object which [=range/start node=] and [=range/end node=] are <var>startNode</var>, and which [=range/start offset=] and [=range/end offset=] are <var>startOffset</var>.
 
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1070,16 +1070,16 @@ result of running these steps:
         <dt><a>caret range</a>
         <dd>null
     </dl>
-1. Otherwise, return a <a>caret position</a> where the
-    <a>caret range</a> is a collapsed
-    {{Range}} object for the position
-    where the text insertion point indicator would have been inserted when applying the <a>transforms</a> that apply to the descendants of the
-    <a>viewport</a>, and the other properties are set after running these steps:
+1. Otherwise, return a <a>caret position</a> where its properties are set after running these steps:
+
+    1. Let <a>caret range</a> to be a collapsed {{Range}} object for the position where the text insertion point indicator whould have been inserted when applying
+        the <a>transforms</a> that apply to the descendants of the <a>viewport</a>.
     1. Let <var>startNode</var> be the [=range/start node=] of the <a>caret range</a>, and let <var>startOffset</var> be the [=range/start offset=] of the <a>caret range</a>.
     1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:
         1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
         1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
     1. Set <a>caret node</a> in <a>caret position</a> to <var>startNode</var>, and set <a>caret offset</a> in <a>caret position</a> to <var>startOffset</var>.
+    1. Set <a>caret range</a>'s [=range/start node=] and [=range/end node=] to <var>startNode</var>, and set <a>caret range</a>'s [=range/start offset=] and [=range/end offset=] to <var>startOffset</var>.
 
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1145,6 +1145,8 @@ aborting on the first step that returns a value:
 
 Note: This {{DOMRect}} object is not <a spec=html>live</a>.
 
+Issue(10230): Consider removing <a>caret range</a> concept from <dfn>caret position</dfn> interface.
+
 <h2 id=extension-to-the-element-interface caniuse="element-scroll-methods">
 Extensions to the {{Element}} Interface</h2>
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1011,7 +1011,7 @@ Note: Some non-conforming implementations are known to return 32 instead of 24.
 partial interface Document {
   Element? elementFromPoint(double x, double y);
   sequence&lt;Element> elementsFromPoint(double x, double y);
-  CaretPosition? caretPositionFromPoint(double x, double y);
+  CaretPosition? caretPositionFromPoint(double x, double y, ShadowRoot... shadowRoots);
   readonly attribute Element? scrollingElement;
 };
 </pre>
@@ -1042,7 +1042,7 @@ instance, an element can be excluded from being a target for hit testing by usin
 1. If the document has a [=root element=], and the last item in <var>sequence</var> is not the [=root element=], append the [=root element=] to <var>sequence</var>.
 1. Return <var>sequence</var>.
 
-The <dfn method for=Document>caretPositionFromPoint(<var>x</var>, <var>y</var>)</dfn> method must return the
+The <dfn method for=Document>caretPositionFromPoint(<var>x</var>, <var>y</var>, ...<var>shadowRoots</var>)</dfn> method must return the
 result of running these steps:
 
 1. If there is no <a>viewport</a> associated with the document, return null.
@@ -1074,17 +1074,12 @@ result of running these steps:
     <a>caret range</a> is a collapsed
     {{Range}} object for the position
     where the text insertion point indicator would have been inserted when applying the <a>transforms</a> that apply to the descendants of the
-    <a>viewport</a>, and the other properties are set as follows:
-
-    <dl>
-        <dt><a>caret node</a>
-        <dd>The [=range/start node=]
-            of the <a>caret range</a>.
-
-        <dt><a>caret offset</a>
-        <dd>The [=range/start offset=] of
-            the <a>caret range</a>.
-    </dl>
+    <a>viewport</a>, and the other properties are set after running these steps:
+    1. Let <var>startNode</var> be the [=range/start node=] of the <a>caret range</a>, and let <var>startOffset</var> be the [=range/start offset=] of the <a>caret range</a>.
+    1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:
+        1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
+        1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
+    1. Set <a>caret node</a> in <a>caret position</a> to <var>startNode</var>, and set <a>caret offset</a> in <a>caret position</a> to <var>startOffset</var>.
 
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1072,7 +1072,7 @@ result of running these steps:
     </dl>
 1. Otherwise:
 
-    1. Let <var>caretRange</var> to be a collapsed {{Range}} object for the position where the text insertion point indicator would have been inserted when applying
+    1. Let <var>caretRange</var> to be a collapsed [=range=] object for the position where the text insertion point indicator would have been inserted when applying
         the <a>transforms</a> that apply to the descendants of the <a>viewport</a>.
     1. Let <var>startNode</var> be the [=range/start node=] of the <var>caretRange</var>, and let <var>startOffset</var> be the [=range/start offset=] of the <var>caretRange</var>.
     1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:


### PR DESCRIPTION
Per https://github.com/w3c/csswg-drafts/issues/9932, add `shadowRoots` parameter to `caretPositionFromPoint` API.

Implementation bugs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1889503
https://issues.chromium.org/issues/332774620
https://bugs.webkit.org/show_bug.cgi?id=172137

WPT test coverage will be added subsequently.