### PR TITLE
[css-color-5] <hue-interpolation-method> error occurs at parse time

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -250,9 +250,6 @@ After normalizing both percentages, the result is produced via the following alg
 	[[css-color-4#hue-interpolation]].
 	If no <<hue-interpolation-method>> is specified, it is as if
 	''shorter'' had been specified.
-	If the specified color space is a
-	''rectangular-orthogonal-color'' space,
-	then specifying a <<hue-interpolation-method>> is an error.
 3. If an alpha multiplier was produced during percentage normalization,
 	the alpha component of the interpolated result is multiplied
 	by the alpha multiplier.


### PR DESCRIPTION
[`<color-interpolation-method>`](https://drafts.csswg.org/css-color-5/#color-interpolation-method) does not allow to specify `<hue-interpolation-method>` with `<rectangular-color-space>`, therefore I suggest to remove this from step 2 of [Calculating the Result of color-mix](https://drafts.csswg.org/css-color-5/#color-mix-result):

  > 2. [...] If the specified color space is a rectangular-orthogonal-color space, then specifying a `<hue-interpolation-method>` is an error.

**Note:** in the sentence above (which is removed by this PR), *rectangular-orthogonal-color* is an autolink that has no target; maybe [`<rectangular-color-space>`](https://drafts.csswg.org/css-color-5/#typedef-rectangular-color-space) should have been used?