### PR TITLE
[css-easing-2] correct the `<linear-stop-list>` syntax

### DIFF
--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -170,7 +170,7 @@ A [=linear easing function=] has the following syntax:
 
 <pre class="prod">
   <dfn>&lt;linear-easing-function></dfn> = <dfn function lt="linear()">linear(<<linear-stop-list>>)</dfn>
-  <dfn>&lt;linear-stop-list></dfn> = [ <<linear-stop>> ]#
+  <dfn>&lt;linear-stop-list></dfn> = [ <<linear-stop>> ]{2,}
   <dfn>&lt;linear-stop></dfn> = <<number>> && <<linear-stop-length>>?
   <dfn>&lt;linear-stop-length></dfn> = <<percentage>>{1,2}
 </pre>


### PR DESCRIPTION
The [parsing algo](https://drafts.csswg.org/css-easing/#linear-easing-function-parsing) for the `linear()` easing function says, "3. If there are less than two items in stopList, then return failure."

So in the current syntax `<linear-stop-list> = [ <linear-stop> ]#`, the `{2,}` would be more accurate than `#`.