### PR TITLE
[css-mixins-1] Do arbitrary function substitution before evaluation

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -228,13 +228,6 @@ At computed-value time,
 every <<dashed-function>> must be [=substitute a dashed function|substituted=]
 before finally being checked against the property's grammar.
 
-When a value is being computed,
-substitution of ''var()'', ''env()'' and ''attr()''
-must take place <em>before</em> <<dashed-function>> substitution.
-
-Note: This means arguments passed to a custom function
-never contain ''var()'', or similar functions.
-
 A ''var()'' function within a [=local variable=],
 or within the ''@function/result'' descriptor,
 invokes [=locally substitute a var()|local substitution=],
@@ -260,10 +253,13 @@ described in [[!css-variables]].
 			* Append the result of [=resolving an argument=] to |dependency values|,
 				using |dependency value| as value,
 				and |dependency| as parameter.
-		4. [=Evaluate a custom function=],
+		4. [=substitute arbitrary substitution functions|Substitute=]
+			any [=arbitrary substitution functions=]
+			within |dashed function|'s arguments.
+		5. [=Evaluate a custom function=],
 			using |function|, |dashed function| and |dependency values|.
-		5. If failure was returned, return failure.
-		6. Otherwise,
+		6. If failure was returned, return failure.
+		7. Otherwise,
 			replace the <<dashed-function>> with the [=equivalent token sequence=]
 			of the value resulting from the evaluation.
 </div>
@@ -402,8 +398,10 @@ Parameters and Locals {#parameters}
 A <dfn>resolved local value</dfn> is the value of a [=local variable=] or [=descriptor=], except:
 
 * Any ''var()'' functions are replaced by [=locally substitute a var()|local substitution=].
-* Any ''env()'' or ''attr()'' functions are substituted normally.
 * Any <<dashed-function>>s are replaced by [=substitute a dashed function|dashed function substitution=].
+* Any [=arbitrary substitution functions=]
+	other than ''var()'' and <<dashed-function>>s
+	are substituted normally.
 
 If any substitution algorithm returns failure,
 then the [=resolved local value=] of a [=local variable=]


### PR DESCRIPTION
The previous attempt at defining this ("do var()/etc first") is pretty clumsy, and doesn't really work when there's another dashed-function in the argument list.

Also handle all arbitrary function substitution in "resolved local value", not just env() and attr().