### PR TITLE
[css-backgrounds-4] Define background-repeat|position longhands with a logical property group

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -48,6 +48,7 @@ Tiling Images: the 'background-repeat-x', 'background-repeat-y', 'background-rep
 		Percentages: N/A
 		Computed value: as specified
 		Animation type: discrete
+		Logical property group: background-repeat
 	</pre>
 
 	<pre class="prod">
@@ -262,6 +263,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
+		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's horizontal component.
@@ -276,6 +278,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
+		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's vertical component.
@@ -290,6 +293,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to inline-size of background positioning area <em>minus</em> inline-size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
+		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's inline-axis component.
@@ -304,6 +308,7 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to size of background positioning area <em>minus</em> size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
+		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's block-axis component.


### PR DESCRIPTION
Follow-up on https://github.com/w3c/csswg-drafts/issues/116#issuecomment-2295641610.

For example, flow-relative and physical `background-position-*` need to be in the same logical property group in order to maintain the appropriate order of declarations within a CSS declaration block, eg. with `style.cssText = 'background-repeat: repeat; background-repeat-block: no-repeat; background-repeat-y: repeat'`.

Cf. [serialize a CSS declaration block](https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block)  and [set a CSS declaration](https://drafts.csswg.org/cssom-1/#set-a-css-declaration).