### PR TITLE
[cssom] [css-page] Add orientation to CSSPageDescriptors

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2120,6 +2120,7 @@ interface CSSPageDescriptors : CSSStyleDeclaration {
   attribute [LegacyNullToEmptyString] CSSOMString margin-bottom;
   attribute [LegacyNullToEmptyString] CSSOMString margin-left;
   attribute [LegacyNullToEmptyString] CSSOMString size;
+  attribute [LegacyNullToEmptyString] CSSOMString orientation;
   attribute [LegacyNullToEmptyString] CSSOMString marks;
   attribute [LegacyNullToEmptyString] CSSOMString bleed;
 };


### PR DESCRIPTION
I found this was missing while implementing `CSSPageDescriptors` in Gecko.

`@page{ orientation: ... }` Is generally treated the same as `@page{ size: ... }` in this way and definitely is a descriptor on page-rules, so it should be included in `CSSPageDescriptors`.