### PR TITLE
Add move Event

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1016,6 +1016,16 @@ compatibility reasons.
 
 Note: Some non-conforming implementations are known to return 32 instead of 24.
 
+<h2 id=extensions-to-the-windoweventhandlers-interface>Extensions to the {{WindowEventHandlers}} Interface</h3>
+
+<pre class=idl>
+partial interface WindowEventHandlers {
+    attribute EventHandler onmove;
+};
+</pre>
+
+<dfn attribute for=Window>onmove</dfn> is the <a>event handler IDL attribute</a> for the <a event>move</a> event.
+
 
 <h2 id=extensions-to-the-document-interface>Extensions to the {{Document}} Interface</h2>
 
@@ -1997,6 +2007,22 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. Otherwise, <a>fire an event</a> named <a event>scrollend</a> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scrollend event targets</a>.
 
+<h3 id=moving-viewports>Moving viewports</h3>
+
+This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
+
+When <a for=/>updating the rendering</a>, after running the scroll steps:
+
+1. For each fully active Document in docs, <dfn export for=Document>run the move steps</dfn> for that Document.
+
+When asked to <a>run the move steps</a> for a {{Document}} <var>doc</var>, run these steps:
+
+1. If <var>doc</var>'s client window has had its position relative to the <a>Web-exposed screen area</a> changed
+    (e.g. as a result of the user moving the browser window)
+    since the last time these steps were run,
+    <a>fire an event</a> named <a event>move</a>
+    at the {{Window}} object associated with <var>doc</var>.
+
 <h3 id=event-summary>Event summary</h3>
 
 <i>This section is non-normative.</i>
@@ -2027,6 +2053,12 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
    <td>Fired at the {{VisualViewport}}, {{Document}}, or element when a scroll is <a lt="scroll completed">completed</a>: the
       {{VisualViewport}}, <a>viewport</a>, or element has been scrolled, the scroll sequence has ended and any scroll offset changes have
       been applied.
+  <tr>
+   <td><dfn event for="Window">move</dfn>
+   <td>{{Event}}
+   <td>{{Window}}
+   <td>Fired at the {{Window}} when the client window is moved relative to the <a>Web-exposed screen area</a>.
+  <tr>
 </table>
 
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2013,9 +2013,9 @@ This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTM
 
 When <a for=/>updating the rendering</a>, after running the scroll steps:
 
-1. For each fully active Document in docs, <dfn export for=Document>run the move steps</dfn> for that Document.
+1. For each fully active Document in docs, [=run the move steps=] for that Document.
 
-When asked to <a>run the move steps</a> for a {{Document}} <var>doc</var>, run these steps:
+When asked to <dfn export for=Document>run the move steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 
 1. If <var>doc</var>'s client window has had its position relative to the <a>Web-exposed screen area</a> changed
     (e.g. as a result of the user moving the browser window)

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1016,16 +1016,6 @@ compatibility reasons.
 
 Note: Some non-conforming implementations are known to return 32 instead of 24.
 
-<h2 id=extensions-to-the-windoweventhandlers-interface>Extensions to the {{WindowEventHandlers}} Interface</h3>
-
-<pre class=idl>
-partial interface WindowEventHandlers {
-    attribute EventHandler onmove;
-};
-</pre>
-
-<dfn attribute for=Window>onmove</dfn> is the <a>event handler IDL attribute</a> for the <a event>move</a> event.
-
 
 <h2 id=extensions-to-the-document-interface>Extensions to the {{Document}} Interface</h2>
 
@@ -2010,10 +2000,6 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
 <h3 id=moving-viewports>Moving viewports</h3>
 
 This section integrates with the <a for=/>event loop</a> defined in HTML. [[!HTML]]
-
-When <a for=/>updating the rendering</a>, after running the scroll steps:
-
-1. For each fully active Document in docs, [=run the move steps=] for that Document.
 
 When asked to <dfn export for=Document>run the move steps</dfn> for a {{Document}} <var>doc</var>, run these steps:
 


### PR DESCRIPTION
This is the CSS part of https://github.com/w3c/csswg-drafts/issues/7693. HTML part to be filed separately.

(this replaces https://github.com/w3c/csswg-drafts/pull/9664, which was trying to do it all in CSS, monkey patching HTML)