### PR TITLE
[css-view-transitions-1] Swap the order between setting the phase and calling the update callback

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1600,11 +1600,11 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |callbackPromise| be null.
 
+		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
+
 		1. If |transition|'s [=ViewTransition/update callback=] is null,
 			then set |callbackPromise| to [=a promise resolved with=] undefined,
 			in |transition|'s [=relevant Realm=].
-
-		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
 
 		1. Otherwise, set |callbackPromise| to the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
 

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1604,9 +1604,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			then set |callbackPromise| to [=a promise resolved with=] undefined,
 			in |transition|'s [=relevant Realm=].
 
-		1. Otherwise, set |callbackPromise| to the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
-
 		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
+
+		1. Otherwise, set |callbackPromise| to the result of [=/invoking=] |transition|'s [=ViewTransition/update callback=].
 
 		1. Let |fulfillSteps| be to following steps:
 			1. [=Resolve=] |transition|'s [=ViewTransition/update callback done promise=] with undefined.
@@ -1986,6 +1986,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Scope view transition names to matching tree context. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 * Fix scoping to match name instead of element. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 * Add a rendering characteristics note about out-of-viewport elements. See <a href="https://github.com/w3c/csswg-drafts/issues/8282">issue 8282</a>.
+* Swap the order of invoking the update callback and setting the phase. See <a href="https://github.com/w3c/csswg-drafts/issues/10822">issue 10822</a>.
 
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1598,9 +1598,9 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. [=Assert=]: |transition|'s [=ViewTransition/phase=] is "`done`", or before "`update-callback-called`".
 
-		1. Let |callbackPromise| be null.
-
 		1. If |transition|'s [=ViewTransition/phase=] is not "`done`", then set |transition|'s [=ViewTransition/phase=] to "`update-callback-called`".
+
+		1. Let |callbackPromise| be null.
 
 		1. If |transition|'s [=ViewTransition/update callback=] is null,
 			then set |callbackPromise| to [=a promise resolved with=] undefined,


### PR DESCRIPTION
This fixes an issue where skipping the transition from within thet update callback would call the update callback twice.

Closes #10822
