### PR TITLE
[css-scroll-snap-2] scroll-{start=>initial}-target rename cleanup

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -1182,7 +1182,7 @@ Overflow and Scroll Positions</h3>
 	of the <a>scroll container</a>
 	satisfies the [[#alignment-values|expected alignment]]
 	of the <a>alignment subject</a> and <a>alignment container</a>.
-	However, the [[css-scroll-snap-2#scroll-start-target-with-place-content|scroll-start-target]]
+	However, the [[css-scroll-snap-2#scroll-initial-target-with-place-content|scroll-initial-target]]
 	property, when present, overrides the <a>content-distribution properties</a>
 	in determining the <a>initial scroll position</a>.
 

--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -342,7 +342,7 @@ Scrolling Overflow</h3>
 	and, unless otherwise specified,
 	coincides with its [=scroll origin position=].
 	However, the 'align-content' and 'justify-content' properties [[!CSS-ALIGN-3]] as well as the
-	'scroll-start-target' property [[!CSS-SCROLL-SNAP-2]] can be used to change the [=initial scroll position=],
+	'scroll-initial-target' property [[!CSS-SCROLL-SNAP-2]] can be used to change the [=initial scroll position=],
 	see [[css-align-3#overflow-scroll-position]].
 
 	A <dfn export>scroll position</dfn> is a particular alignment


### PR DESCRIPTION
`scroll-start-target` was [renamed](https://github.com/w3c/csswg-drafts/commit/40b30fe918e1262c71386cd123e66a48ffaa65f5) `scroll-initial-target` in the scroll-snap-2 spec, resulting in some links in other specs breaking. This updates other specs that made mention of `scroll-start-target`.