### PR TITLE
[css-overflow-4][css-page-floats-3][editorial] Syntax simplification

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -340,7 +340,7 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 			The given string is treated as an independent paragraph
 			for bidi purposes.
 
-		<dt dfn-type=function><dfn>fade( [ <<length>> | <<percentage>> ] )</dfn>
+		<dt dfn-type=function><dfn>fade( [ <<length-percentage>> ] )</dfn>
 		<dd>
 			Clip inline content that overflows its line box.
 			Characters may be only partially rendered.

--- a/css-page-floats-3/Overview.bs
+++ b/css-page-floats-3/Overview.bs
@@ -806,7 +806,7 @@ The 'clear' property</h2>
 
   <pre class="propdef">
     Name: float-offset
-    Value: <<length>> | <<percentage>>
+    Value: <<length-percentage>>
     Initial: 0
     Applies to: floats
     Inherited: no


### PR DESCRIPTION
Replaces the two remaining `<type> | <percentage>` with `<type-percentage>`.