### PR TITLE
[css-values-4] Add missing final return step to calc simplification #11572

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -4936,6 +4936,8 @@ Simplification</h4>
 
 			5. Return |root|.
 
+		10. Return |root|.
+
 	</div>
 
 


### PR DESCRIPTION
Without this, it is possible to run off the end of the algorithm if `root` is a math-function node without enough information to compute its value.

Fixes #11572.