### PR TITLE
[css-view-transitions-2] `view-transition-class` is a tree-scoped name

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -645,6 +645,8 @@ div.box {
 		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
 			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with another <<custom-ident>>.
 
+			Each [=view transition name=] is a [=tree-scoped name=].
+
 			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
 			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view transitions:
 			classes from the old document would only apply if their corresponding 'view-transition-name' was not specified in the new document.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -645,7 +645,7 @@ div.box {
 		:: All of the specified <<custom-ident>> values (apart from <css>none</css>) are applied when used in [=named view transition pseudo-element=] selectors.
 			<css>none</css> is an invalid <<custom-ident>> for 'view-transition-class', even when combined with another <<custom-ident>>.
 
-			Each [=view transition name=] is a [=tree-scoped name=].
+			Each 'view transition class' is a [=tree-scoped name=].
 
 			Note: If the same 'view-transition-name' is specified for an element both in the old and new states of the transition,
 			only the 'view-transition-class' values from the new state apply. This also applies for cross-document view transitions:
@@ -980,7 +980,7 @@ Prepend the following step to the [=Perform pending transition operations=] algo
 <div algorithm="additional capture steps">
 When capturing the old or new state for an element, perform the following steps given a [=captured element=] |capture| and an [=element=] |element|:
 
-	1. Set |capture|'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class'.
+	1. Set |capture|'s [=captured element/class list=] to the [=computed value=] of |element|'s 'view-transition-class', if it is associated with |element|'s [=node document=].
 
 	Note: This is written in a monkey-patch manner, and will be merged into the algorithm once the L1 spec graduates.
 </div>


### PR DESCRIPTION
Resolution: https://github.com/w3c/csswg-drafts/issues/10529#issuecomment-2274241823
Closes #10529