### PR TITLE
[css-text-4] use "see individual properties" terminology for whitespace property

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -1424,7 +1424,7 @@ White Space and Wrapping: the 'white-space' property</h2>
 	Value: normal | pre | pre-wrap | pre-line | <<'white-space-collapse'>> || <<'text-wrap-mode'>> || <<'white-space-trim'>>
 	Initial: normal
 	Applies to: text
-	Inherited: individual properties
+	Inherited: see individual properties
 	Canonical order: n/a
 	Computed value: specified keyword
 	Animation type: discrete


### PR DESCRIPTION
The `whitespace` property includes `Inherited: individual properties`, but it seems to be the only instance of this value in all of the specs. Lots of other property uses `Inherited: see individual properties`. I presume `whitespace` should use this as well, so I've made this small editorial PR to correct this.