### PR TITLE
[css-tables-3] Fix misprint

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -932,7 +932,7 @@ spec:css-sizing-3; type:property; text:box-sizing
 				<li>All css properties of <a>table-column</a> and <a>table-column-group</a> boxes are ignored,
 					except when explicitly specified by this specification.
 
-				<li>The 'margin', 'padding', 'overflow' and 'z-index' of <a>table-track</a> and <a>table-track-group</a boxes> are ignored.
+				<li>The 'margin', 'padding', 'overflow' and 'z-index' of <a>table-track</a> and <a>table-track-group</a> boxes are ignored.
 
 				<li>The 'margin' of <a>table-cell</a> boxes is ignored (as if it was set to 0px).
 


### PR DESCRIPTION
The closing tag in the source code:
```
</a boxes>
```
Fixed tag, moved "boxes" into the text.
