### PR TITLE
[css-overflow-5] Allow scroll to target unreachable scroll marker targets

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -301,13 +301,25 @@ Selecting The Active Scroll Marker: the '':target-current'' pseudo-class</h4>
 		1. While |active| is a [=scroll container=] containing [=scroll target=] elements targeted by |group|:
 			1. Let <var>scroller</var> be |active|.
 			1. Let <var>targets</var> be the set of the [=scroll target=] elements whose nearest ancestor [=scroll container=] is |scroller|
-			   and the [=scroll container=] elements which contain [=scroll target=] elements targeted by the [=scroll marker group=] whose nearest ancestor [=scroll container=] is |scroller|.
+				and the [=scroll container=] elements which contain [=scroll target=] elements targeted by the [=scroll marker group=] whose nearest ancestor [=scroll container=] is |scroller|.
 			1. Let <var>primary</var> be the primary scrolling axis, assumed to be the block direction of the container's writing-mode.
 			1. Let <var>secondary</var> be the scrolling axis perpendicular to primary.
 			1. Let <var>position</var> be the 'eventual scroll position' considering ongoing scrolling operations.
 			1. For each <var>axis</var> of |primary|, followed by |secondary|:
 				1. 	Let <var>scrollport size</var> be the client size of |scroller| in the dimension |axis|.
 				1. 	For each |target| in |targets|, <a>determine the scroll-into-view position</a> of |target| in |axis|, storing this as the associated |target position| of |target|.
+				1. 	Let <var>scroll size</var> be the length of the <a>scrollable overflow area</a> of the |scroller| in the dimension |axis|.
+				1. 	Let <var>scroll range</var> be <code>|scroll size| - |scrollport size|</code>.
+				1.  If |scroll range| is greater than 0, redistribute unreachable target positions:
+					1.  Let <var>distribute range</var> be <code>min(1/8 * |scrollport size|, |scroll range| / 2)</code>.
+					1.  Let <var>before targets</var> be all |targets| whose associated |target position| is less than <code>|distribute range|</code>.
+					1.  Let <var>minimum position</var> be the minimum |target position| of |before targets|.
+					1.  Update the associated |target position| of each target in |before targets| to
+						<code>(|target position| - |minimum position|) / (|distribute range| - |minimum position|) * |distribute range|</code>.
+					1.  Let <var>after targets</var> be all |targets| whose associated |target position| is greater than <code>|scroll range| - |distribute range|</code>.
+					1.  Let <var>maximum position</var> be the maximum |target position| of |after targets|.
+					1.  Update the associated |target position| of each target in |after targets| to
+						<code>(|target position| - (|scroll range| - |distribute range|)) / (|maximum position| - (|scroll range| - |distribute range|)) * |distribute range| + (|scroll range| - |distribute range|)</code>.
 				1. 	Let |selected position| be the largest |target position|
 					where |target position| is equal to or before |position| in the |axis|,
 					or whose nearest smaller |target position| < |position| - |scrollport size| / 2 and whose |target position| < |position| + |scrollport size| / 2.


### PR DESCRIPTION
Adds to the non-normative suggested compromise for selecting the active scroll marker the proposed compromise resolved on in  #11165 to ensure that scrolling from start to end scrolls through all of the markers in that scroller.