### PR TITLE
[css-spec-selectors-4] Corrected a typo (replacing a sentence-final comma with period) 

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -686,7 +686,7 @@ Data Model</h3>
 Scoped Selectors</h3>
 
 	Some host applications may choose to <dfn export lt="scoped selector" local-lt="scope">scope</dfn> selectors
-	to a particular subtree or fragment of the document,
+	to a particular subtree or fragment of the document.
 	The root of the scoping subtree is called the <dfn export>scoping root</dfn>.
 
 	When a selector is <a>scoped</a>,


### PR DESCRIPTION
In the first paragraph of this section (https://drafts.csswg.org/selectors/#scoping), changed the comma after 'of the document' to period

> Some host applications may choose to scope selectors to a particular subtree or fragment of the document, The root of the scoping subtree is called the scoping root.

