### PR TITLE
[css-values-5] Group <progress> and <color-interpolation-method>

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -537,7 +537,7 @@ Interpolated Color Values: the ''color-mix()'' notation</h3>
 
 	<pre class=prod>
 		<<color-mix()>> =
-		  color-mix( <<progress>> && <<color-interpolation-method>>?, <<color>>, <<color>> ) |
+		  color-mix( [<<progress>> && <<color-interpolation-method>>?], <<color>>, <<color>> ) |
 		  color-mix( <<color-interpolation-method>>, [<<color>> && <<percentage [0,100]>>?]#{2} )
 	</pre>
 


### PR DESCRIPTION
The current syntax allows `color-mix(in lab, red, green 1)`. I suspect that this is not intentional: the progress and interpolation method should be grouped together.