### PR TITLE
[css-values-4] Math functions also match mixed types

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -4458,6 +4458,7 @@ Type Checking</h3>
 	according to which of those productions its [=CSSNumericValue/type=] [=CSSNumericValue/matches=].
 	(These categories are mutually exclusive.)
 	If it can't [=CSSNumericValue/match=] any of these,
+	or the <<length-percentage>>/etc mixed types,
 	the [=math function=] is invalid.
 
 	Note: Algebraic simplifications do not affect the validity of a [=math function=] or its resolved type.


### PR DESCRIPTION
  > A math function resolves to `<number>`, `<length>`, `<angle>`, `<time>`, `<frequency>`, `<resolution>`, `<flex>`, or `<percentage>` [...] **If it can’t match any of these, the math function is invalid.**

From [CSS Typed OM](https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match):

  > A type matches `<length-percentage>` if its only non-zero entry is either `«[ "length" → 1 ]»` or `«[ "percent" → 1 ]»`.