### PR TITLE
[web-animations-2] Change progress to overallProgress

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -969,13 +969,13 @@ Add the following sentence:
 
 </div>
 
-### Calculating the progress of an animation ### {#the-progress-of-an-animation}
+### Calculating the overall progress of an animation ### {#the-overall-progress-of-an-animation}
 
-  An animation's <dfn export for=animation>progress</dfn> is the ratio of its
+  An animation's <dfn export for=animation>overallProgress</dfn> is the ratio of its
    [=animation/current time=] to its [=associated effect end=].
 
-  <div algorithm="calculate animation progress">
-    The [=animation/progress=] of an [=animation=], |animation|, is calculated as follows:
+  <div algorithm="calculate animation overall progress">
+    The [=animation/overallProgress=] of an [=animation=], |animation|, is calculated as follows:
 
     <dl class=switch>
 
@@ -983,21 +983,21 @@ Add the following sentence:
         * |animation| does not have an [=animation/associated effect=], or
         * |animation|'s [=animation/current time=] is an [=unresolved=] time value,
     ::
-        |animation|'s [=animation/progress=] is null.
+        |animation|'s [=animation/overallProgress=] is null.
     : If |animation|'s [=associated effect end=] is zero,
     ::
         : If |animation|'s [=animation/current time=] is negative,
-        :: |animation|'s [=animation/progress=] is zero.
+        :: |animation|'s [=animation/overallProgress=] is zero.
 
         : Otherwise,
-        :: |animation|'s [=animation/progress=] is one.
+        :: |animation|'s [=animation/overallProgress=] is one.
     : If |animation|'s [=associated effect end=] is infinite,
     ::
-        |animation|'s [=animation/progress=] is zero.
+        |animation|'s [=animation/overallProgress=] is zero.
     : Otherwise,
     ::
         <blockquote>
-          <code><a for="animation">progress</a> = min(max([=animation/current time=] / |animation|'s [=associated effect end=], 0), 1)
+          <code><a for="animation">overallProgress</a> = min(max([=animation/current time=] / |animation|'s [=associated effect end=], 0), 1)
           </code>
         </blockquote>
 
@@ -2425,7 +2425,7 @@ Update the attribute type for currentTime.
 <h3 id="the-animation-interface">The <code>Animation</code> interface</h3>
 
 Update the startTime and currentTime of the Animation interface, and add
-rangeStart, rangeEnd, and progress as follows:
+rangeStart, rangeEnd, and overallProgress as follows:
 
 <pre class="idl">
 [Exposed=Window]
@@ -2434,7 +2434,7 @@ partial interface Animation {
     attribute CSSNumberish?       currentTime;
     attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart;
     attribute (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd;
-    readonly attribute double? progress;
+    readonly attribute double? overallProgress;
 };
 </pre>
 
@@ -2480,8 +2480,8 @@ Add:
 >     When reading the attribute, the returned value is either a
 >     {{TimelineRangeOffset}} or the {{DOMString}} "normal".
 >
-> :  <dfn attribute for=Animation>progress</dfn>
-> ::  Specifies the [=animation/progress=] of the <a>animation</a> as a proportion of its
+> :  <dfn attribute for=Animation>overallProgress</dfn>
+> ::  Specifies the [=animation/overallProgress=] of the <a>animation</a> as a proportion of its
 >     [=associated effect end=].
 </div>
 


### PR DESCRIPTION
In line with the CSS working group's resolution[1] to change Animation.progress to Animation.overallProgress, this patch updates the relevant portions of the web-animations-2 spec.

[1] https://github.com/w3c/csswg-drafts/issues/8799#issuecomment-2461097047
