### PR TITLE
[css-view-transition-2] Clarify timeout behavior for inbound view transition

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -995,14 +995,16 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 			Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
 
-		1.At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout. To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following steps:
+		1. To skip the transition after a timeout, the user agent may perform the following steps [=in parallel=]:
 
-			1. If |newDocument|'s [=inbound view transition params=] is |params|, then set |newDocument|'s [=inbound view transition params=] to null.
+			1. Wait for an [=implementation-defined=] [=duration=].
 
-			1. If |newDocument|'s [=active view transition=] is |params|'s [=view transition params/resolved transition=], and |newDocument|'s [=active view transition=]'s [=ViewTransition/phase=] is not "`done`",
-				then [=skip the view transition|skip=] |newDocument|'s [=active view transition=] with a "{{TimeoutError}}" {{DOMException}}.
+			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following steps:
 
-			Note: This allows user agents to
+				1. If |newDocument|'s [=inbound view transition params=] is |params|, then set |newDocument|'s [=inbound view transition params=] to null.
+
+				1. If |newDocument|'s [=active view transition=] is |params|'s [=view transition params/resolved transition=], and |newDocument|'s [=active view transition=]'s [=ViewTransition/phase=] is not "`done`",
+					then [=skip the view transition|skip=] |newDocument|'s [=active view transition=] with a "{{TimeoutError}}" {{DOMException}}.
 
 		1. Call |proceedWithNavigation|.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -875,9 +875,6 @@ It has the following [=struct/items=]:
 
 	: <dfn>initial snapshot containing block size</dfn>
 	:: a [=tuple=] of two numbers (width and height).
-
-	: <dfn>resolved transition</dfn>
-	:: a {{ViewTransition}} or null, initially null.
 </dl>
 
 ## Additions to the view transition page-visibility change steps ## {#page-visibility-change-steps-additions}
@@ -999,12 +996,9 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 			1. Wait for an [=implementation-defined=] [=duration=].
 
-			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following steps:
+			1. [=Queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following step:
 
 				1. If |newDocument|'s [=inbound view transition params=] is |params|, then set |newDocument|'s [=inbound view transition params=] to null.
-
-				1. If |newDocument|'s [=active view transition=] is |params|'s [=view transition params/resolved transition=], and |newDocument|'s [=active view transition=]'s [=ViewTransition/phase=] is not "`done`",
-					then [=skip the view transition|skip=] |newDocument|'s [=active view transition=] with a "{{TimeoutError}}" {{DOMException}}.
 
 		1. Call |proceedWithNavigation|.
 
@@ -1101,9 +1095,6 @@ Prepend the following step to the [=Perform pending transition operations=] algo
 
 	1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
 
-	1. Set |inboundViewTransitionParams|'s [=view transition params/resolved transition=] to |transition|.
-
-		Note: this allows skipping the transition after an [=implementation-defined=] timeout.
 
 	1. Return |transition|.
 </div>

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -875,6 +875,9 @@ It has the following [=struct/items=]:
 
 	: <dfn>initial snapshot containing block size</dfn>
 	:: a [=tuple=] of two numbers (width and height).
+
+	: <dfn>resolved transition</dfn>
+	:: a {{ViewTransition}} or null, initially null.
 </dl>
 
 ## Additions to the view transition page-visibility change steps ## {#page-visibility-change-steps-additions}
@@ -992,6 +995,15 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 			Note: The inbound transition is activated after the dispatch of {{Window/pagereveal}} to ensure mutations made in this event apply to the captured new state.
 
+		1.At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout. To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |newDocument|'s [=relevant global object=] to perform the following steps:
+
+			1. If |newDocument|'s [=inbound view transition params=] is |params|, then set |newDocument|'s [=inbound view transition params=] to null.
+
+			1. If |newDocument|'s [=active view transition=] is |params|'s [=view transition params/resolved transition=], and |newDocument|'s [=active view transition=]'s [=ViewTransition/phase=] is not "`done`",
+				then [=skip the view transition|skip=] |newDocument|'s [=active view transition=] with a "{{TimeoutError}}" {{DOMException}}.
+
+			Note: This allows user agents to
+
 		1. Call |proceedWithNavigation|.
 
 	1. Set |oldDocument|'s [=active view transition=] to |outboundTransition|.
@@ -1087,9 +1099,9 @@ Prepend the following step to the [=Perform pending transition operations=] algo
 
 	1. Set |transition|'s [=ViewTransition/active types=] to |resolvedRule|.
 
-	1. At any given time, the UA may decide to skip the inbound transition, e.g. after an [=implementation-defined=] timeout.
-		To do so, the UA should [=queue a global task=] on the [=DOM manipulation task source=] given |document|'s [=relevant global object=] to perform the following step:
-			If |transition|'s [=ViewTransition/phase=] is not "`done`", then [=skip the view transition=] |transition| with a "{{TimeoutError}}" {{DOMException}}.
+	1. Set |inboundViewTransitionParams|'s [=view transition params/resolved transition=] to |transition|.
+
+		Note: this allows skipping the transition after an [=implementation-defined=] timeout.
 
 	1. Return |transition|.
 </div>


### PR DESCRIPTION
The previous wording of this was somewhat handwavy, made it more rigorous.

- The timeout starts when the transition is created (before pageswap)
- If the timeout expires before the transition is resolved (pagereveal), the inbound transition params are cleared and the behavior is similar to having the transition skipped at pageswap.
- If the timeout expires while the navigation is active, it is skipped with a `TimeoutError`.

Closes #10800
