### PR TITLE
Fix reverse HLG transform

### DIFF
--- a/css-color-hdr/Overview.bs
+++ b/css-color-hdr/Overview.bs
@@ -578,7 +578,7 @@ Predefined color spaces for HDR: {#predefined-HDR}
 			E = (Edash ** 2) / 3;
 		}
 		else {
-			E = Math.exp(((Edash - c) / a) + b) / 12;
+			E = (Math.exp((Edash - c) / a) + b) / 12;
 		}
 	</pre>
 


### PR DESCRIPTION
The +b needs to happen outside of the exp() call to be the reverse of the original HLG.

We found this while writing tests for GTK doing roundtrips to HLG and back. See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7493