### PR TITLE
[css-overflow-5] Editorial fix of button order.

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -428,7 +428,7 @@ They exist after their [=originating element's=] ''::scroll-marker-group'' pseud
 Four distinct ''::scroll-button()'' pseudo-elements can exist on a [=scroll container=],
 each associated with a [=flow-relative=] direction,
 based on their [=originating element's=] [=writing mode=]:
-in order, [=block-start=], [=inline-start=], [=block-end=], and [=inline-end=].
+in order, [=block-start=], [=inline-start=], [=inline-end=], and [=block-end=].
 The ''::scroll-button()'' pseudo-elements are both focusable and activatable by default,
 with their activation behavior being to scroll their [=originating element=]
 by one "page" in their associated direction,


### PR DESCRIPTION
In #10912 we resolved on the block directions wrapping the inline direction.