### PR TITLE
[cssom-view] Remove `caret range` concept from `CaretPosition` interface.

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1070,9 +1070,6 @@ result of running these steps:
         <dt><a>caret offset</a>
         <dd>The amount of 16-bit units to the left of where the
         text insertion point indicator would have inserted.
-
-        <dt><a>caret range</a>
-        <dd>null
     </dl>
 1. Otherwise:
 
@@ -1085,7 +1082,6 @@ result of running these steps:
     1. Return a <a>caret position</a> with its properties set as follows:
         1. <a>caret node</a> is set to <var>startNode</var>.
         1. <a>caret offset</a> is set to <var>startOffset</var>.
-        1. <a>caret range</a> is set to a collapsed {{Range}} object which [=range/start node=] and [=range/end node=] are <var>startNode</var>, and which [=range/start offset=] and [=range/end offset=] are <var>startOffset</var>.
 
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of
@@ -1118,7 +1114,7 @@ in that the latter can return a <code>frameset</code> element.
 <h3 id=the-caretposition-interface>The {{CaretPosition}} Interface</h3>
 
 A <dfn>caret position</dfn> gives the position of a text insertion point indicator. It always has an associated
-<dfn>caret node</dfn>, <dfn>caret offset</dfn>, and <dfn>caret range</dfn>. It is represented by a {{CaretPosition}} object.
+<dfn>caret node</dfn>, and <dfn>caret offset</dfn>. It is represented by a {{CaretPosition}} object.
 
 <pre class=idl>
 [Exposed=Window]
@@ -1136,20 +1132,17 @@ The <dfn attribute for=CaretPosition>offset</dfn> attribute must return the <a>c
 The <dfn method for=CaretPosition>getClientRect()</dfn> method must follow these steps,
 aborting on the first step that returns a value:
 
-1. If <a>caret range</a> is not null:
-    1. Let <var>list</var> be the result of invoking the {{Range/getClientRects()}} method on the range.
-    1. If <var>list</var> is empty, return null.
-    1. Return the {{DOMRect}} object in <var>list</var> at index 0.
 1. If <a>caret node</a> is a text entry widget that is a replaced element,
     and that is in the document,
     return a [=scaled=] {{DOMRect}} object for the caret in the widget
     as represented by the <a>caret offset</a> value.
     The <a>transforms</a> that apply to the element and its ancestors are applied.
-1. Return null.
+1. Otherwise:
+
+    1. Let <var>caretRange</var> be a collapsed {{Range}} object which [=range/start node=] and [=range/end node=] are set to <a>caret node</a>, and which [=range/start offset=] and [=range/end offset=] are set to <a>caret offset</a>.
+    1. Return the {{DOMRect}} object which is the result of invoking the {{Range/getBoundingClientRect()}} method on <var>caretRange</var>.
 
 Note: This {{DOMRect}} object is not <a spec=html>live</a>.
-
-Issue(10230): Consider removing <a>caret range</a> concept from <a>caret position</a> interface.
 
 <h2 id=extension-to-the-element-interface caniuse="element-scroll-methods">
 Extensions to the {{Element}} Interface</h2>

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1114,7 +1114,7 @@ in that the latter can return a <code>frameset</code> element.
 <h3 id=the-caretposition-interface>The {{CaretPosition}} Interface</h3>
 
 A <dfn>caret position</dfn> gives the position of a text insertion point indicator. It always has an associated
-<dfn>caret node</dfn>, and <dfn>caret offset</dfn>. It is represented by a {{CaretPosition}} object.
+<dfn>caret node</dfn> and <dfn>caret offset</dfn>. It is represented by a {{CaretPosition}} object.
 
 <pre class=idl>
 [Exposed=Window]
@@ -1139,7 +1139,7 @@ aborting on the first step that returns a value:
     The <a>transforms</a> that apply to the element and its ancestors are applied.
 1. Otherwise:
 
-    1. Let <var>caretRange</var> be a collapsed {{Range}} object which [=range/start node=] and [=range/end node=] are set to <a>caret node</a>, and which [=range/start offset=] and [=range/end offset=] are set to <a>caret offset</a>.
+    1. Let <var>caretRange</var> be a collapsed {{Range}} object whose [=range/start node=] and [=range/end node=] are set to <a>caret node</a>, and whose [=range/start offset=] and [=range/end offset=] are set to <a>caret offset</a>.
     1. Return the {{DOMRect}} object which is the result of invoking the {{Range/getBoundingClientRect()}} method on <var>caretRange</var>.
 
 Note: This {{DOMRect}} object is not <a spec=html>live</a>.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1083,6 +1083,8 @@ result of running these steps:
         1. <a>caret node</a> is set to <var>startNode</var>.
         1. <a>caret offset</a> is set to <var>startOffset</var>.
 
+Note: This <a>caret position</a> is not <a spec=html>live</a>.
+
 Note: The specifics of hit testing are out of scope of this
 specification and therefore the exact details of
 {{elementFromPoint()}} and {{caretPositionFromPoint()}}


### PR DESCRIPTION
Per #10230, `CaretPosition` backed by live range can cause issues. We should remove the `caret range` concept from `CaretPosition` interface.

This is also a long-standing issue. https://lists.w3.org/Archives/Public/www-style/2011May/0051.html
