### PR TITLE
[cssom-view-1] Apply scroll snap to scroll-into-view-position

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1496,6 +1496,10 @@ run the following steps:
             <dt>If <var>element edge D</var> is outside <var>scrolling box edge D</var> and <var>element width</var> is less than <var>scrolling box width</var>
             <dd>Align <var>element edge D</var> with <var>scrolling box edge D</var>.
         </dl>
+    1. If <var>target</var> is an <a for="/">Element</a>, and the target element defines some <a>scroll snap positions</a>,
+        then the user agent must <a>scroll snap</a> the resulting <var>position</var> to one of that element’s <a>scroll snap positions</a>
+        if its nearest <a>scroll container</a> is a <a>scroll snap container</a>.
+        The user agent <em>may</em> also do this even when the <a>scroll container</a> has ''scroll-snap-type: none''.
     1. Return <var>position</var>.
 
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1496,7 +1496,7 @@ run the following steps:
             <dt>If <var>element edge D</var> is outside <var>scrolling box edge D</var> and <var>element width</var> is less than <var>scrolling box width</var>
             <dd>Align <var>element edge D</var> with <var>scrolling box edge D</var>.
         </dl>
-    1. If <var>target</var> is an <a for="/">Element</a>, and the target element defines some <a>scroll snap positions</a>,
+    1. If <var>target</var> is an [=/Element=], and the target element defines some <a>scroll snap positions</a>,
         then the user agent must <a>scroll snap</a> the resulting <var>position</var> to one of that element’s <a>scroll snap positions</a>
         if its nearest <a>scroll container</a> is a <a>scroll snap container</a>.
         The user agent <em>may</em> also do this even when the <a>scroll container</a> has ''scroll-snap-type: none''.


### PR DESCRIPTION
When determining the scroll into view position of an element, the UA should account for defined scroll snap positions. These are applied when scrolling due to https://www.w3.org/TR/css-scroll-snap-1/#choosing added in https://github.com/w3c/csswg-drafts/commit/8401d613596842b7ab337e1a3190a771601240aa however applying them here ensures that specs using the scroll into view position are snapping aware.