### PR TITLE
[css-anchor-position-1]/[css-fonts-4]/[css-position-4] (editorial) make "see prose" value consistent (drop parens from outliers)

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -2198,7 +2198,7 @@ Initial: normal
 Percentages: n/a
 Inherited: no
 Computed Value: ''position-animation/normal'', or an [=overriding position rectangle=] (see prose)
-Animation type: (see prose)
+Animation type: see prose
 Applies to: [=absolutely positioned boxes=]
 </pre>
 

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -7121,7 +7121,7 @@ Applies to: all elements and text
 Inherited: yes
 Percentages: n/a
 Computed value: the keyword ''font-variation-settings/normal'' or a list, each item a string paired with a number
-Animation type: (see prose)
+Animation type: see prose
 </pre>
 
 <wpt>

--- a/css-position-4/Overview.bs
+++ b/css-position-4/Overview.bs
@@ -650,7 +650,7 @@ Name: overlay
 Value: none | auto
 Initial: none
 Inherited: no
-Animation Type: (see prose)
+Animation Type: see prose
 </pre>
 
 When an element is [=in the top layer=],


### PR DESCRIPTION
Looking through all the `Animation type:` properties, there are three locations which say `(see prose)` and 1 location ([the `border-*-color` properties](https://github.com/w3c/csswg-drafts/blob/main/css-borders-4/Overview.bs#L57)) that use `see prose` (no parens). This PR makes them consistent, choosing to drop the parens from the three locations that have `(see prose)`, which although the more popular choice for `Animation type:` is overall a far less common stylistic choice.

This makes it more consistent with the other properties, such as `Percentages: see prose` (found in [css-box-3, height](https://github.com/w3c/csswg-drafts/blob/main/css-box-3/block-layout.bs#L1362) and [css-page-floats-3, float-offset](https://github.com/w3c/csswg-drafts/blob/main/css-page-floats-3/Overview.bs#L813)) and other "see" properties, e.g. `see individual properties`.