### PR TITLE
[css-scroll-snap-2][editorial] Move up scroll-start-target definition table

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -227,6 +227,25 @@ Interaction with RTL and LTR</h4>
 The 'scroll-start-target' property {#scroll-start-target}
 -------------------------------------------
 
+<pre class="propdef">
+	Name: scroll-start-target
+	Value: [ none | auto ]
+	Initial: ''none''
+	Applies to: all elements
+	Inherited: no
+	Percentages: N/A
+	Computed Value: see individual properties
+	Animation type: none
+</pre>
+
+<dl dfn-type=value dfn-for="scroll-start-target">
+	<dt><dfn>none</dfn>
+	<dd>The element is not an [=initial scroll target=].
+	<dt><dfn>auto</dfn>
+	<dd>The element is potentially an [=initial scroll target=]
+		for its nearest [=scroll container=] ancestor.
+</dl>
+
 <h4 dfn export id="initial-scroll-target">
 Initial scroll target</h4>
 
@@ -254,29 +273,6 @@ Initial scroll target</h4>
 			and <var ignore>scrolling box</var> set to |scrollcontainer|.
 		1. Set |scrollcontainer|'s <a>initial scroll position</a> to |position|.
 	</div>
-
-
-<h4 id="scroll-start-target-shorthand">
-The scroll-start-target shorthand</h4>
-
-	<pre class="propdef shorthand">
-		Name: scroll-start-target
-		Value: [ none | auto ]
-		Initial: ''none''
-		Applies to: all elements
-		Inherited: no
-		Percentages: N/A
-		Computed Value: see individual properties
-		Animation type: none
-	</pre>
-
-	<dl dfn-type=value dfn-for="scroll-start-target, scroll-start-target-block, scroll-start-target-inline, scroll-start-target-x, scroll-start-target-y">
-		<dt><dfn>none</dfn>
-		<dd>The element is not an [=initial scroll target=].
-		<dt><dfn>auto</dfn>
-		<dd>The element is potentially an [=initial scroll target=]
-			for its nearest [=scroll container=] ancestor.
-	</dl>
 
 <h4 id="scroll-start-target-with-place-content">
 Interaction with 'place-content'</h4>


### PR DESCRIPTION
- removed *3.2.2. The scroll-start-target **shorthand*** and moved up its content (the property definition table)
- removed remnants of `scroll-start-target-*` longhands (removed in #10227)