### PR TITLE
[css-sizing-4] Avoid duplicating new values for logical properties

### DIFF
--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -117,7 +117,7 @@ ISSUE(820): Add shorthands.
 New Sizing Values: the ''stretch'', ''fit-content'', and ''contain'' keywords</h3>
 
 	<pre class="propdef partial">
-	Name: width, height, inline-size, block-size, min-width, min-height, min-inline-size, min-block-size, max-width, max-height, max-inline-size, max-block-size
+	Name: width, height, min-width, min-height, max-width, max-height
 	New Values: stretch | fit-content | contain
 	</pre>
 


### PR DESCRIPTION
Fixes #7370.

For example, both `inline-size` and `width` are extended with new values, but `inline-size` is defined with `<'width'>`. Therefore a value for `inline-size` is parsed against the new values twice.