### PR TITLE
[css-shapes-2] Clarify shape/path interpolation

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -351,7 +351,7 @@ Interpolating the ''shape()'' Function</h5>
 
 	''shape()'' and ''path()'' functions can be <l spec=css-values-4>[=interpolated=]</l> with each other
 	if their associated list of path data commands is the same length
-	and has the same commands, in order, with the first value of the ''path()'' function interpolating with the
+	and has the same commands, in order, with the first command of the ''path()'' function interpolating with the
 	initial <<coordinate-pair>> in the ''shape()'' function.
 
 		Note: The first command of a ''path()'' function is guaranteed to be a ''move'', see <a href="https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands">moveTo</a> in the SVG spec.

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -351,7 +351,11 @@ Interpolating the ''shape()'' Function</h5>
 
 	''shape()'' and ''path()'' functions can be <l spec=css-values-4>[=interpolated=]</l> with each other
 	if their associated list of path data commands is the same length
-	and has the same commands, in order.
+	and has the same commands, in order, with the first value of the ''path()'' function interpolating with the
+	initial <<coordinate-pair>> in the ''shape()'' function.
+
+		Note: The first command of a ''path()'' function is guaranteed to be a ''move'', see <a href="https://www.w3.org/TR/SVG2/paths.html#PathDataMovetoCommands">moveTo</a> in the SVG spec.
+
 	If the starting and ending values are both ''path()'' functions,
 	the interpolated value is a ''path()'' function;
 	otherwise it's a ''shape()'' function.


### PR DESCRIPTION
Match the first moveTo of the `path()` with the "from" of the `shape()`

This is guaranteed to work since `path()` always starts with an M or m.

See resolution: https://github.com/w3c/csswg-drafts/issues/10740#issuecomment-2379740446

Closes #10740
