### PR TITLE
[css-regions-1] Fix spurious / in <img>

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -112,7 +112,7 @@ Introduction</h2>
 
 		<figure style="float:left; margin:1em;">
 			<img alt="Article and aside rendering without CSS Regions"
-				src="images/linked-boxes-before.png"/>
+				src="images/linked-boxes-before.png">
 			<figcaption>
 				Rendering without CSS Regions
 			</figcaption>
@@ -120,7 +120,7 @@ Introduction</h2>
 
 		<figure style="float:left; margin:1em;">
 			<img alt="Article and aside rendering with CSS Regions"
-				src="images/linked-boxes-after.png"/>
+				src="images/linked-boxes-after.png">
 			<figcaption>
 				Rendering with CSS Regions
 			</figcaption>
@@ -164,7 +164,7 @@ Introduction</h2>
 
 		<figure>
 			<img alt="Wide nav bar showing all of the links"
-				src="images/menu-wide.png"/>
+				src="images/menu-wide.png">
 			<figcaption>
 				Wide rendering with menu shown
 			</figcaption>
@@ -172,7 +172,7 @@ Introduction</h2>
 
 		<figure>
 			<img alt="Narrow nav bar with some of the links in the menu"
-				src="images/menu-narrow.png"/>
+				src="images/menu-narrow.png">
 			<figcaption>
 				Narrow rendering with menu shown
 			</figcaption>
@@ -1610,7 +1610,7 @@ The Region Flow Content Box (RFCB)</h3>
 	</ul>
 
 	<figure>
-		<img src="images/RFCB.svg" width=600 alt="The ::before, RFCB and ::after boxes contained in the Region Box"/>
+		<img src="images/RFCB.svg" width=600 alt="The ::before, RFCB and ::after boxes contained in the Region Box">
 		<figcaption>
 			The Region Flow Content Box (RFCB)
 		</figcaption>
@@ -1674,7 +1674,7 @@ Regions visual formatting steps</h3>
 	</ul>
 
 	<figure>
-		<img src="images/regions-layout-three-steps.svg" width=600 alt="visual representation of the three-step process"/>
+		<img src="images/regions-layout-three-steps.svg" width=600 alt="visual representation of the three-step process">
 		<figcaption>
 			Regions visual formatting steps
 		</figcaption>
@@ -1904,7 +1904,7 @@ Step 1 - Phase 1: Laying out RFCBs with used height of zero</h4>
 	Conceptually, this produces the layout illustrated below.
 
 	<figure>
-		<img src="images/flow-fragment-height-phase-1.png" width=500 alt="Step 1 - Phase 1: Layout RFCBs with used heights of 0"/>
+		<img src="images/flow-fragment-height-phase-1.png" width=500 alt="Step 1 - Phase 1: Layout RFCBs with used heights of 0">
 		<figcaption>
 			Step 1 - Phase 1: Layout RFCBs with used heights of 0
 		</figcaption>
@@ -1941,7 +1941,7 @@ Step 1 - Phase 2: Layout flow to compute the RFCBs' flow fragments heights</h4>
 	This results in a resolved flow fragment height: FH-C.
 
 	<figure>
-		<img src="images/flow-fragment-height-phase-2.png" width=370 alt="Step 1 - Phase 2: Measure flow fragments heights"/>
+		<img src="images/flow-fragment-height-phase-2.png" width=370 alt="Step 1 - Phase 2: Measure flow fragments heights">
 		<figcaption>
 			Step 1 - Phase 2: Measure flow fragments heights
 		</figcaption>
@@ -1973,7 +1973,7 @@ Step 2: Layout document and regions without named flows</h4>
 	FH-C becomes rC's used 'height'.
 
 	<figure>
-		<img src="images/regions-visual-formatting-step-2.png" width=370 alt="Step 2: Layout document and regions without named flows"/>
+		<img src="images/regions-visual-formatting-step-2.png" width=370 alt="Step 2: Layout document and regions without named flows">
 		<figcaption>
 			Step 2: Layout document and regions without <a>named flows</a>
 		</figcaption>
@@ -2004,7 +2004,7 @@ Step 3: named flows layout</h4>
 	computed in Step 1 Phase 2.
 
 	<figure>
-		<img src="images/regions-visual-formatting-step-3.png" width=370 alt="Step 3: Final result after laying out named flows in regions"/>
+		<img src="images/regions-visual-formatting-step-3.png" width=370 alt="Step 3: Final result after laying out named flows in regions">
 		<figcaption>
 			Step 3: Final result after laying out <a>named flows</a> in regions
 		</figcaption>


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-regions-1\Overview.bs
```

Throws errors:
```
LINE 114:4: Spurious / in <img>.
LINE 122:4: Spurious / in <img>.
LINE 166:4: Spurious / in <img>.
LINE 174:4: Spurious / in <img>.
LINE 1613:3: Spurious / in <img>.
LINE 1677:3: Spurious / in <img>.
LINE 1907:3: Spurious / in <img>.
LINE 1944:3: Spurious / in <img>.
LINE 1976:3: Spurious / in <img>.
LINE 2007:3: Spurious / in <img>.
```