### PR TITLE
[css-view-transitions-1] Don't animate transform/size by default when prefers-reduced-motion is on

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1538,6 +1538,14 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 								backdrop-filter: <var>backdropFilter</var>;
 							}
 						}
+
+						@media (prefers-reduced-motion) {
+							@keyframes -ua-view-transition-group-anim-<var>transitionName</var> {
+								from {
+									backdrop-filter: <var>backdropFilter</var>;
+								}
+							}
+						}
 					</pre>
 
 					Note: The above code example contains variables to be replaced.
@@ -1987,7 +1995,7 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Fix scoping to match name instead of element. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 * Add a rendering characteristics note about out-of-viewport elements. See <a href="https://github.com/w3c/csswg-drafts/issues/8282">issue 8282</a>.
 * Swap the order of invoking the update callback and setting the phase. See <a href="https://github.com/w3c/csswg-drafts/issues/10822">issue 10822</a>.
-
+* Don't animate transform/size by default when `prefers-reduced-motion` is on. See <a href="https://github.com/w3c/csswg-drafts/issues/10267">issue 10267</a>.
 <h3 id="changes-since-2022-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2022-05-25 Working Draft</a>
 </h3>


### PR DESCRIPTION
Closes #10267
