### PR TITLE
[css-values-5] [css-mixins-1] Define local `type()` functions

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -113,7 +113,7 @@ and its syntax is:
 <dfn><<function-dependency-list>></dfn> = <<function-parameter>>#
 <dfn><<function-parameter>></dfn> = <<custom-property-name>> <<css-type>>? [ : <<declaration-value>> ]?
 <dfn><<css-type>></dfn> = <<syntax-component>> | <<type()>>
-<dfn>&lt;type()></dfn> = <dfn>type( <<syntax>> )</dfn>
+<dfn function lt="type()" for="@function">&lt;type()></dfn> = type( <<syntax>> )
 </pre>
 
 The name of the resulting [=custom function=] is given by the <<function-name>>,

--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -113,7 +113,7 @@ and its syntax is:
 <dfn><<function-dependency-list>></dfn> = <<function-parameter>>#
 <dfn><<function-parameter>></dfn> = <<custom-property-name>> <<css-type>>? [ : <<declaration-value>> ]?
 <dfn><<css-type>></dfn> = <<syntax-component>> | <<type()>>
-<dfn>&lt;type()></dfn> = type( <<syntax>> )
+<dfn>&lt;type()></dfn> = <dfn>type( <<syntax>> )</dfn>
 </pre>
 
 The name of the resulting [=custom function=] is given by the <<function-name>>,
@@ -126,7 +126,7 @@ and the [=return type=] is optionally given by the <<css-type>> following the "r
 	[=function dependency=],
 	or [=custom function=] return value
 	can be described by a single <<syntax-component>>,
-	then the <code>type()</code> function may be omitted:
+	then the ''type()'' function may be omitted:
 
 	<pre class='lang-css'>
 	@function --foo(--a &lt;length&gt;) { /* ... */ }
@@ -136,7 +136,7 @@ and the [=return type=] is optionally given by the <<css-type>> following the "r
 
 	However,
 	any <<syntax>> that requires a <<syntax-combinator>>
-	needs to be wrapped in the <code>type()</code> function:
+	needs to be wrapped in the ''type()'' function:
 
 	<pre class='lang-css'>
 	@function --foo(--a type(&lt;number&gt; | &lt;percentage&gt;)) { /* ... */ }

--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1557,7 +1557,7 @@ Ian's proposal:
 		attr() = attr( <<attr-name>> <<attr-type>>? , <<declaration-value>>?)
 
 		<dfn>&lt;attr-name></dfn> = [ <<ident-token>>? '|' ]? <<ident-token>>
-		<dfn>&lt;attr-type></dfn> = <dfn>type( <<syntax>> )</dfn> | string | <<attr-unit>>
+		<dfn>&lt;attr-type></dfn> = <dfn function lt="type()" for="attr()">type( <<syntax>> )</dfn> | string | <<attr-unit>>
 	</pre>
 
 	The <dfn>&lt;attr-unit></dfn> production matches any [=identifier=]

--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1557,7 +1557,7 @@ Ian's proposal:
 		attr() = attr( <<attr-name>> <<attr-type>>? , <<declaration-value>>?)
 
 		<dfn>&lt;attr-name></dfn> = [ <<ident-token>>? '|' ]? <<ident-token>>
-		<dfn>&lt;attr-type></dfn> = type( <<syntax>> ) | string | <<attr-unit>>
+		<dfn>&lt;attr-type></dfn> = <dfn>type( <<syntax>> )</dfn> | string | <<attr-unit>>
 	</pre>
 
 	The <dfn>&lt;attr-unit></dfn> production matches any [=identifier=]


### PR DESCRIPTION
These are distinct functions as per https://github.com/w3c/csswg-drafts/issues/11468#issuecomment-2580865934. By defining them locally, these specs won’t link out to the `type()` function from `css-backgrounds-4`.