### PR TITLE
[css-animations-2] Fix custom-ident to dashed-ident for animation-timeline

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -654,7 +654,7 @@ the following effects:
 :   <dfn>none</dfn>
 ::  The animation is not associated with a [=timeline=].
 
-:   <dfn><<custom-ident>></dfn>
+:   <dfn><<dashed-ident>></dfn>
 ::  If a named [=scroll progress timeline=] or [=view progress timeline=]
     is in scope on this element,
     use the referenced timeline


### PR DESCRIPTION
In #8746 it was resolved to switch from `<custom-ident>` to `<dashed-ident>` for timeline names, and this was done in the grammar in 9f39808. However, further down in the spec, it still shows `<custom-ident>`