### PR TITLE
[css-inline-3] Clarify the condition when inline formatting context is established

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -94,7 +94,7 @@ Inline Layout Model</h2>
 	[=inline-level boxes=] are [[#alignment|aligned to each other]] along the [=block axis=],
 	typically by the [=baselines=] of their text.
 
-	Any [=block container=] that directly contains
+	Any [=block container=] that directly contains only
 	[=inline-level=] content--
 	such as [=inline boxes=], [=atomic inlines=], and [=text sequences=]--
 	establishes an [=inline formatting context=]


### PR DESCRIPTION
A block container establishes an inline formatting context only when it directly contains exclusively inline-level content

I am submitting the pull request under the [CC0](https://creativecommons.org/public-domain/cc0/) license.
