### PR TITLE
[css-conditional-5] snapped matches scrollsnapchanging #10784

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -43,6 +43,7 @@ Default Highlight: css
 	spec:css-contain-2; type:dfn; text:layout containment box
 	spec:css-contain-2; type:dfn; text:size containment box
 	spec:css-pseudo-4; type:dfn; text:fictional tag sequence
+	spec:css-scroll-snap-2; type:dfn; text:scrollsnapchanging
 	spec:css-sizing-4; type:property; text:contain-intrinsic-size
 	spec:css-sizing-4; type:property; text:aspect-ratio
 	spec:intersection-observer; type:dfn; text:intersection root
@@ -1195,7 +1196,8 @@ Scroll snapping: the '@container/snapped' feature</h4>
 	</pre>
 
 	The '@container/snapped' [=container feature=] queries whether a [=snap target=]
-	is snapped to its [=snap container=] in the given axis.
+	is, or would be, snapped to its [=snap container=], in the given axis. That is,
+	it matches any [=snap target=] that the {{scrollsnapchanging}} event is fired for.
 
 	<dl dfn-type=value dfn-for="@container/snapped">
 		<dt><dfn>none</dfn>


### PR DESCRIPTION
Edit to clarify the resolution[1] in #10784 that scroll-state(snapped) matches the snap target for scrollsnapchanging, not scrollsnapchanged. That is, the snapped query changes evaluation during a scroll operation.

[1] https://github.com/w3c/csswg-drafts/issues/10784#issuecomment-2379901508
