### PR TITLE
[css-anchor-positioning-1] Clarify that an element can anchor to another within the same skipped contents

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -386,7 +386,8 @@ in anchor positioning.
 	* |el| is either an [=element=]
 		or a [=part-like pseudo-element=].
 
-	* |el| is not in the [=skipped contents=] of another element.
+	* |el| is not in the skipped contents of another element,
+		or there is another element such that |el| is in the [=skipped contents=] of that that element but |query el| is not.
 
 	* |el| is in scope for |query el|,
 		per the effects of 'anchor-scope' on |query el|

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -386,8 +386,12 @@ in anchor positioning.
 	* |el| is either an [=element=]
 		or a [=part-like pseudo-element=].
 
-	* |el| is not in the skipped contents of another element,
-		or there is another element such that |el| is in the [=skipped contents=] of that that element but |query el| is not.
+	* If |el| is in the [=skipped contents=] of another element,
+		then |query el| is in the [=skipped contents=] of that same element.
+
+		Note: In other words, |query el| can anchor to |el| 
+		if they're both in the same skipped "leaf",
+		but it can't anchor "across" leafs.
 
 	* |el| is in scope for |query el|,
 		per the effects of 'anchor-scope' on |query el|


### PR DESCRIPTION
The complicated wording indicates that you have to have exactly the same "leaf" skipped contents. IOW, anchors can't flow across an element that skips its contents to something outside, but two things in a skipped subtree without intervening skipped-causing elements can anchor to each other.

This change allows browsers to avoid layout of skipped content when starting to skip subtrees.