### PR TITLE
[css-view-transitions-2] Editorial: fix a few nits for WD publishing

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -555,7 +555,7 @@ An '':active-view-transition'' pseudo-class matches the [=document element=] whe
 
 ### The '':active-view-transition-type()'' pseudo-class ### {#the-active-view-transition-type-pseudo}
 
-The <dfn id='active-view-transition-type-pseudo'>:active-view-transition-type()</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
+The <dfn id="active-view-transition-type-pseudo">:active-view-transition-type()</dfn> pseudo-class applies to the root element of the document, if it has a matching [=active view transition=].
 It has the following syntax definition:
 
 <pre class=prod>
@@ -822,7 +822,7 @@ li {
 
 ## Additions to 'view-transition-name' ## {#additions-to-vt-name}
 
-In addition to the existing values, the 'view-transition-name' also accepts an <dfn for=view-transition-name type=value export>auto</dfn> keyword.
+In addition to the existing values, the 'view-transition-name' also accepts an <dfn for=view-transition-name export>auto</dfn> keyword.
 To resolve the [=used value=] of 'view-transition-name' for |element|:
 	1. Let |computed| be the [=computed value=] of 'view-transition-name'.
 	1. If |computed| is <css>none</css>, return null.
@@ -1482,12 +1482,11 @@ Changes from <a href="https://www.w3.org/TR/2024/WD-css-view-transitions-2-20240
 * First pass at layered capture (<a href="https://github.com/w3c/csswg-drafts/issues/10585">#10585</a>)
 * Allow transitions when traversing into a document that was created using cross-origin redirects (<a href="https://github.com/w3c/csswg-drafts/issues/11063">#11063</a>#11063)
 * Clarify a few nesting details (<a href="https://github.com/w3c/csswg-drafts/issues/10780">#10780</a> and <a href="https://github.com/w3c/csswg-drafts/issues/10633">#10633</a>)
-* Allow `auto` as a keyword (<a href="https://github.com/w3c/csswg-drafts/issues/8320">#8320</a>)
+* Allow `auto` as a keyword for 'view-transition-name' (<a href="https://github.com/w3c/csswg-drafts/issues/8320">#8320</a>)
 * Clarify timeout behavior for inbound view transition (<a href="https://github.com/w3c/csswg-drafts/issues/10800">#10800</a>)
 * When hiding the document, and inbound cross-document view transition should be skipped. (<a href="https://github.com/w3c/csswg-drafts/issues/9822">#9822</a>)
 * Rename UpdateCallback to something more specific.
 * Clarify that CSSViewTransitionRule returns an empty string for invalid/missing navigation descriptor (<a href="https://github.com/w3c/csswg-drafts/issues/10654">#10654</a>)
 * Initial spec for nested view transitions (<a href="https://github.com/w3c/csswg-drafts/issues/10334">#10334</a>)
 * `view-transition-class` is a tree-scoped name (<a href="https://github.com/w3c/csswg-drafts/issues/10529">#10529</a>)
-* Fix typo: if => of
 * Stop extending CSSRule with obsolete pattern (See <a href="https://github.com/w3c/csswg-drafts/issues/10606">#10606</a>)


### PR DESCRIPTION
- Remove `type` from dfn
- Remove typo fixes from changelog