### PR TITLE
[web-animations-2] Fix numbering of steps for the computation of "at progress timeline boundary"

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -1244,7 +1244,7 @@ an <a>animation effect</a>.
 
         return false
 
-   1.  Let <var>effective start time</var> be the <a>animation</a>'s
+    1.  Let <var>effective start time</var> be the <a>animation</a>'s
         [=animation/start time=] if resolved, or zero otherwise.
 
     1.  Set <var>unlimited current time</var> based on the first matching


### PR DESCRIPTION
Due to faulty indentation, "Let effective start time be the animation’s start time if resolved, or zero otherwise." is step 1 and all other steps are sub steps.