### PR TITLE
[css-font-4][editorial] Fix <'font'> syntax, simplify <font-variant-css2> and <font-width-css3> syntaxes

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -1705,7 +1705,7 @@ Shorthand font property: the 'font' property</h3>
 		<<font-variant-css2>> ||
 		<<'font-weight'>> ||
 		<<font-width-css3>> ]? <<'font-size'>> [ / <<'line-height'>> ]?
-		<<'font-family'>> ] |
+		<<'font-family'>># ] |
 		<<system-family-name>>
 	Initial: see individual properties
 	Applies to: all elements and text
@@ -1750,7 +1750,7 @@ Shorthand font property: the 'font' property</h3>
 	'font!!property' shorthand:
 
 	<pre class="prod"><dfn id="font-variant-css21-values"><<font-variant-css2>></dfn>
-		= [normal | small-caps]</pre>
+		= normal | small-caps</pre>
 
 	Values for the 'font-width!!property' property can also be included
 	but only those supported in CSS Fonts level 3,
@@ -1758,9 +1758,9 @@ Shorthand font property: the 'font' property</h3>
 	can be used in the 'font' shorthand:
 
 	<pre class="prod"><dfn id="font-width-css3-values"><<font-width-css3>></dfn>
-		= [normal | ultra-condensed | extra-condensed | condensed |
+		= normal | ultra-condensed | extra-condensed | condensed |
 		  semi-condensed | semi-expanded | expanded | extra-expanded |
-		  ultra-expanded]</pre>
+		  ultra-expanded</pre>
 
 	Therefore we have the following classification
 	of font-related properties


### PR DESCRIPTION
According to the CSS Values and Units specification [as stated](https://drafts.csswg.org/css-values-4/#component-types):

> If the property’s value grammar is a comma-separated repetition, the corresponding type does not include the top-level comma-separated list multiplier. (E.g. if a property named `pairing` is defined as `[ <custom-ident> <integer>? ]#`, then `<'pairing'>` is equivalent to `[ <custom-ident> <integer>? ]`, not `[ <custom-ident> <integer>? ]#`.)

The definition of `<'font-family'>` is `[ <family-name> | <generic-family> ]#`. When used in the context of `<'font'>` without the #-multiplier, this implies that only a single `<family-name>` or `<generic-family>` can be used as the `<'font-family'>` value. However, the `<'font'>` property allows a comma-separated list of family names, which necessitates the explicit inclusion of the #-multiplier with `<'font-family'>` in the `<'font'>` syntax.

Additionally, the brackets are redundant in the syntaxes for `<font-variant-css2>` and `<font-width-css3>`.

Note: I made changes only to font-4, as font-3 appears to be generated from an external source, and I couldn't locate the source.