### PR TITLE
[css-gaps-1] Fix typo

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -504,7 +504,7 @@ Gap decoration color: The 'column-rule-color' and 'row-rule-color' properties {#
 	<pre class='propdef'>
 		Name: column-rule-color, row-rule-color
 		Value: <<line-color-list>> | <<auto-line-color-list>>
-		Initial: curerentcolor
+		Initial: currentcolor
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>masonry containers</a>
 		Inherited: no
 		Animation type: by computed value type


### PR DESCRIPTION
There is a typo in the initial value of `column-rule-color`/`row-rule-color`.