### PR TITLE
[web-animations-1] Array-form keyframes argument can include `null` a…

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -6100,7 +6100,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
       (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
     };
 
-    typedef (sequence<Keyframe> or PropertyIndexedKeyframes) KeyframeArgument;
+    typedef (sequence<Keyframe?> or PropertyIndexedKeyframes) KeyframeArgument;
   </xmp>
 
   The meaning and allowed values of each argument is as follows:


### PR DESCRIPTION
This is implied by the procedure to [process a keyframes argument](https://drafts.csswg.org/web-animations-1/#process-a-keyframes-argument) but is not accepted by the non-normative WebIDL type definition of the `keyframes` argument (appearing above the procedure).

While I do not see how this behavior can be useful to authors, they might appreciate having this clarified in the spec.