### PR TITLE
[css-values] Total attr()-tainting for substitution values

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1743,16 +1743,20 @@ Security</h4>
 	To guard against this,
 	the values produced by an ''attr()'' are considered <dfn export lt="attr()-taint">attr()-tainted</dfn>,
 	as are functions that contain an [=attr()-tainted=] value.
-	[=Registered custom properties=] containing ''attr()''
-	maintain the [=attr()-taint=] on their [=attr()-tainted=] values
-	across [=var() substitution=].
+
+	The substitution value of an [=arbitrary substitution function=]
+	is [=attr()-tainted=] <em>as a whole</em>
+	if any [=attr()-tainted=] values were involved
+	in creating that substitution value.
+	<span class=note>This extends to the [=equivalent token sequence=]
+	when substituting values of [=registered custom properties=].</span>
 
 	Using an [=attr()-tainted=] value as or in a <<url>>
 	makes a declaration [=invalid at computed-value time=].
 
 	<div class=example>
 		For example,
-		all of the following are invalid:
+		all of the following are [=invalid at computed-value time=]:
 
 		* ''background-image: src(attr(foo));'' - can't use it directly.
 		* ''background-image: image(attr(foo))'' - can't use it in other <<url>>-taking functions.
@@ -1765,6 +1769,14 @@ Security</h4>
 		* ''background-image: image("foo.jpg", attr(bgcolor type(&lt;color>)))'' is fine;
 			the ''attr()'' is providing a fallback color,
 			and the <<url>> isn't [=attr()-tainted=].
+
+		Using ''attr()'' indirectly via a [=custom property=]
+		causes [=attr()-tainting=] of the whole custom property value:
+
+		* ''--foo: image("foo.jpg", attr(bgcolor type(&lt;color&gt;))); background-image: var(--foo);''
+			is [=invalid at computed-value time=].
+
+			Issue: Investigate partial tainting of custom property values.
 	</div>
 
 	Note: Implementing this restriction
@@ -1776,7 +1788,7 @@ Security</h4>
 	Note that non-string types can even trigger this,
 	via functions like <css>string()</css>
 	that can stringify other types of values:
-	''--foo: attr(foo type(<number>)); background-image: src(string(var(--foo)))''
+	''--foo: attr(foo type(&lt;number&gt;)); background-image: src(string(var(--foo)))''
 	needs to be invalid as well.
 
 <!-- Big Text: random


### PR DESCRIPTION
This may have been the intended meaning of the spec text already, but I think we should clearly state the outcome of #5092: partial tainting of custom properties was proposed in that issue, discussed, objected to, and therefore *not* accepted.

This PR hopefully makes it clear that attr()-tainting applies to whole substitution values, for now.
