### PR TITLE
[css-view-transitions-1] Fix tree-scoping from element-based to name-based.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1970,6 +1970,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Use snapshot containing block when capturing new state for document element. See <a href="https://github.com/w3c/csswg-drafts/issues/10177">issue #10177</a>.
 * Fix algorithm for dispatching updateDOMCallback promise.
 * Scope view transition names to matching tree context. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
+* Fix scoping to match name instead of element. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -538,6 +538,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			as either an old or new [=/element=]--
 			with the specified [=view transition name=].
 
+			Each [=view transition name=] is a [=tree-scoped name=].
+
+			Note: Since currently only document-scoped view transitions are supported, only view transition names that are associated with the document are respected.
+
 			The values <css>none</css> and <css>auto</css> are excluded from <<custom-ident>> here.
 
 			Note: If this name is not unique
@@ -558,6 +562,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	or [=element-not-rendered|not rendered=],
 	this property has no effect.
 	See [[#algorithms]] for exact details.
+
+	The <dfn>document-scoped view transition name</dfn> for an {{Element}} |element| is its 'view-transition-name' that is associated with |element|'s [=node document=].
 
 ### Rendering Consolidation ### {#named-and-transitioning}
 
@@ -1319,7 +1325,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=list/For each=] |element| of every [=/element=] that is [=/connected=],
 			and has a [=node document=] equal to |document|,
-			and has a [=tree context=] equal to |document|,
 			in [paint order](https://drafts.csswg.org/css2/#painting-order):
 
 			<div class=note>We iterate in paint order to ensure that this order is cached in |namedElements|.
@@ -1335,7 +1340,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				Note: [=box fragment=] here does not refer to fragmentation of <a href="https://www.w3.org/TR/CSS2/visuren.html#inline-boxes">inline boxes</a> across <a href="https://www.w3.org/TR/CSS2/visuren.html#line-box">line boxes</a>.
 					Such inlines can participate in a transition.
 
-			1. Let |transitionName| be the [=computed value=] of 'view-transition-name' for |element|.
+			1. Let |transitionName| be the |element|'s [=document-scoped view transition name=].
 
 			1. If |transitionName| is ''view-transition-name/none'',
 				or |element| is [=element-not-rendered|not rendered=],
@@ -1403,12 +1408,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=list/For each=] |element| of every [=/element=] that is [=/connected=],
 			and has a [=node document=] equal to |document|,
-			and has a [=tree context=] equal to |document|,
 			in [paint order](https://drafts.csswg.org/css2/#painting-order):
 
 			1. If any [=flat tree=] ancestor of this |element| [=skips its contents=], then [=continue=].
 
-			1. Let |transitionName| be the [=computed value=] of 'view-transition-name' for |element|.
+			1. Let |transitionName| be |element|'s [=document-scoped view transition name=].
 
 			1. If |transitionName| is ''view-transition-name/none'',
 				or |element| is [=element-not-rendered|not rendered=],

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -563,7 +563,15 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	this property has no effect.
 	See [[#algorithms]] for exact details.
 
-	The <dfn>document-scoped view transition name</dfn> for an {{Element}} |element| is its 'view-transition-name' that is associated with |element|'s [=node document=].
+	<div algorithm>
+	To get the <dfn>document-scoped view transition name</dfn> for an {{Element}} |element|:
+
+		1. Let |scopedViewTransitionName| be the [=computed value=] of 'view-transition-name' for |element|.
+
+		1. If |scopedViewTransitionName| is associated with |element|'s [=node document=], then return |scopedViewTransitionName|.
+
+		1. Otherwise, return ''view-transition-name/none''.
+	</div>
 
 ### Rendering Consolidation ### {#named-and-transitioning}
 


### PR DESCRIPTION
The previous fix for using the tree context made it inconsistent with how shadow DOM styling works for things like anchor positioning, and made it so that e.g. `::part` cannot set a `view-transition-name`.

Refactored to make the `view-transition-name` a tree-scoped name, rather than check the tree context of the element.

This aligns better with the [existing resolution](https://github.com/w3c/csswg-drafts/issues/10145#issuecomment-2100931679) and should not require a new resolution.

Closes #10145

