### PR TITLE
Fix fill mode regression

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -3347,7 +3347,7 @@ Calculating progress {#core-animation-effect-calculations}
       <div class=switch>
 
       : If the [=fill mode=] is
-          [=fill mode/forwards=] or [=fill mode/backwards=],
+          [=fill mode/forwards=] or [=fill mode/both=],
       ::
           Return the result of evaluating
           <code>max(min(<a>local time</a> − <a>start delay</a>,

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -185,23 +185,8 @@ urlPrefix: https://drafts.css-houdini.org/css-properties-values-api-1/; type: df
     text: universal syntax definition
 </pre>
 <pre class="link-defaults">
-spec:dom; type:interface; text:DocumentOrShadowRoot
-spec:dom; type:interface; text:EventTarget
-spec:dom; type:interface; text:Event
-spec:dom; type:dfn; text:descendant
-spec:dom; type:dfn; for:/; text:document
-spec:dom; type:dfn; for:/; text:shadow root
-spec:css-cascade-5; type:dfn;
-    text:computed value
-    text:shorthand property
-spec:css-color-4; type:value; text:transparent
-spec:css-display-4; type:property;
-    text:visibility
-    text:display
-spec:css-fonts-4; type:property;
-    text:font-size
-    text:font-weight
-spec:css-values-4; type:dfn; text:interpolation
+spec:cssom-1; type: dfn;
+    text: CSS declaration block
 spec:css-backgrounds-3; type:property;
     text:background-image
     text:border-width
@@ -213,9 +198,24 @@ spec:css-backgrounds-3; type:property;
     text:border-top
     text:border-color
     text:box-shadow
-spec:cssom-1; type: dfn;
-    text: CSS declaration block
+spec:css-cascade-5; type:dfn;
+    text:computed value
+    text:shorthand property
+spec:css-color-4; type:value; text:transparent
+spec:css-display-4; type:property;
+    text:visibility
+    text:display
+spec:css-fonts-4; type:property;
+    text:font-size
+    text:font-weight
 spec:css-transforms-1; type:property; text:transform
+spec:css-values-4; type:dfn; text:interpolation
+spec:dom; type:interface; text:DocumentOrShadowRoot
+spec:dom; type:interface; text:EventTarget
+spec:dom; type:interface; text:Event
+spec:dom; type:dfn; text:descendant
+spec:dom; type:dfn; for:/; text:document
+spec:dom; type:dfn; for:/; text:shadow root
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; for:list; text:extend
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -189,11 +189,21 @@ spec:dom; type:interface; text:DocumentOrShadowRoot
 spec:dom; type:interface; text:EventTarget
 spec:dom; type:interface; text:Event
 spec:dom; type:dfn; text:descendant
+spec:dom; type:dfn; for:/; text:document
 spec:dom; type:dfn; for:/; text:shadow root
+spec:css-cascade-5; type:dfn;
+    text:computed value
+    text:shorthand property
 spec:css-color-4; type:value; text:transparent
-spec:css-fonts-4; type:property; text:font-weight
+spec:css-display-4; type:property;
+    text:visibility
+    text:display
+spec:css-fonts-4; type:property;
+    text:font-size
+    text:font-weight
 spec:css-values-4; type:dfn; text:interpolation
 spec:css-backgrounds-3; type:property;
+    text:background-image
     text:border-width
     text:border-bottom-width
     text:border-left-width
@@ -202,6 +212,7 @@ spec:css-backgrounds-3; type:property;
     text:border-top-color
     text:border-top
     text:border-color
+    text:box-shadow
 spec:cssom-1; type: dfn;
     text: CSS declaration block
 spec:css-transforms-1; type:property; text:transform

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1569,7 +1569,8 @@ Waiting for the associated effect</h4>
   In order to emulate this behavior,
   and to provide consistency with HTML's [=media elements=] [[HTML]],
   the [=animation/current time=] of Web Animations' animations
-  do not play forwards beyond the [=end time=] of their [=associated effect=]
+  do not play forwards beyond the
+  [=animation effect/end time=] of their [=associated effect=]
   or play backwards past time zero.
 
   An animation that has reached the natural boundary of its playback range
@@ -1601,7 +1602,7 @@ Waiting for the associated effect</h4>
   This allows, for example, [=seeking=]
   the [=animation/current time=] of an animation
   with <em>no</em> [=associated effect=] to 5s.
-  If [=associated effect=] with an [=end time=] later than 5s
+  If [=associated effect=] with an [=animation effect/end time=] later than 5s
   is later associated with the animation,
   playback will begin from the 5s mark.
 
@@ -1629,7 +1630,7 @@ Waiting for the associated effect</h4>
   until it reaches the [=associated effect end=].
 
   The <dfn>associated effect end</dfn> of an animation
-  is equal to the [=end time=] of the animation's [=associated effect=].
+  is equal to the [=animation effect/end time=] of the animation's [=associated effect=].
   If the animation has no [=associated effect=],
   the [=associated effect end=] is zero.
 
@@ -2669,7 +2670,7 @@ Animation effects {#animation-effects}
   Similar to the [=start delay=],
   an [=animation effect=] also has an <dfn>end delay</dfn>,
   which is primarily of use when sequencing one [=animation effect=]
-  based on the [=end time=] of another [=animation effect=].
+  based on the [=animation effect/end time=] of another [=animation effect=].
 
   The <dfn for="animation effect">end time</dfn>,
   of an [=animation effect=]
@@ -2710,7 +2711,8 @@ Animation effects {#animation-effects}
   : [=animation effect/before phase=]
   ::
       The [=animation effect=]’s [=local time=]
-      falls before the effect's [=active interval=] and [=end time=],
+      falls before
+      the effect's [=active interval=] and [=animation effect/end time=],
       <em>or</em>
       occurs during the range when a negative [=start delay=] is in effect.
 
@@ -2725,7 +2727,7 @@ Animation effects {#animation-effects}
   ::
       The [=animation effect=]’s [=local time=] falls
       after the effect's [=active interval=]
-      or after the [=end time=] if that comes first
+      or after the [=animation effect/end time=] if that comes first
       (due to a negative [=end delay=]),
       but <em>not</em> during the range when a negative [=start delay=]
       is in effect.
@@ -2781,12 +2783,12 @@ Animation effects {#animation-effects}
   : <dfn>before-active boundary time</dfn>
   ::
       <code>max(min(<a>start delay</a>,
-                    <a>end time</a>), 0)</code>
+                    <a for="animation effect">end time</a>), 0)</code>
 
   : <dfn>active-after boundary time</dfn>
   ::
       <code>max(min(<a>start delay</a> + <a>active duration</a>,
-                    <a>end time</a>), 0)</code>
+                    <a for="animation effect">end time</a>), 0)</code>
 
   An [=animation effect=] is in the
   <dfn export for="animation effect">before phase</dfn>
@@ -5179,7 +5181,7 @@ The {{AnimationEffect}} interface {#the-animationeffect-interface}
       The [=end delay=],
       which represents the number of milliseconds
       from the end of an [=animation effect=]’s [=active interval=]
-      until its [=end time=].
+      until its [=animation effect/end time=].
 
   : <dfn>fill</dfn>
   ::
@@ -5407,7 +5409,7 @@ The {{AnimationEffect}} interface {#the-animationeffect-interface}
 
   : <dfn>endTime</dfn>
   ::
-      The [=end time=] of the [=animation effect=]
+      The [=animation effect/end time=] of the [=animation effect=]
       expressed in milliseconds since zero [=local time=]
       (that is, since the associated [=animation=]’s [=start time=]
        if this [=animation effect=] is [=associated with an animation=]).

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -1370,7 +1370,7 @@ Waiting for the associated effect</h4>
 
                 1. Set the [=start time=] of |animation| to |new start time|.
 
-            </div>
+            </dl>
 
         1. [=resolve a promise|Resolve=] |animation|'s [=current ready promise=]
             with |animation|.
@@ -2228,7 +2228,7 @@ Waiting for the associated effect</h4>
 
     1. Let |animation|'s [=pending playback rate=] be
         the additive inverse of its [=effective playback rate=]
-        (i.e. <code>-</a>effective playback rate</a></code>).
+        (i.e. <code>-<a>effective playback rate</a></code>).
 
     1. Run the steps to [=play an animation=] for |animation|
         with the |auto-rewind| flag set to true.
@@ -2373,7 +2373,7 @@ Waiting for the associated effect</h4>
 
   <div algorithm>
     To <dfn lt="animation time to timeline time">convert
-    an animation time to timeline time</a></dfn>
+    an animation time to timeline time</dfn>
     a [=time value=], |time|, that is relative to
     the [=start time=] of an animation, |animation|,
     perform the following steps:
@@ -5475,7 +5475,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
   ::
       Creates a new {{KeyframeEffect}} object using the following procedure:
 
-      1. Create a new {{KeyframeEffect}} object, |effect|.</li>
+      1. Create a new {{KeyframeEffect}} object, |effect|.
 
       1. Set the [=target element=] of |effect| to |target|.
 
@@ -5811,7 +5811,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
                     \[[Configurable]]: <span class=esvalue>true</span>,
                     \[[Value]]: |value|
                   }
-                  and Boolean flag <span class=esvalue>false</a>.
+                  and Boolean flag <span class=esvalue>false</span>.
 
           1. Append |output keyframe| to |result|.
 
@@ -6587,7 +6587,7 @@ The {{CompositeOperation}} and {{CompositeOperationOrAuto}} enumerations {#the-c
 ------------------------------------------------------------------------
 
   The possible values of an [=keyframe effect=]’s composition behavior
-  are represented by the <dfn type=enum-value>CompositeOperation</dfn> enumeration.
+  are represented by the <dfn>CompositeOperation</dfn> enumeration.
 
   <xmp class=idl>
     enum CompositeOperation { "replace", "add", "accumulate" };
@@ -6738,7 +6738,7 @@ The <code>Animatable</code> interface mixin {#the-animatable-interface-mixin}
 
       </div>
 
-  : <dfn lt="getAnimations(options)">sequence<Animation> getAnimations(|options|)</dfn>
+  : <dfn lt="getAnimations(options)">sequence&lt;Animation&gt; getAnimations(|options|)</dfn>
   ::
       1. Let |object| be the object on which this method was called.
 

--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -5676,7 +5676,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
   ::
       The [=composite operation=] used
       to composite this [=keyframe effect=] with the [=effect stack=],
-      as specified by one of the [=CompositeOperation=] enumeration values.
+      as specified by one of the {{CompositeOperation}} enumeration values.
 
       On setting,
       sets the [=composite operation=] property of this [=animation effect=]
@@ -6585,7 +6585,7 @@ The {{KeyframeEffect}} interface {#the-keyframeeffect-interface}
   ::
       The [=composite operation=] used
       to composite this animation with the [=effect stack=],
-      as specified by one of the [=CompositeOperation=] enumeration values.
+      as specified by one of the {{CompositeOperation}} enumeration values.
       This is used for all [=keyframes=] that specify
       an {{CompositeOperationOrAuto/auto}}
       [=keyframe-specific composite operation=].
@@ -6600,7 +6600,7 @@ The {{CompositeOperation}} and {{CompositeOperationOrAuto}} enumerations {#the-c
 ------------------------------------------------------------------------
 
   The possible values of an [=keyframe effect=]’s composition behavior
-  are represented by the <dfn>CompositeOperation</dfn> enumeration.
+  are represented by the {{CompositeOperation}} enumeration.
 
   <xmp class=idl>
     enum CompositeOperation { "replace", "add", "accumulate" };


### PR DESCRIPTION
- **[web-animations-1] Fix markup errors**
- **[web-animations-1] Fix mistake in active time calculation**
- **[web-animations-1] Fix linking to end time term**
- **[web-animations-1] Fix link defaults**
- **[web-animations-1] Sort link defaults**
- **[web-animations-1] Drop unnecessary CompositeOperation dfn**
