### PR TITLE
[css-scroll-snap-2] Rename scroll-start-target to scroll-initial-target

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -80,7 +80,7 @@ Motivating Examples {#examples}
 								overflow-inline: auto;
 						}
 						.carousel .origin {
-								scroll-start-target: auto;
+								scroll-initial-target: nearest;
 						}
 				</pre>
 
@@ -103,7 +103,7 @@ Motivating Examples {#examples}
 						}
 
 						main {
-								scroll-start-target: auto;
+								scroll-initial-target: nearest;
 						}
 				</pre>
 
@@ -131,15 +131,19 @@ Motivating Examples {#examples}
 Setting Where Scroll Starts {#properties-on-the-scroll-container}
 =================================================================
 
-The 'scroll-start-target' property {#scroll-start-target}
+The 'scroll-initial-target' property {#scroll-initial-target}
 -------------------------------------------
+
+Issue: The name "scroll-initial-target" is chosen as the least worst option
+which expresses that it should be scrolled to when its scroll container
+first shows up on the page. A better name for the property would be very much welcome.
 
 <h4 dfn export id="initial-scroll-target">
 Initial scroll target</h4>
 
 	The [=initial scroll target=] of a <a>scroll container</a> |scrollcontainer|
 	is an element or pseudo-element
-	whose 'scroll-start-target'property is non-''scroll-start-target/none''
+	whose 'scroll-initial-target'property is non-''scroll-initial-target/none''
 	and whose nearest <a>scroll container</a> is |scrollcontainer|.
 	When multiple such elements or pseudo-elements exist,
 	user-agents should select the one
@@ -163,11 +167,11 @@ Initial scroll target</h4>
 	</div>
 
 
-<h4 id="scroll-start-target-propdef">scroll-start-target Property Definition</h4>
+<h4 id="scroll-initial-target-propdef">scroll-initial-target Property Definition</h4>
 
 	<pre class="propdef">
-		Name: scroll-start-target
-		Value: none | auto
+		Name: scroll-initial-target
+		Value: none | nearest
 		Initial: ''none''
 		Applies to: all elements
 		Inherited: no
@@ -176,23 +180,23 @@ Initial scroll target</h4>
 		Animation type: none
 	</pre>
 
-	<dl dfn-type=value dfn-for="scroll-start-target">
+	<dl dfn-type=value dfn-for="scroll-initial-target">
 		<dt><dfn>none</dfn>
 		<dd>The element is not an [=initial scroll target=].
-		<dt><dfn>auto</dfn>
+		<dt><dfn>nearest</dfn>
 		<dd>The element is potentially an [=initial scroll target=]
 			for its nearest [=scroll container=] ancestor.
 	</dl>
 
-<h4 id="scroll-start-target-with-place-content">
+<h4 id="scroll-initial-target-with-place-content">
 Interaction with 'place-content'</h4>
 
 	If a [=scroll container's=] [=initial scroll position=]
 	is potentially set by both a [=content-distribution property=]
-	and by 'scroll-start-target' on a descendant,
-	'scroll-start-target' wins.
+	and by 'scroll-initial-target' on a descendant,
+	'scroll-initial-target' wins.
 
-<h4 id="scroll-start-target-fragment-navigation">
+<h4 id="scroll-initial-target-fragment-navigation">
 Post-first layout arrivals</h4>
 
 	While the document is being [[html#updating-the-document|updated]],

--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -134,7 +134,7 @@ Setting Where Scroll Starts {#properties-on-the-scroll-container}
 The 'scroll-initial-target' property {#scroll-initial-target}
 -------------------------------------------
 
-Issue: The name "scroll-initial-target" is chosen as the least worst option
+ISSUE(11173): The name "scroll-initial-target" is chosen as the least worst option
 which expresses that it should be scrolled to when its scroll container
 first shows up on the page. A better name for the property would be very much welcome.
 


### PR DESCRIPTION
In line the CSS working group's resolution[1], this renames the "scroll-start-target" property to "scroll-initial-target" and replaces its keyword "auto" with "nearest."

[1] https://github.com/w3c/csswg-drafts/issues/11173#issuecomment-2536659205

