### PR TITLE
[css-font-loading-3][editorial] Reference WebIDL BufferSource

### DIFF
--- a/css-font-loading-3/Overview.bs
+++ b/css-font-loading-3/Overview.bs
@@ -77,11 +77,9 @@ The <code>FontFace</code> Interface</h2>
 
 	The {{FontFace}} interface represents a single usable font face.
 	CSS ''@font-face'' rules implicitly define FontFace objects,
-	or they can be constructed manually from a url or binary data.
+	or they can be constructed manually from a url or a buffer source.
 
 	<xmp class="idl">
-		typedef (ArrayBuffer or ArrayBufferView) BinaryData;
-
 		dictionary FontFaceDescriptors {
 			CSSOMString style = "normal";
 			CSSOMString weight = "normal";
@@ -99,7 +97,7 @@ The <code>FontFace</code> Interface</h2>
 
 		[Exposed=(Window,Worker)]
 		interface FontFace {
-			constructor(CSSOMString family, (CSSOMString or BinaryData) source,
+			constructor(CSSOMString family, (CSSOMString or BufferSource) source,
 		                optional FontFaceDescriptors descriptors = {});
 			attribute CSSOMString family;
 			attribute CSSOMString style;
@@ -210,7 +208,7 @@ The Constructor</h3>
 
 	A {{FontFace}} can be constructed either
 	from a URL pointing to a font face file,
-	or from an {{ArrayBuffer}} (or {{ArrayBufferView}}) containing the binary representation of a font face.
+	or from a {{BufferSource}} containing the binary representation of a font face.
 
 	When the <dfn constructor for=FontFace>FontFace(family, source, descriptors)</dfn> method is called,
 	execute these steps:
@@ -255,7 +253,7 @@ The Constructor</h3>
 	2. If the {{source!!argument}} argument was a {{CSSOMString}},
 		set <var>font face's</var> internal {{[[Urls]]}} slot to the string.
 
-		If the {{source}} argument was a {{BinaryData}},
+		If the {{source}} argument was a {{BufferSource}},
 		set <var>font face's</var> internal {{[[Data]]}} slot to the passed argument.
 
 	3. If <var>font face's</var> {{[[Data]]}} slot is not <code>null</code>,
@@ -317,7 +315,7 @@ The <code>load()</code> method</h3>
 
 	The {{FontFace/load()}} method of {{FontFace}}
 	forces a url-based font face to request its font data and load.
-	For fonts constructed from binary data,
+	For fonts constructed from a buffer source,
 	or fonts that are already loading or loaded,
 	it does nothing.
 


### PR DESCRIPTION
Rather than defining a custom BinaryData typedef, the FontSource interface should just use the BufferSource definition from WebIDL.

https://webidl.spec.whatwg.org/#BufferSource

I came across this implementing this API for the Ladybird Browser. Let me know if the issue is not as editorial as I think and needs an issue/meeting topic :).