### PR TITLE
[css-exclusions-1]  Fix spurious / in <img>

### DIFF
--- a/css-exclusions-1/Overview.bs
+++ b/css-exclusions-1/Overview.bs
@@ -203,7 +203,7 @@ The 'wrap-flow' property</h4>
   block's descendants to wrap around its <a>exclusion area</a>.
 
   <figure>
-    <img alt="LTR text wrapping on left edge, RTL text wrapping on right edge, and vertical text wrapping on top edge." src="images/exclusion-writing-modes.png" style="width: 70%" />
+    <img alt="LTR text wrapping on left edge, RTL text wrapping on right edge, and vertical text wrapping on top edge." src="images/exclusion-writing-modes.png" style="width: 70%">
     <figcaption>Exclusion with 'wrap-flow': ''start'' interacting with various
     writing modes.</figcaption>
   </figure>
@@ -215,7 +215,7 @@ The 'wrap-flow' property</h4>
   context</a> (see [[!CSS21]]) for its content.
 
   <figure>
-      <img alt="General illustration showing how exclusions combine" src="images/exclusions-illustration.png" style="width: 70%" />
+      <img alt="General illustration showing how exclusions combine" src="images/exclusions-illustration.png" style="width: 70%">
       <figcaption>Combining exclusions</figcaption>
   </figure>
 
@@ -284,31 +284,31 @@ The 'wrap-flow' property</h4>
           <td><code class="html">.exclusion{ wrap-flow: both; }</code></td>
       </tr>
       <tr>
-          <td><img src="images/exclusion_wrap_side_auto.png" alt="Example rendering for wrap-side: auto" /></td>
-          <td><img src="images/exclusion_wrap_side_both.png" alt="Example rendering for wrap-side: both" /></td>
+          <td><img src="images/exclusion_wrap_side_auto.png" alt="Example rendering for wrap-side: auto"></td>
+          <td><img src="images/exclusion_wrap_side_both.png" alt="Example rendering for wrap-side: both"></td>
       </tr>
       <tr>
           <td><code class="html">.exclusion{ wrap-flow: start; }</code></td>
           <td><code class="html">.exclusion{ wrap-flow: end; }</code></td>
       </tr>
       <tr>
-          <td><img src="images/exclusion_wrap_side_left.png" alt="Example rendering for wrap-side: start" /></td>
-          <td><img src="images/exclusion_wrap_side_right.png" alt="Example rendering for wrap-side: end" /></td>
+          <td><img src="images/exclusion_wrap_side_left.png" alt="Example rendering for wrap-side: start"></td>
+          <td><img src="images/exclusion_wrap_side_right.png" alt="Example rendering for wrap-side: end"></td>
       </tr>
       <tr>
           <td><code class="html">.exclusion{ wrap-flow: minimum; }</code></td>
           <td><code class="html">.exclusion{ wrap-flow: maximum; }</code></td>
       </tr>
       <tr>
-          <td><img src="images/exclusion_wrap_side_minimum.png" alt="Example rendering for wrap-side: minimum" /></td>
-          <td><img src="images/exclusion_wrap_side_maximum.png" alt="Example rendering for wrap-side: maximum" /></td>
+          <td><img src="images/exclusion_wrap_side_minimum.png" alt="Example rendering for wrap-side: minimum"></td>
+          <td><img src="images/exclusion_wrap_side_maximum.png" alt="Example rendering for wrap-side: maximum"></td>
       </tr>
       <tr>
           <td><code class="html">.exclusion{ wrap-flow: clear; }</code></td>
           <td></td>
       </tr>
       <tr>
-          <td><img src="images/exclusion_wrap_side_clear.png" alt="Example rendering for wrap-side: clear" /></td>
+          <td><img src="images/exclusion_wrap_side_clear.png" alt="Example rendering for wrap-side: clear"></td>
           <td></td>
       </tr>
   </table>
@@ -435,7 +435,7 @@ The values of this property have the following meanings:
 &lt;/div&gt;
 </code></pre>
 
-  <img class="singleImgExample" src="images/exclusion_wrap_through.png" alt="Example rendering of wrap-through: wrap | none" style="max-width:40%"/>
+  <img class="singleImgExample" src="images/exclusion_wrap_through.png" alt="Example rendering of wrap-through: wrap | none" style="max-width:40%">
 </div>
 
 <!-- End section "wrap-through property" -->
@@ -498,8 +498,8 @@ Exclusions order</h3>
     <td style="width:50%"><code class="html">.middle { z-index: 1; }</code></td>
   </tr>
   <tr>
-    <td><img class="singleImgExample" src="images/exclusion_ordering.png" alt="Example rendering of default exclusion ordering." /></td>
-    <td><img class="singleImgExample" src="images/exclusion_ordering_z_order.png" alt="Example rendering of default exclusion ordering." /></td>
+    <td><img class="singleImgExample" src="images/exclusion_ordering.png" alt="Example rendering of default exclusion ordering."></td>
+    <td><img class="singleImgExample" src="images/exclusion_ordering_z_order.png" alt="Example rendering of default exclusion ordering."></td>
   </tr>
 </table>
 </div>
@@ -678,12 +678,12 @@ Processing Model Example</h4>
   </ul>
 
   <figure>
-    <img src="images/processing-model-example-dom.svg" width="200" alt="DOM tree nodes"/>
+    <img src="images/processing-model-example-dom.svg" width="200" alt="DOM tree nodes">
     <figcaption>DOM tree</figcaption>
   </figure>
 
   <figure>
-    <img src="images/processing-model-example-layout-tree.svg" width="350" alt="Layout tree boxes"/>
+    <img src="images/processing-model-example-layout-tree.svg" width="350" alt="Layout tree boxes">
     <figcaption>Layout tree of generated block boxes</figcaption>
   </figure>
 


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```shell
bikeshed spec css-exclusions-1\Overview.bs
```
Throws errors when called locally:
```shell
LINE 206:5: Spurious / in <img>.
LINE 218:7: Spurious / in <img>.
...
```

### Bikeshed Documentation

> The spec command is the most common one you’ll use. It turns a Bikeshed source file into an output HTML file. The rest of this document mostly describes how to format a source file for use with this command.

[Source](https://speced.github.io/bikeshed/#cli-spec)
Could you please tell where the description how specifications are generated for the drafts.csswg.org domain can be found? Apparently, it's not done using the command `bikeshed spec`, otherwise the document can not be generated. Would like to have the ability to fully reproduce the process locally.






