### PR TITLE
[css-view-transitions-2] When hiding the document, and inbound cross-document view transition should be skipped.

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -879,7 +879,7 @@ It has the following [=struct/items=]:
 
 ## Additions to the view transition page-visibility change steps ## {#page-visibility-change-steps-additions}
 	<div algorithm="visibility change step additions">
-	The next steps are added to the tasks [=view transition page-visibility change steps=] given |document|, as part of the queued task:
+	The next steps are appended to the tasks [=view transition page-visibility change steps=] given |document|, after the current steps in the queued task:
 
 	1. Set |document|'s [=inbound view transition params=] to null.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -877,6 +877,17 @@ It has the following [=struct/items=]:
 	:: a [=tuple=] of two numbers (width and height).
 </dl>
 
+## Additions to the view transition page-visibility change steps ## {#page-visibility-change-steps-additions}
+	<div algorithm="visibility change step additions">
+	The next steps are added to the tasks [=view transition page-visibility change steps=] given |document|, as part of the queued task:
+
+	1. Set |document|'s [=inbound view transition params=] to null.
+
+	Note: this is called from the HTML spec.
+	</div>
+
+
+
 ### Captured elements extension ### {#capture-classes-data-structure}
 The [=captured element=] struct should contain these fields, in addition to the existing ones:
 	<dl>


### PR DESCRIPTION
When hiding the document, and inbound cross-document view transition should be skipped.
This is a missing piece of #9822 that wasn't edited in.

Closes web-platform-tests/wpt#47828
