### PR TITLE
[css-view-transitions] Specify with kind of exception gets used when skipping on resize.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1810,7 +1810,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			1. Return.
 
 		1. If |transition|'s [=ViewTransition/initial snapshot containing block size=] is not equal to the [=snapshot containing block size=],
-			then [=skip the view transition=] for |transition|, and return.
+			then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
 
 		1. [=Update pseudo-element styles=] for |transition|.
 


### PR DESCRIPTION
Fixes #11059