### PR TITLE
[selectors-4] Fix bikeshed warnings

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -37,11 +37,12 @@ spec:css-pseudo-4; type:selector;
 	text: ::after
 	text: ::first-line
 	text: ::first-letter
+spec:dom; type:dfn; text:descendant
+spec:html; type:dfn; text:muted
 spec:html; type:element-attr; for:a; text:href
 spec:html; type:element;
 	text:meta
 	text:audio
-
 </pre>
 
 <style>
@@ -528,7 +529,7 @@ Structure and Terminology</h3>
 
 	A <dfn id="compound" export>compound selector</dfn>
 	is a sequence of <a>simple selectors</a>
-	that are not separated by a <a>combinator</a>,
+	that are not separated by a <a for=selector>combinator</a>,
 	and represents a set of simultaneous conditions on a single element.
 	If it contains a <a>type selector</a> or <a>universal selector</a>,
 	that selector must come first in the sequence.
@@ -547,7 +548,7 @@ Structure and Terminology</h3>
 	optionally followed by additional [=pseudo-class=] selectors,
 	and optionally preceded by a [=compound selector=]
 	or another [=pseudo-compound selector=],
-	without any [=combinators=].
+	without any [=selector/combinators=].
 	(A <a>pseudo-compound selector</a> is represented by <<pseudo-compound-selector>>
 	in the selectors <a href="#grammar">grammar</a>.)
 	A [=pseudo-element=] [=matches=] a [=pseudo-compound selector=]
@@ -572,7 +573,7 @@ Structure and Terminology</h3>
 	Note: A [=pseudo-compound selector=] <strong>is not</strong>
 	a [=compound selector=],
 	and can't be used in places that expect a [=compound selector=] only.
-	[=Pseudo-compound selectors=] act as if they carry a [=combinator=] with themselves,
+	[=Pseudo-compound selectors=] act as if they carry a [=selector/combinator=] with themselves,
 	expressing their relationship with their [=originating element=],
 	just as the ''>'' combinator
 	expresses a relationship with a parent element.
@@ -585,16 +586,16 @@ Structure and Terminology</h3>
 	the <a>child combinator</a> (U+003E, <code>></code>),
 	the <a>next-sibling combinator</a> (U+002B, <code>+</code>),
 	and the <a>subsequent-sibling combinator</a> (U+007E, <code>~</code>).
-	Two given elements are said to <a>match</a> a <a>combinator</a>
+	Two given elements are said to <a>match</a> a <a for=selector>combinator</a>
 	when the condition of relationship between these elements is true.
 
 	A <dfn id="complex" export>complex selector</dfn> is
 	a sequence of one or more <a>compound selectors</a>
 	and/or [=pseudo-compound selectors=],
-	with [=compound selectors=] separated by <a>combinators</a>.
+	with [=compound selectors=] separated by <a for=selector>combinators</a>.
 	It represents a set of simultaneous conditions
 	on a set of elements in the particular relationships
-	described by its <a>combinators</a>.
+	described by its <a for=selector>combinators</a>.
 	(Complex selectors are represented by <<complex-selector>>
 	in the selectors <a href="#grammar">grammar</a>.)
 	A given element or pseudo-element
@@ -712,7 +713,7 @@ Relative Selectors</h3>
 	Certain contexts may accept <dfn lt="relative selector" local-lt="relative" export>relative selectors</dfn>,
 	which are a shorthand for selectors that represent elements relative to one or more
 	<dfn export local-lt="anchor element">relative selector anchor elements</dfn>.
-	Relative selectors begin with a <a>combinator</a>,
+	Relative selectors begin with a <a for=selector>combinator</a>,
 	with a selector representing the [=anchor element=]
 	implied at the start of the selector.
 	(If no combinator is present,
@@ -916,7 +917,7 @@ Internal Structure</h4>
 	Some <a>pseudo-elements</a> are defined to have internal structure.
 	These <a>pseudo-elements</a> may be followed by child/descendant combinators
 	to express those relationships.
-	Selectors containing <a>combinators</a> after the pseudo-element
+	Selectors containing <a for=selector>combinators</a> after the pseudo-element
 	are otherwise invalid.
 
 	<div class="example">
@@ -1133,7 +1134,7 @@ The Matches-Any Pseudo-class: '':is()''</h3>
 	they are not valid within '':is()''.
 
 	Default namespace declarations do not affect the <a>compound selector</a>
-	representing the <a>subject</a> of any selector
+	representing the <a for=selector>subject</a> of any selector
 	within a '':is()'' pseudo-class,
 	unless that compound selector contains
 	an explicit <a>universal selector</a> or <a>type selector</a>.
@@ -1171,7 +1172,7 @@ The Negation (Matches-None) Pseudo-class: '':not()''</h3>
 
 	Note: The specificity of the '':not()'' pseudo-class
 	is replaced by the specificity of the most specific selector in its argument;
-	thus it has the exact behavior of '':not(:is(<var>argument</var>))''.
+	thus it has the exact behavior of '':not(:is(<var ignore>argument</var>))''.
 	See [[#specificity-rules]].
 
 	Pseudo-elements cannot be represented by the negation pseudo-class;
@@ -1195,7 +1196,7 @@ The Negation (Matches-None) Pseudo-class: '':not()''</h3>
 
 	As with '':is()'',
 	default namespace declarations do not affect the <a>compound selector</a>
-	representing the <a>subject</a> of any selector
+	representing the <a for=selector>subject</a> of any selector
 	within a '':not()'' pseudo-class,
 	unless that compound selector contains
 	an explicit <a>universal selector</a> or <a>type selector</a>.
@@ -1978,7 +1979,7 @@ The Language Pseudo-class: '':lang()''</h3>
 
 	Note: The <a>content language</a> of an element is defined by the document language.
 
-  For example, in HTML [[HTML5]], the <a>content language</a> is determined
+	For example, in HTML [[HTML5]], the <a>content language</a> is determined
 	by a combination of the <code>lang</code> attribute,
 	information from <a element>meta</a> elements,
 	and possibly also the protocol (e.g. from HTTP headers).
@@ -3839,7 +3840,7 @@ Match a Selector Against an Element</h3>
 		complex selector, return success.
 
 		<li>Otherwise, consider all possible elements
-		that could be related to this element by the rightmost <a>combinator</a>.
+		that could be related to this element by the rightmost <a for=selector>combinator</a>.
 		If the operation of matching the selector consisting of this selector
 		with the rightmost compound selector and rightmost combinator removed
 		against any one of these elements returns success, then return success.


### PR DESCRIPTION
- Add link-defaults for two definitions
- Fix numerous "Ambiguous for-less link" warnings
- Convert spaces to tabs on line 1980
- Tag var 'argument' with 'ignore' where it's used in a Note
