### PR TITLE
[css-values-5] Allow explicit null-namespace in attr-name

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1556,7 +1556,7 @@ Ian's proposal:
 	<pre class=prod>
 		attr() = attr( <<attr-name>> <<attr-type>>? , <<declaration-value>>?)
 
-		<dfn>&lt;attr-name></dfn> = [ <<ident-token>> '|' ]? <<ident-token>>
+		<dfn>&lt;attr-name></dfn> = [ <<ident-token>>? '|' ]? <<ident-token>>
 		<dfn>&lt;attr-type></dfn> = type( <<syntax>> ) | string | <<attr-unit>>
 	</pre>
 


### PR DESCRIPTION
Otherwise we're making a non-backwards-compatible change against content:attr() from css-content-3 [1].

[1] https://drafts.csswg.org/css-content-3/#strings

