### PR TITLE
[css-overflow-5] Escape single quote for '*'

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -416,7 +416,7 @@ Selecting The Active Scroll Marker: the '':target-current'' pseudo-class</h4>
 <h3 id="scroll-buttons">
 Scroll Buttons</h3>
 
-The <dfn>::scroll-button( '*' | <<scroll-button-direction>> )</dfn> pseudo-elements
+The <dfn>::scroll-button( \'*' | <<scroll-button-direction>> )</dfn> pseudo-elements
 are generated on [=scroll containers=]
 when their computed 'content' value is not ''content/none''.
 They generate boxes as if they were immediately preceding <em>siblings</em>
@@ -759,7 +759,7 @@ Paginated overflow</h3>
 	or the 'continue' property as described here.
 
 <h3 id="fragment-overflow">
-Fragmented Overflow</h2>
+Fragmented Overflow</h3>
 
 	This section introduces and defines the meaning of
 	the ''continue/fragments'' value of the 'continue' property.


### PR DESCRIPTION
Single quotes signal an autolink to a property or descriptor. Here, the single quotes are meant to appear literally, because `*` would be interpreted as a quantifier otherwise.

Update also fixes a markup error.
