### PR TITLE
[css-size-adjust-1] Fix inconsistency aliases

### DIFF
--- a/css-size-adjust-1/Overview.bs
+++ b/css-size-adjust-1/Overview.bs
@@ -60,8 +60,8 @@ Module interactions {#placement}
 --------------------------------
 
   This module adds additional features that are not defined in
-  [[CSS21]].  These features may lead to a different size being computed
-  than would be computed when following [[CSS21]] alone.
+  [[CSS2]].  These features may lead to a different size being computed
+  than would be computed when following [[CSS2]] alone.
 
 Value Definitions {#values}
 -----------------
@@ -108,22 +108,22 @@ conditions are:
 
 <ul>
   <li>when the total amount of text in the block formatting context (see
-  [[!CSS21]]) (excluding text inside descendant block formatting
+  [[!CSS2]]) (excluding text inside descendant block formatting
   contexts) is approximately smaller than the amount that would require
   wrapping to more than one or two lines within that context's
   width,</li>
 
   <li>when the objects to be adjusted are inside a block-level or
   ''display: inline-block'' element with a 'height' other than
-  ''height/auto'' (see [[!CSS21]]),</li>
+  ''height/auto'' (see [[!CSS2]]),</li>
 
   <li>when the objects to be adjusted are inside a
   ''display: inline-block'' element
   with a 'width' other than ''width/auto'' (see
-  [[!CSS21]]),</li>
+  [[!CSS2]]),</li>
 
   <li>when the objects to be adjusted have 'white-space' of ''white-space/pre'' or
-  ''white-space/nowrap'' (see [[!CSS21]]) or a 'text-wrap' of ''text-wrap/nowrap'' (see
+  ''white-space/nowrap'' (see [[!CSS2]]) or a 'text-wrap' of ''text-wrap/nowrap'' (see
   [[!CSS-TEXT-4]]).</li>
 
 </ul>


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-size-adjust-1\Overview.bs
```

Throws errors:
```
LINE ~69: The biblio refs [[CSS2]] and [[CSS21]] are both aliases of the same base reference [[CSS21]]. Please choose one name and use it consistently.
```

A search through the repositories shows that the alias [[!CSS2]] is used three times more often than [[!CSS21]], so I replaced all aliases with [[!CSS2]].