### PR TITLE
[css-backgrounds-4] Fix definition of `<position-three>`

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -235,7 +235,7 @@ Background Positioning: the 'background-position' shorthand property</h3>
 
 	<pre class=prod>
 		<<bg-position>> =  <<position>> | <<position-three>>
-		<position-three> = [
+		<dfn><<position-three>></dfn> = [
 		  [ left | center | right ] && [ [ top | bottom ] <<length-percentage>> ]
 		|
 		  [ [ left | right ] <<length-percentage>> ] && [ top | center | bottom ]


### PR DESCRIPTION
Enclosing `<>` needed to be doubled. Also added a wrapping `<dfn>` to make the term linkable.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
