### PR TITLE
[selectors] Remove the :closed pseudo-class

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2611,15 +2611,11 @@ Sound State: the '':muted'' and '':volume-locked'' pseudo-classes</h3>
 Element Display State Pseudo-classes</h2>
 
 <h3 id="open-state">
-Collapse State: the '':open'' and '':closed'' pseudo-class</h3>
+Collapse State: the '':open'' pseudo-class</h3>
 
 	The <dfn>:open</dfn> pseudo-class represents an element
 	that has both “open” and “closed” states,
 	and which is currently in the “open” state.
-
-	The <dfn>:closed</dfn> pseudo-class represents an element
-	that has both “open” and “closed” states,
-	and which is currently in the closed state.
 
 	Exactly what “open” and “closed” mean is host-language specific,
 	but exemplified by elements such as
@@ -2632,6 +2628,9 @@ Collapse State: the '':open'' and '':closed'' pseudo-class</h3>
 	(for example, one that has ''visibility: collapse'',
 	or belongs to a ''display: none'' subtree)
 	can still be “open” and will match '':open''.
+
+	Note: A ":closed" pseudo-class might be added in the future
+	once the full set of things that support '':open'' is known.
 
 <h3 id="modal-state">
 Modal (Exclusive Interaction) State: the '':modal'' pseudo-class</h3>


### PR DESCRIPTION
This was resolved here: https://github.com/w3c/csswg-drafts/issues/11039#issuecomment-2491673891
