### PR TITLE
[css-backgrounds-4] Added repeat-block and `repeat-inline` keywords for `background-repeat`

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -143,7 +143,7 @@ Tiling Images Shorthand: the 'background-repeat' property</h3>
 	<p>This shorthand sets the values for the
 	'background-repeat-x' and 'background-repeat-y' longhand properties.
 	Where
-	<pre class=prod><dfn><<repeat-style>></dfn> = repeat-x | repeat-y | <<repetition>>{1,2}</pre>
+	<pre class=prod><dfn><<repeat-style>></dfn> = repeat-x | repeat-y | repeat-block | repeat-inline | <<repetition>>{1,2}</pre>
 
 	<p>Single values for <<repeat-style>> have the following
 	meanings:
@@ -156,6 +156,14 @@ Tiling Images Shorthand: the 'background-repeat' property</h3>
 	<dt><dfn>repeat-y</dfn>
 	<dd>
 	Computes to ''no-repeat repeat''.
+
+	<dt><dfn>repeat-block</dfn>
+	<dd>
+	Computes to itself. The [=used value=] will be ''repeat'' in [=block flow direction|block direction=] and ''no-repeat'' in [=inline base direction|inline direction=].
+
+	<dt><dfn>repeat-inline</dfn>
+	<dd>
+	Computes to itself. The [=used value=] will be ''repeat'' in [=inline base direction|inline direction=] and ''no-repeat'' in [=block flow direction|block direction=].
 
 	<dt>''background-repeat-x/repeat''
 	<dd>


### PR DESCRIPTION
This adds the logical values `repeat-block` and `repeat-inline` to `background-repeat` as [resolved in #116](https://github.com/w3c/csswg-drafts/issues/116#issuecomment-1854430181).

Sebastian