### PR TITLE
Revert "[css-namespaces-3] Define <namespace-prefix> with case-sensitive <custom-ident>"

### DIFF
--- a/css-namespaces-3/Overview.bs
+++ b/css-namespaces-3/Overview.bs
@@ -150,7 +150,7 @@ Syntax</h3>
 	<pre>
 		@namespace <<namespace-prefix>>? [ <<string>> | <<url>> ] ;
 
-		<dfn>&lt;namespace-prefix&gt;</dfn> = <<custom-ident>>
+		<dfn>&lt;namespace-prefix&gt;</dfn> = <<ident>>
 	</pre>
 
 	Any ''@namespace'' rules must follow all @charset and @import rules


### PR DESCRIPTION
This reverts commit 184eea92ec36d909eb03f48f8491dc2b1b2eeac6, which prevents CSS-wide keywords and `default` from being valid namespace prefixes, because they are invalid `<custom-ident>`s. Apologize for forgetting that.

There is no tests on WPT, but there is no reason for CSS-wide keywords and `default` to be invalid namespace prefixes, and they are valid in current version of Chrome and FF (at least).

There is no production representing an arbitrary case-sensitive identifier (which might help clarify how identifiers should be interpreted and serialized), so this PR simply revert this change.