### PR TITLE
[css-2024] Added CSS Scroll Anchoring 1, CSSOM 1, CSS Color 5, and Selectors 4 to Rough Interoperability

### DIFF
--- a/css-2024/Overview.bs
+++ b/css-2024/Overview.bs
@@ -29,7 +29,6 @@ Status Text:
 Boilerplate: index no
 </pre>
 <pre class=link-defaults>
-spec:selectors-4; type:selector; text::lang()
 spec:selectors-4; type:dfn; text:document language
 spec:css-ui-3; type:property; text:cursor
 spec:css-ui-3; type:property; text:outline
@@ -584,6 +583,30 @@ Modules with Rough Interoperability</h3>
 		<dd>
 			This module allows authors to position any graphical object and animate it along an author specified path.
 
+		<dt><a href="https://www.w3.org/TR/css-scroll-anchoring-1/">CSS Scroll Anchoring Module Level 1</a>
+		[[CSS-SCROLL-ANCHORING-1]]
+		<dd>
+			This module aims to minimize content shifts
+			by locking the scroll position of a scroll container to a particular anchor element.
+
+		<dt><a href="https://www.w3.org/TR/cssom-1/">CSS Object Model (CSSOM)</a>
+		[[CSSOM-1]]
+		<dd>
+			This module defines APIs for parsing, serializing,
+			and manipulating CSS, Media Queries, and Selectors.
+
+		<dt><a href="https://www.w3.org/TR/css-color-5/">CSS Color Module Level 5</a>
+		[[CSS-COLOR-5]]
+		<dd>
+			Extends CSS Color 4 to add color spaces and color modification functions.
+
+		<dt><a href="https://www.w3.org/TR/selectors-4/">Selectors Level 4</a>
+		[[SELECTORS-4]]
+		<dd>
+			Extends Selectors Level 3 by introducing new pseudo-classes,
+			pseudo-elements, and combinators,
+			enhancing the ability to select elements
+			based on more complex criteria and states.
 	</dl>
 
 <h3 id="css-levels">
@@ -913,7 +936,6 @@ Safe to Release pre-CR Exceptions</h2>
 		<a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
 		and
 		<a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>.
-		<li>The '':dir()'', '':lang()'', and '':focus-within'' pseudo-classes from [[SELECTORS-4]].
 	</ul>
 
 <h2 id="indices">Indices</h2>


### PR DESCRIPTION
This was resolved in https://github.com/w3c/csswg-drafts/issues/9793#issuecomment-2518138682.

Sebastian