### PR TITLE
[css-view-transitions-2] Allow transitions when traversing into a document that was created using cross-origin redirects

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -992,9 +992,11 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 	1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
 
-	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
+	1. If |newDocument| [=was created via cross-origin redirects=] and |newDocument|'s [=latest entry=] is null, then return false.
 
-	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
+		Note: A [=Document=]'s [=latest entry=] would be null if this is a new navigation, rather than a restore from BFCache.
+
+	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
 
 	1. If |isBrowserUINavigation| is true, then return false.
 

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -992,9 +992,9 @@ The [=captured element=] struct should contain these fields, in addition to the 
 
 	1. If |oldDocument|'s [=Document/origin=] is not [=same origin=] as |newDocument|'s [=Document/origin=], then return false.
 
-	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
-
 	1. If |navigationType| is {{NavigationType/traverse}}, then return true.
+
+	1. If |newDocument| [=was created via cross-origin redirects=], then return false.
 
 	1. If |isBrowserUINavigation| is true, then return false.
 


### PR DESCRIPTION
This restriction only makes sense for the initial navigation, not for traversal.

Closes #11063

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
