### PR TITLE
[css-view-transitions-2] CSSViewTransitionRule.navigation returns an empty string for invalid/missing descriptor

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -442,19 +442,28 @@ Note: this needs to be cached in the boolean because the result needs to be read
 			via the URL address bar or clicking a bookmark, as well as any form of user or script initiated {{NavigationType/reload}}.
 	</dl>
 
+This at-rule conforms with the forward-compatible parsing requirement of CSS;
+conformant parsers that don't understand these rules will ignore them without error.
+Any descriptors that are not recognized or implemented by a given user agent,
+or whose value does not match the grammars given here or in a future version of this specification,
+must be ignored in their entirety;
+they do not make the ''@view-transition'' rule invalid.
+
 ### Accessing the ''@view-transition'' rule using CSSOM ### {#cssom}
 
 The {{CSSViewTransitionRule}} represents a ''@view-transition'' rule.
 
 <xmp class=idl>
-		enum ViewTransitionNavigation { "auto", "none" };
-
 		[Exposed=Window]
 		interface CSSViewTransitionRule : CSSRule {
-			readonly attribute ViewTransitionNavigation navigation;
+			readonly attribute CSSOMString navigation;
 			[SameObject] readonly attribute FrozenArray<CSSOMString> types;
 		};
 </xmp>
+
+The {{CSSViewTransitionRule/navigation}} getter step is to return the value of the corresponding ''@view-transition/navigation'' descriptor if one exists, otherwise the empty string.
+
+The {{CSSViewTransitionRule/types}} getter steps is to return the value of the corresponding ''@view-transition/types'' descriptor if one exists, otherwise an empty [=list=].
 
 # Selective view transitions # {#selective-vt}
 


### PR DESCRIPTION
…
Closes #10654

