### PR TITLE
[css-text-decor-4] Define `<length-percentage>` in one definition

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -351,23 +351,20 @@ Text Decoration Line Thickness: the 'text-decoration-thickness' property</h3>
 			use that width,
 			otherwise behaves as ''text-decoration-thickness/auto''.
 
-		<dt><dfn><<length>></dfn>
+		<dt><dfn><<length-percentage>></dfn>
 		<dd>
-			Specifies the thickness of text decoration lines as a fixed length.
-			The UA should round the actual value to the nearest integer device pixel,
-			and ensure it is at least one device pixel.
-
+			A length value specifies the thickness of text decoration lines as a fixed length.
+			
 			Note: A length will inherit as a fixed value,
 			and will not scale with the font.
 
-		<dt><dfn><<percentage>></dfn>
-		<dd>
-			<p>Specifies the thickness of text decoration lines as a percentage of ''1em''.
-			The UA should round the actual value to the nearest integer device pixel,
-			and ensure it is at least one device pixel.
+			A percentage value specifies the thickness of text decoration lines as a percentage of ''1em''.
 
 			Note: A percentage will inherit as a relative value,
 			and will therefore scale with changes in the font as it inherits.
+
+			The UA should round the actual value to the nearest integer device pixel,
+			and ensure it is at least one device pixel.
 	</dl>
 
 <h4 id="text-decoration-thickness">
@@ -684,16 +681,14 @@ Text Underline Offset: the 'text-underline-offset' property</h3>
 			and the UA was able to extract an appropriate metric to use
 			from the font.
 
-		<dt><dfn><<length>>
+		<dt><dfn><<length-percentage>></dfn>
 		<dd>
-			<p>Specifies the offset of underlines as a fixed length.
+			<p>A length value specifies the offset of underlines as a fixed length.
 
 			Note: A length will inherit as a fixed value,
 			and will not scale with the font.
 
-		<dt><dfn><<percentage>>
-		<dd>
-			<p>Specifies the offset of underlines as a percentage of ''1em''.
+			A percentage value specifies the offset of underlines as a percentage of ''1em''.
 
 			Note: A percentage will inherit as a relative value,
 			and will therefore scale with changes in the font as it inherits.


### PR DESCRIPTION
Instead of having a separate definition for `<length>` and `<percentage>`.

Fixes #9469