### PR TITLE
[cssom] Throw on empty 'nested declarations rule' insertion

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1859,7 +1859,7 @@ follow these steps:
   <ul>
    <li> Set <var>declarations</var> to the results of performing <a>parse a CSS declaration block</a>,
    on argument <var>rule</var>.
-   <li> If <var>declarations</var> is a syntax error, <a>throw</a> a {{SyntaxError}} exception.
+   <li> If <var>declarations</var> is empty, <a>throw</a> a {{SyntaxError}} exception.
    <li> Otherwise, set <var>new rule</var> to a new [=nested declarations rule=]
    with <var>declarations</var> as it contents.
   </ul>


### PR DESCRIPTION
The current text expects 'parse a CSS declaration block' to return a syntax error, which it never actually returns.

Follow-up to 7d8f87c8b8de9b7dd64719aeac18004ea76fdad0.
