### PR TITLE
[css-mixins-1] Fix build error

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -578,7 +578,6 @@ or acting as if nothing exists at that location otherwise.
 	The value of the '@function/result' descriptor
 	is <code>20px</code> if the media query's condition is true,
 	and <code>16px</code> otherwise.
-	</pre>
 </div>
 
 <div class='example'>
@@ -594,7 +593,6 @@ or acting as if nothing exists at that location otherwise.
 	</pre>
 	The value of the '@function/result' descriptor
 	is always <code>16px</code> in the above example.
-	</pre>
 </div>
 
 <div class='example'>

--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -104,7 +104,7 @@ The ''@function'' rule defines a [=custom function=],
 and its syntax is:
 
 <pre class="prod def" nohighlight>
-&lt;@function> = @function <<function-name>>( <<function-parameter-list>>? )
+&lt;@function> = @function <<function-name>> <<function-parameter-list>>? )
 	[ using ( <<function-dependency-list>> ) ]?
 	[ returns <<css-type>> ]?
 {

--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -104,7 +104,7 @@ The ''@function'' rule defines a [=custom function=],
 and its syntax is:
 
 <pre class="prod def" nohighlight>
-&lt;@function> = @function <<function-name>> <<function-parameter-list>>? )
+&lt;@function> = @function <<function-name>>( <<function-parameter-list>>? )
 	[ using ( <<function-dependency-list>> ) ]?
 	[ returns <<css-type>> ]?
 {


### PR DESCRIPTION
This PR fixes the following two issues with the css-mixins-1 spec:

- Build errors when building the spec, caused by rogue `</pre>` tags.
- ~~Add the opening paren after `@function`. I believe this was erroneously removed in fe94b66b.~~