### PR TITLE
[css-align-3] Gloss in-flow/out-of-flow jargon

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -1212,7 +1212,7 @@ Overflow and Scroll Positions</h3>
 	Note: The <a>alignment subject</a> is not necessarily
 	identical to the <a>scrollable overflow area</a>:
 	content overflowing the <a>alignment subject</a>,
-	such as an absolutely-positioned or out-of-flow element,
+	such as an absolutely-positioned or <a>out-of-flow</a> element,
 	grows the <a>scrollable overflow area</a> but not the <a>alignment subject</a>,
 	thus an ''align-content/end''-aligned <a>scroll container</a>
 	might not be initially scrolled all the way to the bottom.
@@ -2263,8 +2263,8 @@ Determining the Baselines of a Box</h2>
 		<dt>block containers
 		<dd>
 			The first/last [=baseline set=] of a <a>block container</a>
-			is taken from the first/last in-flow line box in the block container
-			or the first/last in-flow block-level child in the block container
+			is taken from the first/last [=in-flow=] line box in the block container
+			or the first/last [=in-flow=] block-level child in the block container
 			that contributes a set of first/last baselines,
 			whichever comes first/last.
 			If there is no such line box or child,
@@ -2357,7 +2357,7 @@ Determining the Baselines of a Box</h2>
 			and ''vertical-rl'' if 'direction' is ''rtl''.
 
 	For the purposes of finding the baselines of a box,
-	it and all its in-flow descendants with a scrolling mechanism (see the 'overflow' property)
+	it and all its [=in-flow=] descendants with a scrolling mechanism (see the 'overflow' property)
 	must be considered as if scrolled to their initial scroll position.
 	Additionally,
 	if the position of a [=scroll container=]’s first/last baseline


### PR DESCRIPTION
This hyperlinks the terms "in-flow" & "out-of-flow" to their formal definitions for clarity.
I've tried to be consistent with the link syntax in the respective paragraph/section.
With respect to `<dt>block containers`, there's a lot of repeated links to "baseline set" nearby each other, so I don't feel bad about similarly linking "in-flow" twice in one long sentence.