### PR TITLE
[css-view-transitions-1] Fix timing of resolving "update callback done" promise

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1280,8 +1280,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
 
-		1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
-
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
 
 			1. If |capturedElement|'s [=captured element/new element=] is not null,
@@ -1599,11 +1597,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
 
 		1. Let |fulfillSteps| be to following steps:
-			1. [=Activate view transition|Activate=] |transition|.
-
 			1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
 
-				Note: This would be a no-op if the previous step already resolved the promise.
+			1. [=Activate view transition|Activate=] |transition|.
 
 		1. Let |rejectSteps| be the following steps given |reason|:
 			1. [=Reject=] |transition|'s [=ViewTransition/update callback done promise=] with |reason|.


### PR DESCRIPTION
The "update callback done" promise should always be resolved right after the update callback is called, even in failure cases. This is what certain WPTs expect, for instance: css/css-view-transitions/duplicate-tag-rejects-start.html
