### PR TITLE
[css-sizing-3] Supplement the 'Applies to' field for width and heigh

### DIFF
--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -370,7 +370,7 @@ Preferred Size Properties: the 'width' and 'height' properties</h4>
 	Name: width, height
 	Value: auto | <<length-percentage [0,∞]>> | min-content | max-content | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr> | <<width/calc-size()>>
 	Initial: auto
-	Applies to: all elements except <a>non-replaced</a> <a>inlines</a>
+	Applies to: all elements except <a>non-replaced</a> inline elements. 'width' cannot be applied to row groups
 	Inherited: no
 	Logical property group: size
 	Percentages: relative to width/height of <a>containing block</a>


### PR DESCRIPTION
`Applies to` lacks relevant description. Additionally, the additional information I provided may not be formal enough.