### PR TITLE
[css-highlight-api-1] Fix broken links

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -203,7 +203,7 @@ Creating Custom Highlights</h3>
 			<li>
 				For each |range| of {{initialRanges}},
 				let |rangeArg| be the result of [=converted to an ECMAScript value|converting=] |range| to an ECMAScript value,
-				then run [[webidl#es-set-add|the steps for a built-in setlike add function]],
+				then run [[webidl#js-set-add|the steps for a built-in setlike add function]],
 				with |highlight| as the <code>this</code> value,
 				and |rangeArg| as the argument.
 			<li>
@@ -241,7 +241,7 @@ Registering Custom Highlights</h3>
 	<div algorithm="to register a custom highlight">
 		To [=register=] a [=custom highlight=],
 		invoke the <code>set</code> method of the [=highlight registry=]
-		which will run [[webidl#es-map-set|the steps for a built-in maplike set function]],
+		which will run [[webidl#js-map-set|the steps for a built-in maplike set function]],
 		with the [=highlight registry=] as the <code>this</code> value,
 		the passed-in [=custom highlight name=] as <var ignore>keyArg</var>,
 		and the passed-in highlight as <var ignore>valueArg</var>.


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-highlight-api-1\Overview.bs
```

Throws errors:
```
LINE ~203: Couldn't find section '#es-set-add' in spec 'webidl':
[[webidl#es-set-add|the steps for a built-in setlike add function]]
LINE ~241: Couldn't find section '#es-map-set' in spec 'webidl':
[[webidl#es-map-set|the steps for a built-in maplike set function]]
```