### PR TITLE
[css-selectors-4] Add <input> to list of :open elements

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2619,7 +2619,7 @@ Collapse State: the '':open'' pseudo-class</h3>
 
 	Exactly what “open” and “closed” mean is host-language specific,
 	but exemplified by elements such as
-	HTML's <{details}>, <{select}>, and <{dialog}> elements,
+	HTML's <{details}>, <{select}>, <{dialog}>, and <{input}> elements,
 	all of which can be toggled “open” to display more content
 	(or any content at all, in the case of <{dialog}>).
 


### PR DESCRIPTION
Since the list of elements almost includes all of the elements which :open is going to apply to, I figure that adding `<input>` to make it complete will reduce any potential confusion.
