### PR TITLE
[css-mixins-1] Do not allow whitespace before parameter list

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -67,7 +67,7 @@ Defining Custom Functions {#defining-custom-functions}
 	<div class='example'>
 		A simple [=custom function=] to negate a value can be defined as follows:
 		<pre class='lang-css'>
-		@function --negative (--value) {
+		@function --negative(--value) {
 		  result: calc(-1 * var(--value));
 		}
 		</pre>
@@ -101,20 +101,24 @@ The ''@function'' rule defines a [=custom function=],
 and its syntax is:
 
 <pre class="prod def" nohighlight>
-&lt;@function> = @function <<function-name>> [ ( <<function-parameter-list>> ) ]?
+&lt;@function> = @function <<function-name>> <<function-parameter-list>>? )
 	[ using ( <<function-dependency-list>> ) ]?
 	[ returns <<css-type>> ]?
 {
 	<<declaration-rule-list>>
 }
 
-<dfn><<function-name>></dfn> = <<dashed-ident>>
 <dfn><<function-parameter-list>></dfn> = <<function-parameter>>#
 <dfn><<function-dependency-list>></dfn> = <<function-parameter>>#
 <dfn><<function-parameter>></dfn> = <<custom-property-name>> <<css-type>>? [ : <<declaration-value>> ]?
 <dfn><<css-type>></dfn> = <<syntax-component>> | <<type()>>
 <dfn>&lt;type()></dfn> = type( <<syntax>> )
 </pre>
+
+The <dfn><<function-name>></dfn> production
+is a <<function-token>>,
+with the additional restriction that it must start with two dashes
+(U+002D HYPHEN-MINUS).
 
 The name of the resulting [=custom function=] is given by the <<function-name>>,
 the [=function parameters=] are optionally given by <<function-parameter-list>>,


### PR DESCRIPTION
This also makes the parameter list required.

A discussion could be had about 'using' as well, but since it looks like we're going to remove it, that problem will probably disappear on its own.
