### PR TITLE
[css-pseudo-4] Simplified example of `::details-content`

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1328,14 +1328,12 @@ Expandable contents of details element: the ''::details-content'' pseudo-element
 
     <pre class="lang-css">
 details::details-content {
-  display: block;
   opacity: 0;
-  transition: content-visibility 300ms allow-discrete step-end, opacity 300ms;
+  transition: content-visibility 300ms allow-discrete, opacity 300ms;
 }
 
 details[open]::details-content {
   opacity: 1;
-  transition: content-visibility 300ms allow-discrete step-start, opacity 300ms;
 }</pre>
   </div>
 


### PR DESCRIPTION
1. By depending on the animation rules defined in https://drafts.csswg.org/css-contain-3/#content-visibility-animation the step-end and step-start values are not needed.

2. By depending on the change in 
https://github.com/whatwg/html/pull/10265#issuecomment-2145837051 
and
whatwg/html@fb3033a
the display: block is no longer needed.
