### PR TITLE
[css-fonts-4] Fix seeming typo in Font Feature and Variation Resolution

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -6815,8 +6815,8 @@ Font Feature and Variation Resolution</h3>
 As described in the previous section,
 font features and variations can be enabled in a variety of ways,
 either via the use of 'font-variant!!property',
-'font-feature-settings!!property',
-'font''font-variation-settings!!property' in a style rule
+'font-feature-settings!!property', or
+'font-variation-settings!!property' in a style rule
 or within an ''@font-face'' rule.
 The resolution order for the union of these settings is defined below.
 Features defined via CSS properties are applied on top of layout engine default features.


### PR DESCRIPTION
https://drafts.csswg.org/css-fonts-4/#font-feature-variation-resolution looks strange currently, rendering as "either via the use of ‘font-variant’, ‘font-feature-settings’, ‘font’‘font-variation-settings’ in a style rule or within an @font-face rule".

I'm not totally sure of the intention, but I've made the most plausible fix to me.