### PR TITLE
[css-color-5] Validate color profile components case-insensitively

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2029,10 +2029,9 @@ or any other color or monochrome output device which has been characterized.
 			<pre>components: cyan, magenta, yellow, black, orange, green, violet</pre>
 		</div>
 
-		A component must not be named ‘none’,
+		If a component is an [=ASCII case-insensitive=] match for ''none'',
+		the descriptor is invalid,
 		because that would clash with the token for missing values.
-		If this descriptor contains a component called ‘none’,
-		the descriptor is invalid.
 
 		If the name chosen for a component
 		clashes with a CSS numeric constant


### PR DESCRIPTION
[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
