### PR TITLE
[css-gcpm-3] Fix typo

### DIFF
--- a/css-gcpm-3/Overview.bs
+++ b/css-gcpm-3/Overview.bs
@@ -304,7 +304,7 @@ CSS:
 
 
 
-<p class="note">The element ''value()'' can only be used in page margin boxes. And it cannot be combined with other possible values for the content property.</p>
+<p class="note">The ''element()'' value can only be used in page margin boxes. And it cannot be combined with other possible values for the content property.</p>
 <div class="issue">
 <p>This idea would be much more useful if we could also copy (rather than just move) elements. That would avoid the duplication of HTML in the example above.
 </p>


### PR DESCRIPTION
The spec introduces the `element()` value, not a `value()` element.
It looks like this is a simple typo.
