### PR TITLE
[css-ui-4] Editorial improvement; removes redundant group notation from outline property

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -280,7 +280,7 @@ Outline properties</h2>
 
 	<pre class="propdef shorthand">
 	Name: outline
-	Value: [ <<'outline-width'>> || <<'outline-style'>> || <<'outline-color'>> ]
+	Value: <<'outline-width'>> || <<'outline-style'>> || <<'outline-color'>>
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A


### PR DESCRIPTION
Similar to https://github.com/w3c/csswg-drafts/pull/11053, the css-ui-4 has a redundant group around the `outline` property value. It is currently specified as `[ <'outline-width'> || <'outline-style'> || <'outline-color'> ]`, but I think it could be better expressed without the `[]`, as `<'outline-width'> || <'outline-style'> || <'outline-color'>` instead. 

I'd like to point out that `caret` has similar shape, and is expressed as `<'caret-color'> || <'caret-animation'> || <'caret-shape'>`. So I think both should be have a consistent syntax.