### PR TITLE
[css-spec-viewport-1] updated the values for zoom property

### DIFF
--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -398,7 +398,7 @@ Note: 'zoom' does not affect or prevent 'transform' scaling.
 
 <pre class="propdef">
 	Name: zoom
-	Value: <<number [0,∞]>> || <<percentage [0,∞]>>
+	Value: normal | reset | <<number [0,∞]>> || <<percentage [0,∞]>>
 	Initial: 1
 	Applies to: all <<length>> property values of all elements
 	Inherited: no
@@ -411,6 +411,14 @@ Note: 'zoom' does not affect or prevent 'transform' scaling.
 The values of this property have the following meanings:
 
 <dl dfn-for="zoom" dfn-type=value>
+	<dt><dfn>normal</dfn>
+	<dd>
+		Render this element at its normal size.
+
+	<dt><dfn>reset</dfn>
+	<dd>
+		Do not (de)magnify this element if the user applies non-pinch-based zooming (e.g. by pressing <kbd>Ctrl</kbd> \- <kbd>-</kbd> or <kbd>Ctrl</kbd> \+ <kbd>+</kbd> keyboard shortcuts) to the document. Do not use this value, use the standard unset value instead.
+
 	<dt><dfn><<number>></dfn>
 	<dd>
 		Positive floating point number indicating a zoom factor.


### PR DESCRIPTION
I feel that the `values` for CSS `zoom` property are in need of updating to reflect the actual values being used in browser. 

I could of course be totally wrong here, new to this.

[zoom property on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom)

[zoom property on drafts CSSWG](https://drafts.csswg.org/css-viewport/#zoom-property)