### PR TITLE
[css-grid-2] Gloss in-flow/out-of-flow jargon

### DIFF
--- a/css-grid-2/Overview.bs
+++ b/css-grid-2/Overview.bs
@@ -1059,9 +1059,9 @@ Limiting Large Grids</h3>
 Grid Items</h2>
 
 	Loosely speaking, the <dfn export id="grid-item" lt="grid item">grid items</dfn> of a <a>grid container</a>
-	are boxes representing its in-flow contents.
+	are boxes representing its <a>in-flow</a> contents.
 
-	Each in-flow child of a <a>grid container</a>
+	Each <a>in-flow</a> child of a <a>grid container</a>
 	becomes a <a>grid item</a>,
 	and each child <a>text sequence</a>
 	is wrapped in an <a>anonymous</a> <a>block container</a> <a>grid item</a>.
@@ -1908,7 +1908,7 @@ Repeat-to-fill: ''auto-fill'' and ''auto-fit'' repetitions</h5>
 	The <dfn value for="repeat()">auto-fit</dfn> keyword behaves the same as ''auto-fill'',
 	except that after [[#auto-placement-algo|grid item placement]]
 	any empty repeated tracks are <a>collapsed</a>.
-	An empty track is one with no in-flow grid items placed into or spanning across it.
+	An empty track is one with no <a>in-flow</a> grid items placed into or spanning across it.
 	(This can result in <em>all</em> tracks being <a>collapsed</a>,
 	if they're all empty.)
 
@@ -3991,7 +3991,7 @@ With a Grid Container as Containing Block</h3>
 	Note: Thus, by default, the absolutely-positioned box's <a>containing block</a> will correspond
 	to the padding edges of the <a>grid container</a>, as it does for <a>block containers</a>.
 
-	Absolute positioning occurs after layout of the <a>grid</a> and its in-flow contents,
+	Absolute positioning occurs after layout of the <a>grid</a> and its <a>in-flow</a> contents,
 	and does not contribute to the sizing of any grid tracks
 	or affect the size/configuration of the grid in any way.
 	If a <a>grid-placement property</a> refers to a non-existent line
@@ -4012,7 +4012,7 @@ With a Grid Container as Containing Block</h3>
 With a Grid Container as Parent</h3>
 
 	An absolutely-positioned child of a <a>grid container</a>
-	is out-of-flow and not a <a>grid item</a>,
+	is <a>out-of-flow</a> and not a <a>grid item</a>,
 	and so does not affect the placement of other items
 	or the sizing of the grid.
 


### PR DESCRIPTION
This hyperlinks the terms "in-flow" & "out-of-flow" to their formal definitions for clarity.
Currently Bikeshed links it to https://drafts.csswg.org/css-display-4/#in-flow etc. If the CSS2 definition is preferred instead, just let me know.

----

Note to self:
```
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
spec:css-display-4; type:dfn; text:in-flow
spec:css21; type:dfn; text:in-flow
```