### PR TITLE
[css-multicol-1] Clarify effect of `hidden` on `column-rule-width`. #11090

### DIFF
--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -1166,7 +1166,7 @@ Stacking Context</h3>
 	parsing/column-rule-style-invalid.html
 	</wpt>
 
-	The ''border-style/none'' value forces the computed value of 'column-rule-width' to be ''0''.
+	The ''border-style/none'' and ''hidden'' values force the computed value of 'column-rule-width' to be ''0''.
 
 
 <h3 id='crw'>The Width Of Column Rules: the 'column-rule-width' property</h3>


### PR DESCRIPTION
Make the prose for `column-rule-style` consistent with the computed value definition for `column-rule-width` with regards to the effects of `none` and `hidden` values.