### PR TITLE
[css-colors-5] Add <contrast-color()> to <color> production

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -149,7 +149,7 @@ Introduction {#intro}
 	Colors in CSS are represented by the <dfn export><<color>></dfn> type:
 
 	<pre class='prod'>
-	&lt;color> = <<color-base>> | currentColor | <<system-color>> | <<device-cmyk()>>  | <<light-dark()>>
+	&lt;color> = <<color-base>> | currentColor | <<system-color>> | <<device-cmyk()>>  | <<light-dark()>>  | <<contrast-color()>>
 
 	<dfn>&lt;color-base></dfn> = <<hex-color>> | <<color-function>> | <<named-color>> | <<color-mix()>> | transparent
 	<dfn>&lt;color-function></dfn> = <<rgb()>> | <<rgba()>> |


### PR DESCRIPTION
The `<color>` production rule is missing `<contrast-color()>`.