### PR TITLE
[css-view-transitions-2] Stop extending CSSRule with obsolete pattern

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -433,14 +433,6 @@ Note: this needs to be cached in the boolean because the result needs to be read
 
 ### Accessing the ''@view-transition'' rule using CSSOM ### {#cssom}
 
-The <code>CSSRule</code> interface is extended as follows:
-
-<pre class='idl'>
-partial interface CSSRule {
-	const unsigned short VIEW_TRANSITION_RULE = 15;
-};
-</pre>
-
 The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 <xmp class=idl>


### PR DESCRIPTION
Fixes #10606