### PR TITLE
[css-text-decor-4] Gloss out-of-flow jargon

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -93,7 +93,7 @@ Line Decoration: Underline, Overline, and Strike-Through</h2>
 	the decorations are propagated to all [=in-flow=] children.
 
 	<p class="note">
-		Note that text decorations are not propagated to any out-of-flow descendants,
+		Note that text decorations are not propagated to any <a>out-of-flow</a> descendants,
 		nor to the contents of atomic inline-level descendants such as inline blocks and inline tables.
 		They are also not propagated to inline children of inline boxes,
 		although the decoration is <em>applied</em> to such boxes.


### PR DESCRIPTION
This hyperlinks the term "out-of-flow" for clarity. No unlinked instances of "in-flow" were found in this spec.

Didn't add a link on line 152 since it's only an example and currently contains zero links.