### PR TITLE
[css-box-4] Allowed combination of block and inline keywords in margin-trim

### DIFF
--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -373,7 +373,7 @@ Margins at Container Edges: the 'margin-trim' property {#margin-trim}
 
 	<pre class="propdef">
 		Name: margin-trim
-		Value: none | block | inline | [ block-start || inline-start || block-end || inline-end ]
+		Value: none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]
 		Initial: none
 		Applies to: [=block containers=], [=multi-column containers=], [=flex containers=], [=grid containers=]
 		Inherited: no


### PR DESCRIPTION
This adds the change for the [resolution for allowing the combination of `block` and `inline` keywords in `margin-trim`](https://github.com/w3c/csswg-drafts/issues/7884#issuecomment-2160955876).

Fixes #7884.

Sebastian