### PR TITLE
Fix the caret-animation example

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -1237,7 +1237,7 @@ Animation of the insertion caret: 'caret-animation'</h4>
 		</style>
 		<div contentEditable=true
 		     style="border:inset; background: white; width: 10em;
-		            caret-animation: none;
+		            caret-animation: manual;
 		            caret-color: blue;
 		            animation: caret-alternate-test 2s step-end infinite;"
 		>Text area with color-alternating caret</div>


### PR DESCRIPTION
[css-ui-4] The "see how it renders in your browser" example for caret-animation had `caret-animation: none` which is neither auto nor `manual` as the text would suggest. Fix it.
