### PR TITLE
[css-fonts-4] Restore monospace in generic family

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -370,7 +370,7 @@ Syntax of <<generic-family>>
 	<!-- <pre class=prod>
 		<dfn><<generic-family>></dfn> = generic(<<generic-script-specific>>) | <<generic-complete>> | <<generic-incomplete>>`
 		<dfn><<generic-script-specific>></dfn> = <a href="">kai</a> | fangsong | nastaliq 
-		<dfn><<generic-complete>></dfn> = serif | sans-serif | system-ui | cursive | fantasy | math
+		<dfn><<generic-complete>></dfn> = serif | sans-serif | system-ui | cursive | fantasy | math | monospace
 		<dfn><<generic-incomplete>></dfn> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded 
 </pre> -->
 


### PR DESCRIPTION
Following 69f7f7a, I think [`<generic-complete>`](https://drafts.csswg.org/css-fonts-4/#typedef-generic-complete) is missing `monospace`.