### PR TITLE
[css-nesting-1] Specificity of '&' is zero without a parent rule

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -966,7 +966,8 @@ Nesting Selector: the ''&'' selector {#nest-selector}
 	The <a>specificity</a> of the <a>nesting selector</a>
 	is equal to the largest specificity among the complex selectors
 	in the parent style rule's selector list
-	(identical to the behavior of '':is()'').
+	(identical to the behavior of '':is()''),
+	or zero if no such selector list exists.
 
 	<div class="example">
 		For example, given the following style rules:


### PR DESCRIPTION
Fixes #10196.