### PR TITLE
[css-color-4] `<hue>` is already normalized

### DIFF
--- a/css-color-4/hslToRgb.js
+++ b/css-color-4/hslToRgb.js
@@ -5,11 +5,6 @@
  * @return {number[]} Array of sRGB components; in-gamut colors in range [0..1]
  */
 function hslToRgb(hue, sat, light) {
-    hue = hue % 360;
-
-    if (hue < 0) {
-        hue += 360;
-    }
 
     sat /= 100;
     light /= 100;


### PR DESCRIPTION
I propose to remove the `<hue>` normalization in range [0,360) from the HSL to RGB algorithm. I think this is supposed to already have been applied ~~at parse time~~ before, as defined in [4.3. Representing Cylindrical-coordinate Hues: the `<hue>` syntax](https://drafts.csswg.org/css-color-4/#hue-syntax):

  > This number is normalized to the range [0,360).

Furthermore, this is not applied in other conversion algorithms (HWB to RGB, LCH to LAB, etc).