### PR TITLE
[css-scroll-snap-1] Scroll by page should not skip over content.

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -1090,6 +1090,10 @@ Choosing Snap Positions {#choosing}
         if its nearest <a>scroll container</a> is a <a>scroll snap container</a>.
         The user agent <em>may</em> also do this even when the <a>scroll container</a> has ''scroll-snap-type: none''.
 
+    * If a scroll by page operation (e.g. Page down / Page up) is being performed,
+        eligible <a>snap positions</a> that require scrolling less than or equal to the size of the <a>optimal viewing region</a> of the <a>scroll container</a>
+        should be selected before any farther away, ignoring the starting <a>snap positions</a> so that progress is still made in the <a>intended direction</a>.
+
 <h4 id="multiple-aligned-snap-areas">Selecting between multiple aligned snap areas</h4>
 
     When <a>snapping</a> to a scroll position


### PR DESCRIPTION
As per #10914 when selecting a snap point as a result of a scroll by page operation we should always select a snap position that is less than a page away as long it still makes progress in the requested direction if one exists.