### PR TITLE
[css-view-transitions] Clear captured flag on error.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1352,7 +1352,13 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				or |element| is [=element-not-rendered|not rendered=],
 				then [=continue=].
 
-			1. If |usedTransitionNames| [=list/contains=] |transitionName|, then return failure.
+			1. If |usedTransitionNames| [=list/contains=] |transitionName|, then:
+
+				1. [=list/For each=] |element| in |captureElements|:
+
+					1. Set |element|'s [=captured in a view transition=] to false.
+
+				1. return failure.
 
 			1. [=set/Append=] |transitionName| to |usedTransitionNames|.
 


### PR DESCRIPTION
Fixes #11058 