### PR TITLE
Frozen items do not guarantee complete distribution of free space

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -2748,9 +2748,7 @@ Resolving Flexible Lengths</h3>
 			<ol type=a>
 				<li>
 					<strong>Check for flexible items.</strong>
-					If all the flex items on the line are frozen,
-					free space has been distributed;
-					exit this loop.
+					If all the flex items on the line are frozen, exit this loop.
 
 				<li>
 					<strong>Calculate the <dfn>remaining free space</dfn></strong>


### PR DESCRIPTION
Per [sections 9.7(3) and 9.7(4)](https://drafts.csswg.org/css-flexbox-1/#resolve-flexible-lengths), the loop at 9.7(5) may begin with all flex items already frozen and with initial free space remaining that is not distributed.

Example:

```html
<!DOCTYPE html>
<style>
  .flex {
    display: flex;
    flex-flow: row nowrap;
    width: 100px;
    background: red;    
  }
  .flex > div {    
    flex: 0 1 auto;
  }
</style>
<div class="flex">
  <div style="background-color: orange">A</div>
  <div style="background-color: blue">B</div>
  <div style="background-color: green">C</div>
</div>
```

I am submitting the pull request under the [CC0](https://creativecommons.org/public-domain/cc0/) license