### PR TITLE
[css-view-transitions-1] Display live image when element is outside the snapshot containing block in old state

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1907,11 +1907,13 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 				Note: The above code example contains variables to be replaced.
 
-			1. Let |liveSnapshot| be  the result of [=capturing the image=] of |capturedElement|'s [=new element=].
+			1. Let |liveSnapshot| be null.
 
 			1. If |capturedElement|'s [=new element=] is not null, then:
 
 				1. Let |new| be the ''::view-transition-new()'' with the [=view transition name=] |transitionName|.
+
+				1. Set |liveSnapshot| to the result of [=capturing the image=] of |capturedElement|'s [=new element=].
 
 				1. Set |new|'s [=replaced element=] content to |liveSnapshot|.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1172,7 +1172,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<dl dfn-for="captured element">
 		: <dfn>old image</dfn>
-		:: a 2D bitmap, "`live`", or null. Initially null.
+		:: a 2D bitmap, or null. Initially null.
+
+		: <dfn>should generate old pseudo</dfn>
+		:: a boolean, initially false.
 
 		: <dfn>old width</dfn>
 		: <dfn>old height</dfn>
@@ -1368,14 +1371,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Let |capture| be a new [=captured element=] struct.
 
+			1. Set |capture|'s [=should generate old pseudo=] to true.
+
 			1. Let |originalRect| be [=snapshot containing block=] if |element| is the [=document element=],
 				otherwise, the element|'s [=border box=].
 
 			1. Let |boundingBox| be |element|'s [=Element/get the bounding box|bounding box=], with [=ink overflow=] taken into account.
 
 			1. If |boundingBox| intersects with [=snapshot containing block=], then set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
-
-			1. Otherwise, set |capture|'s [=old image=] to "`live`".
 
 			1. Set |capture|'s [=captured element/old width=] to |originalRect|'s {{DOMRect/width}}.
 
@@ -1470,12 +1473,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Append |imagePair| to |group|.
 
-			1. If |capturedElement|'s [=captured element/old image=] is not null, then:
+			1. If |capturedElement|'s [=should generate old pseudo=] is true, then:
 
 				1. Let |old| be a new ''::view-transition-old()'',
 					with its [=view transition name=] set to |transitionName|.
 
-				1. If |capturedElement|'s [=captured element/old image=] is not "`live`", then
+				1. If |capturedElement|'s [=captured element/old image=] is not null, then
 					set |old|'s [=replaced element|replaced=] content to |capturedElement|'s
 					[=captured element/old image=].
 
@@ -1490,7 +1493,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 				1. Append |new| to |imagePair|.
 
-			1. If |capturedElement|'s [=captured element/old image=] is null, then:
+			1. If |capturedElement|'s [=should generate old pseudo=] is false, then:
 				1. [=Assert=]: |capturedElement|'s [=captured element/new element=] is not null.
 
 				1. Set |capturedElement|'s [=captured element/image animation name rule=] to a new {{CSSStyleRule}} representing the following CSS,
@@ -1506,7 +1509,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 					Note: The above code example contains variables to be replaced.
 
 			1. If |capturedElement|'s [=captured element/new element=] is null, then:
-				1. [=Assert=]: |capturedElement|'s [=captured element/old image=] is not null.
+				1. [=Assert=]: |capturedElement|'s [=should generate old pseudo=] is true.
 
 				1. Set |capturedElement|'s [=captured element/image animation name rule=] to a new {{CSSStyleRule}} representing the following CSS,
 					and append it to |document|'s [=document/dynamic view transition style sheet=]:
@@ -1520,8 +1523,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 					Note: The above code example contains variables to be replaced.
 
-			1. If both of |capturedElement|'s [=captured element/old image=] and [=captured element/new element=]
-				are not null, then:
+			1. If [=should generate old pseudo=] is true and [=captured element/new element=]
+				is not null, then:
 
 				1. Let |transform| be |capturedElement|'s [=captured element/old transform=].
 
@@ -1919,7 +1922,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 				1. Set |new|'s [=replaced element=] content to |liveSnapshot|.
 
-			1. If |capturedElement|'s [=old image=] is not "`live`", then:
+			1. If |capturedElement|'s [=old image=] is null, and |capturedElement|'s [=should generate old pseudo=] is true, then:
 
 				1. Let |old| be the ''::view-transition-old()'' with the [=view transition name=] |transitionName|.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1376,9 +1376,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			1. Let |originalRect| be [=snapshot containing block=] if |element| is the [=document element=],
 				otherwise, the element|'s [=border box=].
 
-			1. Let |boundingBox| be |element|'s [=Element/get the bounding box|bounding box=], with [=ink overflow=] taken into account.
-
-			1. If |boundingBox| intersects with [=snapshot containing block=], then set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
+			1. If |element|'s [=ink overflow rectangle=] intersects with [=snapshot containing block=], then set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
 
 			1. Set |capture|'s [=captured element/old width=] to |originalRect|'s {{DOMRect/width}}.
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1172,7 +1172,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<dl dfn-for="captured element">
 		: <dfn>old image</dfn>
