### PR TITLE
[css-shapes-2] Refine use of the word "path" in the intro

### DIFF
--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -151,8 +151,8 @@ The ''shape()'' Function</h4>
 	but does so with more standard CSS syntax,
 	and allows the full range of CSS functionality,
 	such as additional units and math functions.
-	The commands used by ''shape()'' are dynamically turned into path segments when it used for
-	rendering, e.g. when computing the rendered 'clip-path'.
+	The commands used by ''shape()'' are dynamically turned into path segments when it is used for rendering,
+	e.g., when computing the rendered 'clip-path'.
 
 	<pre class=prod>
 		<dfn>shape()</dfn> = shape( <<'fill-rule'>>? from <<coordinate-pair>>, <<shape-command>>#)

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -147,10 +147,12 @@ The ''shape()'' Function</h4>
 	and inherits a number of limitations from SVG,
 	such as implicitly only allowing the ''px'' unit.
 
-	The ''shape()'' function defines a path in the same way,
+	The ''shape()'' function uses a set of commands equivalent to the ones used by ''path()'',
 	but does so with more standard CSS syntax,
 	and allows the full range of CSS functionality,
 	such as additional units and math functions.
+	The commands used by ''shape()'' are dynamically turned into path segments when it used for
+	rendering, e.g. when computing the rendered 'clip-path'.
 
 	<pre class=prod>
 		<dfn>shape()</dfn> = shape( <<'fill-rule'>>? from <<coordinate-pair>>, <<shape-command>>#)


### PR DESCRIPTION
A "shape" is a set of commands to generate a path dynamically, rather than them being synonomous terms.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
