### PR TITLE
[css-inline-3] Fix broken tag

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -2568,7 +2568,7 @@ Ancestor Inlines</h4>
 	and subsequent content.
 
 <h4 id="initial-letter-multi-line">
-Multi-line Initial Letters</h4
+Multi-line Initial Letters</h4>
 
 	If an initial letter is too long to fit on one line,
 	it wraps (according to the usual text-wrapping rules),


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-inline-3\Overview.bs
```

Throws errors:
```
LINE 2571:27: Garbage after the tagname in </h4>.
```