### PR TITLE
[css-view-transitions-1] Fix for fragmented boxes in new DOM.

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1430,6 +1430,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 				or |element| is [=element-not-rendered|not rendered=],
 				then [=continue=].
 
+			1. If |element| has more than one [=box fragment=], then [=continue=].
+
 			1. If |usedTransitionNames| [=list/contains=] |transitionName|,
 				then return failure.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/11071.