### PR TITLE
[css-ui-4] update outline value syntax

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -280,7 +280,7 @@ Outline properties</h2>
 
 	<pre class="propdef shorthand">
 	Name: outline
-	Value: [ <<'outline-color'>> || <<'outline-style'>> || <<'outline-width'>> ]
+	Value: [ <<'outline-width'>> || <<'outline-style'>> || <<'outline-color'>> ]
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A


### PR DESCRIPTION
- addresses https://github.com/w3c/csswg-drafts/issues/7700#issuecomment-1933183097
- addresses https://github.com/TalbotG/web-platform-tests/blob/3a2ba5940decbe028a26482b1c44243ba8d7338f/css/css-ui/parsing/canonical-order-outline-sub-properties-001.html#L132

The `outline` property needs to look consistent with the [`border`](https://drafts.csswg.org/css-backgrounds/#propdef-border) property. The rest of the document follows the `width style color` order from the first commit, so no change is required.
