### PR TITLE
[scroll-animations-1] Use correct CSS property

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -764,7 +764,7 @@ spec:selectors-4; type:dfn; text:selector
 # Attaching Animations to [=Scroll-driven Timelines=] # {#scroll-driven-attachment}
 
 	Animations can be attached to [=scroll-driven timelines=]
-	using the 'scroll-timeline' property (in CSS)
+	using the 'animation-timeline' property (in CSS)
 	or the {{AnimationTimeline}} parameters (in the Web Animations API).
 	The timeline range to which their [=active interval=] is attached
 	can also be further restricted to a particular timeline range


### PR DESCRIPTION
Use the correct CSS property to attach a scroll-driven timeline to an animation.