-		:: an 2D bitmap or null. Initially null.
+		:: a 2D bitmap, "`live`" or null. Initially null.
 
 		: <dfn>old width</dfn>
 		: <dfn>old height</dfn>
@@ -1368,10 +1368,12 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			1. Let |capture| be a new [=captured element=] struct.
 
-			1. Set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
-
 			1. Let |originalRect| be [=snapshot containing block=] if |element| is the [=document element=],
 				otherwise, the element|'s [=border box=].
+
+			1. If |originalRect| does not intersect with [=snapshot containing block=], then set |capture|'s [=old image=] to "`live`".
+
+			1. Otherwise, set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
 
 			1. Set |capture|'s [=captured element/old width=] to |originalRect|'s {{DOMRect/width}}.
 
@@ -1469,9 +1471,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			1. If |capturedElement|'s [=captured element/old image=] is not null, then:
 
 				1. Let |old| be a new ''::view-transition-old()'',
-					with its [=view transition name=] set to |transitionName|,
-					displaying |capturedElement|'s [=captured element/old image=]
-					as its [=replaced element|replaced=] content.
+					with its [=view transition name=] set to |transitionName|.
+
+				1. If |capturedElement|'s [=captured element/old image=] is not "`live`", then
+					set |old|'s [=replaced element|replaced=] content to |capturedElement|'s
+					[=captured element/old image=].
 
 				1. Append |old| to |imagePair|.
 
@@ -1903,11 +1907,19 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 				Note: The above code example contains variables to be replaced.
 
+			1. Let |liveSnapshot| be  the result of [=capturing the image=] of |capturedElement|'s [=new element=].
+
 			1. If |capturedElement|'s [=new element=] is not null, then:
 
 				1. Let |new| be the ''::view-transition-new()'' with the [=view transition name=] |transitionName|.
 
-				1. Set |new|'s [=replaced element=] content to the result of [=capturing the image=] of |capturedElement|'s [=new element=].
+				1. Set |new|'s [=replaced element=] content to |liveSnapshot|.
+
+			1. If |capturedElement|'s [=old image=] is "`live`", then:
+
+				1. Let |old| be the ''::view-transition-old()'' with the [=view transition name=] |transitionName|.
+
+				1. Set |old|'s [=replaced element=] content to |liveSnapshot|.
 
 		This algorithm must be executed to update styles in [=user-agent origin=] if its effects can be observed by a web API.
 
@@ -1979,6 +1991,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Fix algorithm for dispatching updateDOMCallback promise.
 * Scope view transition names to matching tree context. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 * Fix scoping to match name instead of element. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
+* Show live contents if the old element is captured when outside the viewport. See <a href="https://github.com/w3c/csswg-drafts/issues/8282">issue 8282</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1172,7 +1172,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<dl dfn-for="captured element">
 		: <dfn>old image</dfn>
-		:: a 2D bitmap, "`live`" or null. Initially null.
+		:: a 2D bitmap, "`live`", or null. Initially null.
 
 		: <dfn>old width</dfn>
 		: <dfn>old height</dfn>
@@ -1371,9 +1371,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			1. Let |originalRect| be [=snapshot containing block=] if |element| is the [=document element=],
 				otherwise, the element|'s [=border box=].
 
-			1. If |originalRect| does not intersect with [=snapshot containing block=], then set |capture|'s [=old image=] to "`live`".
+			1. Let |boundingBox| be |element|'s [=Element/get the bounding box|bounding box=], with [=ink overflow=] taken into account.
 
-			1. Otherwise, set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
+			1. If |boundingBox| intersects with [=snapshot containing block=], then set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
+
+			1. Otherwise, set |capture|'s [=old image=] to "`live`".
 
 			1. Set |capture|'s [=captured element/old width=] to |originalRect|'s {{DOMRect/width}}.
 
@@ -1917,11 +1919,13 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 				1. Set |new|'s [=replaced element=] content to |liveSnapshot|.
 
-			1. If |capturedElement|'s [=old image=] is "`live`", then:
+			1. If |capturedElement|'s [=old image=] is not "`live`", then:
 
 				1. Let |old| be the ''::view-transition-old()'' with the [=view transition name=] |transitionName|.
 
 				1. Set |old|'s [=replaced element=] content to |liveSnapshot|.
+
+					Note: In case of an exit transition of an offscreen element, the group would have no content.
 
 		This algorithm must be executed to update styles in [=user-agent origin=] if its effects can be observed by a web API.
 


### PR DESCRIPTION
See [resolution](https://github.com/w3c/csswg-drafts/issues/8282#issuecomment-2192185792).

Showing the "live" snapshot in the "old" element if the element was offscreen (outside the snapshot containing block) in the old state.

Putting this in css-view-transitions-1 rather than 2 because it changes behavior in a way that's not author-observable. Hope that's OK and happy to consider alternatives (/cc @nt1m)
