### PR TITLE
[selectors-4] Missing link in a single paragraph

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -4,6 +4,7 @@ Group: CSSWG
 Shortname: selectors
 Level: 4
 Status: ED
+Remove Multiple Links: false
 Work Status: Refining
 ED: https://drafts.csswg.org/selectors/
 TR: https://www.w3.org/TR/selectors-4/


### PR DESCRIPTION
Impact on readability.

Documentation source link: https://www.w3.org/TR/selectors-4/#attribute-representation

Bikeshed link: https://speced.github.io/bikeshed/#metadata-remove-multiple-links

Before:
![xx](https://github.com/user-attachments/assets/9feacce6-4c71-46dd-82db-eca88fb2ce6b)


After:
![xx](https://github.com/user-attachments/assets/9f898224-d780-4f37-a6a1-921390952cbd)