### PR TITLE
[css-syntax-3] Remove duplicate token stream creations

### DIFF
--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -2161,9 +2161,7 @@ Parser Entry Points</h3>
 		3. If |input| is a [=string=],
 			then [=filter code points=] from |input|,
 			[=tokenize=] the result,
-			then create a new [=token stream=]
-			with those tokens as its [=token stream/tokens=],
-			and return it.
+			and return the stream of tokens.
 
 		4. Assert: Only the preceding types should be passed as |input|.
 	</div>
@@ -3189,9 +3187,8 @@ Consume a '@font-face/unicode-range' value</h4>
 
 	1. Let |tokens| be the result of [=CSS/tokenizing=] |input string|
 		with |unicode ranges allowed| set to true.
-		Let |input| be a new [=token stream=] from |tokens|.
 
-	2. [=Consume a list of component values=] from |input|,
+	2. [=Consume a list of component values=] from |tokens|,
 		and return the result.
 
 	Note: The existence of this algorithm


### PR DESCRIPTION
[tokenize](https://drafts.csswg.org/css-syntax-3/#css-tokenize) maps a stream of code points into a stream of tokens:

  > To tokenize a stream of code points **into a stream of CSS tokens** `input`, repeatedly consume a token from `input` until an `<EOF-token>` is reached, pushing each of the returned tokens into a stream.

But a stream of tokens is also created with its result:

  - in [normalize into a token stream](https://drafts.csswg.org/css-syntax-3/#normalize-into-a-token-stream):

  > 3. [...], [tokenize](https://drafts.csswg.org/css-syntax-3/#css-tokenize) the result, then create a new token stream with those tokens as its tokens, and return it.

  - in [consume the value of a unicode-range descriptor](https://drafts.csswg.org/css-syntax-3/#consume-the-value-of-a-unicode-range-descriptor):

  > 1. Let `tokens` be the result of [tokenizing](https://drafts.csswg.org/css-syntax-3/#css-tokenize) [...]. Let `input` be a new token stream from `tokens`.