### PR TITLE
[css-scroll-snap-2] Set pseudo snap Targets to their owning elements.

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -272,6 +272,13 @@ Snap Events {#snap-events}
 	the invisible state will become actionable,
 	at the right time, and always correct.
 
+	<h4 id="snapTarget"> snapTargets </h4>
+
+	A <dfn export>snapTarget</dfn> is an element or pseudo-element which the
+	user-agent has [[css-scroll-snap-1#choosing|chosen]] to
+	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a>
+	a given <a spec=css-scroll-snap lt="scroll snap container">snap container</a> to.
+
 	<table class="data" id="eventhandlers">
 		<thead>
 			<tr>
@@ -288,15 +295,15 @@ Snap Events {#snap-events}
 				<td>scroll containers</td>
 				<td>Fired at the scrolling element or {{Document}} at the end of a scroll (before a {{scrollend}} event)
 					or after a <a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">layout snap</a>
-					if the element that the scrolling element or Document is snapped to changed.</td>
+					if the [[#snapTarget|snapTarget]]s that the scrolling element or Document is snapped to changed.</td>
 			</tr>
 			<tr>
 				<th><dfn for="scrollsnapchanging" event>scrollsnapchanging</dfn></th>
 				<td>{{SnapEvent}}</td>
 				<td>scroll containers</td>
 				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll}} event),
-					if the element that the scrolling would cause the scroller to snap to is
-					different from the target reported by the last scrollsnapchanging event that was fired.</td>
+					if the [[#snapTarget|snapTarget]]s that the scrolling would cause the scroller to snap to are
+					different from the [[#snapTarget|snapTarget]]s selected at the last scrollsnapchanging event that was fired.</td>
 			</tr>
 		</tbody>
 	</table>
@@ -309,18 +316,18 @@ Snap Events {#snap-events}
 	<li>
 		when a scrolling operation is <a spec="cssom-view-1" lt="scroll completed">completed</a>
 		if, for either the block or inline axis, the
-		element which the snap container is snapped to is different from the element
+		[[#snapTarget|snapTarget]] which the snap container is snapped to is different from the [[#snapTarget|snapTarget]]
 		it most recently snapped to in that axis. For snap containers with
 		''scroll-snap-type/proximity'' strictness, the scroll may result in the snap
-		container no longer being snapped to any element. [[css-scroll-snap-1#choosing]]
-		describes the method a UA follows when choosing	between elements which are
+		container no longer being snapped to any [[#snapTarget|snapTarget]]. [[css-scroll-snap-1#choosing]]
+		describes the method a UA follows when choosing	between elements or pseudo-elements which are
 		<a spec="css-scroll-snap-1" lt="scroll snap area">snap areas</a>.
 	</li>
 	<li> if there is a change to a snap container's style such that it goes from
 		having a non-'none' value for [[css-scroll-snap-1#scroll-snap-type|scroll-snap-type]]
 		to having a 'none' value or vice versa.
 	</li>
-	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the element to
+	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the [[#snapTarget|snapTarget]] to
 		which a snap container is snapped to changes, regardless of whether there is
 		a change in scroll position after the layout change.
 	</li>
@@ -338,7 +345,7 @@ Snap Events {#snap-events}
 	one <dfn export>scrollsnapchangeTargetBlock</dfn> and one
 	<dfn export>scrollsnapchangeTargetInline</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
-	snapped in that axis or the {{Element}} to which the container is snapped.
+	snapped in that axis or the [[#snapTarget|snapTarget]] to which the container is snapped.
 
 	When asked to <dfn export for=Document>update scrollsnapchange targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -354,11 +361,11 @@ Snap Events {#snap-events}
 	1. Let <var>inlineScrollSnapchangingTarget</var> be the
 		<a>scrollsnapchangingTargetInline</a> associated with |snapcontainer|.
 	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
-	1. If <var>blockTarget</var> is not the same element as <var>blockScrollSnapchangingTarget</var> or
+	1. If <var>blockTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>blockScrollSnapchangingTarget</var> or
 		1. Set the <a>scrollsnapchangeTargetBlock</a> associated with |snapcontainer| to
 			<var>blockScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
-	1. If <var>inlineTarget</var> is not the same element as <var>inlineScrollSnapchangingTarget</var>:
+	1. If <var>inlineTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>inlineScrollSnapchangingTarget</var>:
 		1. Set the <a>scrollsnapchangeTargetInline</a> associated with |snapcontainer| to
 			<var>inlineScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
@@ -372,20 +379,26 @@ Snap Events {#snap-events}
 	scrolling operation) the <a>scrollsnapchangingTargetBlock</a> and <a>scrollsnapchangingTargetInline</a>
 	associated with that scroller are updated and represent the current snap targets
 	of that scroller. This allows the <a>update scrollsnapchange targets</a> algorithm
-	to use these elements to determine whether a {{scrollsnapchange}} event should be fired.
+	to use these [[#snapTarget|snapTarget]]s to determine whether a {{scrollsnapchange}} event should be fired.
 
 	When asked to <dfn>dispatch pending scrollsnapchange events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
 	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchange event targets</a>:
+		1. Let |blockTarget| and |inlineTarget| be null initially.
+		1. If the <a>scrollsnapchangeTargetBlock</a> associated with <var>target</var> is a pseudo-element,
+			set |blockTarget| to the owning element of that <a>scrollsnapchangeTargetBlock</a>.
+		1. Otherwise, set |blockTarget| to that <a>scrollsnapchangeTargetBlock</a>.
+		1. If the <a>scrollsnapchangeTargetInline</a> associated with <var>target</var> is a pseudo-element,
+			set |inlineTarget| to the owning element of that <a>scrollsnapchangeTargetInline</a>.
+		1. Otherwise, Set |inlineTarget| to that <a>scrollsnapchangeTargetInline</a>.
 		1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			{{SnapEvent/snapTargetInline}} attributes be the <a>scrollsnapchangeTargetBlock</a> and the
-			<a>scrollsnapchangeTargetInline</a>, respectively, that are associated with <var>target</var>.
+			{{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget| respectively.
 	1. Empty <var>doc</var>'s <a>pending scrollsnapchange event targets</a>.
 
 	<h4 id="scrollsnapchanging"> scrollsnapchanging </h4>
 	{{scrollsnapchanging}} is dispatched:
-	* during a scrolling operation, if the element to which a
+	* during a scrolling operation, if the [[#snapTarget|snapTarget]]s to which a
 		 <a spec=css-scroll-snap lt="scroll snap container">snap container</a> would
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snap</a> (in either axis) changes, or
 	* if a [[css-scroll-snap-1#re-snap|layout change]] occurs such that a {{scrollsnapchange}} event
@@ -405,7 +418,7 @@ Snap Events {#snap-events}
 		 determined by the user's input.
 
 	{{scrollsnapchanging}} aims to let the web page know, as early as possible,
-	that the scrolling operation will result in a change in the element the snap
+	that the scrolling operation will result in a change in the [[#snapTarget|snapTarget]] the snap
 	container is snapped to. The user agent should evaluate whether to trigger
 	{{scrollsnapchanging}} based on the	<a>eventual snap target</a> to which the scroller would
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> were the scrolling operation
@@ -427,11 +440,11 @@ Snap Events {#snap-events}
 	one <dfn>scrollsnapchangingTargetBlock</dfn> 
 	and one <dfn>scrollsnapchangingTargetInline</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
-	snapping in that axis or the {{Element}} to which the container is snapping.
+	snapping in that axis or the [[#snapTarget|snapTarget]] to which the container is snapping.
 
 	When asked to <dfn export for=Document>update scrollsnapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-	|snapcontainer|, given an {{Element}} newBlockTarget and an {{Element}}
+	|snapcontainer|, given an [[#snapTarget|snapTarget]] newBlockTarget and an [[#snapTarget|snapTarget]]
 	newInlineTarget, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
@@ -439,14 +452,14 @@ Snap Events {#snap-events}
 		associated with |snapcontainer|.
 	1. Let <var>inlineTarget</var> be the <a>scrollsnapchangingTargetInline</a> that is
 		associated with |snapcontainer|.
-	1. If <var>newBlockTarget</var> is not the same element as <var>blockTarget</var>:
+	1. If <var>newBlockTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>blockTarget</var>:
 		1. Set the <a>scrollsnapchangingTargetBlock</a> associated with |snapcontainer| to
 			<var>newBlockTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
 			<a>pending scrollsnapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
 				<a>pending scrollsnapchanging event targets</a>
-	1. If <var>newInlineTarget</var> is not the same element as <var>inlineTarget</var>:
+	1. If <var>newInlineTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>inlineTarget</var>:
 		1. Set the <a>scrollsnapchangingTargetInline</a> associated with |snapcontainer| to
 			<var>newInlineTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
@@ -457,22 +470,28 @@ Snap Events {#snap-events}
 	When asked to <dfn>dispatch pending scrollsnapchanging events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
 	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchanging event targets</a>:
+		1. Let |blockTarget| and |inlineTarget| be null initially.
+		1. If the <a>scrollsnapchangingTargetBlock</a> associated with <var>target</var> is a pseudo-element,
+			set |blockTarget| to the owning element of that <a>scrollsnapchangingTargetBlock</a>.
+		1. Otherwise, set |blockTarget| to that <a>scrollsnapchangingTargetBlock</a>.
+		1. If the <a>scrollsnapchangingTargetInline</a> associated with <var>target</var> is a pseudo-element,
+			set |inlineTarget| to the owning element of that <a>scrollsnapchangingTargetInline</a>.
+		1. Otherwise, set |inlineTarget| to that <a>scrollsnapchangingTargetInline</a>.
 		1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-			{{SnapEvent/snapTargetInline}} attributes be the <a>scrollsnapchangingTargetBlock</a> and the
-			<a>scrollsnapchangingTargetInline</a>, respectively, that are associated with <var>target</var>.
+			{{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
 	1. Empty <var>doc</var>'s <a>pending scrollsnapchanging event targets</a>.
 
 	<h4 id="snap-events-on-layout-changes">Snap Events due to Layout Changes </h4>
 	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
 	|snapcontainer|, [[css-scroll-snap-1#re-snap|re-snaps]], run these steps:
 
-	1. Let <var>newBlockTarget</var> be the element that |snapcontainer| has
+	1. Let <var>newBlockTarget</var> be the [[#snapTarget|snapTarget]] that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a>  to
 		 in the block axis or null if it did not snap to any element.
-	1. Let <var>newInlineTarget</var> be the element that |snapcontainer| has
+	1. Let <var>newInlineTarget</var> be the [[#snapTarget|snapTarget]] that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
-		 in the inline axis or null if it did not snap to any element.
+		 in the inline axis or null if it did not snap to any element or pseudo-element.
 	1. Run the steps to <a>update scrollsnapchanging targets</a> with <var>newBlockTarget</var>
 		 as newBlockTarget and <var>newInlineTarget</var> as newInlineTarget.
 	1. Run the steps to <a>update scrollsnapchange targets</a> for |snapcontainer|.
@@ -501,14 +520,18 @@ SnapEvent interface
 		::
 			The element that the snap container is snapped to in the block axis
 			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
-			for the associated snap event.
+			for the associated snap event. If the [[#snapTarget|snapTarget]]
+			corresponding to this was a pseudo-element, this will be the owning
+			element of that pseudo-element.
 			</div>
 			<div dfn-type=attribute class=attributes dfn-for="SnapEvent">
 		: <dfn>snapTargetInline</dfn>
 		::
 			The element that the snap container is snapped to in the inline axis
 			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
-			for the associated snap event.
+			for the associated snap event. If the [[#snapTarget|snapTarget]]
+			corresponding to this was a pseudo-element, this will be the owning
+			element of that pseudo-element.
 			</div>
 
 		For {{scrollsnapchange}} events, the snap position is the position already

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -16,6 +16,19 @@ Abstract: This module contains features to control panning and scrolling behavio
 Status Text:
  A test suite and an implementation report will be produced during the
  CR period.
+Ignore MDN Failure: margin-longhands-logical
+Ignore MDN Failure: margin-longhands-physical
+Ignore MDN Failure: propdef-scroll-margin-block
+Ignore MDN Failure: propdef-scroll-margin-inline
+Ignore MDN Failure: scroll-margin
+Ignore MDN Failure: padding-longhands-logical
+Ignore MDN Failure: padding-longhands-physical
+Ignore MDN Failure: scroll-padding
+Ignore MDN Failure: propdef-scroll-padding-block
+Ignore MDN Failure: propdef-scroll-padding-inline
+Ignore MDN Failure: scroll-snap-align
+Ignore MDN Failure: scroll-snap-stop
+Ignore MDN Failure: scroll-snap-type
 </pre>
 
 Introduction {#intro}
@@ -23,7 +36,7 @@ Introduction {#intro}
 
 	<em>This section is not normative.</em>
 
-	<em>This is currently a draft spec over Scroll Snap 1.</em>
+	<em>This is currently a delta spec over Scroll Snap 1.</em>
 
 	Scroll experiences don't always start at the beginning. Interactions with
 	carousels, swipe controls, and listviews often start somewhere in the middle,
@@ -38,87 +51,88 @@ Introduction {#intro}
 	when snap completes and conveniences for
 	snapping to children programmatically.
 
-  First Layout
-  ------------
+First Layout {#first-layout}
+------------
 
-  This event should follow the Animation code path. When animation objects are created and fire events, this is when a box has it's first layout.
+	This event should follow the Animation code path. When animation objects are created and fire events, this is when a box has it's first layout.
 
-<!--
-████████ ██     ██    ███    ██     ██ ████████  ██       ████████  ██████
-██        ██   ██    ██ ██   ███   ███ ██     ██ ██       ██       ██    ██
-██         ██ ██    ██   ██  ████ ████ ██     ██ ██       ██       ██
-██████      ███    ██     ██ ██ ███ ██ ████████  ██       ██████    ██████
-██         ██ ██   █████████ ██     ██ ██        ██       ██             ██
-██        ██   ██  ██     ██ ██     ██ ██        ██       ██       ██    ██
-████████ ██     ██ ██     ██ ██     ██ ██        ████████ ████████  ██████
+<!-- Big Text: examples
+
+█████▌ █     █  ███▌  █     █ ████▌  █▌    █████▌  ███▌ 
+█▌      █   █  ▐█ ▐█  ██   ██ █▌  █▌ █▌    █▌     █▌  █▌
+█▌       █ █   █▌  █▌ █▌█ █▐█ █▌  █▌ █▌    █▌     █▌    
+████      █    █▌  █▌ █▌ █ ▐█ ████▌  █▌    ████    ███▌ 
+█▌       █ █   █████▌ █▌   ▐█ █▌     █▌    █▌         █▌
+█▌      █   █  █▌  █▌ █▌   ▐█ █▌     █▌    █▌     █▌  █▌
+█████▌ █     █ █▌  █▌ █▌   ▐█ █▌     █████ █████▌  ███▌ 
 -->
 
 Motivating Examples {#examples}
 ===============================
 
-    <div class="example">
-        A carousel that starts in the middle:
+		<div class="example">
+				A carousel that starts in the middle:
 
-        <pre class="lang-css">
-            .carousel {
-                overflow-inline: auto;
-                scroll-start: center;
-            }
-        </pre>
+				<pre class="lang-css">
+						.carousel {
+								overflow-inline: auto;
+								scroll-start: center;
+						}
+				</pre>
 
-        <pre class="lang-html">
-            &lt;div class="carousel">
-                &lt;img src="img1.jpg">
-                &lt;img src="img2.jpg">
-                &lt;img src="img3.jpg">
-                &lt;img src="img4.jpg">
-                &lt;img src="img5.jpg">
-            &lt;/div>
-        </pre>
+				<pre class="lang-html">
+						&lt;div class="carousel">
+								&lt;img src="img1.jpg">
+								&lt;img src="img2.jpg">
+								&lt;img src="img3.jpg">
+								&lt;img src="img4.jpg">
+								&lt;img src="img5.jpg">
+						&lt;/div>
+				</pre>
 
-        <!-- <figure>
-            <img src="images/element_snap_positions.png" alt="">
+				<!-- <figure>
+						<img src="images/element_snap_positions.png" alt="">
 
-            <figcaption>
-                The layout of the scroll container’s contents in the example.
-                The snapport is represented by the red rectangle, and the snap area is represented by the yellow rectangle.  Since the scroll-snap-align is “center” in the inline (horizontal) axis, a snap position is established at each scroll position which aligns the X-center of the snapport (represented by a red dotted line) with the X-center of a snap area (represented by a yellow dotted line).
-            </figcaption>
-        </figure> -->
-    </div>
+						<figcaption>
+								The layout of the scroll container’s contents in the example.
+								The snapport is represented by the red rectangle, and the snap area is represented by the yellow rectangle.  Since the scroll-snap-align is “center” in the inline (horizontal) axis, a snap position is established at each scroll position which aligns the X-center of the snapport (represented by a red dotted line) with the X-center of a snap area (represented by a yellow dotted line).
+						</figcaption>
+				</figure> -->
+		</div>
 
-    <div class="example">
-        A search bar is available when the user scrolls back to the top:
+		<div class="example">
+				A search bar is available when the user scrolls back to the top:
 
-        <pre class="lang-css">
-            .scrollport {
-                overflow-block: auto;
-            }
+				<pre class="lang-css">
+						.scrollport {
+								overflow-block: auto;
+						}
 
-            main {
-                scroll-start-target: auto;
-            }
-        </pre>
+						main {
+								scroll-start-target: auto;
+						}
+				</pre>
 
-        <pre class="lang-html">
-            &lt;div class="scrollport">
-                &lt;nav>
-                    ...
-                &lt;/nav>
-                &lt;main>
-                    ...
-                &lt;/main>
-            &lt;/div>
-        </pre>
+				<pre class="lang-html">
+						&lt;div class="scrollport">
+								&lt;nav>
+										...
+								&lt;/nav>
+								&lt;main>
+										...
+								&lt;/main>
+						&lt;/div>
+				</pre>
 
-        <!-- <figure>
-            <img src="images/element_snap_positions.png" alt="">
+				<!-- <figure>
+						<img src="images/element_snap_positions.png" alt="">
 
-            <figcaption>
-                The layout of the scroll container’s contents in the example.
-                The snapport is represented by the red rectangle, and the snap area is represented by the yellow rectangle.  Since the scroll-snap-align is “center” in the inline (horizontal) axis, a snap position is established at each scroll position which aligns the X-center of the snapport (represented by a red dotted line) with the X-center of a snap area (represented by a yellow dotted line).
-            </figcaption>
-        </figure> -->
-    </div>
+						<figcaption>
+								The layout of the scroll container’s contents in the example.
+								The snapport is represented by the red rectangle, and the snap area is represented by the yellow rectangle.  Since the scroll-snap-align is “center” in the inline (horizontal) axis, a snap position is established at each scroll position which aligns the X-center of the snapport (represented by a red dotted line) with the X-center of a snap area (represented by a yellow dotted line).
+						</figcaption>
+				</figure> -->
+		</div>
 
 Setting Where Scroll Starts {#properties-on-the-scroll-container}
 =================================================================
@@ -135,7 +149,7 @@ The 'scroll-start' property {#scroll-start}
 
 	This property is a shorthand property that sets all of the scroll-start-* longhands in one declaration.
 	The first value defines the scroll starting point in the block axis,
-	the second sets it in the inline axis. If the second value is omitted, it defaults to ''scroll-start/start''. If ''scroll-start-target'' is set on any child, ''scroll-start'' is not used, in favor of using the element as the offset.
+	the second sets it in the inline axis. If the second value is omitted, it defaults to ''scroll-start/start''. If ''scroll-start-target'' is set on any child, 'scroll-start' is not used, in favor of using the element as the offset.
 
 	Values are defined as follows:
 
@@ -160,61 +174,93 @@ The 'scroll-start' property {#scroll-start}
 			Equivalent to ''0%'', ''50%'', and ''100%'', respectively.
 	</dl>
 
-<h4 id="display-none-behavior">Interaction with ''display: none'' and initial creation</h4>
-  Same behavior that animations follow with <a href="#first-layout">first layout</a>.
+<h4 id="display-none-behavior">
+Interaction with ''display: none'' and initial creation</h4>
 
-<h4 id="slow-page-load-behavior">Slow page loading or document streaming behavior</h4>
-  TODO
+	Same behavior that animations follow with [[#first-layout]].
 
-<h4 id="fragment-navigation-behavior">Interaction with ''fragment navigation''</h4>
-  TODO
-  If the scrollport has a in-page '':target'' via a URL fragment or a previous scroll position, then ''scroll-start'' is unused. Existing target logic should go unchanged. This makes ''scroll-start'' a soft request in the scroll position resolution routines.  
+<h4 id="slow-page-load-behavior">
+Slow page loading or document streaming behavior</h4>
 
-<h4 id="place-content-behavior">Interaction with ''place-content''</h4>
-  TODO  
-  Side note: While ''place-content'' can make a scroller appear to start in the center
-  or end, no browser supports it and it appears complicated to resolve.
+	TODO
 
-<h4 id="find-in-page-behavior">Interaction with "find in page"</h4>
-  TODO
+<h4 id="fragment-navigation-behavior">
+Interaction with "fragment navigation"</h4>
 
-<h4 id="scroll-snap-container-behavior">Interaction ''scroll-snap'' containers</h4>
-  This effectively will layout and start scroll at the snapped child, thus negating / cancelling ''scroll-start''. ''scroll-start'' will only work if nothing else has effected the scroll position.
+	TODO
 
-<h4 id="nested-scrollers">Nested scrollers with ''scroll-start''</h4>
-  Should follow patterns that scroll snap has set.
+	If the scrollport has a in-page '':target'' via a URL fragment or a previous scroll position, then 'scroll-start' is unused. Existing target logic should go unchanged. This makes 'scroll-start' a soft request in the scroll position resolution routines.
 
-<h4 id="toggling-display-none">Interaction when ''display'' is toggled</h4>
-  Same behavior that animations follow with ''first layout''.
+<h4 id="place-content-behavior">
+Interaction with 'place-content'</h4>
 
-<h4 id="rtl">Interaction with RTL and LTR</h4>
-  Logical properties are offered for length offsets that should be flow relative. Furthermore, the ''end'' and ''start'' keywords are always logical.
+	TODO
+
+	Note: While 'place-content' can make a scroller appear to start in the center
+	or end, no browser supports it and it appears complicated to resolve.
+
+<h4 id="find-in-page-behavior">
+Interaction with "find in page"</h4>
+
+	TODO
+
+<h4 id="scroll-snap-container-behavior">
+Interaction with "scroll-snap" containers</h4>
+
+	This effectively will layout and start scroll at the snapped child, thus negating / cancelling 'scroll-start'. 'scroll-start' will only work if nothing else has effected the scroll position.
+
+<h4 id="nested-scrollers">
+Nested scrollers with 'scroll-start'</h4>
+
+	Should follow patterns that scroll snap has set.
+
+<h4 id="toggling-display-none">
+Interaction when 'display' is toggled</h4>
+
+	Same behavior that animations follow with [[#first-layout]].
+
+<h4 id="rtl">
+Interaction with RTL and LTR</h4>
+
+	Logical properties are offered for length offsets that should be flow relative. Furthermore, the ''end'' and ''start'' keywords are always logical.
 
 The 'scroll-start-target' property {#scroll-start-target}
 -------------------------------------------
 
-  <pre class="propdef shorthand">
-  Name: scroll-start-target
-  Value: [ none | auto ]{1,2}
-  </pre>
+	<pre class="propdef shorthand">
+	Name: scroll-start-target
+	Value: [ none | auto ]{1,2}
+	</pre>
 
-  This property is a shorthand property that sets all of the scroll-start-target-* longhands in one declaration.
-  The first value defines the scroll starting point in the block axis,
-  the second sets it in the inline axis.
-  If the second value is omitted, it defaults to ''none''.
+	This property is a shorthand property that sets all of the scroll-start-target-* longhands in one declaration.
+	The first value defines the scroll starting point in the block axis,
+	the second sets it in the inline axis.
+	If the second value is omitted, it defaults to ''scroll-start-target/none''.
 
-  Values are defined as follows:
+	Values are defined as follows:
 
-  <dl dfn-type=value dfn-for="scroll-start-target, scroll-start-target-x, scroll-start-target-y, scroll-start-target-block, scroll-start-target-inline">
-    <dt><dfn>none</dfn>
-    <dd>Element is not a ''scroll-start-target''.
-    <dt><dfn>auto</dfn>
-    <dd>Element is used to calculate the ''scroll-start'' position, 
-    taking into account ''scroll-padding'' or ''scroll-margin'' ,
-    same as a ''scroll-snap'' target.
-  </dl>
+	<dl dfn-type=value dfn-for="scroll-start-target, scroll-start-target-x, scroll-start-target-y, scroll-start-target-block, scroll-start-target-inline">
+		<dt><dfn>none</dfn>
+		<dd>Element is not a ''scroll-start-target''.
+		<dt><dfn>auto</dfn>
+		<dd>Element is used to calculate the 'scroll-start' position,
+		taking into account ''scroll-padding'' or ''scroll-margin'' ,
+		same as a ''scroll-snap'' target.
+	</dl>
 
-Styling Snapped Items {#todo}
+
+<!-- Big Text: :snapped 
+
+ █▌   ███▌  █    █▌  ███▌  ████▌  ████▌  █████▌ ████▌ 
+███▌ █▌  █▌ █▌   █▌ ▐█ ▐█  █▌  █▌ █▌  █▌ █▌     █▌  █▌
+ █▌  █▌     ██▌  █▌ █▌  █▌ █▌  █▌ █▌  █▌ █▌     █▌  █▌
+      ███▌  █▌▐█ █▌ █▌  █▌ ████▌  ████▌  ████   █▌  █▌
+ █▌      █▌ █▌  ██▌ █████▌ █▌     █▌     █▌     █▌  █▌
+███▌ █▌  █▌ █▌   █▌ █▌  █▌ █▌     █▌     █▌     █▌  █▌
+ █▌   ███▌  █▌   ▐▌ █▌  █▌ █▌     █▌     █████▌ ████▌ 
+-->
+
+Styling Snapped Items {#styling-snapped}
 =============================
 
 The Snapped-element Pseudo-class: '':snapped'' {#snapped}
@@ -252,14 +298,15 @@ Need to figure out resolution of the initial frame.
 Snap Events {#snap-events}
 ===================
 
-<!--
-████████ ██     ██ ████████ ██    ██ ████████  ██████
-██       ██     ██ ██       ███   ██    ██    ██    ██
-██       ██     ██ ██       ████  ██    ██    ██
-██████   ██     ██ ██████   ██ ██ ██    ██     ██████
-██        ██   ██  ██       ██  ████    ██          ██
-██         ██ ██   ██       ██   ███    ██    ██    ██
-████████    ███    ████████ ██    ██    ██     ██████
+<!-- Big Text: events
+
+█████▌ █▌   █▌ █████▌ █    █▌ █████▌  ███▌ 
+█▌     █▌   █▌ █▌     █▌   █▌   █▌   █▌  █▌
+█▌     █▌   █▌ █▌     ██▌  █▌   █▌   █▌    
+████   ▐▌   █  ████   █▌▐█ █▌   █▌    ███▌ 
+█▌      █  ▐▌  █▌     █▌  ██▌   █▌       █▌
+█▌      ▐▌ █   █▌     █▌   █▌   █▌   █▌  █▌
+█████▌   ▐█    █████▌ █▌   ▐▌   █▌    ███▌ 
 -->
 
 {{scrollsnapchange}} and {{scrollsnapchanging}} {#scrollsnapchange-and-scrollsnapchanging}
@@ -272,43 +319,41 @@ Snap Events {#snap-events}
 	the invisible state will become actionable,
 	at the right time, and always correct.
 
-	<h4 id="snapTarget"> snapTargets </h4>
+<h4 id="snapTarget">
+Snap Targets</h4>
 
-	A <dfn export>snapTarget</dfn> is an element or pseudo-element which the
+	A <dfn export>snap target</dfn> is an element or pseudo-element which the
 	user-agent has [[css-scroll-snap-1#choosing|chosen]] to
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a>
 	a given <a spec=css-scroll-snap lt="scroll snap container">snap container</a> to.
 
-	<table class="data" id="eventhandlers">
+	<table class="data" id="eventhandlers" dfn-type=event dfn-for=SnapEvent>
 		<thead>
 			<tr>
-				<th>Event</th>
-				<th>Interface</th>
-				<th>Targets</th>
-				<th>Description</th>
-			</tr>
-		</thead>
+				<th>Event
+				<th>Interface
+				<th>Targets
+				<th>Description
 		<tbody>
 			<tr>
-				<th><dfn for="scrollsnapchange" event>scrollsnapchange</dfn></th>
-				<td>{{SnapEvent}}</td>
-				<td>scroll containers</td>
+				<th><dfn>scrollsnapchange</dfn>
+				<td>{{SnapEvent}}
+				<td>scroll containers
 				<td>Fired at the scrolling element or {{Document}} at the end of a scroll (before a {{scrollend}} event)
-					or after a <a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">layout snap</a>
-					if the [[#snapTarget|snapTarget]]s that the scrolling element or Document is snapped to changed.</td>
-			</tr>
+					or after a [[css-scroll-snap-1#re-snap|layout snap]]
+					if the [=snap targets=] that the scrolling element or Document is snapped to changed.
 			<tr>
-				<th><dfn for="scrollsnapchanging" event>scrollsnapchanging</dfn></th>
-				<td>{{SnapEvent}}</td>
-				<td>scroll containers</td>
-				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll}} event),
-					if the [[#snapTarget|snapTarget]]s that the scrolling would cause the scroller to snap to are
-					different from the [[#snapTarget|snapTarget]]s selected at the last scrollsnapchanging event that was fired.</td>
-			</tr>
-		</tbody>
+				<th><dfn>scrollsnapchanging</dfn>
+				<td>{{SnapEvent}}
+				<td>scroll containers
+				<td>Fired at the scrolling element or {{Document}} during scrolling (before a {{scroll!!event}} event),
+					if the [=snap targets=] that the scrolling would cause the scroller to snap to are
+					different from the [=snap targets=] selected at the last scrollsnapchanging event that was fired.
 	</table>
 
-	<h4 for="scrollsnapchange" id="scrollsnapchange"> scrollsnapchange </h4>
+<h4 id="scrollsnapchange">
+{{scrollsnapchange}}</h4>
+
 	{{scrollsnapchange}} indicates that the snap area to which a snap container is snapped along either axis has changed.
 	{{scrollsnapchange}} is dispatched:
 
@@ -316,21 +361,21 @@ Snap Events {#snap-events}
 	<li>
 		when a scrolling operation is <a spec="cssom-view-1" lt="scroll completed">completed</a>
 		if, for either the block or inline axis, the
-		[[#snapTarget|snapTarget]] which the snap container is snapped to is different from the [[#snapTarget|snapTarget]]
+		[=snap target=] which the snap container is snapped to is different from the [=snap target=]
 		it most recently snapped to in that axis. For snap containers with
 		''scroll-snap-type/proximity'' strictness, the scroll may result in the snap
-		container no longer being snapped to any [[#snapTarget|snapTarget]]. [[css-scroll-snap-1#choosing]]
+		container no longer being snapped to any [=snap target=]. [[css-scroll-snap-1#choosing]]
 		describes the method a UA follows when choosing	between elements or pseudo-elements which are
 		<a spec="css-scroll-snap-1" lt="scroll snap area">snap areas</a>.
-	</li>
+
 	<li> if there is a change to a snap container's style such that it goes from
-		having a non-'none' value for [[css-scroll-snap-1#scroll-snap-type|scroll-snap-type]]
-		to having a 'none' value or vice versa.
-	</li>
-	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the [[#snapTarget|snapTarget]] to
+		having a non-''scroll-snap-type/none'' value for 'scroll-snap-type'
+		to having a ''scroll-snap-type/none'' value or vice versa.
+
+	<li> if, after a [[css-scroll-snap-1#re-snap|layout change]], the [=snap target=] to
 		which a snap container is snapped to changes, regardless of whether there is
 		a change in scroll position after the layout change.
-	</li>
+
 	</ol>
 
 	Scrolling operations always lead to {{scrollend}} events being fired. If a
@@ -345,7 +390,7 @@ Snap Events {#snap-events}
 	one <dfn export>scrollsnapchangeTargetBlock</dfn> and one
 	<dfn export>scrollsnapchangeTargetInline</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
-	snapped in that axis or the [[#snapTarget|snapTarget]] to which the container is snapped.
+	snapped in that axis or the [=snap target=] to which the container is snapped.
 
 	When asked to <dfn export for=Document>update scrollsnapchange targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
@@ -356,16 +401,16 @@ Snap Events {#snap-events}
 		with |snapcontainer|.
 	1. Let <var>inlineTarget</var> be the <a>scrollsnapchangeTargetInline</a> associated
 		with |snapcontainer|.
-	1. Let <var>blockScrollSnapchangingTarget</var> be the <a>scrollsnapchangingTargetBlock</a>
+	1. Let <var>blockScrollSnapchangingTarget</var> be the <a>scrollsnapchanging block-axis target</a>
 		associated with |snapcontainer|.
 	1. Let <var>inlineScrollSnapchangingTarget</var> be the
-		<a>scrollsnapchangingTargetInline</a> associated with |snapcontainer|.
+		<a>scrollsnapchanging inline-axis target</a> associated with |snapcontainer|.
 	1. Let <var>snap targets changed</var> be a boolean flag that is initially false.
-	1. If <var>blockTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>blockScrollSnapchangingTarget</var> or
+	1. If <var>blockTarget</var> is not the same [=snap target=] as <var>blockScrollSnapchangingTarget</var> or
 		1. Set the <a>scrollsnapchangeTargetBlock</a> associated with |snapcontainer| to
 			<var>blockScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
-	1. If <var>inlineTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>inlineScrollSnapchangingTarget</var>:
+	1. If <var>inlineTarget</var> is not the same [=snap target=] as <var>inlineScrollSnapchangingTarget</var>:
 		1. Set the <a>scrollsnapchangeTargetInline</a> associated with |snapcontainer| to
 			<var>inlineScrollSnapchangingTarget</var>.
 		1. Set <var>snap targets changed</var> to true.
@@ -376,12 +421,12 @@ Snap Events {#snap-events}
 				<a>pending scrollsnapchange event targets</a>.
 
 	Note: When snapping occurs on a scroller (either due to a layout change or a
-	scrolling operation) the <a>scrollsnapchangingTargetBlock</a> and <a>scrollsnapchangingTargetInline</a>
+	scrolling operation) the <a>scrollsnapchanging block-axis target</a> and <a>scrollsnapchanging inline-axis target</a>
 	associated with that scroller are updated and represent the current snap targets
 	of that scroller. This allows the <a>update scrollsnapchange targets</a> algorithm
-	to use these [[#snapTarget|snapTarget]]s to determine whether a {{scrollsnapchange}} event should be fired.
+	to use these [=snap targets=] to determine whether a {{scrollsnapchange}} event should be fired.
 
-	When asked to <dfn>dispatch pending scrollsnapchange events</dfn> for a {{Document}},
+	When asked to <dfn export for=Document>dispatch pending scrollsnapchange events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
 	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchange event targets</a>:
 		1. Let |blockTarget| and |inlineTarget| be null initially.
@@ -398,7 +443,7 @@ Snap Events {#snap-events}
 
 	<h4 id="scrollsnapchanging"> scrollsnapchanging </h4>
 	{{scrollsnapchanging}} is dispatched:
-	* during a scrolling operation, if the [[#snapTarget|snapTarget]]s to which a
+	* during a scrolling operation, if the [=snap targets=] to which a
 		 <a spec=css-scroll-snap lt="scroll snap container">snap container</a> would
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snap</a> (in either axis) changes, or
 	* if a [[css-scroll-snap-1#re-snap|layout change]] occurs such that a {{scrollsnapchange}} event
@@ -409,7 +454,7 @@ Snap Events {#snap-events}
 	scrollbar arrow clicks, arrow key presses, "behavior: smooth" programmatic
 	scrolls) or might directly track a user's input (e.g. touch scrolling, scrollbar
 	dragging). In either case, the user agent [[css-scroll-snap-1#choosing|chooses]] an
-	<dfn>eventual snap target</dfn> in each axis to which the scroller will
+	<dfn export>eventual snap target</dfn> in each axis to which the scroller will
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> after the scrolling operation
 	reaches its intended scroll position.
 	* In the former case, the intended scroll position is the scroll animation's
@@ -418,7 +463,7 @@ Snap Events {#snap-events}
 		 determined by the user's input.
 
 	{{scrollsnapchanging}} aims to let the web page know, as early as possible,
-	that the scrolling operation will result in a change in the [[#snapTarget|snapTarget]] the snap
+	that the scrolling operation will result in a change in the [=snap target=] the snap
 	container is snapped to. The user agent should evaluate whether to trigger
 	{{scrollsnapchanging}} based on the	<a>eventual snap target</a> to which the scroller would
 	<a spec="css-scroll-snap-1" lt="scroll snap">snap</a> were the scrolling operation
@@ -430,53 +475,53 @@ Snap Events {#snap-events}
 	container's scroll position and result in a different eventual snap target.
 
 
-	{{scrollsnapchanging}} events are fired before {{scroll}} events.
+	{{scrollsnapchanging}} events are fired before {{scroll!!event}} events.
 
 	Each {{Document}} has an associated list of
 	<dfn export for=Document>pending scrollsnapchanging event targets</dfn>, initially empty.
 
 	Each
 	<a spec=css-scroll-snap lt="scroll snap container">snap container</a> has
-	one <dfn>scrollsnapchangingTargetBlock</dfn> 
-	and one <dfn>scrollsnapchangingTargetInline</dfn> in the block and inline axes
+	one <dfn>scrollsnapchanging block-axis target</dfn>
+	and one <dfn>scrollsnapchanging inline-axis target</dfn> in the block and inline axes
 	respectively, each of which can either be null if the container is not
-	snapping in that axis or the [[#snapTarget|snapTarget]] to which the container is snapping.
+	snapping in that axis or the [=snap target=] to which the container is snapping.
 
 	When asked to <dfn export for=Document>update scrollsnapchanging targets</dfn>
 	for a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
-	|snapcontainer|, given an [[#snapTarget|snapTarget]] newBlockTarget and an [[#snapTarget|snapTarget]]
+	|snapcontainer|, given an [=snap target=] newBlockTarget and an [=snap target=]
 	newInlineTarget, run these steps:
 
 	1. Let <var>doc</var> be |snapcontainer|'s associated {{Document}}.
-	1. Let <var>blockTarget</var> be the <a>scrollsnapchangingTargetBlock</a> that is
+	1. Let <var>blockTarget</var> be the <a>scrollsnapchanging block-axis target</a> that is
 		associated with |snapcontainer|.
-	1. Let <var>inlineTarget</var> be the <a>scrollsnapchangingTargetInline</a> that is
+	1. Let <var>inlineTarget</var> be the <a>scrollsnapchanging inline-axis target</a> that is
 		associated with |snapcontainer|.
-	1. If <var>newBlockTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>blockTarget</var>:
-		1. Set the <a>scrollsnapchangingTargetBlock</a> associated with |snapcontainer| to
+	1. If <var>newBlockTarget</var> is not the same [=snap target=] as <var>blockTarget</var>:
+		1. Set the <a>scrollsnapchanging block-axis target</a> associated with |snapcontainer| to
 			<var>newBlockTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
 			<a>pending scrollsnapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
 				<a>pending scrollsnapchanging event targets</a>
-	1. If <var>newInlineTarget</var> is not the same [[#snapTarget|snapTarget]] as <var>inlineTarget</var>:
-		1. Set the <a>scrollsnapchangingTargetInline</a> associated with |snapcontainer| to
+	1. If <var>newInlineTarget</var> is not the same [=snap target=] as <var>inlineTarget</var>:
+		1. Set the <a>scrollsnapchanging inline-axis target</a> associated with |snapcontainer| to
 			<var>newInlineTarget</var>.
 		1. If |snapcontainer| is not already in <var>doc</var>'s
 			<a>pending scrollsnapchanging event targets</a>,
 			1. Append |snapcontainer| to <var>doc</var>'s
 				<a>pending scrollsnapchanging event targets</a>.
 
-	When asked to <dfn>dispatch pending scrollsnapchanging events</dfn> for a {{Document}},
+	When asked to <dfn export for=Document>dispatch pending scrollsnapchanging events</dfn> for a {{Document}},
 		<var>doc</var>, run these steps:
 	1. For each item <var>target</var> in |doc|'s <a>pending scrollsnapchanging event targets</a>:
 		1. Let |blockTarget| and |inlineTarget| be null initially.
-		1. If the <a>scrollsnapchangingTargetBlock</a> associated with <var>target</var> is a pseudo-element,
-			set |blockTarget| to the owning element of that <a>scrollsnapchangingTargetBlock</a>.
-		1. Otherwise, set |blockTarget| to that <a>scrollsnapchangingTargetBlock</a>.
-		1. If the <a>scrollsnapchangingTargetInline</a> associated with <var>target</var> is a pseudo-element,
-			set |inlineTarget| to the owning element of that <a>scrollsnapchangingTargetInline</a>.
-		1. Otherwise, set |inlineTarget| to that <a>scrollsnapchangingTargetInline</a>.
+		1. If the <a>scrollsnapchanging block-axis target</a> associated with <var>target</var> is a pseudo-element,
+			set |blockTarget| to the owning element of that <a>scrollsnapchanging block-axis target</a>.
+		1. Otherwise, set |blockTarget| to that <a>scrollsnapchanging block-axis target</a>.
+		1. If the <a>scrollsnapchanging inline-axis target</a> associated with <var>target</var> is a pseudo-element,
+			set |inlineTarget| to the owning element of that <a>scrollsnapchanging inline-axis target</a>.
+		1. Otherwise, set |inlineTarget| to that <a>scrollsnapchanging inline-axis target</a>.
 		1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
 			and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
 			{{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
@@ -486,10 +531,10 @@ Snap Events {#snap-events}
 	When a <a spec=css-scroll-snap lt="scroll snap container">snap container</a>,
 	|snapcontainer|, [[css-scroll-snap-1#re-snap|re-snaps]], run these steps:
 
-	1. Let <var>newBlockTarget</var> be the [[#snapTarget|snapTarget]] that |snapcontainer| has
+	1. Let <var>newBlockTarget</var> be the [=snap target=] that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a>  to
 		 in the block axis or null if it did not snap to any element.
-	1. Let <var>newInlineTarget</var> be the [[#snapTarget|snapTarget]] that |snapcontainer| has
+	1. Let <var>newInlineTarget</var> be the [=snap target=] that |snapcontainer| has
 		 <a spec="css-scroll-snap-1" lt="scroll snap">snapped</a> to
 		 in the inline axis or null if it did not snap to any element or pseudo-element.
 	1. Run the steps to <a>update scrollsnapchanging targets</a> with <var>newBlockTarget</var>
@@ -497,61 +542,61 @@ Snap Events {#snap-events}
 	1. Run the steps to <a>update scrollsnapchange targets</a> for |snapcontainer|.
 
 
-SnapEvent interface
+SnapEvent interface {#snapevent-interface}
 -------------------
 
 <pre class="idl">
-			dictionary SnapEventInit : EventInit {
-				Node? snapTargetBlock;
-				Node? snapTargetInline;
-			};
+dictionary SnapEventInit : EventInit {
+	Node? snapTargetBlock;
+	Node? snapTargetInline;
+};
 
-			[Exposed=Window]
-			interface SnapEvent : Event {
-				constructor(DOMString type, optional SnapEventInit eventInitDict = {});
-				readonly attribute Node? snapTargetBlock;
-				readonly attribute Node? snapTargetInline;
-			};
+[Exposed=Window]
+interface SnapEvent : Event {
+	constructor(DOMString type, optional SnapEventInit eventInitDict = {});
+	readonly attribute Node? snapTargetBlock;
+	readonly attribute Node? snapTargetInline;
+};
 </pre>
 
-<dl>
-			<div dfn-type=attribute class=attributes dfn-for="SnapEvent">
+<dl dfn-type=attribute dfn-for=SnapEvent>
 		: <dfn>snapTargetBlock</dfn>
 		::
 			The element that the snap container is snapped to in the block axis
 			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
-			for the associated snap event. If the [[#snapTarget|snapTarget]]
+			for the associated snap event. If the [=snap target=]
 			corresponding to this was a pseudo-element, this will be the owning
 			element of that pseudo-element.
-			</div>
-			<div dfn-type=attribute class=attributes dfn-for="SnapEvent">
+
 		: <dfn>snapTargetInline</dfn>
 		::
 			The element that the snap container is snapped to in the inline axis
 			at the <a spec="css-scroll-snap-1" lt="scroll snap position">snap position</a>
-			for the associated snap event. If the [[#snapTarget|snapTarget]]
+			for the associated snap event. If the [=snap target=]
 			corresponding to this was a pseudo-element, this will be the owning
 			element of that pseudo-element.
-			</div>
+</dl>
 
-		For {{scrollsnapchange}} events, the snap position is the position already
-		realized by the snap container after a scroll snap. For {{scrollsnapchanging}}
-		events it is the snap position that the snap container will eventually
-		snap to when the scrolling operation ends.
+For {{scrollsnapchange}} events,
+the snap position is the position
+already realized by the snap container after a scroll snap.
+For {{scrollsnapchanging}} events
+it is the snap position
+that the snap container will eventually snap to
+when the scrolling operation ends.
 
-	</dl>
-
-	A {{SnapEvent}} should not bubble and should not be cancellable.
+{{SnapEvent}}s do not bubble and are not cancellable.
 
 
-<!--
-██        ███████  ██    ██  ██████   ██     ██    ███    ██    ██ ████████   ██████
-██       ██     ██ ███   ██ ██    ██  ██     ██   ██ ██   ███   ██ ██     ██ ██    ██
-██       ██     ██ ████  ██ ██        ██     ██  ██   ██  ████  ██ ██     ██ ██
-██       ██     ██ ██ ██ ██ ██   ████ █████████ ██     ██ ██ ██ ██ ██     ██  ██████
-██       ██     ██ ██  ████ ██    ██  ██     ██ █████████ ██  ████ ██     ██       ██
-██       ██     ██ ██   ███ ██    ██  ██     ██ ██     ██ ██   ███ ██     ██ ██    ██
-████████  ███████  ██    ██  ██████   ██     ██ ██     ██ ██    ██ ████████   ██████
+<!-- Big Text: Longhand
+
+█▌     ███▌  █    █▌  ███▌  █▌  █▌  ███▌  █    █▌ ████▌ 
+█▌    █▌  █▌ █▌   █▌ █▌  █▌ █▌  █▌ ▐█ ▐█  █▌   █▌ █▌  █▌
+█▌    █▌  █▌ ██▌  █▌ █▌     █▌  █▌ █▌  █▌ ██▌  █▌ █▌  █▌
+█▌    █▌  █▌ █▌▐█ █▌ █▌ ██▌ █████▌ █▌  █▌ █▌▐█ █▌ █▌  █▌
+█▌    █▌  █▌ █▌  ██▌ █▌  █▌ █▌  █▌ █████▌ █▌  ██▌ █▌  █▌
+█▌    █▌  █▌ █▌   █▌ █▌  █▌ █▌  █▌ █▌  █▌ █▌   █▌ █▌  █▌
+█████  ███▌  █▌   ▐▌  ███▌  █▌  █▌ █▌  █▌ █▌   ▐▌ ████▌ 
 -->
 
 Appendix A: Longhands {#longhands}
@@ -643,14 +688,14 @@ Event handlers on elements, Document objects and Window objects {#event-handlers
 
 	<table class="data" dfn-type=attribute dfn-for="Document,Element,Window">
 		<tr>
-			<th><a>Event handler</a></th>
-			<th><a>Event handler event type</a></th>
+			<th><a>Event handler</a>
+			<th><a>Event handler event type</a>
 		<tr>
-			<td><dfn>onsnapchanged</dfn></td>
-			<td>{{snapchanged}}</td>
+			<td><dfn>onscrollsnapchange</dfn>
+			<td>{{scrollsnapchange}}
 		<tr>
-			<td><dfn>onsnapchanging</dfn></td>
-			<td>{{snapchanging}}</td>
+			<td><dfn>onscrollsnapchanging</dfn>
+			<td>{{scrollsnapchanging}}
 	</table>
 
 
@@ -658,7 +703,7 @@ Extensions to the <code>GlobalEventHandlers</code> Interface Mixin {#interface-g
 --------------------------------------------------------------------------------------------------------
 
 	This specification extends the {{GlobalEventHandlers}} interface mixin from
-	HTML to add <a>event handler IDL attributes</a> for {{SnapEvents}} as defined
+	HTML to add <a>event handler IDL attributes</a> for {{SnapEvent}}s as defined
 	in [[#event-handlers-on-elements-document-and-window-objects]].
 
 	<h4 id="interface-globaleventhandlers-idl">IDL Definition</h4>
@@ -669,3 +714,13 @@ Extensions to the <code>GlobalEventHandlers</code> Interface Mixin {#interface-g
 		attribute EventHandler onsnapchanging;
 	};
 	</pre>
+
+Privacy Considerations {#privacy}
+======================
+
+TODO
+
+Security Considerations {#security}
+=======================
+
+TODO


### PR DESCRIPTION
This specifies the resolution from
https://github.com/w3c/csswg-drafts/issues/10175 that when the targets of a snap event are pseudo elements, the snap event should the owning elements of the pseudo-elements as snap targets.