### PR TITLE
[resize-observer-1] Add note about invocations from update the rendering loop in the html spec #10512

### DIFF
--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -393,6 +393,11 @@ Content rect for the <a>SVGGraphicsElement</a>s without CSS layout boxes is a re
 
 <h3 id="algorithms">Algorithms</h3>
 
+<p class="note">
+The following algorithms are invoked as a part of [=update the rendering=] in the html spec:
+<a>gather active resize observations at depth</a>, <a>has active resize observations</a>, <a>has skipped resize observations</a>, <a>broadcast active resize observations</a> and <a>deliver resize loop error notification</a>.
+</p>
+
 <h4 id="gather-active-observations-h">Gather active resize observations at depth</h4>
 
 It computes all active resize observations for a |document|. To <dfn>gather active resize observations at depth</dfn>, run these steps:

--- a/resize-observer-1/Overview.bs
+++ b/resize-observer-1/Overview.bs
@@ -393,10 +393,12 @@ Content rect for the <a>SVGGraphicsElement</a>s without CSS layout boxes is a re
 
 <h3 id="algorithms">Algorithms</h3>
 
-<p class="note">
-The following algorithms are invoked as a part of [=update the rendering=] in the html spec:
-<a>gather active resize observations at depth</a>, <a>has active resize observations</a>, <a>has skipped resize observations</a>, <a>broadcast active resize observations</a> and <a>deliver resize loop error notification</a>.
-</p>
+Note: The following algorithms are invoked as a part of [=update the rendering=] in the html spec:
+<a>gather active resize observations at depth</a>,
+<a>has active resize observations</a>,
+<a>has skipped resize observations</a>,
+<a>broadcast active resize observations</a>
+and <a>deliver resize loop error notification</a>.
 
 <h4 id="gather-active-observations-h">Gather active resize observations at depth</h4>
 


### PR DESCRIPTION
Adding a short note to clarify which of the algorithms are called from the [HTML Event Loops Processing Model](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model).