### PR TITLE
[css-shapes-1] Restore the default value of <radial-size> when omitted

### DIFF
--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -462,10 +462,10 @@ Supported Shapes</h3>
 				the circle's radius.
 				Rather than referring to the [=gradient box=],
 				values are resolved against the [=<basic-shape>/reference box=].
+				Two <<length-percentage>> values are invalid.
+				If omitted it defaults to ''<radial-size>/closest-side''.
 
-			* Two <<length-percentage>> values are invalid.
-
-				The <<position>> argument defines
+			* The <<position>> argument defines
 				the center of the circle.
 				Unless otherwise specified,
 				this defaults to <css>center</css> if omitted.
@@ -476,6 +476,7 @@ Supported Shapes</h3>
 				the horizontal and vertical radiuses of the ellipse.
 				Rather than referring to the [=gradient box=],
 				values are resolved against the [=<basic-shape>/reference box=].
+				If omitted it defaults to ''<radial-size>/closest-side''.
 
 			* The <<position>> argument defines
 				the center of the ellipse.


### PR DESCRIPTION
It was lost in #9723 and is different than in `<radial-gradient()>`:

  > [`<radial-size>`](https://drafts.csswg.org/css-images-3/#typedef-radial-size)
Determines the size of the gradient’s [ending shape](https://drafts.csswg.org/css-images-3/#ending-shape). If omitted it defaults to [farthest-corner](https://drafts.csswg.org/css-images-3/#valdef-radial-extent-farthest-corner).