### PR TITLE
[css-anchor-position] Add 'center' to the <inset-area> variants that are missing it. #10383

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -539,9 +539,11 @@ Its syntax is:
 	[ inline-start | center | inline-end | span-inline-start | span-inline-end
 	| span-all ]
 |
-	[ self-block-start | self-block-end | span-self-block-start | span-self-block-end | span-all ]
+	[ self-block-start | center | self-block-end | span-self-block-start
+        | span-self-block-end | span-all ]
 	||
-	[ self-inline-start | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ]
+	[ self-inline-start | center | self-inline-end | span-self-inline-start
+        | span-self-inline-end | span-all ]
 |
 	[ start | center | end | span-start | span-end | span-all ]{1,2}
 |


### PR DESCRIPTION
Seems like an oversight.