### PR TITLE
[css-viewport] Define the viewport property in window

### DIFF
--- a/css-viewport/Overview.bs
+++ b/css-viewport/Overview.bs
@@ -362,8 +362,27 @@ only the value previously set to it.
 }
 </pre>
 
-<h2 id='zoom-property'>
-	The 'zoom' property
+<h2 id=extensions-to-the-window-interface>Extensions to the {{Window}} Interface</h2>
+
+<pre class=idl>
+partial interface Window {
+[SameObject, Replaceable] readonly attribute Viewport? viewport;
+};
+</pre>
+
+<h2 id=viewport>Viewport</h2>
+
+<h3 id="the-viewport-interface">The {{Viewport}} Interface</h3>
+
+<pre class=idl>
+[Exposed=Window]
+interface Viewport : EventTarget {
+  readonly attribute double zoom;
+};
+</pre>
+
+<h2 id='zoom'>
+	The <dfn attribute for=Viewport>zoom</dfn> property
 </h2>
 
 An element becomes zoomed when the 'zoom' property has a positive computed value different than 1


### PR DESCRIPTION
In preparation to add the segments property we need to make sure that the viewport property is properly specified. This patch already adds the zoom property to the viewport interface as it was already defined.
