### PR TITLE
[css-conditional-5] Clarify how container query length units are evaluated

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1581,9 +1581,9 @@ Container Relative Lengths: the ''cqw'', ''cqh'', ''cqi'', ''cqb'', ''cqmin'', '
 	</table>
 
 	For each element,
-	[=container query length=] units are evaluated
-	as [=container size queries=] on the relevant axis (or axes)
-	described by the unit.
+	[=container query length=] units are evaluated using the same
+	rules as [=container size queries=] when querying the size
+	on the relevant axis (or axes) described by the unit.
 	The [=query container=] for each axis
 	is the nearest ancestor container
 	that accepts [=container size queries=] on that axis.

--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1581,8 +1581,8 @@ Container Relative Lengths: the ''cqw'', ''cqh'', ''cqi'', ''cqb'', ''cqmin'', '
 	</table>
 
 	For each element,
-	[=container query length=] units are evaluated using the same
-	rules as [=container size queries=] when querying the size
+	[=container query length=] units are evaluated
+	using the same rules as [=container size queries=]
 	on the relevant axis (or axes) described by the unit.
 	The [=query container=] for each axis
 	is the nearest ancestor container


### PR DESCRIPTION
This doesn't change how they work, it just makes it more clear.
Saying that "[container query length](https://drafts.csswg.org/css-conditional-5/#container-query-length) units are evaluated as [container size queries](https://drafts.csswg.org/css-conditional-5/#container-size-query) on the relevant axis" didn't make much sense, since a container query length unit needs to evaluate to a pixel amount while a container size query evaluates to a boolean or unknown.