### PR TITLE
[css-view-transitions-1] Ignore names from shadow DOM

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1404,7 +1404,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		1. Let |usedTransitionNames| be a new [=/set=] of strings.
 
 		1. [=list/For each=] |element| of every [=/element=] that is [=/connected=],
-			and has a [=node document=] equal to to |document|,
+			and has a [=node document=] equal to |document|,
+			and has a [=tree context=] equal to |document|,
 			in [paint order](https://drafts.csswg.org/css2/#painting-order):
 
 			1. If any [=flat tree=] ancestor of this |element| [=skips its contents=], then [=continue=].

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1942,8 +1942,8 @@ This should be feasible since access to this data should already be prevented in
 
 This appendix is <em>informative</em>.
 
-<h3 id="changes-since-2022-05-30">
-Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230530/">2022-05-30 Working Draft</a>
+<h3 id="changes-since-2023-05-30">
+Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230530/">2023-05-30 Working Draft</a>
 </h3>
 * Use a keyframe to add plus-lighter blending during cross-fade. See <a href="https://github.com/w3c/csswg-drafts/issues/8924">issue 8924</a>.
 * Add mix-blend-mode to list of properties copied over to the ''::view-transition-group''. See <a href="https://github.com/w3c/csswg-drafts/issues/8962">issue 8962</a>.
@@ -1965,6 +1965,8 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Remove references to cross-document view-transitions, to keep the L1 spec clean. See <a href="https://github.com/w3c/csswg-drafts/issues/9886">Issue 9886</a>.
 * Export an algorithm to skip the active transition when the page is hidden. See <a href="https://github.com/w3c/csswg-drafts/issues/9543">issue 9543</a>.
 * Use snapshot containing block when capturing new state for document element. See <a href="https://github.com/w3c/csswg-drafts/issues/10177">issue #10177</a>.
+* Fix algorithm for dispatching updateDOMCallback promise.
+* Scope view transition names to matching tree context. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1320,7 +1320,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		1. Set |transition|'s [=ViewTransition/initial snapshot containing block size=] to the [=snapshot containing block size=].
 
 		1. [=list/For each=] |element| of every [=/element=] that is [=/connected=],
-			and has a [=node document=] equal to to |document|,
+			and has a [=node document=] equal to |document|,
+			and has a [=tree context=] equal to |document|,
 			in [paint order](https://drafts.csswg.org/css2/#painting-order):
 
 			<div class=note>We iterate in paint order to ensure that this order is cached in |namedElements|.


### PR DESCRIPTION
Applies resolution at https://github.com/w3c/csswg-drafts/issues/10145.