### PR TITLE
[*][editorial] Drop autolinks to value in `<pre>`

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -3734,9 +3734,9 @@ Specifying Predefined Colors: the ''color()'' function</h3>
 		<dfn>color()</dfn> = color( <<colorspace-params>> [ / [ <<alpha-value>> | none ] ]? )
 		<dfn>&lt;colorspace-params></dfn> = [ <<predefined-rgb-params>> | <<xyz-params>>]
 		<dfn>&lt;predefined-rgb-params></dfn> = <<predefined-rgb>> [ <<number>> | <<percentage>> | none ]{3}
-		<dfn>&lt;predefined-rgb></dfn> = ''srgb'' | ''srgb-linear'' | ''display-p3'' | ''a98-rgb'' | ''prophoto-rgb'' | ''rec2020''
+		<dfn>&lt;predefined-rgb></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020
 		<dfn>&lt;xyz-params></dfn> = <<xyz-space>> [ <<number>> | <<percentage>> | none ]{3}
-		<dfn>&lt;xyz-space></dfn> = ''xyz'' | ''xyz-d50'' | ''xyz-d65''
+		<dfn>&lt;xyz-space></dfn> = xyz | xyz-d50 | xyz-d65
 	</pre>
 
 	<wpt>
@@ -4682,8 +4682,8 @@ Color Space for Interpolation</h3>
 
 	<pre class='prod'>
 		<dfn export>&lt;color-space></dfn> = &lt;rectangular-color-space> | &lt;polar-color-space>
-		<dfn export>&lt;rectangular-color-space></dfn> = ''srgb'' | ''srgb-linear'' | ''display-p3'' | ''a98-rgb'' | ''prophoto-rgb'' | ''rec2020'' | ''lab'' | ''oklab'' | ''xyz'' | ''xyz-d50'' | ''xyz-d65''
-		<dfn export>&lt;polar-color-space></dfn> = ''hsl'' | ''hwb'' | ''lch'' | ''oklch''
+		<dfn export>&lt;rectangular-color-space></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65
+		<dfn export>&lt;polar-color-space></dfn> = hsl | hwb | lch | oklch
 		<dfn export>&lt;hue-interpolation-method></dfn> = [ shorter | longer | increasing | decreasing ] hue
 		<dfn export id="color-interpolation-method">&lt;color-interpolation-method></dfn> = in [ <<rectangular-color-space>> | <<polar-color-space>> <<hue-interpolation-method>>? ]
 	</pre>

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1845,7 +1845,7 @@ or any other color or monochrome output device which has been characterized.
 		It's defined as:
 
 		<pre class='prod'>
-		@color-profile = @color-profile [<<dashed-ident>> | ''device-cmyk''] { <<declaration-list>> }
+		@color-profile = @color-profile [<<dashed-ident>> | device-cmyk] { <<declaration-list>> }
 		</pre>
 
 	<wpt>
