### PR TITLE
[scoping-1] Link the ::slotted tests from the right section.

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -508,6 +508,22 @@ Selecting Slot-Assigned Content: the ''::slotted()'' pseudo-element</h4>
 	The only way to style assigned text nodes
 	is by styling the <a>slot</a> and relying on inheritance.
 
+<wpt>
+	css-scoping-shadow-slotted-nested.html
+	css-scoping-shadow-slotted-rule.html
+	reslot-text-inheritance.html
+	slotted-invalidation.html
+	slotted-link.html
+	slotted-matches.html
+	slotted-nested.html
+	slotted-parsing.html
+	slotted-placeholder.html
+	slotted-slot.html
+	slotted-specificity-002.html
+	slotted-specificity.html
+	slotted-with-pseudo-element.html
+</wpt>
+
 <h4 id='the-has-slotted-pseudo'>
 Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-class</h4>
 
@@ -526,22 +542,6 @@ Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-cla
 	more fine-grained matching by accepting a selector argument.
 	'':has-slotted'' is <em>not</em> an alias of '':has-slotted(*)'',
 	as the latter would not match slotted text nodes, but '':has-slotted'' does.
-
-<wpt>
-	css-scoping-shadow-slotted-nested.html
-	css-scoping-shadow-slotted-rule.html
-	reslot-text-inheritance.html
-	slotted-invalidation.html
-	slotted-link.html
-	slotted-matches.html
-	slotted-nested.html
-	slotted-parsing.html
-	slotted-placeholder.html
-	slotted-slot.html
-	slotted-specificity-002.html
-	slotted-specificity.html
-	slotted-with-pseudo-element.html
-</wpt>
 
 <!--
  ██████     ███     ██████   ██████     ███    ████████  ████████


### PR DESCRIPTION
The tests that are currently in https://drafts.csswg.org/css-scoping-1/#the-has-slotted-pseudo don't appear to be about that selector.