### PR TITLE
[css-conditional-5] Link scroll-state snapshotting to cssom-view #10796

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1114,7 +1114,7 @@ Updating Scroll State</h4>
 
 	To avoid such layout cycles, ''scroll-state'' [=query containers=] update their
 	current state as part of [=run snapshot post-layout state steps=] which is only
-	run at specific points in thee in the
+	run at specific points in the
 	<a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">HTML event loop processing model</a>.
 
 	When asked to [=run snapshot post-layout state steps=], update the current state

--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1109,20 +1109,17 @@ Scroll State Container Features</h3>
 <h4 id="updating-scroll-state">
 Updating Scroll State</h4>
 
-	Issue(10796): This section is subject to change as a result of resolving
-	the issue of unifying scroll-snapshotting layout state across several specifications.
-
 	Scroll state may cause layout cycles since queried scroll state may cause style changes,
-	which may lead to scroll state changes as a result of layout. The same issue exists for
-	[=scroll progress timelines=], and scroll state is handled in a similar manner.
+	which may lead to scroll state changes as a result of layout.
 
 	To avoid such layout cycles, ''scroll-state'' [=query containers=] update their
-	current state once as the last step of [=run the scroll steps=]. Then, after the
-	resizeObserver loop in the
-	<a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">HTML event loop processing model</a>,
-	update the current state of every ''scroll-state'' [=query container=].
-	If that state has changed since the scroll state update in [=run the scroll steps=],
-	re-run the style and layout update a single time if necessary.
+	current state as part of [=run snapshot post-layout state steps=] which is only
+	run at specific points in thee in the
+	<a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">HTML event loop processing model</a>.
+
+	When asked to [=run snapshot post-layout state steps=], update the current state
+	of every ''scroll-state'' [=query container=]. This snapshotted state will be used
+	for any style and layout updates until the next time these steps are run.
 
 <h4 id="stuck">
 Sticky positioning: the '@container/stuck' feature</h4>

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2024,7 +2024,7 @@ When asked to <dfn export>run snapshot post-layout state steps</dfn> for a {{Doc
 
 1. For each CSS feature that needs to snapshot post-layout state, take a snapshot of the relevant state in <var>doc</var>.
 
-The state that is snapshot is defined in other specifications. These steps must not invalidate <var>doc</var> or any other {{Document}}s in such a way that other post-layout snapshotting steps can observe that such snapshotting happened. It follows that the order of which such snapshotting takes place should not matter.
+The state that is snapshot is defined in other specifications. These steps must not invalidate <var>doc</var> or any other {{Document}}s in such a way that other post-layout snapshotting steps can observe that such snapshotting happened. It follows that the order of which such snapshotting takes place must not matter.
 
 
 Security and Privacy Considerations {#priv-sec}


### PR DESCRIPTION
scroll-state() snapshotting should happen as part of "run snapshot post- layout state steps".

Resolution: https://github.com/w3c/csswg-drafts/issues/10796#issuecomment-2379885032
