### PR TITLE
[css-values-5] Require only the name of the media feature

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -311,7 +311,7 @@ Media Query Progress Values: the ''media-progress()'' notation</h3>
 	Similar to the ''progress()'' notation,
 	the <dfn>media-progress()</dfn> functional notation
 	returns a <<number>> value
-	representing current value of the specified [=media query=]
+	representing current value of the specified [=media feature=]
 	[[!MEDIAQUERIES-4]]
 	as a [=progress value=]
 	between two explicit values of the [=media query=]
@@ -320,14 +320,14 @@ Media Query Progress Values: the ''media-progress()'' notation</h3>
 	The syntax of ''media-progress()'' is defined as follows:
 
 	<pre class=prod>
-		<dfn><<media-progress()>></dfn> = media-progress(<<media-feature>> from <<calc-sum>> to <<calc-sum>>)
+		<dfn><<media-progress()>></dfn> = media-progress(<<mf-name>> from <<calc-sum>> to <<calc-sum>>)
 	</pre>
 
 	The value returned by a valid ''media-progress()'' notation is
 	<var>progress value</var> / (<var>end value</var> - <var>start value</var>,
 	as a <<number>>.
 
-	The specified [=media query=] must be a valid “range” type query,
+	The specified <<mf-name>> must be a valid “range” type query,
 	and its specified [=progress start value=] and [=progress end value=]
 	must be valid values for the specified [=media query=],
 	or else the function is invalid.


### PR DESCRIPTION
[`media-progress()`](https://drafts.csswg.org/css-values-5/#media-progress-func) currently wants a full (range) [media feature](https://drafts.csswg.org/mediaqueries-4/#typedef-media-feature). For example: `1px < width`.

But I think `media-progress(width from 0px to 2px)` is expected, ie. the media feature *name*.