### PR TITLE
[css-conditional-3] supports() must return false for invalid custom property value

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -901,11 +901,10 @@ partial namespace CSS {
 
       1. If |property| is an [=ASCII case-insensitive=] match
         for any defined CSS property that the UA supports,
+        or is a [=custom property name string=],
         and |value| successfully [=CSS/parses=] according to that property's grammar,
         return <code>true</code>.
-      2. Otherwise, if |property| is a [=custom property name string=],
-        return <code>true</code>.
-      3. Otherwise, return <code>false</code>.
+      2. Otherwise, return <code>false</code>.
 
       Note: No CSS escape or whitespace processing is performed on the property name,
       so <code>CSS.supports(" width", "5px")</code> will return <code>false</code>,


### PR DESCRIPTION
Fixes #8823.