### PR TITLE
[css-ui-4] Editorial improvement; removes redundant group notation from outline-color property

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -436,7 +436,7 @@ Outline Colors: the 'outline-color' property</h3>
 
 	<pre class="propdef">
 	Name: outline-color
-	Value: auto | [ <<color>> | <<image-1D>> ]
+	Value: auto | <<color>> | <<image-1D>>
 	Initial: auto
 	Applies to: all elements
 	Inherited: no


### PR DESCRIPTION
I was reading through the css-ui-4 spec and noticed that the outline-color property was specified as `auto | [ <<color>> | <<image-1D>> ]`. This confuses me because I don't understand why these needed to be disambiguated using the group notation. There doesn't seem to be any ambiguity, so I removed the group notation and changed it to `auto | <<color>> | <<image-1D>>`.

If this is _not correct_, I'm happy to close this PR, but for my own edification I'd love to know why the group notation is considered important here.