### PR TITLE
[css-values-5] Drop duplicate definition of ident()

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1877,7 +1877,7 @@ Constructing <<custom-ident>> values: the ''ident()'' function</h3>
 	that can be used to manually construct <<custom-ident>> values from several parts.
 
 	<pre class=prod>
-	<dfn function lt="ident()"><<ident()>></dfn> = ident( <<ident-arg>>+ )
+	<<ident()>> = ident( <<ident-arg>>+ )
 	<dfn><<ident-arg>></dfn> = <<string>> | <<integer>> | <<ident>>
 	</pre>
 


### PR DESCRIPTION
Previous update introduced a definition of the `ident()` function in the prose. The definition in the production block needs to be dropped not to duplicate it.

