### PR TITLE
[cssom] Don't serialize empty rules

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1709,10 +1709,14 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
         <ol>
             <li>If |decls| is not null, prepend it to |rules|.
             <li>For each |rule| in |rules|:
-                <ol>
-                    <li>Append a newline followed by two spaces to |s|.
-                    <li>Append |rule| to |s|.
-                </ol>
+                <ul>
+                    <li>If |rule| is the empty string, do nothing.
+                    <li>Otherwise:
+                        <ol>
+                            <li>Append a newline followed by two spaces to |s|.
+                            <li>Append |rule| to |s|.
+                        </ol>
+                </ul>
             <li>Append a newline followed by RIGHT CURLY BRACKET (U+007D) to |s|.
             <li>Return |s|.
         </ol>


### PR DESCRIPTION
With CSSOM, it's possible to reach into a CSSNestedDeclarations rule and remove its declarations, causing it to serialize as the empty string. Such rules add "whitespace junk" when serializing the outer rule, which looks unattractive.

Fixed by ignoring rules that serialize to the empty string.
