### PR TITLE
[css-values-5] Define the appropriate components as optional

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -433,7 +433,7 @@ Representing Interpolation Progress: the <<progress>> type</h3>
 
 	Its syntax is defined as follows:
 	<pre class=prod>
-		<<progress>> = [ <<percentage>> | <<number>> | <<'animation-timeline'>> ]? && by <<easing-function>>
+		<<progress>> = [ <<percentage>> | <<number>> | <<'animation-timeline'>> ] && [ by <<easing-function>> ]?
 	</pre>
 
 	where:


### PR DESCRIPTION
`<progress>` currently requires a timing function and allow omitting the progress numeric value. I think this is a typo.