### PR TITLE
[css-nesting-1][editorial] `@container` is now a conditional group rule

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -641,10 +641,9 @@ Nesting Other At-Rules {#conditionals}
 	<div class=note>
 		Specifically, these rules are capable of being [=nested group rules=]:
 
-		* all the [=conditional group rules=] (''@media'', ''@supports'')
+		* all the [=conditional group rules=] (''@container'', ''@media'', ''@supports'')
 		* ''@layer''
 		* ''@scope''
-		* ''@container''
 	</div>
 
 	The meanings and behavior of such [=nested group rules=]


### PR DESCRIPTION
Follow up on https://github.com/w3c/csswg-drafts/commit/23459f3bc644814fb441ed5732b818fbf4d70ee4.

  > The `@container` rule is a conditional group rule [...]

https://drafts.csswg.org/css-conditional-5/#container-rule