### PR TITLE
[css-values-5] Allow a single `<syntax-component>`

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -214,7 +214,7 @@ used in specifications to define CSS features,
 and which represents a [=syntax definition=]:
 
 <pre class="prod def" nohighlight>
-	<dfn><<syntax>></dfn> = '*' | <<syntax-component>> [ <<syntax-combinator>> <<syntax-component>> ]+
+	<dfn><<syntax>></dfn> = '*' | <<syntax-component>> [ <<syntax-combinator>> <<syntax-component>> ]*
 	<dfn><<syntax-component>></dfn> = <<syntax-single-component>> <<syntax-multiplier>>?
 	                   | '<' transform-list '>'
 	<dfn><<syntax-single-component>></dfn> = '<' <<syntax-type-name>> '>' | <<ident>>


### PR DESCRIPTION
The current syntax requires two or more syntax components, which is probably not intentional.