### PR TITLE
[css-values-5] Require calc-size() calculation types to match <length…

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1771,7 +1771,8 @@ The first argument given is the <dfn>calc-size basis</dfn>,
 and the second is the <dfn>calc-size calculation</dfn>.
 For either argument,
 if a <<calc-sum>> is given,
-it must resolve to a <<length>>.
+its [=CSSNumericValue/type=] must [=CSSNumericValue/match=] <<length-percentage>>,
+and it must resolve to a <<length>>.
 
 Within the [=calc-size calculation=],
 if the [=calc-size basis=] is not ''calc-size()/any'',


### PR DESCRIPTION
The current definition says calculations must resolve to `<length>` but exemples and section 9.1 show their type can match `<length-percentage>`, therefore I suggest requiring it explicitly.