### PR TITLE
[cssom-view] Change `document.caretPositionFromPoint`'s `shadowRoots` parameter from rest parameter to a dictionary with an array of shadow roots

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1015,8 +1015,12 @@ Note: Some non-conforming implementations are known to return 32 instead of 24.
 partial interface Document {
   Element? elementFromPoint(double x, double y);
   sequence&lt;Element> elementsFromPoint(double x, double y);
-  CaretPosition? caretPositionFromPoint(double x, double y, ShadowRoot... shadowRoots);
+  CaretPosition? caretPositionFromPoint(double x, double y, optional <span>CaretPositionFromPointOptions</span> options = {});
   readonly attribute Element? scrollingElement;
+};
+
+dictionary <dfn dictionary>CaretPositionFromPointOptions</dfn> {
+  sequence&lt;ShadowRoot> <dfn dict-member for="CaretPositionFromPointOptions">shadowRoots</dfn> = [];
 };
 </pre>
 
@@ -1046,7 +1050,7 @@ instance, an element can be excluded from being a target for hit testing by usin
 1. If the document has a [=root element=], and the last item in <var>sequence</var> is not the [=root element=], append the [=root element=] to <var>sequence</var>.
 1. Return <var>sequence</var>.
 
-The <dfn method for=Document>caretPositionFromPoint(<var>x</var>, <var>y</var>, ...<var>shadowRoots</var>)</dfn> method must return the
+The <dfn method for=Document>caretPositionFromPoint(<var>x</var>, <var>y</var>, <var>options</var>)</dfn> method must return the
 result of running these steps:
 
 1. If there is no <a>viewport</a> associated with the document, return null.
@@ -1076,7 +1080,7 @@ result of running these steps:
     1. Let <var>caretPosition</var> be a <a for=/>tuple</a> consisting of a <var>caretPositionNode</var> (a <a for=/>node</a>) and a <var>caretPositionOffset</var> (a non-negative integer) for the position where the text insertion point indicator would have been inserted when applying
         the <a>transforms</a> that apply to the descendants of the <a>viewport</a>.
     1. Let <var>startNode</var> be the <var>caretPositionNode</var> of the <var>caretPosition</var>, and let <var>startOffset</var> be the <var>caretPositionOffset</var> of the <var>caretPosition</var>.
-    1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>shadowRoots</var>, repeat these steps:
+    1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>options</var>["{{CaretPositionFromPointOptions/shadowRoots}}"], repeat these steps:
         1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
         1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
     1. Return a <a>caret position</a> with its properties set as follows:


### PR DESCRIPTION
Per issue #10345, We should change the API signature from `document.caretPositionFromPoint(double x, double y, ShadowRoot... shadowRoots)` to `document.caretPositionFromPoint(double x, double y, optional CaretPositionFromPointOptions options = {})` where `CaretPositionFromPointOptions` is defined as:

```
dictionary CaretPositionFromPointOptions {
  sequence<ShadowRoot> shadowRoots = [];
};
```