### PR TITLE
[css-view-transitions-1] Remove redundant declaration.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1325,8 +1325,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		1. Let |captureElements| be a new [=/list=] of elements.
 
-		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
-
 		1. If the [=snapshot containing block size=] exceeds an [=implementation-defined=] maximum, then return failure.
 
 		1. Set |transition|'s [=ViewTransition/initial snapshot containing block size=] to the [=snapshot containing block size=].


### PR DESCRIPTION
Step 1 is exactly the same.