### PR TITLE
[css-scroll-snap-2] Rename snap events

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -262,7 +262,7 @@ Snap Events {#snap-events}
 ████████    ███    ████████ ██    ██    ██     ██████
 -->
 
-{{snapchanged}} and {{snapchanging}} {#snapchanged-and-snapchanging}
+{{scrollsnapchange}} and {{scrollsnapchanging}} {#scrollsnapchange-and-scrollsnapchanging}
 --------------------------------------------
 
 	CSS scroll snap points are often used as a mechanism to
@@ -283,7 +283,7 @@ Snap Events {#snap-events}
 		</thead>
 		<tbody>
 			<tr>
-				<th><dfn for="snapchanged" event>snapchanged</dfn></th>
+				<th><dfn for="scrollsnapchange" event>scrollsnapchange</dfn></th>
 				<td>{{SnapEvent}}</td>
 				<td>scroll containers</td>
 				<td>Fired at the scrolling element or {{Document}} at the end of a scroll (before a {{scrollend}} event)
@@ -291,19 +291,19 @@ Snap Events {#snap-events}
 					if the element that the scrolling element or Document is snapped to changed.</td>
 			</tr>
 			<tr>
-				<th><dfn for="snapchanging" event>snapchanging</dfn></th>
+				<th><dfn for="scrollsnapchanging" event>scrollsnapchanging</dfn></th>
 				<td>{{SnapEvent}}</td>
 				<td>scroll containers</td>
 				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll}} event),
 					if the element that the scrolling would cause the scroller to snap to is
-					different from the target reported by the last snapchanging event that was fired.</td>
+					different from the target reported by the last scrollsnapchanging event that was fired.</td>
 			</tr>
 		</tbody>
 	</table>
 
-	<h4 for="snapchanged" id="snapchanged"> snapchanged </h4>
-	{{snapchanged}} indicates that the snap area to which a snap container is snapped along either axis has changed.
-	{{snapchanged}} is dispatched:
+	<h4 for="scrollsnapchange" id="scrollsnapchange"> scrollsnapchange </h4>
+	{{scrollsnapchange}} indicates that the snap area to which a snap container is snapped along either axis has changed.
+	{{scrollsnapchange}} is dispatched:
 
 	<ol>
 	<li>
@@ -327,70 +327,70 @@ Snap Events {#snap-events}
 	</ol>
 
 	Scrolling operations always lead to {{scrollend}} events being fired. If a
-	scrolling operation also results in a {{snapchanged}} event being fired, the
-	{{snapchanged}} event should be fired before the {{scrollend}} event.
+	scrolling operation also results in a {{scrollsnapchange}} event being fired, the
+	{{scrollsnapchange}} event should be fired before the {{scrollend}} event.
 
 	Each {{Document}} has an associated list of
-	<dfn export for=Document>pending snapchanged event targets</dfn>, initially empty.
+	<dfn export for=Document>pending scrollsnapchange event targets</dfn>, initially empty.
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
-	one <dfn export>snapchangedTargetBlock</dfn> and one
-	<dfn export>snapchangedTargetInline</dfn> in the block and inline axes
+	one <dfn export>scrollsnapchangeTargetBlock</dfn> and one
+	<dfn export>scrollsnapchangeTargetInline</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
 	snapped in that axis or the {{Element}} to which the container is snapped.
 
-	When asked to <dfn export for=Document>update snapchanged targets</dfn>
+	When asked to <dfn export for=Document>update scrollsnapchange targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
 	|snapcontainer|, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-	1. Let <var>blockTarget</var> be the <a>snapchangedTargetBlock</a> associated
+	1. Let <var>blockTarget</var> be the <a>scrollsnapchangeTargetBlock</a> associated
 		with |snapcontainer|.
-	1. Let <var>inlineTarget</var> be the <a>snapchangedTargetInline</a> associated
+	1. Let <var>inlineTarget</var> be the <a>scrollsnapchangeTargetInline</a> associated
 		with |snapcontainer|.
-	1. Let <var>blockSnapchangingTarget</var> be the <a>snapchangingTargetBlock</a>
+	1. Let <var>blockScrollSnapchangingTarget</var> be the <a>scrollsnapchangingTargetBlock</a>
 		associated with |snapcontainer|.
-	1. Let <var>inlineSnapchangingTarget</var> be the
-		<a>snapchangingTargetInline</a> associated with |snapcontainer|.
+	1. Let <var>inlineScrollSnapchangingTarget</var> be the
+		<a>scrollsnapchangingTargetInline</a> associated with |snapcontainer|.
 	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
-	1. If <var>blockTarget</var> is not the same element as <var>blockSnapchangingTarget</var> or
-		1. Set the <a>snapchangedTargetBlock</a> associated with |snapcontainer| to
-			<var>blockSnapchangingTarget</var>.
+	1. If <var>blockTarget</var> is not the same element as <var>blockScrollSnapchangingTarget</var> or
+		1. Set the <a>scrollsnapchangeTargetBlock</a> associated with |snapcontainer| to
+			<var>blockScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
-	1. If <var>inlineTarget</var> is not the same element as <var>inlineSnapchangingTarget</var>:
-		1. Set the <a>snapchangedTargetInline</a> associated with |snapcontainer| to
-			<var>inlineSnapchangingTarget</var>.
+	1. If <var>inlineTarget</var> is not the same element as <var>inlineScrollSnapchangingTarget</var>:
+		1. Set the <a>scrollsnapchangeTargetInline</a> associated with |snapcontainer| to
+			<var>inlineScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
 	1. If <var>snap targets changed</var> is true:
 		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a>pending snapchanged event targets</a>:
+			<a>pending scrollsnapchange event targets</a>:
 			1. Append |snapcontainer| to <var>doc</var>'s
-				<a>pending snapchanged event targets</a>.
+				<a>pending scrollsnapchange event targets</a>.
 
 	Note: When snapping occurs on a scroller (either due to a layout change or a
-	scrolling operation) the <a>snapchangingTargetBlock</a> and <a>snapchangingTargetInline</a>
+	scrolling operation) the <a>scrollsnapchangingTargetBlock</a> and <a>scrollsnapchangingTargetInline</a>
 	associated with that scroller are updated and represent the current snap targets
-	of that scroller. This allows the <a>update snapchanged targets</a> algorithm
-	to use these elements to determine whether a {{snapchanged}} event should be fired.
+	of that scroller. This allows the <a>update scrollsnapchange targets</a> algorithm
+	to use these elements to determine whether a {{scrollsnapchange}} event should be fired.
 
-	When asked to <dfn>dispatch pending snapchanged events</dfn> for a {{Document}},
+	When asked to <dfn>dispatch pending scrollsnapchange events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
-	1. For each item <var>target</var> in |doc|'s <a>pending snapchanged event targets</a>:
-		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanged}} at <var>target</var>
+	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchange event targets</a>:
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangedTargetBlock</a> and the
-			<a>snapchangedTargetInline</a>, respectively, that are associated with <var>target</var>.
-	1. Empty <var>doc</var>'s <a>pending snapchanged event targets</a>.
+			{{SnapEvent/snapTargetInline}} attributes be the <a>scrollsnapchangeTargetBlock</a> and the
+			<a>scrollsnapchangeTargetInline</a>, respectively, that are associated with <var>target</var>.
+	1. Empty <var>doc</var>'s <a>pending scrollsnapchange event targets</a>.
 
