### PR TITLE
[css-scoping-1] update has-slotted to match flattened slottables

### DIFF
--- a/css-scoping-1/Overview.bs
+++ b/css-scoping-1/Overview.bs
@@ -513,7 +513,7 @@ Matching on the Presence of Slot-Assigned Nodes: the '':has-slotted'' pseudo-cla
 
 	The <dfn selector>:has-slotted</dfn> pseudo-class
 	matches <{slot}> elements
-	which have a non-empty list of <a lt="find slottables">slotted nodes</a>.
+	which have a non-empty list of <a lt="find flattened slottables">flattened slotted nodes</a>.
 
 	When '':has-slotted'' matches a slot with fallback content,
 	we can conclude that the fallback content is <em>not</em> being displayed.


### PR DESCRIPTION
This updates the `:has-slotted` specification to use the "flattened slottables" concept, per the resolution in https://github.com/w3c/csswg-drafts/issues/6867#issuecomment-2593536333.

