### PR TITLE
[css-overflow-3] Correct scrollbar space description

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -728,11 +728,11 @@ Scrollbars and Layout</h2>
 <h3 id="scrollbar-sizing">
 Scrollbar Contributions to Sizing</h3>
 
-	When reserving space for a scrollbar placed at the edge of an element's box,
-	the reserved space is inserted between the inner border edge
-	and the outer padding edge.
-	For the purpose of the <a spec=css-backgrounds>background positioning area</a> and <a spec=css-backgrounds>background painting area</a> however,
-	this reserved space is considered to be part of the [=padding box=].
+	The space reserved for the scrollbar is located between the 
+	padding area and the border area of the scroll container box.
+	However, for the purpose of the <a spec=css-backgrounds>background positioning area</a> 
+	and <a spec=css-backgrounds>background painting area</a>, this 
+	reserved space is treated as part of the [=padding area=].
 
 	<div class="example">
 		In the following document fragment,

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -728,11 +728,11 @@ Scrollbars and Layout</h2>
 <h3 id="scrollbar-sizing">
 Scrollbar Contributions to Sizing</h3>
 
-	The space reserved for the scrollbar is located between the 
-	padding area and the border area of the scroll container box.
+	The space reserved for the scrollbar is located between 
+	the [=padding area=] and the [=border area=] of the [=scroll container=] box.
 	However, for the purpose of the <a spec=css-backgrounds>background positioning area</a> 
-	and <a spec=css-backgrounds>background painting area</a>, this 
-	reserved space is treated as part of the [=padding area=].
+	and <a spec=css-backgrounds>background painting area</a>,
+	this reserved space is treated as part of the [=padding area=].
 
 	<div class="example">
 		In the following document fragment,


### PR DESCRIPTION
The terms "inner" and "outer" are not defined for border and padding edges in [The CSS Box Model](
https://www.w3.org/TR/css-box-4/#box-model). These terms are unnecessary, undefined in this context, and their removal makes the description more clear.

