### PR TITLE
[css-lists-3] Correct the counter-set example

### DIFF
--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -900,7 +900,7 @@ Manipulating Counter Values: the 'counter-increment' and 'counter-set' propertie
 			h1::before {
 					content: "Chapter " counter(chapter) ". ";
 					counter-increment: chapter;  /* Add 1 to chapter */
-					counter-reset: section;      /* Set section to 0 */
+					counter-set: section;      /* Set section to 0 */
 			}
 			h2::before {
 					content: counter(chapter) "." counter(section) " ";


### PR DESCRIPTION
For following reasons I think [the example](https://drafts.csswg.org/css-lists/#example-838dca3e) has a typo and it should use `counter-set` instead of `counter-reset`:
- the example is part of the `Manipulating Counter Values: the counter-increment and counter-set properties` section
- `counter-reset` creates a new counter so the comment `/* Set section to 0 */` is not accurate. The `counter-set` makes the comment more accurate.