### PR TITLE
[css-values-5] Disallow whitespace in `<attr-name>`

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1588,6 +1588,9 @@ Ian's proposal:
 		As with [=attribute selectors=],
 		the case-sensitivity of <<attr-name>> depends on the document language.
 
+		Whitespace is not allowed
+		between any of the components of <<attr-name>>.
+
 		If ''attr()'' is used in a property applied to an element,
 		it references the attribute of the given name on that element;
 		if applied to a pseudo-element,


### PR DESCRIPTION
This is not allowed in `<wq-name>`, and shouldn't be allowed in `<attr-name>` either.
