### PR TITLE
[css-scoping] First pass at adding `:has-slotted`

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -512,11 +512,11 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-class</h4>
 
 	The <dfn selector>:has-slotted</dfn> pseudo-class
-	matches <{slot}> elements 
+	matches <{slot}> elements
 	which have a non-empty list of <a lt="find slottables">slotted nodes</a>.
 
 	When '':has-slotted'' matches a slot with fallback content,
-	we can conclude that the fallback content is being displayed.
+	we can conclude that the fallback content is <em>not</em> being displayed.
 
 	Note: Even a single whitespace text node is sufficient to make '':has-slotted''' apply.
 	This is by design, so that the behavior of this pseudo-class is consistent with the behavior of the {{HTMLSlotElement/assignedNodes()}} method.

--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -24,7 +24,10 @@ spec:dom; type:dfn;
 	text:find slottables
 	text:find flattened slottables
 	text:element; for:/
-spec:html; type:element; text:style
+spec:html; type:element;
+	text:style
+spec:html; type:dfn;
+	text:assignedNodes
 spec:selectors-4; type:dfn;
 	text: static profile
 	text: dynamic profile
@@ -40,7 +43,7 @@ spec:dom; type:dfn; text:child
 spec:css-color-5; type:function; text:color()
 </pre>
 
-<!-- 
+<!--
 
 <h2 id="intro">
 Introduction</h2>
@@ -506,6 +509,25 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 	which can't be selected by ''::slotted()''.
 	The only way to style assigned text nodes
 	is by styling the <a>slot</a> and relying on inheritance.
+
+<h4 id='the-has-slotted-pseudo'>
+Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-class</h4>
+
+	The <dfn selector>:has-slotted</dfn> pseudo-class,
+	applies to any slot element with a non-empty list of <a lt="find slottables">slotted nodes</a>.
+	It is false on any other element.
+
+	When '':has-slotted'' matches a slot with fallback content,
+	we can conclude that the fallback content is being displayed.
+
+	Note: Even a single whitespace text node is sufficient to make '':has-slotted''' apply.
+	This is by design, so that the behavior of this pseudo-class is consistent with the behavior of the <a lt="assignedNodes">''assignedNodes()''</a> method.
+	A future version of this specification is expected to introduce a way to exclude this case from matching.
+
+	Note: It is expected that a future version of this specification will introduce a functional '':has-slotted()'' pseudo-class that allows
+	more fine-grained matching by accepting a selector argument.
+	'':has-slotted'' is <em>not</em> an alias of '':has-slotted(*)'',
+	as the latter would not match slotted text nodes, but '':has-slotted'' does.
 
 <wpt>
 	css-scoping-shadow-slotted-nested.html

--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -26,8 +26,6 @@ spec:dom; type:dfn;
 	text:element; for:/
 spec:html; type:element;
 	text:style
-spec:html; type:dfn;
-	text:assignedNodes
 spec:selectors-4; type:dfn;
 	text: static profile
 	text: dynamic profile
@@ -521,7 +519,7 @@ Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-cla
 	we can conclude that the fallback content is being displayed.
 
 	Note: Even a single whitespace text node is sufficient to make '':has-slotted''' apply.
-	This is by design, so that the behavior of this pseudo-class is consistent with the behavior of the <a lt="assignedNodes">''assignedNodes()''</a> method.
+	This is by design, so that the behavior of this pseudo-class is consistent with the behavior of the {{HTMLSlotElement/assignedNodes()}} method.
 	A future version of this specification is expected to introduce a way to exclude this case from matching.
 
 	Note: It is expected that a future version of this specification will introduce a functional '':has-slotted()'' pseudo-class that allows

--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -511,9 +511,9 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 <h4 id='the-has-slotted-pseudo'>
 Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-class</h4>
 
-	The <dfn selector>:has-slotted</dfn> pseudo-class,
-	applies to any slot element with a non-empty list of <a lt="find slottables">slotted nodes</a>.
-	It is false on any other element.
+	The <dfn selector>:has-slotted</dfn> pseudo-class
+	matches <{slot}> elements 
+	which have a non-empty list of <a lt="find slottables">slotted nodes</a>.
 
 	When '':has-slotted'' matches a slot with fallback content,
 	we can conclude that the fallback content is being displayed.


### PR DESCRIPTION
In #6867 we [resolved](https://github.com/w3c/csswg-drafts/issues/6867#issuecomment-1332344714) to add `:has-slotted`. This PR is a first pass to add this.

The reference to `assignedNodes()` reference doesn’t work, not sure why. 🤷🏽‍♀️

There is [another open PR](https://github.com/w3c/csswg-drafts/pull/10586) by @keithamus but it adds `:has-slotted()` instead, which is both considerably harder to implement, and not what the resolution is about. I did however include a note that this will be included in a future version.