### PR TITLE
[css-color-4] Clarify intended use of the parse a CSS <color> algorithm

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -1221,6 +1221,13 @@ Parsing a <<color>> Value</h3>
 	4. Return |used color|.
 </div>
 
+Note: This algorithm is not intented 
+to parse a CSS <<color>> value 
+specified in a CSS stylesheet
+or with a CSSOM interface,
+but in other places 
+like HTML attributes or Canvas interfaces.
+
 
 
 


### PR DESCRIPTION
Unless explicitly specified, I would use [parse a CSS `<color>` value](https://drafts.csswg.org/css-color-4/#parse-a-css-color-value) to parse a `<color>` appearing in a stylesheet or a CSSOM input. But I should not, which I suggest to make explicit.