### PR TITLE
[selectors-4] Fix unrendered comment in `:empty` example

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2983,7 +2983,7 @@ Tree-Structural pseudo-classes</h2>
 			&lt;p>&lt;/p>
 			&lt;p>
 			&lt;p> &lt;/p>
-			&lt;p><!-- comment -->&lt;/p>
+			&lt;p> &lt;!-- comment -->&lt;/p>
 		</pre>
 
 		''div:empty'' is not a valid representation of the <code>&lt;div></code> elements


### PR DESCRIPTION
Also included a space here, since there's no example of the combination of whitespace and comment.