### PR TITLE
[css-contain-3] Fix a typo in the text of size container features

### DIFF
--- a/css-contain-3/Overview.bs
+++ b/css-contain-3/Overview.bs
@@ -805,7 +805,7 @@ Size Container Features</h3>
 	(including [=container query length=] units)
 	and [=custom properties=]
 	in [=container query=] conditions
-	are evaluated based on the the [=computed values=] of the [=query container=].
+	are evaluated based on the [=computed values=] of the [=query container=].
 
 	Note: This is different from the handling of relative units in [=media queries=].
 


### PR DESCRIPTION
Fixes `the the` → `the`.