### PR TITLE
[css-custom-highlight-1] Fix IDL definition of `HighlightRegistry`

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -236,7 +236,7 @@ Registering Custom Highlights</h3>
 	};
 
 	[Exposed=Window]
-	partial interface HighlightRegistry {
+	interface HighlightRegistry {
 		maplike<DOMString, Highlight>;
 	};
 	</xmp>


### PR DESCRIPTION
A recent update added a method to the `HighlightRegistry` interface through a `partial interface` definition. That's totally fine. However, the initial `interface` definition was also turned into a `partial interface` definition. That is incorrect, a `partial interface` definition always extends an interface that must be defined (without `partial`) somewhere.

This update drops `partial` from the core interface definition accordingly.

