### PR TITLE
[css-overflow-5] Remove normative active marker algorithm.

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -288,33 +288,51 @@ The 'scroll-marker-group' property</h4>
 	This 'eventual scroll position' is used to determine the active marker within each [=scroll marker group=].
 	Since markers themselves may represent just the start of the content (e.g. headers), we consider the active marker to be the first one which we are at or beyond the scroll position of.
 
-	<div algorithm="scroll tracking">
-		Whenever a [=scroll container=] is scrolled, or layout changes the scroll position, the user agent must run these steps to determine the active marker:
+	Whenever a [=scroll container=] participating in one or more [=scroll marker groups=] is scrolled, or layout changes the eventual scroll position,
+	the user agent should determine and update the active marker for each [=scroll marker group=]
+	based on the section of content most likely to be of interest given the target scroll position.
 
-		1. Let <var>position</var> be the 'eventual scroll position' for the scrolling operation.
-		1. For each focusgroup <var>group</var> containing one or more [=scroll marker control=] elements whose [=scroll target=] is a descendant of [=scroll container=]:
+	<div algorithm="scroll tracking" class=example>
+		Example algorithm to determine the active marker for a given scroll marker <var>group</var>.
 
-			1. 	Let <var>markers</var> be all of the [=scroll marker control=] elements which are a part of the [=scroll marker group=] for the [=scroll container=].
-			1. 	Let <var>targets</var> be the [=scroll target=]s of |markers|, associated with the item of |markers| they came from, and sorted in [=tree order=].
-			1. 	For each |target| in |targets|, <a>determine the scroll-into-view position</a> of |target|, storing this as the associated |target position| of |target|.
-			1. 	Let |selected target| be the largest-indexed item of |targets|
-				whose associated |target position| is equal to or before |position| in both the block and inline axises in the current writing mode direction of the [=scroll container=].
+		1. Let |scroller| be the nearest common ancestor [=scroll container=] of all of the [=scroll marker=] elements in |group|.
+		1. Let |active| be scroller.
+		1. While |active| is a [=scroll container=] containing [=scroll target=] elements targeted by |group|:
+			1. Let <var>scroller</var> be |active|.
+			1. Let <var>targets</var> be the set of the [=scroll target=] elements whose nearest ancestor [=scroll container=] is |scroller|
+			   and the [=scroll container=] elements which contain [=scroll target=] elements targeted by the [=scroll marker group=] whose nearest ancestor [=scroll container=] is |scroller|.
+			1. Let <var>primary</var> be the primary scrolling axis, assumed to be the block direction of the container's writing-mode.
+			1. Let <var>secondary</var> be the scrolling axis perpendicular to primary.
+			1. Let <var>position</var> be the 'eventual scroll position' considering ongoing scrolling operations.
+			1. For each <var>axis</var> of |primary|, followed by |secondary|:
+				1. 	Let <var>scrollport size</var> be the client size of |scroller| in the dimension |axis|.
+				1. 	For each |target| in |targets|, <a>determine the scroll-into-view position</a> of |target| in |axis|, storing this as the associated |target position| of |target|.
+				1. 	Let |selected position| be the largest |target position|
+					where |target position| is equal to or before |position| in the |axis|,
+					or whose nearest smaller |target position| < |position| - |scrollport size| / 2 and whose |target position| < |position| + |scrollport size| / 2.
 
-				Issue: When the next marker is closer to being aligned than the previous we should use the next marker, in a manner similar to mandatory snap point selection.
-
-			1. 	: If there is no such item,
-				::
-					Set the active state of all |markers| in the |group| to false and return.
-
-			1. 	Let |selected marker| be the marker associated with |selected target|.
-				If multiple items of |markers| are associated with |selected target|,
-				set |selected marker| to be the marker that is earliest in tree order.
-			1. 	Set the active state of |selected marker| to true.
-			1.	: If the active element was the <a href="https://open-ui.org/components/focusgroup.explainer/#last-focused-memory">last-focused element</a> of the |group|,
+				1. 	: If there is no such position,
 					::
-						Focus |selected marker|
-			1. 	Set the <a href="https://open-ui.org/components/focusgroup.explainer/#last-focused-memory">last-focused element</a> of the |group| to |selected marker|.
-			1. 	Set the active state of all other |markers| in the |group| to false.
+						Set the |selected position| to the first one.
+
+				1. Let |active| be the all of the |targets| whose associated |target position| is |selected position|.
+			1. Let |active| be the first item in |active| if it has more than one potential target.
+
+		1. 	Let |selected marker| be the [=scroll marker=] associated with |active|.
+			If multiple [=scroll marker=] elements are associated with |active|,
+			set |selected marker| to be the marker that is earliest in tree order among them.
+		1.  Return |selected marker|
+	</div>
+
+		<div algorithm="update active marker">
+		Whenever the UA determines that a new marker is the <var>active marker</var> for a [=scroll marker group=] <var>group</var> it must run the following steps:
+
+		1. 	Set the active state of |active marker| to true.
+		1.	: If |active marker| was the <a href="https://open-ui.org/components/focusgroup.explainer/#last-focused-memory">last-focused element</a> of the |group|,
+				::
+					Focus |active marker|
+		1. 	Set the <a href="https://open-ui.org/components/focusgroup.explainer/#last-focused-memory">last-focused element</a> of the |group| to |active marker|.
+		1. 	Set the active state of all other [=scroll marker=] elements in |group| to false.
 	</div>
 
 <h4 id="scroll-marker-activation">Activation behavior</h4>


### PR DESCRIPTION
As resolved in #10917:
- removes the normative algorithm for determining the active marker and leaves it up to the UA,
- additionally defines an example algorithm that takes into account improvements mentioned in the issue for selecting the next marker when it is nearer to being in view.

The example algorithm also
- includes recursive marker selection within nested scroll containers as proposed in #11098, and
- uses the writing mode as the primary axis following the proposed primary axis algorithm in #11198.