### PR TITLE
[css-backgrounds-3]/[css-box-3]/[css-speech-1] drop parens around "see individual properties"

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -1853,7 +1853,7 @@ Line Colors: the 'border-color' properties</h3>
 	<pre class="propdef">
 	Name: border-color
 	Value: <<color>>{1,4}
-	Initial: (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements except [=ruby base containers=] and [=ruby annotation containers=]
 	Inherited: no
 	Percentages: N/A
@@ -1911,7 +1911,7 @@ Line Colors: the 'border-color' properties</h3>
 	<pre class="propdef">
 	Name: border-style
 	Value: <<line-style>>{1,4}
-	Initial: (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements except [=ruby base containers=] and [=ruby annotation containers=]
 	Inherited: no
 	Percentages: N/A
@@ -2055,7 +2055,7 @@ Line Thickness: the 'border-width' properties</h3>
 	<pre class="propdef">
 	Name: border-width
 	Value: <<line-width>>{1,4}
-	Initial: (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements except [=ruby base containers=] and [=ruby annotation containers=]
 	Inherited: no
 	Percentages: see individual properties

--- a/css-box-3/block-layout.bs
+++ b/css-box-3/block-layout.bs
@@ -1128,7 +1128,7 @@ and <a href="#Collapsing">“Collapsing margins.”</a>
 <pre class=propdef>
 Name: padding
 Value: <var>&lt;length&gt;</var>{1,4}
-Initial: (see individual properties)
+Initial: see individual properties
 Applies to: all elements
 Inherited: no
 Animation type: see individual properties
@@ -1206,7 +1206,7 @@ block</em> is <em>horizontal,</em> otherwise the height
 <pre class=propdef>
 Name: margin
 Value: [ <var>&lt;length&gt;</var> | <var>&lt;percentage&gt;</var> | auto]{1,4}
-Initial: (see individual properties)
+Initial: see individual properties
 Applies to: see text
 Inherited: no
 Animation type: see individual properties

--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -632,11 +632,11 @@ The 'pause' shorthand property</h3>
 	<pre class=propdef>
 	Name: pause
 	Value: <<'pause-before'>> <<'pause-after'>>?
-	Initial: N/A (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Computed value: N/A (see individual properties)
+	Computed value: see individual properties
 	</pre>
 
 	The 'pause' property is a shorthand property for 'pause-before' and 'pause-after'.
@@ -739,11 +739,11 @@ The 'rest' shorthand property</h3>
 	<pre class=propdef>
 	Name: rest
 	Value: <<'rest-before'>> <<'rest-after'>>?
-	Initial: N/A (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Computed value: N/A (see individual properties)
+	Computed value: see individual properties
 	</pre>
 
 	The 'rest' property is a shorthand for 'rest-before' and 'rest-after'.
@@ -896,11 +896,11 @@ The 'cue' shorthand property</h3>
 	<pre class=propdef>
 	Name: cue
 	Value: <<'cue-before'>> <<'cue-after'>>?
-	Initial: N/A (see individual properties)
+	Initial: see individual properties
 	Applies to: all elements
 	Inherited: no
 	Percentages: N/A
-	Computed value: N/A (see individual properties)
+	Computed value: see individual properties
 	</pre>
 
 	The 'cue' property is a shorthand for 'cue-before' and 'cue-after'.


### PR DESCRIPTION
In css-backgrounds-3/css-box-3 the `Initial:` and `Computed value:` properties use `(see individual properties)` (note the parens). In css-speech-1 it uses `N/A (see individual properties)`. Both of these seem inconsistent with the overwhelming style of `see computed properties` (no `N/A`, no parens). This PR drops the parens around the term to make it more consistent. The `N/A` seems redundant in css-speech-1 as it's not "not applicable", it is applicable, the application being that the individual properties should be consulted. Of course I am happy to take guidance here if we feel as if `N/A (see individual properties)` should be kept, but it seems to be the only instance across all the specs is within css-speech-1.