### PR TITLE
[css-logical-1] Fix spurious / in <img>

### DIFF
--- a/css-logical-1/Overview.bs
+++ b/css-logical-1/Overview.bs
@@ -62,7 +62,7 @@ Introduction</h2>
         that works across different writing systems:
 
     <figure>
-        <img src="./images/example01.png" width="300" height="109" />
+        <img src="./images/example01.png" width="300" height="109">
         <figcaption>Rendering of the below code in a compatible browser</figcaption>
     </figure>
 


### PR DESCRIPTION
Fix bikeshed error.

The command:
```
bikeshed spec css-logical-1\Overview.bs
```

Throws error:
```
LINE 65:9: Spurious / in <img>.
```