### PR TITLE
[css-borders-4] Accept infinity keyword in superellipse()

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -366,7 +366,7 @@ Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: che
 'corner-shape' values</h4>
 
 	<pre class=prod>
-		<dfn><<corner-shape-value>></dfn> = ''round'' | ''scoop'' | ''bevel'' | ''notch'' | ''straight'' | ''squircle'' | superellipse(<<number [0,&infin;]>>)
+		<dfn><<corner-shape-value>></dfn> = ''round'' | ''scoop'' | ''bevel'' | ''notch'' | ''straight'' | ''squircle'' | superellipse(<<number [0,&infin;]>> | infinity)
 	</pre>
 
 	<dl dfn-type="value" dfn-for="<corner-shape-value>">


### PR DESCRIPTION
This is already specified in prose but missing in the production rule.

  > The `superellipse( <number> | infinity )` function describes [...]

  > `<corner-shape-value> = ... | superellipse(<number [0,∞]>)`

https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value