### PR TITLE
Fix typo in CSS Grid 3 overview

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -1334,7 +1334,7 @@ Security Considerations</h2>
 
 	As a layout specification,
 	this spec introduces no new security considerations
-	beyond taht exposed by CSS layout in general.
+	beyond that exposed by CSS layout in general.
 
 <h2 id=privacy>
 Privacy Considerations</h2>


### PR DESCRIPTION
Fixes a small typo I noticed while reading the new Editor's Draft.