### PR TITLE
[css-namespaces-3] Define <namespace-prefix> with case-sensitive <cus…

### DIFF
--- a/css-namespaces-3/Overview.bs
+++ b/css-namespaces-3/Overview.bs
@@ -150,7 +150,7 @@ Syntax</h3>
 	<pre>
 		@namespace <<namespace-prefix>>? [ <<string>> | <<url>> ] ;
 
-		<dfn>&lt;namespace-prefix&gt;</dfn> = <<ident>>
+		<dfn>&lt;namespace-prefix&gt;</dfn> = <<custom-ident>>
 	</pre>
 
 	Any ''@namespace'' rules must follow all @charset and @import rules


### PR DESCRIPTION
[`<namespace-prefix>`](https://drafts.csswg.org/css-namespaces-3/#typedef-namespace-prefix) is defined with `<ident>` but namespace prefixes are [case-sensitive](https://drafts.csswg.org/css-namespaces-3/#prefixes):

  > Namespace prefixes are, like CSS counter names, case-sensitive.

This PR defines it with [`<custom-ident>`](https://drafts.csswg.org/css-values-4/#identifier-value), like [counter names](https://drafts.csswg.org/css-lists-3/#typedef-counter-name).