### PR TITLE
[css-scroll-snap-2] Remove scroll-start-target-* longhand vestiges

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -173,7 +173,7 @@ Initial scroll target</h4>
 		Animation type: none
 	</pre>
 
-	<dl dfn-type=value dfn-for="scroll-start-target, scroll-start-target-block, scroll-start-target-inline, scroll-start-target-x, scroll-start-target-y">
+	<dl dfn-type=value dfn-for="scroll-start-target">
 		<dt><dfn>none</dfn>
 		<dd>The element is not an [=initial scroll target=].
 		<dt><dfn>auto</dfn>
@@ -189,7 +189,7 @@ Interaction with 'place-content'</h4>
 	and by 'scroll-start-target' on a descendant,
 	'scroll-start-target' wins.
 
-<h4 id="scroll-start-fragment-navigation">
+<h4 id="scroll-start-target-fragment-navigation">
 Post-first layout arrivals</h4>
 
 	While the document is being [[html#updating-the-document|updated]],


### PR DESCRIPTION
This removes longhand references to scroll-start-target-* as these have been dropped.
