### PR TITLE
[css-highlight-api-1] Fix unquoted attribute values

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -626,7 +626,7 @@ Appendix D. Changes</h2>
 
 	<em>This section is non-normative</em>.
 
-<h3 class=no-num" id="changes-since-20211215">
+<h3 class="no-num" id="changes-since-20211215">
 Changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-20211215/">15 December 2021 Working Draft</a></h3>
 
 	In addition to various editorial improvements and minor tweaks,
@@ -641,7 +641,7 @@ Changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-202
 	* Added an I18N warning about placement of [=range=] endpoints in the middle of a
 		[=grapheme=] or [=supplementary character=].
 
-<h3 class=no-num" id="changes-since-20201208">
+<h3 class="no-num" id="changes-since-20201208">
 Changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-20201208/">8 December 2020 Working Draft</a></h3>
 
 	In addition to various editorial improvements and minor tweaks,
@@ -670,7 +670,7 @@ Changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-202
 		in support of exposing highlights to accessibility tools.
 		(See <a href="https://github.com/w3c/csswg-drafts/pull/6498">Issue 6498</a>)
 
-<h3 class=no-num" id="changes-since-20201022">
+<h3 class="no-num" id="changes-since-20201022">
 Changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-20201022/">22 October 2020 Working Draft</a></h3>
 
 	There have been only editorial changes since the <a href="https://www.w3.org/TR/2020/WD-css-highlight-api-1-20201022/">22 October 2020 Working Draft</a>;


### PR DESCRIPTION
Fix bikeshed errors.

The command:

```
bikeshed spec css-highlight-api-1\Overview.bs
```

Throws errors:

```
LINE 629:11: Character " (at 629:17) is invalid in unquoted attribute values.
LINE 629:11: Garbage after class=.
LINE 629:1: Garbage at 629:5 in <h3>.
LINE 644:11: Character " (at 644:17) is invalid in unquoted attribute values.
LINE 644:11: Garbage after class=.
LINE 644:1: Garbage at 644:5 in <h3>.
LINE 673:11: Character " (at 673:17) is invalid in unquoted attribute values.
LINE 673:11: Garbage after class=.
LINE 673:1: Garbage at 673:5 in <h3>.
```