### PR TITLE
[css-color-4] CSS gamut mapping applies on actual values

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -5504,7 +5504,7 @@ Deviations from Perceptual Uniformity: Hue Curvature</h4>
 <h3 id="css-gamut-mapping" algorithm="to CSS gamut map">
 CSS Gamut Mapping to an RGB Destination</h3>
 
-<wpt title="Used values of color are not exposed to script, making this hard to test in an automated manner."></wpt>
+<wpt title="Actual values of color are not exposed to script, making this hard to test in an automated manner."></wpt>
 
 	The <dfn export>CSS gamut mapping algorithm</dfn>
 	applies to individual,


### PR DESCRIPTION
This sentence in [13.2. CSS Gamut Mapping to an RGB Destination](https://drafts.csswg.org/css-color-4/#css-gamut-mapping) suggests that CSS gamut mapping is applied to get used values:

  > **TESTS**
  >
  > Used values of color are not exposed to script, making this hard to test in an automated manner.

From my understanding, used values of color are exposed by [`getComputedStyle()`](https://drafts.csswg.org/cssom-1/#resolved-values):

  > - [...]
  > - `color`
  > - `outline-color`
  > - A resolved value special case property like `color` defined in another specification
  >
  > The resolved value is the [used value](https://drafts.csswg.org/css-cascade-5/#used-value).

I guess the resolved value should not depend on the display device ([13.1. An Introduction to Gamut Mapping](https://drafts.csswg.org/css-color-4/#gamut-mapping-intro)):

  > [...] if the destination is the display device (a screen, or a printer) then out of gamut values must be converted to an in-gamut color.

Therefore I think [*actual values*](https://drafts.csswg.org/css-cascade-5/#actual) was the expected term in the first sentence.