-	<h4 id="snapchanging"> snapchanging </h4>
-	{{snapchanging}} is dispatched:
+	<h4 id="scrollsnapchanging"> scrollsnapchanging </h4>
+	{{scrollsnapchanging}} is dispatched:
 	* during a scrolling operation, if the element to which a
 		 <a spec=css-scroll-snap lt="scroll snap container">snap container</a> would
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snap</a> (in either axis) changes, or
-	* if a [[css-scroll-snap-1#re-snap|layout change]] occurs such that a {{snapchanged}} event
-		 is to be dispatched. In this case, as with the scrolling case, the {{snapchanging}} event
-		 should be dispatched before the {{snapchanged}} event.
+	* if a [[css-scroll-snap-1#re-snap|layout change]] occurs such that a {{scrollsnapchange}} event
+		 is to be dispatched. In this case, as with the scrolling case, the {{scrollsnapchanging}} event
+		 should be dispatched before the {{scrollsnapchange}} event.
 
 	A scrolling operation might animate towards a particular position (e.g.
 	scrollbar arrow clicks, arrow key presses, "behavior: smooth" programmatic
@@ -404,64 +404,64 @@ Snap Events {#snap-events}
 	* In the latter case, the intended scroll position is the current scroll offset as
 		 determined by the user's input.
 
-	{{snapchanging}} aims to let the web page know, as early as possible,
+	{{scrollsnapchanging}} aims to let the web page know, as early as possible,
 	that the scrolling operation will result in a change in the element the snap
 	container is snapped to. The user agent should evaluate whether to trigger
-	{{snapchanging}} based on the	<a>eventual snap target</a> to which the scroller would
+	{{scrollsnapchanging}} based on the	<a>eventual snap target</a> to which the scroller would
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> were the scrolling operation
 	to reach its intended scroll position.
 
-	Note: Since snapchanging gives the web page hints about future snapping,
-	the snapping hinted at by a snapchanging event might not materialize since it
+	Note: Since scrollsnapchanging gives the web page hints about future snapping,
+	the snapping hinted at by a scrollsnapchanging event might not materialize since it
 	will be possible for subsequent scrolling input to further alter the snap
 	container's scroll position and result in a different eventual snap target.
 
 
-	{{snapchanging}} events are fired before {{scroll}} events.
+	{{scrollsnapchanging}} events are fired before {{scroll}} events.
 
 	Each {{Document}} has an associated list of
-	<dfn export for=Document>pending snapchanging event targets</dfn>, initially empty.
+	<dfn export for=Document>pending scrollsnapchanging event targets</dfn>, initially empty.
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
-	one <dfn>snapchangingTargetBlock</dfn> 
-	and one <dfn>snapchangingTargetInline</dfn>in the block and inline axes
+	one <dfn>scrollsnapchangingTargetBlock</dfn> 
+	and one <dfn>scrollsnapchangingTargetInline</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
 	snapping in that axis or the {{Element}} to which the container is snapping.
 
-	When asked to <dfn export for=Document>update snapchanging targets</dfn>
+	When asked to <dfn export for=Document>update scrollsnapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
 	|snapcontainer|, given an {{Element}} newBlockTarget and an {{Element}}
 	newInlineTarget, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-	1. Let <var>blockTarget</var> be the <a>snapchangingTargetBlock</a> that is
+	1. Let <var>blockTarget</var> be the <a>scrollsnapchangingTargetBlock</a> that is
 		associated with |snapcontainer|.
-	1. Let <var>inlineTarget</var> be the <a>snapchangingTargetInline</a> that is
+	1. Let <var>inlineTarget</var> be the <a>scrollsnapchangingTargetInline</a> that is
 		associated with |snapcontainer|.
 	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
-		1. Set the <a>snapchangingTargetBlock</a> associated with |snapcontainer| to
+		1. Set the <a>scrollsnapchangingTargetBlock</a> associated with |snapcontainer| to
 			<var>newBlockTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a>pending snapchanging event targets</a>,
+			<a>pending scrollsnapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
-				<a>pending snapchanging event targets</a>
+				<a>pending scrollsnapchanging event targets</a>
 	1. If <var>newInlineTarget</var> is not the same element as <var>inlineTarget</var>:
-		1. Set the <a>snapchangingTargetInline</a> associated with |snapcontainer| to
+		1. Set the <a>scrollsnapchangingTargetInline</a> associated with |snapcontainer| to
 			<var>newInlineTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
-			<a>pending snapchanging event targets</a>,
+			<a>pending scrollsnapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
-				<a>pending snapchanging event targets</a>.
+				<a>pending scrollsnapchanging event targets</a>.
 
-	When asked to <dfn>dispatch pending snapchanging events</dfn> for a {{Document}},
+	When asked to <dfn>dispatch pending scrollsnapchanging events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
-	1. For each item <var>target</var> in |doc|'s <a>pending snapchanging event targets</a>:
-		1. Fire a {{SnapEvent}}, |snapevent|, named {{snapchanging}} at <var>target</var>
+	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchanging event targets</a>:
+		1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			{{SnapEvent/snapTargetInline}} attributes be the <a>snapchangingTargetBlock</a> and the
-			<a>snapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
-	1. Empty <var>doc</var>'s <a>pending snapchanging event targets</a>.
+			{{SnapEvent/snapTargetInline}} attributes be the <a>scrollsnapchangingTargetBlock</a> and the
+			<a>scrollsnapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
+	1. Empty <var>doc</var>'s <a>pending scrollsnapchanging event targets</a>.
 
 	<h4 id="snap-events-on-layout-changes">Snap Events due to Layout Changes </h4>
 	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -473,9 +473,9 @@ Snap Events {#snap-events}
 	1. Let <var>newInlineTarget</var> be the element that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
 		 in the inline axis or null if it did not snap to any element.
-	1. Run the steps to <a>update snapchanging targets</a> with <var>newBlockTarget</var>
+	1. Run the steps to <a>update scrollsnapchanging targets</a> with <var>newBlockTarget</var>
 		 as newBlockTarget and <var>newInlineTarget</var> as newInlineTarget.
-	1. Run the steps to <a>update snapchanged targets</a> for |snapcontainer|.
+	1. Run the steps to <a>update scrollsnapchange targets</a> for |snapcontainer|.
 
 
 SnapEvent interface
@@ -511,8 +511,8 @@ SnapEvent interface
 			for the associated snap event.
 			</div>
 
-		For {{snapchanged}} events, the snap position is the position already
-		realized by the snap container after a scroll snap. For {{snapchanging}}
+		For {{scrollsnapchange}} events, the snap position is the position already
+		realized by the snap container after a scroll snap. For {{scrollsnapchanging}}
 		events it is the snap position that the snap container will eventually
 		snap to when the scrolling operation ends.
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1917,7 +1917,7 @@ Whenever a <a>viewport</a> gets scrolled (whether in response to user interactio
 
 1. Let <var>doc</var> be the <a>viewport’s</a> associated {{Document}}.
 1. If <var>doc</var> is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a>
+    run the steps to <a spec=css-scroll-snap-2 lt="update scrollsnapchanging targets">update scrollsnapchanging targets</a>
     for <var>doc</var> with <var>doc</var>'s <a spec="css-scroll-snap-2">eventual snap target</a> in the block axis
     as newBlockTarget and <var>doc</var>'s <a spec="css-scroll-snap-2">eventual snap target</a> in the inline axis
     as newInlineTarget.
@@ -1928,7 +1928,7 @@ Whenever an element gets scrolled (whether in response to user interaction or by
 
 1. Let <var>doc</var> be the element's <a>node document</a>.
 1. If the element is a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-    run the steps to <a spec=css-scroll-snap-2 lt="update snapchanging targets">update snapchanging targets</a>
+    run the steps to <a spec=css-scroll-snap-2 lt="update scrollsnapchanging targets">update scrollsnapchanging targets</a>
     for the element with the element's <a spec="css-scroll-snap-2">eventual snap target</a> in the block axis
     as newBlockTarget and the element's <a spec="css-scroll-snap-2">eventual snap target</a> in the inline axis
     as newInlineTarget.
@@ -1944,14 +1944,14 @@ Whenever a <a>visual viewport</a> gets scrolled (whether in response to user int
 
 When asked to <dfn export for=Document>run the scroll steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
-1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanging events</a> for <var>doc</var>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending scrollsnapchanging events</a> for <var>doc</var>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scroll event targets</a>,
     in the order they were added to the list, run these substeps:
 
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scroll</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scroll</a> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll event targets</a>.
-1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanged events</a> for <var>doc</var>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending scrollsnapchange events</a> for <var>doc</var>.
 
 Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent must run these steps:
 
@@ -1962,10 +1962,10 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
         If <var>box</var> belongs to a {{VisualViewport}}, let <var>doc</var> be the {{VisualViewport}}'s <a for=visualviewport>associated document</a> and <var>target</var>
         be the {{VisualViewport}}. Otherwise, <var>box</var> belongs to an element and let <var>doc</var> be the element's <a>node document</a> and <var>target</var> be the element.
     1. If <var>box</var> belongs to a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>, |snapcontainer|,
-        run the <a spec=css-scroll-snap-2 lt="update snapchanged targets">update snapchanged targets</a> steps for |snapcontainer|.
+        run the <a spec=css-scroll-snap-2 lt="update scrollsnapchange targets">update scrollsnapchange targets</a> steps for |snapcontainer|.
     1. If <var>target</var> is already in <var>doc</var>'s <a>pending scrollend event targets</a>, abort these steps.
     1. Append <var>target</var> to <var>doc</var>'s <a>pending scrollend event targets</a>.
-1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending snapchanged targets</a> for <var>doc</var>.
+1. Run the steps to <a spec="css-scroll-snap-2">dispatch pending scrollsnapchange targets</a> for <var>doc</var>.
 1. For each item <var>target</var> in <var>doc</var>'s <a>pending scrollend event targets</a>, in the order they were added to the list, run these substeps:
     1. If <var>target</var> is a {{Document}}, <a>fire an event</a> named <a event>scrollend</a> that bubbles at <var>target</var>.
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.


### PR DESCRIPTION
This renames snapchanged to scrollsnapchange and snapchanging to scrollsnapchanging, per the CSSWG [resolution](https://github.com/w3c/csswg-drafts/issues/9697#issuecomment-2089278615)
