### PR TITLE
[css-scroll-snap-2] [editorial] remove group notation from scroll-start-target

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -167,7 +167,7 @@ Initial scroll target</h4>
 
 	<pre class="propdef">
 		Name: scroll-start-target
-		Value: [ none | auto ]
+		Value: none | auto
 		Initial: ''none''
 		Applies to: all elements
 		Inherited: no


### PR DESCRIPTION
Similar to #11094 & https://github.com/w3c/csswg-drafts/pull/11053, the css-scroll-snap-2 has a redundant group around the `scroll-start-target` property value. It is currently specified as `[ auto | none ]`, but I think it could be better expressed without the `[]`, as `auto | none` instead.