### PR TITLE
[cssom-view-1] Add: run snapshot post-layout state steps #10796

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2015,6 +2015,18 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
 </table>
 
 
+Post-Layout State Snapshotting {#post-layout-snapshot}
+======================================================
+
+Some CSS features use post-layout state, like scroll position, as input to the next style and layout update.
+
+When asked to <dfn export>run snapshot post-layout state steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
+
+1. For each CSS feature that needs to snapshot post-layout state, take a snapshot of the relevant state.
+
+The state that is snapshot is defined in other specifications. These steps must not invalidate <var>doc</var> or any other {{Document}}s in such a way that other post-layout snapshotting steps can observe that such snapshotting happened. It follows that the order of which such snapshotting takes place should not matter.
+
+
 Security and Privacy Considerations {#priv-sec}
 ===============================================
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2022,7 +2022,7 @@ Some CSS features use post-layout state, like scroll position, as input to the n
 
 When asked to <dfn export>run snapshot post-layout state steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
-1. For each CSS feature that needs to snapshot post-layout state, take a snapshot of the relevant state.
+1. For each CSS feature that needs to snapshot post-layout state, take a snapshot of the relevant state in <var>doc</var>.
 
 The state that is snapshot is defined in other specifications. These steps must not invalidate <var>doc</var> or any other {{Document}}s in such a way that other post-layout snapshotting steps can observe that such snapshotting happened. It follows that the order of which such snapshotting takes place should not matter.
 


### PR DESCRIPTION
Add "run snapshot post-layout state steps" as resolved in issue #10796. Let other specifications specify what they snapshot on a feature-by-feature basis.

Resolution: https://github.com/w3c/csswg-drafts/issues/10796#issuecomment-2379885032
