### PR TITLE
[css-shapes-2] Editorial: Reword example about polygon

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -410,7 +410,7 @@ The ''shape()'' Function</h4>
 
 <div class=example>
 The ''shape()'' function enables shapes that are responsive, rather than scalable.
-While the ''polygon()'' shape is also responsive, it doesn't support curves.
+While the ''polygon()'' shape is also responsive, it only support simple rounded corners and not complex curves.
 
 To demonstrate, let's start with a speech bubble, such as the following:
 


### PR DESCRIPTION
The example had an incorrect comment about limitations of `polygon()`, reworded.