### PR TITLE
[css-color-hdr-1] Accept `dynamic-range-limit-mix()` as a type instead of a literal function

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -259,7 +259,7 @@ The 'dynamic-range-limit' property {#the-dynamic-range-limit-property}
 	
 	<pre class='propdef'>
 		Name: dynamic-range-limit
-		Value: standard | high | constrained-high | ''dynamic-range-limit-mix()''
+		Value: standard | high | constrained-high | <<dynamic-range-limit-mix()>>
 		Initial: high
 		Applies to: all elements
 		Inherited: no


### PR DESCRIPTION
In the value definition (syntax) of [`dynamic-range-limit`](https://drafts.csswg.org/css-color-hdr-1/#propdef-dynamic-range-limit), `dynamic-range-limit-mix()` represents a [literal function](https://drafts.csswg.org/css-values-4/#component-types) taking no argument:

  > Functional notations and their arguments. These may be written literally as defined in 2.6 Functional Notation Definitions, or referenced by a non-terminal using the function’s name, followed by an empty parentheses pair, between `<` and `>`, e.g. `<calc()>`, and references the correspondingly-named functional notation.

The Bikeshed linking mechanism is a bit wobbly, if I may say so (speced/bikeshed#2906), so this PR only changes references used in other syntaxes (there is only `dymaic-range-limit`).