### PR TITLE
[css-shapes-2] Match `shape()` main syntax with command-specific syntax

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -186,13 +186,13 @@ The ''shape()'' Function</h4>
 						| by <<length-percentage>> ]
 		<<curve-command>> = curve
 						[ [ to <<position>> && [ with <<control-point>> [ / <<control-point>> ]? ] ]
-						| [ by <<coordinate-pair>> && [ with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ] ]
+						| [ by <<coordinate-pair>> with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ]
 		<<smooth-command>> = smooth
-						[ [ to <<position>> && [ with <<control-point>> ]? ]
-						| [ by <<coordinate-pair>> && [ with <<relative-control-point>> ]? ] ]
-		<<arc-command>> = arc [ <<command-end-point>>
-								&& [ of <<coordinate-pair>> ]
-								&& <<arc-sweep>>? && <<arc-size>>? && [rotate <<angle>>]? ]
+						[ [ to <<position>> [ with <<control-point>> ]? ]
+						| [ by <<coordinate-pair>> [ with <<relative-control-point>> ]? ] ]
+		<<arc-command>> = arc <<command-end-point>>
+								[ [ of <<coordinate-pair>> ]
+								  && <<arc-sweep>>? && <<arc-size>>? && [rotate <<angle>>]? ]
 
 		<<command-end-point>> = [ to <<position>> | by <<coordinate-pair>> ]
 		<<control-point>> = [ <<position>> | <<relative-control-point>> ]

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -191,7 +191,7 @@ The ''shape()'' Function</h4>
 						[ [ to <<position>> [ with <<control-point>> ]? ]
 						| [ by <<coordinate-pair>> [ with <<relative-control-point>> ]? ] ]
 		<<arc-command>> = arc <<command-end-point>>
-								[ [ of <<coordinate-pair>> ]
+								[ [ of <<length-percentage>>{1,2} ]
 								  && <<arc-sweep>>? && <<arc-size>>? && [rotate <<angle>>]? ]
 
 		<<command-end-point>> = [ to <<position>> | by <<coordinate-pair>> ]

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -185,7 +185,7 @@ The ''shape()'' Function</h4>
 						[ to [ <<length-percentage>> | top | center | bottom | y-start | y-end ]
 						| by <<length-percentage>> ]
 		<<curve-command>> = curve
-						[ [ to <<position>> && [ with <<control-point>> [ / <<control-point>> ]? ] ]
+						[ [ to <<position>> with <<control-point>> [ / <<control-point>> ]? ]
 						| [ by <<coordinate-pair>> with <<relative-control-point>> [ / <<relative-control-point>> ]? ] ]
 		<<smooth-command>> = smooth
 						[ [ to <<position>> [ with <<control-point>> ]? ]
@@ -318,7 +318,7 @@ The ''shape()'' Function</h4>
 			the command's starting point, the command's end point, or the [=reference box=], respectively.
 			If such component is not provided, the <<coordinate-pair>> is relative to the segment's start.
 
-		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] || <<arc-sweep>>? || <<arc-size>>?|| rotate <<angle>>? ]
+		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] && <<arc-sweep>>? && <<arc-size>>? && rotate <<angle>>? ]
 		<dd>
 			Add an <a href="https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands">elliptical arc</a> command
 			to the list of path data commands,


### PR DESCRIPTION
Closes #11368
