### PR TITLE
[css-syntax-3] Do not consume a qualified rule block twice

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2753,11 +2753,6 @@ Consume a qualified rule</h4>
 			</details>
 
 			Otherwise, [=consume a block=] from |input|,
-			and assign the results to |rule|'s
-			lists of [=declarations=] and child [=rules=].
-
-
-			[=Consume a block=] from |input|,
 			and let |child rules| be the result.
 			If the first item of |child rules| is a [=list=] of [=declarations=],
 			remove it from |child rules|


### PR DESCRIPTION
[*Consume a qualified rule*](https://drafts.csswg.org/css-syntax-3/#consume-qualified-rule) consumes two blocks in a row:

  > Otherwise, consume a block from `input`, and assign the results to `rule`’s lists of declarations and child rules. 
  > 
  > Consume a block from `input`, and let `child rules` be the result.

I assume it is a typo from https://github.com/w3c/csswg-drafts/commit/e5547b96f5de6fb5a68d050f42d562c448b99d0b.