### PR TITLE
[css-shapes-2] Fix syntax typos

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -173,7 +173,7 @@ The ''shape()'' Function</h4>
 
 	<pre class=prod>
 		<<shape-command>> = <<move-command>> | <<line-command>> | close |
-		                  <<horizontal-line-command>> | <<vertical-line-command>> | 
+		                  <<horizontal-line-command>> | <<vertical-line-command>> |
 		                  <<curve-command>> | <<smooth-command>> | <<arc-command>>
 
 		<<move-command>> = move <<command-end-point>>
@@ -185,14 +185,13 @@ The ''shape()'' Function</h4>
 						[ to [ <<length-percentage>> | top | center | bottom | y-start | y-end ]
 						| by <<length-percentage>> ]
 		<<curve-command>> = curve
-						[ [ to <<position>> && [ with <<control-point>> [ / <<control-point>> ]? ] ]
-						| [ by <<coordinate-pair>> && [ with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ] ]
+						[ [ to <<position>> with <<control-point>> [ / <<control-point>> ]? ]
+						| [ by <<coordinate-pair>> with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ]
 		<<smooth-command>> = smooth
-						[ [ to <<position>> && [ with <<control-point>> ]? ]
-						| [ by <<coordinate-pair>> && [ with <<relative-control-point>> ]? ] ]
-		<<arc-command>> = arc [ <<command-end-point>>
-								&& [ of <<coordinate-pair>> ]
-								&& <<arc-sweep>>? && <<arc-size>>? && [rotate <<angle>>]? ]
+						[ [ to <<position>> [ with <<control-point>> ]? ]
+						| [ by <<coordinate-pair>> [ with <<relative-control-point>> ]? ] ]
+		<<arc-command>> = arc <<command-end-point>>
+						[ [ of <<coordinate-pair>> ] && <<arc-sweep>>? && <<arc-size>>? && [ rotate <<angle>> ]? ]
 
 		<<command-end-point>> = [ to <<position>> | by <<coordinate-pair>> ]
 		<<control-point>> = [ <<position>> | <<relative-control-point>> ]
@@ -286,7 +285,7 @@ The ''shape()'' Function</h4>
 			if two  <<control-point>>s or <<relative-control-point>>s are provided,
 			it specifies a <a href="https://www.w3.org/TR/SVG/paths.html#PathDataCubicBezierCommands">cubic curve</a>.
 
-		<dt><dfn><<smooth-command>></dfn> = <dfn value>smooth</dfn> [ [ to <<position>> [with <<control-point>> ]? ]
+		<dt><dfn><<smooth-command>></dfn> = <dfn value>smooth</dfn> [ [ to <<position>> [ with <<control-point>> ]? ]
 						| [ by <<coordinate-pair>> [ with <<relative-control-point>> ]? ] ]
 		<dd>
 			Adds a smooth Bézier curve command to the list of path data commands,
@@ -318,7 +317,7 @@ The ''shape()'' Function</h4>
 			the command's starting point, the command's end point, or the [=reference box=], respectively.
 			If such component is not provided, the <<coordinate-pair>> is relative to the segment's start.
 
-		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] || <<arc-sweep>>? || <<arc-size>>?|| rotate <<angle>>? ]
+		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [ [ of <<length-percentage>>{1,2} ] && <<arc-sweep>>? && <<arc-size>>? && [ rotate <<angle>> ]? ]
 		<dd>
 			Add an <a href="https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands">elliptical arc</a> command
 			to the list of path data commands,


### PR DESCRIPTION
Follow-up to 233bbec, 8b76107, and partially fixes #11368.