### PR TITLE
[css-conditional-3] Fix Web IDL, `bool` should have been `boolean`

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -793,7 +793,7 @@ The {{CSSMediaRule}} interface represents a ''@media'' at-rule:
 [Exposed=Window]
 interface CSSMediaRule : CSSConditionRule {
     [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-    readonly attribute bool matches;
+    readonly attribute boolean matches;
 };
 </pre>
 
@@ -809,7 +809,7 @@ js/CSSConditionRule.html
     for the list of media queries specified with the ''@media'' at-rule.
     <wpt title=".media returns a MediaList matching the @media condition."></wpt>
 
-  <dt><code>matches</code> of type {{bool}}, readonly
+  <dt><code>matches</code> of type {{boolean}}, readonly
     <dd>The <code>matches</code> attribute returns true
       if the rule is in an stylesheet attached to a document
       whose {{Window}} matches this rule’s {{CSSMediaRule/media}} [=media query=],
@@ -831,7 +831,7 @@ The {{CSSSupportsRule}} interface represents a ''@supports'' rule.
 <pre class='idl'>
 [Exposed=Window]
 interface CSSSupportsRule : CSSConditionRule {
-  readonly attribute bool matches;
+  readonly attribute boolean matches;
 };
 </pre>
 
@@ -841,7 +841,7 @@ js/CSSConditionRule.html
 <wpt title="CSSSupportsRule represents an @supports rule."></wpt> -->
 
 <dl class='idl-attributes'>
-  <dt><code>matches</code> of type {{bool}}, readonly
+  <dt><code>matches</code> of type {{boolean}}, readonly
     <dd>The <code>matches</code> attribute returns the evaluation of
       the [=CSS feature query=] represented in {{CSSConditionRule/conditionText}}.
       <wpt title="CSSSupportsRule.matches returns true if matches feature query"></wpt>


### PR DESCRIPTION
Introduced by recent commit:
https://github.com/w3c/csswg-drafts/commit/3dab354901b4c9b2a716475efb98445317c65727

There's no `bool` type in Web IDL, only `boolean`.
