### PR TITLE
[css-scroll-snap-2] Add snap event handler attributes for Document and Element

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -613,7 +613,7 @@ ISSUE: This section should be moved to the HTML event handler
 Event handlers on elements, Document objects and Window objects {#event-handlers-on-elements-document-and-window-objects}
 ------------------------------------------------------------------------------------------------------
 
-	The following are the <a>event handlers</a> (and their corresponding <a>event handler event types</a>)
+	The following are additional <a>event handlers</a> (and their corresponding <a>event handler event types</a>)
 	that must be supported by all <a>HTML elements</a> as both <a>event handler content attributes</a>
 	and <a>event handler IDL attributes</a>; and that must be supported by all {{Window}} objects and {{Document}} objects, as
 	<a>event handler IDL attributes</a>:

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -301,6 +301,25 @@ Snap Events {#snap-events}
 		</tbody>
 	</table>
 
+	<h3 id="event-handlers-on-elements-and-document-objects">Event handlers on elements
+	and Document objects</h3>
+
+	The following are the <a>event handlers</a> (and their corresponding <a>event handler event types</a>)
+	that must be supported by all <a>HTML elements</a>, as both <a>event handler content attributes</a>
+	and <a>event handler IDL attributes</a>:
+
+	<table class="data" dfn-type=attribute dfn-for="Document,Element">
+		<tr>
+			<th><a>Event handler</a></th>
+			<th><a>Event handler event type</a></th>
+		<tr>
+			<td><dfn>onsnapchanged</dfn></td>
+			<td>{{snapchanged}}</td>
+		<tr>
+			<td><dfn>onsnapchanging</dfn></td>
+			<td>{{snapchanging}}</td>
+	</table>
+
 	<h4 for="snapchanged" id="snapchanged"> snapchanged </h4>
 	{{snapchanged}} indicates that the snap area to which a snap container is snapped along either axis has changed.
 	{{snapchanged}} is dispatched:
@@ -519,6 +538,23 @@ SnapEvent interface
 	</dl>
 
 	A {{SnapEvent}} should not bubble and should not be cancellable.
+
+<h3 id="interface-globaleventhandlers">
+Extensions to the <code>GlobalEventHandlers</code> Interface Mixin</h3>
+
+	This specification extends the {{GlobalEventHandlers}} interface mixin from
+	HTML to add <a>event handler IDL attributes</a> for {{SnapEvents}} as defined
+	in [[#event-handlers-on-elements-and-document-objects]].
+
+	<h4 id="interface-globaleventhandlers-idl">IDL Definition</h4>
+
+	<pre class="idl">
+	partial interface mixin GlobalEventHandlers {
+		attribute EventHandler onsnapchanged;
+		attribute EventHandler onsnapchanging;
+	};
+	</pre>
+
 <!--
 ██        ███████  ██    ██  ██████   ██     ██    ███    ██    ██ ████████   ██████
 ██       ██     ██ ███   ██ ██    ██  ██     ██   ██ ██   ███   ██ ██     ██ ██    ██

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -301,25 +301,6 @@ Snap Events {#snap-events}
 		</tbody>
 	</table>
 
-	<h3 id="event-handlers-on-elements-and-document-objects">Event handlers on elements
-	and Document objects</h3>
-
-	The following are the <a>event handlers</a> (and their corresponding <a>event handler event types</a>)
-	that must be supported by all <a>HTML elements</a>, as both <a>event handler content attributes</a>
-	and <a>event handler IDL attributes</a>:
-
-	<table class="data" dfn-type=attribute dfn-for="Document,Element">
-		<tr>
-			<th><a>Event handler</a></th>
-			<th><a>Event handler event type</a></th>
-		<tr>
-			<td><dfn>onsnapchanged</dfn></td>
-			<td>{{snapchanged}}</td>
-		<tr>
-			<td><dfn>onsnapchanging</dfn></td>
-			<td>{{snapchanging}}</td>
-	</table>
-
 	<h4 for="snapchanged" id="snapchanged"> snapchanged </h4>
 	{{snapchanged}} indicates that the snap area to which a snap container is snapped along either axis has changed.
 	{{snapchanged}} is dispatched:
@@ -539,21 +520,6 @@ SnapEvent interface
 
 	A {{SnapEvent}} should not bubble and should not be cancellable.
 
-<h3 id="interface-globaleventhandlers">
-Extensions to the <code>GlobalEventHandlers</code> Interface Mixin</h3>
-
-	This specification extends the {{GlobalEventHandlers}} interface mixin from
-	HTML to add <a>event handler IDL attributes</a> for {{SnapEvents}} as defined
-	in [[#event-handlers-on-elements-and-document-objects]].
-
-	<h4 id="interface-globaleventhandlers-idl">IDL Definition</h4>
-
-	<pre class="idl">
-	partial interface mixin GlobalEventHandlers {
-		attribute EventHandler onsnapchanged;
-		attribute EventHandler onsnapchanging;
-	};
-	</pre>
 
 <!--
 ██        ███████  ██    ██  ██████   ██     ██    ███    ██    ██ ████████   ██████
@@ -637,3 +603,46 @@ Physical Longhands for 'scroll-start-target' {#scroll-start-target-longhands-phy
 	</pre>
 
 	...
+
+Appendix B: Event Handlers {#event-handlers}
+============================================================
+
+ISSUE: This section should be moved to the HTML event handler
+<a href="https://html.spec.whatwg.org/#event-handlers-on-elements,-document-objects,-and-window-objects">specification</a>.
+
+Event handlers on elements, Document objects and Window objects {#event-handlers-on-elements-document-and-window-objects}
+------------------------------------------------------------------------------------------------------
+
+	The following are the <a>event handlers</a> (and their corresponding <a>event handler event types</a>)
+	that must be supported by all <a>HTML elements</a> as both <a>event handler content attributes</a>
+	and <a>event handler IDL attributes</a>; and that must be supported by all {{Window}} objects and {{Document}} objects, as
+	<a>event handler IDL attributes</a>:
+
+	<table class="data" dfn-type=attribute dfn-for="Document,Element,Window">
+		<tr>
+			<th><a>Event handler</a></th>
+			<th><a>Event handler event type</a></th>
+		<tr>
+			<td><dfn>onsnapchanged</dfn></td>
+			<td>{{snapchanged}}</td>
+		<tr>
+			<td><dfn>onsnapchanging</dfn></td>
+			<td>{{snapchanging}}</td>
+	</table>
+
+
+Extensions to the <code>GlobalEventHandlers</code> Interface Mixin {#interface-globaleventhandlers}
+--------------------------------------------------------------------------------------------------------
+
+	This specification extends the {{GlobalEventHandlers}} interface mixin from
+	HTML to add <a>event handler IDL attributes</a> for {{SnapEvents}} as defined
+	in [[#event-handlers-on-elements-document-and-window-objects]].
+
+	<h4 id="interface-globaleventhandlers-idl">IDL Definition</h4>
+
+	<pre class="idl">
+	partial interface mixin GlobalEventHandlers {
+		attribute EventHandler onsnapchanged;
+		attribute EventHandler onsnapchanging;
+	};
+	</pre>


### PR DESCRIPTION
Add snap event handler attributes for Document and Element

This adds the onsnapchanged and onsnapchanging attributes to the css-scroll-snap-2 [specification](https://drafts.csswg.org/css-scroll-snap-2/#snap-events) for elements and Document objects.

Heavily influenced by css-animations' [extensions to GlobalInterfaceHandlers](https://drafts.csswg.org/css-animations/#interface-globaleventhandlers).