### PR TITLE
[css-shapes-2][editorial] Fix minor syntax issue

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -210,7 +210,7 @@ The ''shape()'' Function</h4>
 			Percentages are resolved against the width or height, respectively,
 			of the [=reference box=].
 
-		<dt><dfn><<command-end-point>></dfn> = [ <dfn value for="shape(), <command-end-point>">by</dfn> <<position>> | <dfn value for="shape(), <command-end-point>">to</dfn> <<coordinate-pair>> ]
+		<dt><dfn><<command-end-point>></dfn> = [ <dfn value for="shape(), <command-end-point>">to</dfn> <<position>> | <dfn value for="shape(), <command-end-point>">by</dfn> <<coordinate-pair>> ]
 		<dd>
 			Every command can be specified in "absolute" or "relative" coordinates,
 			determined by their ''shape()/by'' or ''shape()/to'' component.


### PR DESCRIPTION
The changed line says `<position>`  can be used with `by` but in the production list and a few lines below, the spec says `<position>` can only be used with `to`.