### PR TITLE
Define viewport object

### DIFF
--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -362,8 +362,27 @@ only the value previously set to it.
 }
 </pre>
 
-<h2 id='zoom-property'>
-	The 'zoom' property
+<h2 id=extensions-to-the-window-interface>Extensions to the {{Window}} Interface</h2>
+
+<pre class=idl>
+partial interface Window {
+[SameObject, Replaceable] readonly attribute Viewport? viewport;
+};
+</pre>
+
+<h2 id=viewport>Viewport</h2>
+
+<h3 id="the-viewport-interface">The {{Viewport}} Interface</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface Viewport : EventTarget {
+  readonly attribute double zoom;
+};
+</pre>
+
+<h2 id='zoom'>
+	The <dfn attribute for=Viewport>zoom</dfn> property
 </h2>
 
 An element becomes zoomed when the 'zoom' property has a positive computed value different than 1

--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -346,7 +346,7 @@ only the value previously set to it.
 
 <div class="note">
 	That is, unless previously set, <code>VirtualKeyboard.overlaysContent</code> returns false
-	even if <code>interactive-widget=overlays-content</code> is set via the <code>&ltmeta&gt</code>
+	even if <code>interactive-widget=overlays-content</code> is set via the <code>&lt;meta&gt;</code>
 	tag.
 </div>
 


### PR DESCRIPTION
[css-viewport-1] Define viewport object.

In preparation to add the segments property we need to make sure that the viewport property is properly specified. This patch already adds the zoom property which is already defined.
