### PR TITLE
[css-tables-3] Fix spurious / in <img>

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -150,7 +150,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 	</style>
 
 	<figure>
-		<img alt="[see-caption-below]" src="images/table-structure.png" width=493 />
+		<img alt="[see-caption-below]" src="images/table-structure.png" width=493>
 		<figcaption>Two representations of the structure of a table (tree vs layout)</figcaption>
 	</figure>
 
@@ -632,7 +632,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 				The following schema describes the algorithm in a different way,
 					to make it easier to understand.
 			</p>
-			<img alt="[see-caption-below]" src="images/CSS-Tables-Layout-Merged.svg" style="width: 100%" />
+			<img alt="[see-caption-below]" src="images/CSS-Tables-Layout-Merged.svg" style="width: 100%">
 			<figcaption>Overview of the table layout algorithm. Not normative.</figcaption>
 		</figure>
 
@@ -2912,7 +2912,7 @@ With a table-internal box as non-containing block parent</h3>
 		The same applies for footer rows and the table bottom border.
 
 		<figure>
-			<img alt="[see-caption-below]" src="./images/CSS-Tables-Repeating-Headers.svg" style="width:100%; max-width: 500px;" />
+			<img alt="[see-caption-below]" src="./images/CSS-Tables-Repeating-Headers.svg" style="width:100%; max-width: 500px;">
 			<figcaption>Expected rendering of table with headers and footers fragmented across two pages</figcaption>
 		</figure>
 

--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -1800,7 +1800,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 
 				</div>
 			</details>
-			<img alt="[see-caption-below]" src="images/CSS-Tables-Column-Width-Assignment.svg" style="width: 100%" />
+			<img alt="[see-caption-below]" src="images/CSS-Tables-Column-Width-Assignment.svg" style="width: 100%">
 			<figcaption>Overview of the width distribution algorithm. Not normative.</figcaption>
 		</figure>
 
@@ -1986,14 +1986,14 @@ spec:css-sizing-3; type:property; text:box-sizing
 						<td>Baseline<table><tr><td>After</td></tr></table></td>
 						<td><table><tr><td>Baseline</td></tr></table>After</td>
 						<td><table align=right><tr><td>Before</td></tr></table><p>Baseline</p></td>
-						<td><img src="http://w3.org/favicon.ico" /><p>Baseline</p></td>
-						<td><img src="http://w3.org/favicon.ico" title="Baseline"/><br/><img src="http://w3.org/favicon.ico" title="After"/></td>
-						<td><img src="http://w3.org/favicon.ico" /><img src="http://w3.org/favicon.ico" /><!--Baseline--></td>
+						<td><img src="http://w3.org/favicon.ico"><p>Baseline</p></td>
+						<td><img src="http://w3.org/favicon.ico" title="Baseline"/><br/><img src="http://w3.org/favicon.ico" title="After"></td>
+						<td><img src="http://w3.org/favicon.ico"><img src="http://w3.org/favicon.ico"><!--Baseline--></td>
 					</tr></table>
 				</xmp>
 
 				<figure>
-					<img alt="[see-caption-below]" src="images/td-baseline-example-rendering.png" width="585" height="185" />
+					<img alt="[see-caption-below]" src="images/td-baseline-example-rendering.png" width="585" height="185">
 					<figcaption>Rendering of <a href="https://jsfiddle.net/x8sh0f60/3/">this example</a> in a compliant browser</figcaption>
 				</figure>
 			</div>
@@ -2654,7 +2654,7 @@ With a table-internal box as non-containing block parent</h3>
 			The correct rendering of this code snippet is depicted here:
 
 			<figure>
-				<img alt="[see-caption-below]" src="images/empty-cells-example.gif" width=500 height=300 />
+				<img alt="[see-caption-below]" src="images/empty-cells-example.gif" width=500 height=300>
 				<figcaption>Rendering of three columns whose middle one is hidden by empty-cells:hide</figcaption>
 			</figure>
 		</div>
@@ -2864,7 +2864,7 @@ With a table-internal box as non-containing block parent</h3>
 			and the vertical gap must be inserted after the repeated footer.
 
 		<figure>
-			<img alt="[see-caption-below]" src="./images/CSS-Tables-Fragmentation-1.svg" style="width:100%; max-width: 500px;" />
+			<img alt="[see-caption-below]" src="./images/CSS-Tables-Fragmentation-1.svg" style="width:100%; max-width: 500px;">
 			<figcaption>Expected rendering of table fragmented across two pages</figcaption>
 		</figure>
 
@@ -2876,7 +2876,7 @@ With a table-internal box as non-containing block parent</h3>
 			in its previous fragment (top borders must not be repainted in continuation fragments).
 
 		<figure>
-			<img alt="[see-caption-below]" src="./images/CSS-Tables-Fragmentation-2.svg" style="width:100%; max-width: 500px;" />
+			<img alt="[see-caption-below]" src="./images/CSS-Tables-Fragmentation-2.svg" style="width:100%; max-width: 500px;">
 			<figcaption>Expected rendering of table containing a tall row fragmented across two pages</figcaption>
 		</figure>
 


### PR DESCRIPTION
Fix bikeshed errors.

The command:
```
bikeshed spec css-tables-3\Overview.bs
```

Throws errors:
```
LINE 153:3: Spurious / in <img>.
LINE 635:4: Spurious / in <img>.
LINE 1803:4: Spurious / in <img>.
LINE 1996:6: Spurious / in <img>.
LINE 2657:5: Spurious / in <img>.
LINE 2867:4: Spurious / in <img>.
LINE 2879:4: Spurious / in <img>.
LINE 2915:4: Spurious / in <img>.
```