### PR TITLE
[css-color-hdr-1] use one-or-more for `dynamic-range-limit-mix` grammar production

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -318,7 +318,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 
 
 <pre class='prod'>
-	<dfn>dynamic-range-limit-mix()</dfn> = dynamic-range-limit-mix( [ <<ident>> && <<percentage [0,100]>> ]+)
+	<dfn>dynamic-range-limit-mix()</dfn> = dynamic-range-limit-mix( [ <<ident>> && <<percentage [0,100]>> ]#)
 </pre>
 
 <wpt>


### PR DESCRIPTION
Based on the parsing tests in WPT (https://github.com/web-platform-tests/wpt/blob/master/css/css-color-hdr/parsing.html) it seems as though commas are _required_ for each set of ident && <lengthpercentage> groups here, however the spec is using the `+` sigil which allows for "one or more" but doesn't specify commas. I think what might be desired here is to use `#` which is "one or more comma separated". This would satisfy the requirement for commas.

I think, in addition, we might want to specify something like `#{2,}` - considering all examples in the parse tests expect two or more values, and the spec talks about summing all values, I am unsure if it is redundant or not to specify just one value (e.g. `dynamic-range-limit-mix(high 10%)`).

This doesn't resolve the recursive affordances that the WPTs allude to, but baby steps 😆 