### PR TITLE
[css-values-5] Make it clear that `allow-keywords` can't just interpolate with intrinsic sizes.

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2696,7 +2696,7 @@ Interpolating sizing keywords: the 'interpolate-size' property</h3>
 
 		<dt><dfn>allow-keywords</dfn>
 		<dd>
-			Two values can be interpolated if
+			Two values can also be interpolated if
 			one of them is an <<intrinsic-size-keyword>>
 			and the other is a <<length-percentage>>.
 			This is done by treating


### PR DESCRIPTION
The current wording is a tiny bit ambiguous; it could also be interpreted to mean that `interpolate-size: allow-keywords` only lets you interpolate between an intrinsic size and a length percentage, but not two length percentages.

I do realize how unlikely this interpretation is, but I had to do a double-take while reading so I thought I'd PR it.