### PR TITLE
[web-animations-2] Fix bikeshed indentation errors

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -919,7 +919,7 @@ with:
 >
 >    1. If |has finite timeline| is true,
 >        and the |animation|'s [=animation/current time=] is [=unresolved=]
->    * Set the |auto align start time| flag to true.
+>       * Set the |auto align start time| flag to true.
 
 Replace:
 
@@ -980,8 +980,8 @@ Add the following sentence:
     <dl class=switch>
 
     : If <em>any</em> of the following are true:
-      * |animation| does not have an [=animation/associated effect=], or
-      * |animation|'s [=animation/current time=] is an [=unresolved=] time value,
+        * |animation| does not have an [=animation/associated effect=], or
+        * |animation|'s [=animation/current time=] is an [=unresolved=] time value,
     ::
         |animation|'s [=animation/progress=] is null.
     : If |animation|'s [=associated effect end=] is zero,
@@ -996,10 +996,10 @@ Add the following sentence:
         |animation|'s [=animation/progress=] is zero.
     : Otherwise,
     ::
-      <blockquote>
-        <code><a for="animation">progress</a> = min(max([=animation/current time=] / |animation|'s [=associated effect end=], 0), 1)
-        </code>
-      </blockquote>
+        <blockquote>
+          <code><a for="animation">progress</a> = min(max([=animation/current time=] / |animation|'s [=associated effect end=], 0), 1)
+          </code>
+        </blockquote>
 
     </dl>
   </div>
@@ -3093,9 +3093,11 @@ partial interface KeyframeEffect {
 ::  Amend the procedure to create a new {{KeyframeEffect}} object with the
     same properties as {{KeyframeEffect/KeyframeEffect(source)/source}} to include setting the
     <a>iteration composite operation</a> from <var>source</var> on <var>effect</var>.
+
 </div>
 
 <div class="attributes">
+
 :   <dfn attribute for=KeyframeEffect>iterationComposite</dfn>
 ::  The <a>iteration composite operation</a> property of this
     <a>keyframe effect</a> as specified by one of the
@@ -3103,6 +3105,7 @@ partial interface KeyframeEffect {
 
     On setting, sets the <a>iteration composite operation</a> property of this
     <a>animation effect</a> to the provided value.
+
 </div>
 
 <h4 id="creating-a-new-keyframeeffect-object">Creating a new <code>KeyframeEffect</code> object</h4>
@@ -3280,6 +3283,7 @@ partial dictionary KeyframeAnimationOptions {
 </pre>
 
 <div class="members">
+
 :   <dfn dict-member for=KeyframeAnimationOptions>rangeStart</dfn>
 ::  If present and not "normal",
     specifies the start of the <a>animation</a>’s [=animation attachment range=].
@@ -3298,6 +3302,7 @@ partial dictionary KeyframeAnimationOptions {
     and {{TimelineRangeOffset/offset}};
     a {{CSSNumericValue}} is interpreted as a {{TimelineRangeOffset}}
     with that {{TimelineRangeOffset/offset}} and a null {{TimelineRangeOffset/rangeName}}.
+
 </div>
 
 Passing a {{CSSKeywordValue}} with a {{CSSKeywordValue/value}} other than "normal"


### PR DESCRIPTION
Fixes the various indentation errors when running bikeshed on the web-animations-2 spec.