### PR TITLE
[css-regions-1] Fix inconsistency aliases

### DIFF
--- a/css-regions-1/Overview.bs
+++ b/css-regions-1/Overview.bs
@@ -468,7 +468,7 @@ The 'flow-into' property</h3>
 
 	Each <a>CSS Region</a> in a <a>region chain</a>
 	establishes a containing block for absolutely positioned
-	elements in the <a>named flow</a> (see [[!CSS21]]).
+	elements in the <a>named flow</a> (see [[!CSS2]]).
 	That first <a>CSS Region</a> in a <a>region chain</a>
 	establishes the initial containing block for such absolutely
 	positioned elements.
@@ -630,7 +630,7 @@ The 'flow-from' property</h3>
 	and the value of 'content' computes to ''content/none''
 	are generated as <a>CSS Regions</a>,
 	which is an update to the behavior
-	described in [[!CSS21]].
+	described in [[!CSS2]].
 
 	If an element has <a>style containment</a> (See [[!CSS-CONTAIN-1]]),
 	then the 'flow-from' property must be <a for=property>scoped</a> to that element.
@@ -979,7 +979,7 @@ The region-fragment property</h3>
 		on the last line,
 		the 'overflow' property controls
 		the visibility of the overflowing content.
-		See the 'overflow' property definition ([[CSS21]]).
+		See the 'overflow' property definition ([[CSS2]]).
 	</div>
 
 <h2 id="cssom_view_and_css_regions">
@@ -1631,7 +1631,7 @@ RFCB 'width' resolution</h4>
 	At various points in the visual formatting of documents containing regions,
 	the used 'width' of RFCBs and regions need to be resolved.
 	In all cases, the resolution is done following the rules for
-	<a href="https://www.w3.org/TR/CSS2/visudet.html#Computing_widths_and_margins">calculating widths and margins</a> (see [[!CSS21]]).
+	<a href="https://www.w3.org/TR/CSS2/visudet.html#Computing_widths_and_margins">calculating widths and margins</a> (see [[!CSS2]]).
 	Sometimes, resolving the used 'width' value requires
 	measuring the content's <code>min-content</code>
 	and <code>max-content</code> values


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-regions-1\Overview.bs
```

Throws errors:
```
LINE ~627: The biblio refs [[CSS21]] and [[CSS2]] are both aliases of the same base reference [[CSS21]]. Please choose one name and use it consistently.
LINE ~1631: The biblio refs [[CSS21]] and [[CSS2]] are both aliases of the same base reference [[CSS21]]. Please choose one name and use it consistently.
```

A search through the repositories shows that the alias [[!CSS2]] is used three times more often than [[!CSS21]], so I replaced all aliases with [[!CSS2]].