### PR TITLE
[web-animations-1] Fix markup

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1013,7 +1013,7 @@ Setting the associated effect of an animation</h4>
 
         1. Abort these steps.
 
-    2. Update either |animation|'s [=hold time=] or
+    1. Update either |animation|'s [=hold time=] or
         [=start time=] as follows:
 
         <dl class=switch>
@@ -1037,7 +1037,7 @@ Setting the associated effect of an animation</h4>
             where |timeline time| is the current [=time value=]
             of the [=timeline=] associated with |animation|.
 
-        </div>
+        </dl>
 
     1. If |animation| has no associated [=timeline=]
         or the associated [=timeline=] is [=inactive timeline|inactive=],
@@ -1123,7 +1123,7 @@ Setting the associated effect of an animation</h4>
             Set |animation|'s [=hold time=] to |previous current time|
             even if |previous current time| is [=unresolved=].
 
-        </div>
+        </dl>
 
     1. If |animation| has a [=pending play task=] or a [=pending pause task=],
         cancel that task and [=resolve a Promise|resolve=]


### PR DESCRIPTION
Fixes the numbering of the list items in this procedure: https://drafts.csswg.org/web-animations-1/#animation-silently-set-the-current-time