### PR TITLE
[css-rythm-1] [editorial] remove redundant `px` dimension from `line-height-step` initial value

### DIFF
--- a/css-rhythm-1/Overview.bs
+++ b/css-rhythm-1/Overview.bs
@@ -356,7 +356,7 @@ Adjusting Line Box Heights: the 'line-height-step' property {#line-height-step}
 	<pre class='propdef'>
 	Name: line-height-step
 	Value: <<length [0,∞]>>
-	Initial: 0px
+	Initial: 0
 	Applies to: block containers
 	Inherited: yes
 	Percentages: N/A


### PR DESCRIPTION
The `line-height-step` property in css-rythm-1 defines its initial value as `0px`. AIUI - it being a zero value means the `px` is redundant.

It seems to be more common to use `0` rather than `0px`. In fact here are all the places that have an initial of `0`:
 - css-box (`margin*`, `padding*`)
 - css-scroll-snap (`scroll-margin*`)
 - css-inline (`baseline-shift`)
 - css-shapes (`shape-margin`, `shape-padding`)
 - css-text (`text-indent`, `line-padding`, `hyphenate-limit-zone`)
 - css-text-decor (`text-decoration-trim`)
 - css-ui (`outline-offset`)
 - css-borders (`border-*-radius` & `border-radius`)
 - css-logical (okay maybe an unfair comparison as it's mostly logical equivalents of box/borders)
 
And here are the places that have an initial of `0px`:
 - css-rythm (`line-height-step` - that's this one)
 - css-tables (`border-spacing` - this initial value is `0px 0px`)
 - css-animation (`animation-delay` - `0s`)
 - css-animation (`transition-delay`, `transition-duration` - both `0s`)
 - css-overflow (`overflow-clip-margin*` - all `0px`)
 - css-backgrounds (`background-position*` - all `0%`)

If this PR gets merged I'll follow up with one correcting `css-overflow` and perhaps the others 😉