### PR TITLE
[selectors-4] Add :has() to the list of logical combination pseudo-classes

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -1043,7 +1043,7 @@ Logical Combinations</h2>
 	[=compound selector|compounding=] (logical AND),
 	[=selector lists=] (logical OR),
 	and the <dfn>logical combination pseudo-classes</dfn>
-	'':is()'', '':where()'', and '':not()''.
+	'':is()'', '':where()'', '':not()'', and '':has()''.
 	The [=logical combination pseudo-classes=]
 	are allowed anywhere that any other [=pseudo-classes=] are allowed,
 	but pass any restrictions to their arguments.


### PR DESCRIPTION
As discussed in #10693.