### PR TITLE
[css-anchor-position-1] Fix markup

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -604,7 +604,7 @@ Its syntax is:
 	But if the positioned element is larger than that space
 	(such as if the anchor is very close to the right edge of the screen),
 	it will shift leftwards to stay visible.
-</di>
+</div>
 
 
 <h4 id=resolving-spans>


### PR DESCRIPTION
`</di>` instead of `</div>` makes the gist of the spec appears under a note markup