### PR TITLE
[css-exclusions-1] Fix bikeshed errors

### DIFF
--- a/css-exclusions-1/Overview.bs
+++ b/css-exclusions-1/Overview.bs
@@ -14,7 +14,7 @@ Editor: Vincent Hardy, Adobe, vhardy@adobe.com
 Editor: Alan Stearns, Adobe, astearns@adobe.com, w3cid 46659
 !Issues list: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?query_format=advanced&amp;product=CSS&amp;component=Exclusions&amp;resolution=---&amp;cmdtype=doit">in Bugzilla</a>
 !Test Suite: <a href="http://test.csswg.org/suites/css3-exclusions/nightly-unstable/">http://test.csswg.org/suites/css3-exclusions/nightly-unstable/</a>
-Abstract: CSS Exclusions define arbitrary areas around which inline content ([[!CSS21]]) can flow. CSS Exclusions can be defined on any CSS block-level elements. CSS Exclusions extend the notion of content wrapping previously limited to floats.
+Abstract: CSS Exclusions define arbitrary areas around which inline content ([[!CSS2]]) can flow. CSS Exclusions can be defined on any CSS block-level elements. CSS Exclusions extend the notion of content wrapping previously limited to floats.
 Ignored Terms: div, dl, dfn
 </pre>
 <pre class=link-defaults>
@@ -156,7 +156,7 @@ The 'wrap-flow' property</h4>
         No exclusion is created. Inline flow content interacts with the element
         as usual. In particular, if the element is a
         <a href="https://www.w3.org/TR/CSS2/visuren.html#floats">float</a>
-        (see [[!CSS21]]), the behavior is unchanged.
+        (see [[!CSS2]]), the behavior is unchanged.
 
     <dt><dfn>both</dfn>
     <dd>
@@ -212,7 +212,7 @@ The 'wrap-flow' property</h4>
   <a href="https://www.w3.org/TR/css3-writing-modes/#text-flow">writing mode</a> [[!CSS3-WRITING-MODES]] of the content wrapping around the 'exclusion area'.
 
   An <a>exclusion element</a> establishes a new <a href="">block formatting
-  context</a> (see [[!CSS21]]) for its content.
+  context</a> (see [[!CSS2]]) for its content.
 
   <figure>
       <img alt="General illustration showing how exclusions combine" src="images/exclusions-illustration.png" style="width: 70%" />
@@ -444,13 +444,13 @@ The values of this property have the following meanings:
 <h3 id="exclusions-order">
 Exclusions order</h3>
 
-  Exclusions follow the painting order (See [[!CSS21]] Appendix E). Exclusions are
+  Exclusions follow the painting order (See [[!CSS2]] Appendix E). Exclusions are
   applied in reverse to the document order in which they are defined. The last exclusion
   appears on top of all other exclusion, thus it affects the inline flow content of
   all other preceding exclusions or elements descendant of the same containing block.
   The 'z-index' property can be used to change the ordering of
   <a href="https://www.w3.org/TR/CSS2/visuren.html#choose-position">positioned</a> exclusion
-  boxes (see [[!CSS21]]). Statically positioned exclusions are not affected by the
+  boxes (see [[!CSS2]]). Statically positioned exclusions are not affected by the
   'z-index' property and thus follow the painting order.
 
 <div class="example">
@@ -569,7 +569,7 @@ Step 1: resolve exclusion boxes belonging to each <a>wrapping context</a></h4>
 <h4 id="step-2">
 Step 2: resolve wrapping contexts and lay out containing blocks</h4>
 
-  In this step, starting from the top of the <a href="https://www.w3.org/TR/CSS2/visuren.html#z-index">rendering tree</a> (see [[!CSS21]]), the agent processes each
+  In this step, starting from the top of the <a href="https://www.w3.org/TR/CSS2/visuren.html#z-index">rendering tree</a> (see [[!CSS2]]), the agent processes each
   containing block in two sub-steps.
 
 <h4 id="step-2-A">
@@ -697,7 +697,7 @@ Step 1: resolve exclusion boxes belonging to each <a>wrapping context</a></h5>
   <code class="idl">e1</code> is absolutely positioned and <code class="idl">d1</code>
   is relatively positioned. However, while <code class="idl">e2</code> is also absolutely
   positioned, its containing block is the initial containing block (ICB). See the
-  section 10.1 of the CSS 2.1 specification ([[!CSS21]]) for details.
+  section 10.1 of the CSS 2.1 specification ([[!CSS2]]) for details.
 
   As a result of the computation of containing blocks for the tree, the boxes
   belonging to the <a>wrapping context</a>s of all the elements can be determined:


### PR DESCRIPTION
The command:

```shell
bikeshed spec css-exclusions-1\Overview.bs
```

Throws error when called locally:
```shell
LINE ~51: The biblio refs [[CSS2]] and [[CSS21]] are both aliases of the same base reference [[CSS21]]. Please choose one name and use it consistently.
```

A search through the repositories shows that the alias `[[!CSS2]]` is used three times more often than `[[!CSS21]]`, so I replaced all aliases with `[[!CSS2]]`.

> All future specifications should refer to CSS 2.2 when referring to CSS level 2;

[Sourse](https://drafts.csswg.org/css2/#about)

But did not find a list of preferred aliases, so relied on the frequency of alias usage in the project. If such a list exists somewhere, please let me know.