### PR TITLE
[css-round-display-1] Fix spurious / in <img>

### DIFF
--- a/css-round-display-1/Overview.bs
+++ b/css-round-display-1/Overview.bs
@@ -300,7 +300,7 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
     </pre>
 
     <figure>
-        <img src="images/viewport_fit_contain.png" alt="An image about the viewport applied to the bounding box specified with 'viewport-fit: contain'" style="width: 300px; text-align: center"/>
+        <img src="images/viewport_fit_contain.png" alt="An image about the viewport applied to the bounding box specified with 'viewport-fit: contain'" style="width: 300px; text-align: center">
         <figcaption>
             With '<code>viewport-fit: contain</code>'
         </figcaption>
@@ -321,7 +321,7 @@ If it have to be guaranteed that any part of the web page isn’t hidden, avoidi
     </pre>
 
     <figure>
-        <img src="images/viewport_fit_cover.png" alt="An image about the viewport applied to the bounding box specified with 'viewport-fit: cover'" style="width: 300px; text-align: center"/>
+        <img src="images/viewport_fit_cover.png" alt="An image about the viewport applied to the bounding box specified with 'viewport-fit: cover'" style="width: 300px; text-align: center">
         <figcaption>
             With '<code>viewport-fit: cover</code>'
         </figcaption>


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-round-display-1\Overview.bs
```

Throws errors:
```
LINE 303:9: Spurious / in <img>.
LINE 324:9: Spurious / in <img>.
```