### PR TITLE
[css-scoping-1] add :has-slotted() psuedo class

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -424,6 +424,44 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 	The only way to style assigned text nodes
 	is by styling the <a>slot</a> and relying on inheritance.
 
+<h4 id='has-slotted-pseudo'>
+Matching Selectors Against Slot-Assigned Content: the '':has-slotted()'' pseudo-class</h4>
+
+	The <dfn selector>:has-slotted()</dfn> pseudo-class, when evaluated 
+	<a>in the context of a shadow tree</a>,
+	matches the <a>slot</a>, if one of its
+	<a lt="find flattened slottables">assigned, after flattening,</a> matches the provided <<compound-selector>>.
+	In any other context, it matches nothing. This pseudo-class only exists on <a>slots</a>.
+
+	The [=specificity=] of '':has-slotted()'' is that of a pseudo-class,
+	plus the [=specificity=] of its argument.
+
+	The grammar of the '':has-slotted()'' pseudo-element is:
+
+	<pre class=prod>:has-slotted( <<compound-selector>> )</pre>
+
+	<div class="example">
+		For example, say you had a component with both children and a shadow tree,
+		like the following:
+
+		<pre>
+			&lt;x-foo>
+				&lt;div id="one" slot="foo" class="foo">...&lt;/div>
+				&lt;"shadow tree">
+					&lt;slot id="theslot" name="foo">&lt;/slot>
+				&lt;/"shadow tree">
+			&lt;/x-foo>
+		</pre>
+
+		For a stylesheet within the <a>shadow tree</a>,
+		selectors like '':has-slotted(*)'', '':has-slotted(div)'', '':has-slotted(.foo)'', and '':has-slotted(#one)''
+		will match ''#theslot'', while '':has-slotted(p)'', '':has-slotted(:not(.foo))'', '':has-slotted(#two)''
+		will not.
+	</div>
+
+	Note: '':has-slotted()'' will only match the ''slot'' element, not the contents. Slotted contents
+	can be matched with the ''::slotted()'' pseudo-element.
+
 <!--
  ██████     ███     ██████   ██████     ███    ████████  ████████
 ██    ██   ██ ██   ██    ██ ██    ██   ██ ██   ██     ██ ██
@@ -613,7 +651,7 @@ Name-Defining Constructs and Inheritance</h3>
 
 		For example,
 		given the following document
-		(using the imaginary <::shadow></::shadow> markup
+		(using the imaginary ''<::shadow></::shadow>'' markup
 		to indicate an element's [=shadow tree=]):
 
 		<xmp highlight=markup>
@@ -733,7 +771,7 @@ Serialized Tree-Scoped References</h4>
 
 		For example,
 		given the following document
-		(using the imaginary <::shadow></::shadow> markup
+		(using the imaginary ''<::shadow></::shadow>'' markup
 		to indicate an element's [=shadow tree=]):
 
 		<xmp highlight=markup>


### PR DESCRIPTION
Based on the discussion in https://github.com/w3c/csswg-drafts/issues/6867, and the conclusions within, I thought I'd have a go at specifying a `:has-slotted( <<compound-selector>> )` pseudo class.

I put this in `css-scoping-1`; the resolution was to add it in `css-selectors-5` but I thought it might be useful living next to `:host`, `:host()`, `:host-context()` and `::slotted()`. I am of course happy to move it if folks disagree with this choice.

My intent for this PR is largely to present something worthy of discussion. I hope I've achieved that, apologies if this PR amounts to just noise.