### PR TITLE
[css-pseudo-4] Add a new pseudo element search-text

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -570,7 +570,7 @@ Styling the First-Letter Pseudo-elements</h4>
 Highlight Pseudo-elements</h2>
 
 <h3 id="highlight-selectors">
-Selecting Highlighted Content: the ''::selection'',  ''::target-text'', ''::spelling-error'', and ''::grammar-error'' pseudo-elements</h3>
+Selecting Highlighted Content</h3>
 
   The <dfn export lt="highlight pseudo-element">highlight pseudo-elements</dfn>
   represent portions of a document that have been given a particular status
@@ -641,6 +641,12 @@ Selecting Highlighted Content: the ''::selection'',  ''::target-text'', ''::spel
       css/css-pseudo/grammar-error-002-manual.html
       css/css-pseudo/grammar-error-003-manual.html
       </wpt>
+
+    <dt><dfn>::search-text</dfn>
+    <dd>
+      The ''::search-text'' pseudo-element represents
+      texts that are the results shown when using the user agent’s find-in-page feature.
+
   </dl>
 
   The <a>highlight pseudo-elements</a>
@@ -1001,6 +1007,9 @@ Backgrounds</h4>
   over the ''::target-text'' overlay which is drawn
   over the ''::spelling-error'' overlay
   which is drawn over the ''::grammar-error'' overlay.
+  The ''::search-text'' overlay is drawn over or below
+  the ''::selection'' overlay depending on UA, and
+  drawn over the the ''::target-text'' overlay.
 
   <wpt>
   css/css-pseudo/selection-overlay-and-grammar-001.html


### PR DESCRIPTION
Add a new pseudo-element **::search-text** which is [highlight pseudo-elements](https://drafts.csswg.org/css-pseudo/#highlight-pseudos) allowing CSS styling of the search results shown using a browser’s find-in-page feature and its painting order among others.

There are resolutions from CSSWG:
 - Add **::search-text** : https://github.com/w3c/csswg-drafts/issues/10212#issuecomment-2089302563
 - Painting order of **::search-text**: https://github.com/w3c/csswg-drafts/issues/10213#issuecomment-2089311110