### PR TITLE
[css-grid-2] Fixed link to "Stretch 'auto' Tracks" section

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -4688,7 +4688,7 @@ Track Sizing Algorithm</h3>
 		<li>[[#algo-content|Resolve Intrinsic Track Sizes]]
 		<li>[[#algo-grow-tracks|Maximize Tracks]]
 		<li>[[#algo-flex-tracks|Expand Flexible Tracks]]
-		<li>[[#algo-stretch|Expand Stretched <css>auto</css> Tracks]]
+		<li><a section href=#algo-stretch>Expand Stretched <css>auto</css> Tracks</a>
 	</ol>
 
 <h3 id="algo-init">


### PR DESCRIPTION
Fixed a link to the section "Stretch 'auto' Tracks" by reusing the markup from CSS Grid 1.

The issue is that Bikeshed doesn't seem to allow markup within section link shortcuts.

Sebastian