### PR TITLE
[css-cascade-6] Clarify circular dependency (In wording) in finding scoping limits.

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -539,7 +539,8 @@ Identifying Scoping Roots and Limits</h4>
 	: Finding any [=scoping limits=]
 	:: For each [=scope=] created by a [=scoping root=],
 		its [=scoping limits=] are set to all elements
-		that are [=in scope=] and that match <<scope-end>>,
+		that are [=in scope=] (Only in terms of [=scoping roots=])
+		and that match <<scope-end>>,
 		interpreting '':scope'' and ''&''
 		exactly as in [=scoped style rules=].
 

--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -539,7 +539,7 @@ Identifying Scoping Roots and Limits</h4>
 	: Finding any [=scoping limits=]
 	:: For each [=scope=] created by a [=scoping root=],
 		its [=scoping limits=] are set to all elements
-		that are [=in scope=] (Only in terms of [=scoping roots=])
+		that are [=descendants=] of the [=scoping root=]
 		and that match <<scope-end>>,
 		interpreting '':scope'' and ''&''
 		exactly as in [=scoped style rules=].


### PR DESCRIPTION
Finding scoping limits mention in-scope elements, which in turn mentions scoping limits, which in turn etc etc. Just a wording issue, since it can be inferred that the scoping limit portion is ignored at this time.

Still, I think this is helps reduce confusion on first-read.