### PR TITLE
[css-mixins-1] Fix anchor for CSSFunctionDeclarations

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -670,8 +670,8 @@ Note: This also applies to the "leading" declarations in the ''@function'' rule,
 </div>
 
 
-The {{CSSFunctionDeclarations}} Interface {#the-cssnestrule}
------------------------------
+The {{CSSFunctionDeclarations}} Interface {#the-function-declarations-interface}
+--------------------------------------------------------------------------------
 
 The {{CSSFunctionDeclarations}} interface represents a run
 of consecutive [=declarations=] within a ''@function'' rule.


### PR DESCRIPTION
This section was originally copied from css-nesting-1, and I must have forgotten to adjust this.
