### PR TITLE
[css-line-grid-1] Spurious / in <img>

### DIFF
--- a/css-line-grid-1/Overview.bs
+++ b/css-line-grid-1/Overview.bs
@@ -82,7 +82,7 @@ Background</h3>
 		<img src="images/line-grid-multicol.png"
 			width="480"
 			alt="Vertical rhythm kept through pictures and different size of text in a multi-column document"
-			/>
+		>
 		<p class="caption">Vertical rhythm kept through pictures and different size of text in a multi-column document.</p>
 	</div>
 
@@ -91,7 +91,7 @@ Background</h3>
 			<img src="images/line-grid-wrap.png"
 				width="276"
 				alt="Large text wraps within line grids"
-				/>
+			>
 			<p class="caption">Large text wraps within line grids.</p>
 		</div>
 
@@ -126,7 +126,7 @@ Background</h3>
 
 	<figure>
 		<img src="images/sidenote-aligned.png"
-			alt="sidenote rendering with aligned baselines"/>
+			alt="sidenote rendering with aligned baselines">
 		<figcaption>
 			Sidenote with baselines aligned to the body text.
 		</figcaption>
@@ -136,7 +136,7 @@ Background</h3>
 		<img src="images/width-multiple-of-em.png"
 			width="180" height="142"
 			alt="East Asian layouts may require width be a multiple of em without fractions"
-			/>
+		>
 		<p class="caption">East Asian layouts may require width
 			be a multiple of <em>em</em> without fractions.</p>
 	</div>
@@ -380,14 +380,14 @@ Snapping Line Boxes: the 'line-snap' property</h3>
 
 		<figure style="float:left;">
 			<img src="images/simple-no-snap.png"
-				alt="line positions before snapping"/>
+				alt="line positions before snapping">
 			<figcaption>
 				Before line snapping
 			</figcaption>
 		</figure>
 		<figure style="float:left;">
 			<img src="images/simple-snapped.png"
-				alt="line positions after snapping"/>
+				alt="line positions after snapping">
 			<figcaption>
 				After line snapping
 			</figcaption>
@@ -408,14 +408,14 @@ Snapping Line Boxes: the 'line-snap' property</h3>
 		</p>
 		<figure style="float:left;">
 			<img src="images/top-no-snap.png"
-				alt="line positions before snapping"/>
+				alt="line positions before snapping">
 			<figcaption>
 				Before line snapping
 			</figcaption>
 		</figure>
 		<figure style="float:left;">
 			<img src="images/top-snapped.png"
-				alt="line positions after snapping"/>
+				alt="line positions after snapping">
 			<figcaption>
 				After line snapping
 			</figcaption>
@@ -648,14 +648,14 @@ Interacting with other alignments</h3>
 
 		<figure style="float:left;">
 			<img src="images/first-center-part-snapped.png"
-				alt="line positions at step 1"/>
+				alt="line positions at step 1">
 			<figcaption>
 				Partial shifting
 			</figcaption>
 		</figure>
 		<figure style="float:left;">
 			<img src="images/first-center-snapped.png"
-				alt="line positions after full snapping"/>
+				alt="line positions after full snapping">
 			<figcaption>
 				Full line snapping
 			</figcaption>
@@ -671,14 +671,14 @@ Interacting with other alignments</h3>
 		</p>
 		<figure style="float:left;">
 			<img src="images/second-center-part-snapped.png"
-				alt="line positions at step 1"/>
+				alt="line positions at step 1">
 			<figcaption>
 				Partial shifting
 			</figcaption>
 		</figure>
 		<figure style="float:left;">
 			<img src="images/second-center-snapped.png"
-				alt="line positions after full snapping"/>
+				alt="line positions after full snapping">
 			<figcaption>
 				Full line snapping
 			</figcaption>
@@ -701,14 +701,14 @@ Interacting with other alignments</h3>
 
 		<figure style="float:left;">
 			<img src="images/bottom-no-snap.png"
-				alt="line positions before snapping"/>
+				alt="line positions before snapping">
 			<figcaption>
 				Before snapping
 			</figcaption>
 		</figure>
 		<figure style="float:left;">
 			<img src="images/bottom-snapped.png"
-				alt="line positions after snapping"/>
+				alt="line positions after snapping">
 			<figcaption>
 				After line snapping
 			</figcaption>


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-line-grid-1\Overview.bs
```

Throws errors:
```
LINE 82:3: Spurious / in <img>.
LINE 91:4: Spurious / in <img>.
LINE 128:3: Spurious / in <img>.
LINE 136:3: Spurious / in <img>.
LINE 382:4: Spurious / in <img>.
LINE 389:4: Spurious / in <img>.
LINE 410:4: Spurious / in <img>.
LINE 417:4: Spurious / in <img>.
LINE 650:4: Spurious / in <img>.
LINE 657:4: Spurious / in <img>.
LINE 673:4: Spurious / in <img>.
LINE 680:4: Spurious / in <img>.
LINE 703:4: Spurious / in <img>.
LINE 710:4: Spurious / in <img>.
```