### PR TITLE
[css-shapes-2] by/to should always come before rest of parameters.

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -273,8 +273,8 @@ The ''shape()'' Function</h4>
 			instead of a <<length-percentage>>,
 			would draw a line to that <<position>>, with the <<position>>'s horizontal component remaining the same as the starting point.
 
-		<dt><dfn><<curve-command>></dfn> = <dfn value>curve</dfn> [ [ to <<position>> && with <<control-point>> [ / <<control-point>> ]? ]
-						| [ by <<coordinate-pair>> && with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ]
+		<dt><dfn><<curve-command>></dfn> = <dfn value>curve</dfn> [ [ to <<position>> with <<control-point>> [ / <<control-point>> ]? ]
+						| [ by <<coordinate-pair>> with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ]
 		<dd>
 			Adds a Bézier curve command to the list of path data commands,
 			ending at the point specified by the <<position>> following the ''shape()/to'' keyword,
@@ -286,8 +286,8 @@ The ''shape()'' Function</h4>
 			if two  <<control-point>>s or <<relative-control-point>>s are provided,
 			it specifies a <a href="https://www.w3.org/TR/SVG/paths.html#PathDataCubicBezierCommands">cubic curve</a>.
 
-		<dt><dfn><<smooth-command>></dfn> = <dfn value>smooth</dfn> [ [ to <<position>> && [with <<control-point>> ]? ]
-						| [ by <<coordinate-pair>> && [ with <<relative-control-point>> ]? ] ]
+		<dt><dfn><<smooth-command>></dfn> = <dfn value>smooth</dfn> [ [ to <<position>> [with <<control-point>> ]? ]
+						| [ by <<coordinate-pair>> [ with <<relative-control-point>> ]? ] ]
 		<dd>
 			Adds a smooth Bézier curve command to the list of path data commands,
 			ending at the point specified by the <<position>> following the ''shape()/to'' keyword, or the <<coordinate-pair>> following the ''shape()/by'' keyword, as specified by <<command-end-point>>.


### PR DESCRIPTION
This applies to curve/smooth.
(Forgot to upload this as part of the previous PR, which included the `arc` fix)

Resolution: https://github.com/w3c/csswg-drafts/issues/10666#issuecomment-2578298392

See #10666

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