@@ -2407,8 +2407,8 @@ or any other color or monochrome output device which has been characterized.
 		<pre class='prod'>
 			<dfn>device-cmyk()</dfn> = <<legacy-device-cmyk-syntax>> | <<modern-device-cmyk-syntax>>
 			<dfn>&lt;legacy-device-cmyk-syntax></dfn> = device-cmyk( <<number>>#{4} )
-			<dfn>&lt;modern-device-cmyk-syntax></dfn> = device-cmyk( <<cmyk-component>>{4} [ / [ <<alpha-value>> | ''none'' ] ]? )
-			<dfn>&lt;cmyk-component></dfn> = <<number>> | <<percentage>> | ''none''
+			<dfn>&lt;modern-device-cmyk-syntax></dfn> = device-cmyk( <<cmyk-component>>{4} [ / [ <<alpha-value>> | none ] ]? )
+			<dfn>&lt;cmyk-component></dfn> = <<number>> | <<percentage>> | none
 		</pre>
 
 		The arguments of the ''device-cmyk()'' function specify the cyan, magenta, yellow, and black components, in order,
@@ -2653,8 +2653,8 @@ or any other color or monochrome output device which has been characterized.
 
 	<pre class='prod'>
 		<dfn export>&lt;color-space></dfn> = <<rectangular-color-space>> | <<polar-color-space>> | <<custom-color-space>>
-		<dfn export>&lt;rectangular-color-space></dfn> = ''srgb'' | ''srgb-linear'' | ''display-p3'' | ''a98-rgb'' | ''prophoto-rgb'' | ''rec2020'' | ''lab'' | ''oklab'' | ''xyz'' | ''xyz-d50'' | ''xyz-d65''
-		<dfn export>&lt;polar-color-space></dfn> = ''hsl'' | ''hwb'' | ''lch'' | ''oklch''
+		<dfn export>&lt;rectangular-color-space></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65
+		<dfn export>&lt;polar-color-space></dfn> = hsl | hwb | lch | oklch
 		<dfn export>&lt;custom-color-space></dfn> = <<dashed-ident>>
 		<dfn export>&lt;hue-interpolation-method></dfn> = [ shorter | longer | increasing | decreasing ] hue
 		<dfn export id="color-interpolation-method">&lt;color-interpolation-method></dfn> = in [ <<rectangular-color-space>> | <<polar-color-space>> <<hue-interpolation-method>>? | <<custom-color-space>> ]

--- a/css-easing-2/Overview.bs
+++ b/css-easing-2/Overview.bs
@@ -599,7 +599,7 @@ A <a>cubic Bézier easing function</a> has the following syntax:
 
 <pre class="prod">
   <dfn>&lt;cubic-bezier-easing-function></dfn> =
-    ''ease'' | ''ease-in'' | ''ease-out'' | ''ease-in-out'' | <<cubic-bezier()>>
+    ease | ease-in | ease-out | ease-in-out | <<cubic-bezier()>>
 
   <dfn>cubic-bezier()</dfn> = cubic-bezier( [ <<number [0,1]>>, <<number>> ]#{2} )
 </pre>
@@ -781,11 +781,11 @@ It is defined by a number of <dfn for=steps()>steps</dfn>, and a <dfn for=steps(
 It has the following syntax:
 
 <pre class="prod">
-  <dfn>&lt;step-easing-function></dfn> = ''step-start'' | ''step-end'' | <<steps()>>
+  <dfn>&lt;step-easing-function></dfn> = step-start | step-end | <<steps()>>
 
   <dfn>steps()</dfn> = steps( <<integer>>, <<step-position>>?)
-  <dfn type>&lt;step-position></dfn> = ''jump-start'' | ''jump-end'' | ''jump-none'' | ''jump-both''
-                | ''start'' | ''end''
+  <dfn type>&lt;step-position></dfn> = jump-start | jump-end | jump-none | jump-both
+                | start | end
 </pre>
 
 <wpt>

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -369,16 +369,16 @@ Syntax of <<generic-family>>
 
 	<!-- <pre class=prod>
 		<dfn><<generic-family>></dfn> = generic(<<generic-script-specific>>) | <<generic-complete>> | <<generic-incomplete>>
-		<dfn><<generic-script-specific>></dfn> = <a href="">kai</a> | fangsong | nastaliq 
+		<dfn><<generic-script-specific>></dfn> = <a href="">kai</a> | fangsong | nastaliq
 		<dfn><<generic-complete>></dfn> = serif | sans-serif | system-ui | cursive | fantasy | math | monospace
-		<dfn><<generic-incomplete>></dfn> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded 
+		<dfn><<generic-incomplete>></dfn> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded
 </pre> -->
 
 <pre class=prod>
 	<dfn><<generic-family>></dfn> = <<generic-script-specific>>| <<generic-complete>> | <<generic-incomplete>>
-	<dfn><<generic-script-specific>></dfn> = ''generic(fangsong)'' | ''generic(kai)'' | ''generic(khmer-mul)'' |  ''generic(nastaliq)''
-	<dfn><<generic-complete>></dfn> = ''serif'' | ''sans-serif'' | ''system-ui'' | ''cursive'' | ''fantasy'' | ''math'' | ''monospace''
-	<dfn><<generic-incomplete>></dfn> = ''ui-serif'' | ''ui-sans-serif'' | ''ui-monospace'' | ''ui-rounded''
+	<dfn><<generic-script-specific>></dfn> = generic(fangsong) | generic(kai) | generic(khmer-mul) |  generic(nastaliq)
+	<dfn><<generic-complete>></dfn> = serif | sans-serif | system-ui | cursive | fantasy | math | monospace
+	<dfn><<generic-incomplete>></dfn> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded
 </pre>
 
 	To make the syntax less succeptible to clashes, more recently defined generic font families are identified using a functional syntax.
@@ -401,7 +401,7 @@ Syntax of <<system-family-name>>
 </h4>
 
 	<pre class="prod">
-		<l><<system-family-name>></l> = ''caption'' | ''icon'' | ''menu'' | ''message-box'' | ''small-caption'' | ''status-bar''
+		<l><<system-family-name>></l> = caption | icon | menu | message-box | small-caption | status-bar
 	</pre>
 
 <h4 id="font-families">

--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -780,7 +780,7 @@ Shapes from Box Values</h2>
 	Its syntax is:
 
 	<pre class="prod">
-		<dfn><<shape-box>></dfn> = <<visual-box>> | ''margin-box''
+		<dfn><<shape-box>></dfn> = <<visual-box>> | margin-box
 	</pre>
 
 	The definitions of the values are:


### PR DESCRIPTION
`<pre>''keyword''</pre>` no longer links to `keyword` definition, which means `''keyword''` now generates `'keyword'`, which is inappropriate.

Related: https://github.com/speced/bikeshed/issues/3011