### PR TITLE
[scroll-animations-1] allow explicitly setting `null` as a source when constructing a `ScrollTimeline`

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -311,7 +311,7 @@ spec:selectors-4; type:dfn; text:selector
 			1.  Set the {{ScrollTimeline/source}} of |timeline| to:
 
 				<dl class="switch">
-					:   If the `source` member of |options| is present and not null,
+					:   If the `source` member of |options| is present,
 					::  The `source` member of |options|.
 
 					:   Otherwise,


### PR DESCRIPTION
It should be possible to explicitly set a `null` source when constructing a `ScrollTimeline`. This addresses https://github.com/w3c/csswg-drafts/issues/11340.