### PR TITLE
[css-2024] Fix section number for text-decoration (#11598)

### DIFF
--- a/css-2020/Overview.bs
+++ b/css-2020/Overview.bs
@@ -365,7 +365,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
 		  [[CSS-TEXT-3]]
 		<dd>
-			Extends and supersedes CSS2&sect;16 excepting &sect;16.2,
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 

--- a/css-2021/Overview.bs
+++ b/css-2021/Overview.bs
@@ -361,7 +361,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
 		  [[CSS-TEXT-3]]
 		<dd>
-			Extends and supersedes CSS2&sect;16 excepting &sect;16.2,
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 

--- a/css-2022/Overview.bs
+++ b/css-2022/Overview.bs
@@ -409,7 +409,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
 		  [[CSS-TEXT-3]]
 		<dd>
-			Extends and supersedes CSS2&sect;16 excepting &sect;16.2,
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 

--- a/css-2023/Overview.bs
+++ b/css-2023/Overview.bs
@@ -410,7 +410,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
 		[[CSS-TEXT-3]]
 		<dd>
-			Extends and supersedes CSS2&sect;16 excepting &sect;16.2,
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 

--- a/css-2024/Overview.bs
+++ b/css-2024/Overview.bs
@@ -451,7 +451,7 @@ Fairly Stable Modules with limited implementation experience</h3>
 		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
 		[[CSS-TEXT-3]]
 		<dd>
-			Extends and supersedes CSS2&sect;16 excepting &sect;16.2,
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
 			defining properties for text manipulation and specifying their processing model.
 			It covers line breaking, justification and alignment, white space handling, and text transformation.
 


### PR DESCRIPTION
CSS Text Module Level 3 extends and supersedes everything in chapter 16 of CSS2, except text-decoration. text-decoration is defined in CSS2 section 16.3, not 16.2.