### PR TITLE
[css-shapes-2] by/to should always come before rest of parameters.

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -318,7 +318,7 @@ The ''shape()'' Function</h4>
 			the command's starting point, the command's end point, or the [=reference box=], respectively.
 			If such component is not provided, the <<coordinate-pair>> is relative to the segment's start.
 
-		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> [[<<by-to>> <<coordinate-pair>>] || [of <<length-percentage>>{1,2}] || <<arc-sweep>>? || <<arc-size>>?|| rotate <<angle>>? ]
+		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] || <<arc-sweep>>? || <<arc-size>>?|| rotate <<angle>>? ]
 		<dd>
 			Add an <a href="https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands">elliptical arc</a> command
 			to the list of path data commands,


### PR DESCRIPTION
This applies to arc/curve/smooth.

Also fixes a bug where the arc target point was using only coordinate-pair.

Resolution: https://github.com/w3c/csswg-drafts/issues/10666#issuecomment-2578298392

Closes #10666