### PR TITLE
[css-align-3] Fix broken link

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -916,7 +916,7 @@ Self-Alignment for Absolutely Positioned Boxes</h5>
 		(similar to ''safe'').
 
 	(For [=absolutely-positioned=] [=alignment subjects=] that fail the above conditions,
-	see [[#auto-safety-defaults]].)
+	see [[#auto-safety-default]].)
 
 <h5 id=auto-safety-default>
 All Other Alignment</h5>


### PR DESCRIPTION
The link `#auto-safety-defaults` does not exist, the correct link is `#auto-safety-default`.






