### PR TITLE
[css-view-transitions] Rename UpdateCallback to something more specific.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -171,14 +171,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	A successful [=view transition=] goes through the following phases:
 
-	1. Developer calls <code>document.{{Document/startViewTransition}}({{UpdateCallback|updateCallback}})</code>,
+	1. Developer calls <code>document.{{Document/startViewTransition}}({{ViewTransitionUpdateCallback|updateCallback}})</code>,
 		which returns a {{ViewTransition}}, <var>viewTransition</var>.
 
 	1. Current state captured as the “old” state.
 
 	1. Rendering paused.
 
-	1. Developer's {{UpdateCallback|updateCallback}} function, if provided, is called,
+	1. Developer's {{ViewTransitionUpdateCallback|updateCallback}} function, if provided, is called,
 		which updates the document state.
 
 	1. <code><var>viewTransition</var>.{{ViewTransition/updateCallbackDone}}</code> fulfills.
@@ -237,14 +237,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	to an underlying document state change.
 	That means a failure to create a visual transition,
 	which can happen due to misconfiguration or device constraints,
-	will not prevent the developer's {{UpdateCallback}} being called,
+	will not prevent the developer's {{ViewTransitionUpdateCallback}} being called,
 	even if it's known in advance that the transition animations cannot happen.
 
 	For example, if the developer calls {{ViewTransition/skipTransition()}} at the start of the [[#lifecycle|view transition lifecycle]],
 	the steps relating to the animated transition,
 	such as creating the [=view transition tree=],
 	will not happen.
-	However, the {{UpdateCallback}} will still be called.
+	However, the {{ViewTransitionUpdateCallback}} will still be called.
 	It's only the visual transition that's skipped,
 	not the underlying state change.
 
@@ -252,7 +252,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	then that needs to be handled by another feature.
 	<code>{{NavigateEvent|navigateEvent}}.{{NavigateEvent/signal}}</code> is an example of a feature developers could use to handle this.
 
-	Although the View Transition API allows DOM changes to be asynchronous via the {{UpdateCallback}},
+	Although the View Transition API allows DOM changes to be asynchronous via the {{ViewTransitionUpdateCallback}},
 	the API is not responsible for queuing or otherwise scheduling DOM changes
 	beyond any scheduling needed for the transition itself.
 	Some asynchronous DOM changes can happen concurrently (e.g if they're happening within independent components),
@@ -935,29 +935,29 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<xmp class=idl>
 		partial interface Document {
-			ViewTransition startViewTransition(optional UpdateCallback updateCallback);
+			ViewTransition startViewTransition(optional ViewTransitionUpdateCallback updateCallback);
 		};
 
-		callback UpdateCallback = Promise<any> ();
+		callback ViewTransitionUpdateCallback = Promise<any> ();
 	</xmp>
 
 	<dl class="domintro non-normative">
-		: <code>{{ViewTransition|viewTransition}} = {{Document|document}}.{{startViewTransition}}({{UpdateCallback|updateCallback}})</code>
+		: <code>{{ViewTransition|viewTransition}} = {{Document|document}}.{{startViewTransition}}({{ViewTransitionUpdateCallback|updateCallback}})</code>
 		:: Starts a new [=view transition=]
 			(canceling the {{Document|document}}’s existing [=active view transition=], if any).
 
-			{{UpdateCallback|updateCallback}}, if provided, is called asynchronously, once the current state of the document is captured.
-			Then, when the promise returned by {{UpdateCallback|updateCallback}} fulfills,
+			{{ViewTransitionUpdateCallback|updateCallback}}, if provided, is called asynchronously, once the current state of the document is captured.
+			Then, when the promise returned by {{ViewTransitionUpdateCallback|updateCallback}} fulfills,
 			the new state of the document is captured
 			and the transition is initiated.
 
-			Note that {{UpdateCallback|updateCallback}}, if provided, is *always* called,
+			Note that {{ViewTransitionUpdateCallback|updateCallback}}, if provided, is *always* called,
 			even if the transition cannot happen
 			(e.g. due to duplicate `view-transition-name` values).
 			The transition is an enhancement around the state change, so a failure to create a transition never prevents the state change.
 			See [[#transitions-as-enhancements]] for more details on this principle.
 
-			If the promise returned by {{UpdateCallback|updateCallback}} rejects, the transition is skipped.
+			If the promise returned by {{ViewTransitionUpdateCallback|updateCallback}} rejects, the transition is skipped.
 	</dl>
 
 ### {{Document/startViewTransition()}} Method Steps ### {#ViewTransition-prepare}
@@ -1010,7 +1010,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	<dl class="domintro non-normative">
 		: <code>{{ViewTransition|viewTransition}}.{{ViewTransition/updateCallbackDone}}</code>
-		:: A promise that fulfills when the promise returned by {{UpdateCallback|updateCallback}} fulfills, or rejects when it rejects.
+		:: A promise that fulfills when the promise returned by {{ViewTransitionUpdateCallback|updateCallback}} fulfills, or rejects when it rejects.
 
 			Note: The View Transition API wraps a DOM change and creates a visual transition.
 			However, sometimes you don't care about the success/failure of the transition animation,
@@ -1032,7 +1032,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		: <code>{{ViewTransition|viewTransition}}.{{ViewTransition/finished}}</code>
 		:: A promise that fulfills once the end state is fully visible and interactive to the user.
 
-			It only rejects if {{UpdateCallback|updateCallback}} returns a rejected promise,
+			It only rejects if {{ViewTransitionUpdateCallback|updateCallback}} returns a rejected promise,
 			as this indicates the end state wasn't created.
 
 			Otherwise, if a transition fails to begin,
@@ -1043,7 +1043,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		: <code>{{ViewTransition|viewTransition}}.{{ViewTransition/skipTransition}}()</code>
 		:: Immediately finish the transition, or prevent it starting.
 
-			This never prevents {{UpdateCallback|updateCallback}} being called,
+			This never prevents {{ViewTransitionUpdateCallback|updateCallback}} being called,
 			as the DOM change is independent of the transition.
 			See [[#transitions-as-enhancements]] for more details on this principle.
 
@@ -1073,7 +1073,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			The description of the phases below tries to be as precise as possible, with an intent to provide an unambiguous set of steps for implementors to follow in order to produce a spec-compliant implementation.
 
 		: <dfn>update callback</dfn>
-		:: an {{UpdateCallback}} or null. Initially null.
+		:: a {{ViewTransitionUpdateCallback}} or null. Initially null.
 
 		: <dfn>ready promise</dfn>
 		:: a {{Promise}}.
@@ -1248,7 +1248,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			perform the following steps:
 
 		Note: This algorithm captures the current state of the document,
-		calls the transition's {{UpdateCallback}},
+		calls the transition's {{ViewTransitionUpdateCallback}},
 		then captures the new state of the document.
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
@@ -1999,12 +1999,12 @@ Changes from <a href="https://www.w3.org/TR/2022/WD-css-view-transitions-1-20221
 * Pointer events resolve to the documentElement when rendering is suppressed. See <a href="https://github.com/w3c/csswg-drafts/issues/7797">issue 7797</a>.
 * Add rendering constraints to elements participating in a transition. See <a href="https://github.com/w3c/csswg-drafts/issues/8139">issue 8139</a> and <a href="https://github.com/w3c/csswg-drafts/issues/7882">issue 7882</a>.
 * Remove html specifics from UA stylesheet to support ViewTransitions on SVG Documents.
-* Rename updateDOMCallback to {{UpdateCallback}}. See <a href="https://github.com/w3c/csswg-drafts/issues/8144">issue 8144</a>.
+* Rename updateDOMCallback to {{ViewTransitionUpdateCallback}}. See <a href="https://github.com/w3c/csswg-drafts/issues/8144">issue 8144</a>.
 * Rename snapshot viewport to [=snapshot containing block=].
 * Skip the transition if viewport size changes. See <a href="https://github.com/w3c/csswg-drafts/issues/8045">issue 8045</a>.
 * Add support for :only-child. See <a href="https://github.com/w3c/csswg-drafts/issues/8057">issue 8057</a>.
 * Add concept of a tree of pseudo-elements under [=pseudo-element root=]. See <a href="https://github.com/w3c/csswg-drafts/issues/8113">issue 8113</a>.
-* When skipping a transition, the {{UpdateCallback}} is called in own task rather than synchronously. See <a href="https://github.com/w3c/csswg-drafts/issues/7904">issue 7904</a>
+* When skipping a transition, the {{ViewTransitionUpdateCallback}} is called in own task rather than synchronously. See <a href="https://github.com/w3c/csswg-drafts/issues/7904">issue 7904</a>
 * When capturing images, at least the in-viewport part of the image should be captured, downscale if needed. See <a href="https://github.com/w3c/csswg-drafts/issues/8561">issue 8561</a>.
 * Applying the [=ink overflow=] to the captured image is implementation defined, and doesn't affect the image's [=natural size=]. See <a href="https://github.com/w3c/csswg-drafts/issues/8597">issue 8597</a>.
 * Fragmented elements don't participate in view transitions. See <a href="https://github.com/w3c/csswg-drafts/issues/8339">issue 8339</a>.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -714,13 +714,12 @@ div.box {
 # Extending {{Document/startViewTransition|document.startViewTransition()}} # {#extend-document-types}
 	<xmp class=idl>
 		dictionary StartViewTransitionOptions {
-			UpdateCallback? update = null;
+			ViewTransitionUpdateCallback? update = null;
 			sequence<DOMString>? types = null;
 		};
 
 		partial interface Document {
-
-			ViewTransition startViewTransition(optional (UpdateCallback or StartViewTransitionOptions) callbackOptions = {});
+			ViewTransition startViewTransition(optional (ViewTransitionUpdateCallback or StartViewTransitionOptions) callbackOptions = {});
 		};
 	</xmp>
 
@@ -730,7 +729,7 @@ div.box {
 
 		1. Let |updateCallback| be null.
 
-		1. If |callbackOptions| is an an {{UpdateCallback}}, set |updateCallback| to |callbackOptions|.
+		1. If |callbackOptions| is a {{ViewTransitionUpdateCallback}}, set |updateCallback| to |callbackOptions|.
 
 		1. Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |updateCallback| to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
 


### PR DESCRIPTION
The WebIDL namespace is global, it's a bit better if we call this something a bit more view-transitions-specific so that other specs don't rely on it, since UpdateCallback is otherwise very generic.

I don't think this would be a normative change since the name of a callback isn't exposed anywhere author visible.