### PR TITLE
[css-align-3] Example 3 changing the order of images to match the text

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -828,20 +828,26 @@ Overflow Alignment: the ''safe'' and ''unsafe'' keywords and scroll safety limit
 				</div>
 			</div>
 			<figcaption>
-				The items in the figure on the left centered unless they overflow,
-				in which case all the overflow goes off the end edge,
-				while those in the figure on the right are are all strictly centered,
-				even if the one that is too long to fit overflows on both sides.
-				If the container was placed
-				against the left edge of the page,
-				the “safe” behavior would be more desirable,
-				as the long item would be fully readable,
-				rather than clipped by the left edge of the screen.
-				In other circumstances,
-				the “unsafe” centering behavior might be better,
-				as it correctly centers all the items.
+				An example of "safe" (on the left)
+				vs "unsafe" (on the right)
+				centering,
+				when the centered item is larger than its container.
 			</figcaption>
 		</figure>
+
+		The items in the figure on the left are centered unless they overflow,
+		in which case all the overflow goes off the end edge,
+		while those in the figure on the right are are all strictly centered,
+		even if the one that is too long to fit overflows on both sides.
+
+		If the container was placed
+		against the left edge of the page,
+		the “safe” behavior would be more desirable,
+		as the long item would be fully readable,
+		rather than clipped by the left edge of the screen.
+		In other circumstances,
+		the “unsafe” centering behavior might be better,
+		as it correctly centers all the items.
 	</div>
 
 	To control this situation,

--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -812,26 +812,26 @@ Overflow Alignment: the ''safe'' and ''unsafe'' keywords and scroll safety limit
 			}
 			</style>
 			<div style="display:table; margin: 0 auto 1em;">
-				<div style="display:table-cell; padding-right: 50px;" class='cross-auto-figure'>
-					<div>
-						<div>About</div>
-						<div style="white-space: nowrap; margin-left: -31px;">Authoritarianism</div>
-						<div>Blog</div>
-					</div>
-				</div>
-				<div style="display:table-cell; padding-left: 50px;" class='cross-auto-figure'>
+				<div style="display:table-cell; padding-right: 70px;" class='cross-auto-figure'>
 					<div>
 						<div>About</div>
 						<div style="white-space: nowrap;">Authoritarianism</div>
 						<div>Blog</div>
 					</div>
 				</div>
+				<div style="display:table-cell; padding-left: 70px;" class='cross-auto-figure'>
+					<div>
+						<div>About</div>
+						<div style="white-space: nowrap; margin-left: -31px;">Authoritarianism</div>
+						<div>Blog</div>
+					</div>
+				</div>
 			</div>
 			<figcaption>
-				The items in the figure on the left are all strictly centered,
-				even if the one that is too long to fit overflows on both sides,
-				while those in the figure on the right are centered unless they overflow,
-				in which case all the overflow goes off the end edge.
+				The items in the figure on the left centered unless they overflow,
+				in which case all the overflow goes off the end edge,
+				while those in the figure on the right are are all strictly centered,
+				even if the one that is too long to fit overflows on both sides.
 				If the container was placed
 				against the left edge of the page,
 				the “safe” behavior would be more desirable,

--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -916,7 +916,7 @@ Self-Alignment for Absolutely Positioned Boxes</h5>
 		(similar to ''safe'').
 
 	(For [=absolutely-positioned=] [=alignment subjects=] that fail the above conditions,
-	see [[#auto-safety-default]].)
+	see [[#auto-safety-defaults]].)
 
 <h5 id=auto-safety-default>
 All Other Alignment</h5>

--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -916,7 +916,7 @@ Self-Alignment for Absolutely Positioned Boxes</h5>
 		(similar to ''safe'').
 
 	(For [=absolutely-positioned=] [=alignment subjects=] that fail the above conditions,
-	see [[#auto-safety-defaults]].)
+	see [[#auto-safety-default]].)
 
 <h5 id=auto-safety-default>
 All Other Alignment</h5>


### PR DESCRIPTION
In the first paragraph of the example and section heading, the order of the keywords `safe` and `unsafe`, but the figure for illustrates this keywords in the opposite order, which may cause confusion.

Changed the order of the images and the order of the image descriptions.