### PR TITLE
[css-transitions-2][css-animations-2] Define order of transitioncancel and animationcancel events

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -234,6 +234,18 @@ last) as follows:
     computed value of the 'animation-name' property of the (common) <a>owning
     element</a>.
 
+When determining the composite order in order
+to sort [[#events|animation events]]
+where either or both of the events is an {{animationcancel}} event,
+treat the CSS Animation(s) for which the {{animationcancel}} event was generated
+as having an [=owning element=] corresponding to
+the owning element in use at the moment when the CSS Animation was cancelled.
+Furthermore,
+use the position of the animation in the 'animation-name' property
+in effect at the time when the CSS Animation was cancelled
+sorting such that positions of cancelled animations sort
+before positions of animations that have not been cancelled.
+
 The composite order of CSS Animations <em>without</em> an <a>owning element</a>
 is based on their position in the <a>global animation list</a>.
 

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -363,6 +363,11 @@ are sorted in composite order (first to last) as follows:
     such that &lsquo;-moz-column-width&rsquo; sorts before
     &lsquo;column-width&rsquo;).
 
+When determining the composite order in order to sort transition events
+where either or both of the events is a {{transitioncancel}} event,
+use the [=owning element=] and [=transition generation=]
+that were set immediately prior to cancelling the transition.
+
 Transitions generated using the markup defined in this specification are
 <em>not</em> added to the <a>global animation list</a> when they are created.
 Instead, these animations are appended to the <a>global animation list</a> at
@@ -372,7 +377,7 @@ Transitions that have been disassociated from their <a>owning element</a>
 but are still [=play state/idle=] do not have a defined
 composite order.
 
-Note, this behavior relies on the fact that disassociating a transition
+Note: This behavior relies on the fact that disassociating a transition
 from its <a>owning element</a> always causes it to enter (or remain) in the
 [=play state/idle|idle play state=].
 


### PR DESCRIPTION
- **[css-transitions-2] Define order for sorting transitioncancel events**
- **[css-animations-2] Define order for sorting animationcancel events**

Fixes #11064.
