### PR TITLE
[css-sizing] Add calc-size to productions for width/height and min/max-width/height.

### DIFF
--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -368,7 +368,7 @@ Preferred Size Properties: the 'width' and 'height' properties</h4>
 
 	<pre class=propdef>
 	Name: width, height
-	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr>
+	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
 	Initial: auto
 	Applies to: all elements except <a>non-replaced</a> <a>inlines</a>
 	Inherited: no
@@ -388,7 +388,7 @@ Minimum Size Properties: the 'min-width' and 'min-height' properties</h4>
 
 	<pre class=propdef>
 	Name: min-width, min-height
-	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr>
+	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
 	Initial: auto
 	Applies to: all elements that accept 'width' or 'height'
 	Inherited: no
@@ -411,7 +411,7 @@ Maximum Size Properties: the 'max-width' and 'max-height' properties</h4>
 
 	<pre class=propdef>
 	Name: max-width, max-height
-	Value: none | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr>
+	Value: none | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
 	Initial: none
 	Applies to: all elements that accept 'width' or 'height'
 	Inherited: no
@@ -425,6 +425,8 @@ Maximum Size Properties: the 'max-width' and 'max-height' properties</h4>
 	the <dfn export lt="max width | maximum width | max size | maximum size">maximum width</dfn> (or “max width”)
 	and <dfn export lt="max height | maximum height">maximum height</dfn> (or “max height”)
 	of the box, respectively.
+
+	Note: The ''max-width/none'' keyword is not usable within <</calc-size()>>.
 
 
 <h3 id="sizing-values" oldids='width-height-keywords'>
@@ -517,6 +519,11 @@ Sizing Values: the <<length-percentage [0,∞]>>, ''width/auto'' | ''max-width/n
 			exactly as for <<length-percentage>> values standing alone.
 
 			Negative <<length-percentage>> values are invalid.
+
+		<dt><dfn function lt="calc-size()"><</calc-size()>></dfn>
+		<dd>
+			See <</calc-size()>>.
+
 	</dl>
 
 	In all cases,

--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -368,7 +368,7 @@ Preferred Size Properties: the 'width' and 'height' properties</h4>
 
 	<pre class=propdef>
 	Name: width, height
-	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
+	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <<width/calc-size()>>
 	Initial: auto
 	Applies to: all elements except <a>non-replaced</a> <a>inlines</a>
 	Inherited: no
@@ -388,7 +388,7 @@ Minimum Size Properties: the 'min-width' and 'min-height' properties</h4>
 
 	<pre class=propdef>
 	Name: min-width, min-height
-	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
+	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <<min-width/calc-size()>>
 	Initial: auto
 	Applies to: all elements that accept 'width' or 'height'
 	Inherited: no
@@ -411,7 +411,7 @@ Maximum Size Properties: the 'max-width' and 'max-height' properties</h4>
 
 	<pre class=propdef>
 	Name: max-width, max-height
-	Value: none | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <</calc-size()>>
+	Value: none | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <<max-width/calc-size()>>
 	Initial: none
 	Applies to: all elements that accept 'width' or 'height'
 	Inherited: no
@@ -425,8 +425,6 @@ Maximum Size Properties: the 'max-width' and 'max-height' properties</h4>
 	the <dfn export lt="max width | maximum width | max size | maximum size">maximum width</dfn> (or “max width”)
 	and <dfn export lt="max height | maximum height">maximum height</dfn> (or “max height”)
 	of the box, respectively.
-
-	Note: The ''max-width/none'' keyword is not usable within <</calc-size()>>.
 
 
 <h3 id="sizing-values" oldids='width-height-keywords'>
@@ -520,9 +518,12 @@ Sizing Values: the <<length-percentage [0,∞]>>, ''width/auto'' | ''max-width/n
 
 			Negative <<length-percentage>> values are invalid.
 
-		<dt><dfn function lt="calc-size()"><</calc-size()>></dfn>
+		<dt><dfn function lt="calc-size()">calc-size()</dfn>
 		<dd>
 			See <</calc-size()>>.
+
+			Note: The ''max-width/none'' keyword is
+			not usable within ''max-width/calc-size()''.
 
 	</dl>
 

--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -145,6 +145,10 @@ New Sizing Values: the ''stretch'', ''fit-content'', and ''contain'' keywords</h
 			applies [=stretch-fit sizing=].
 	</dl>
 
+	Note: These new values add to the set of values
+	that the definition of <<calc-size()>>
+	refers to as "allowed in the context".
+
 <!-- Big Text: aspect-r
 
  ███▌   ███▌  ████▌  █████▌  ███▌  █████▌       ████▌ 


### PR DESCRIPTION
This adds calc-size() support to the grammar productions for width/height and min/max-width/height, which also implies adding them to the productions for block/inline-size and min/max-block/inline-size and to flex-basis.

This is part of #626.