### PR TITLE
[css-shapes-2] Fix spurious / in <img>

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -490,7 +490,7 @@ Declaring Shapes</h3>
 		<img class="singleImgExample"
 		src="images/shapes_CSS2.1_MBP.png"
 		alt="Example rendering of circle shape and box model."
-		style="max-width:40%"/>
+		style="max-width:40%">
 	</div>
 
 <h3 id="shape-outside-property">
@@ -565,7 +565,7 @@ The 'shape-inside' Property</h4>
 
 	<figure>
 		<img alt="Content flowing with and without a shape-inside"
-		     src="images/shape-inside-content.png"/>
+		     src="images/shape-inside-content.png">
 		<figcaption>Effect of shape-inside on inline content.</figcaption>
 	</figure>
 
@@ -581,10 +581,10 @@ The 'shape-inside' Property</h4>
 	<figure>
 		<img alt="Overflow interacting with rounded rect"
 		     style="display:inline-block;vertical-align:top"
-		     src="images/rounded-rect-overflow.png"/>
+		     src="images/rounded-rect-overflow.png">
 		<img alt="Overflow interacting with ellipse"
 		     style="display:inline-block;vertical-align:top"
-		     src="images/ellipse-overflow.png"/>
+		     src="images/ellipse-overflow.png">
 		<figcaption>
 			Overflow interacting with exclusion areas
 			defined by 'shape-inside' and 'shape-padding'.
@@ -654,7 +654,7 @@ The 'shape-padding' Property</h4>
 
 	<div class="example">
 		<figure>
-			<img src="images/shape-padding.png" alt="Example of a shape-padding offset"/>
+			<img src="images/shape-padding.png" alt="Example of a shape-padding offset">
 			<figcaption>
 				A 'shape-padding' creating an offset from a circular 'shape-inside'.
 				The light blue rectangles represent inline content


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-shapes-2\Overview.bs
```

Throws errors:
```
LINE 490:3: Spurious / in <img>.
LINE 567:3: Spurious / in <img>.
LINE 582:3: Spurious / in <img>.
LINE 585:3: Spurious / in <img>.
LINE 657:4: Spurious / in <img>.
```