### PR TITLE
[css-borders-4] Do not allow a trailing slash in `corner-shape`

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -410,7 +410,7 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 
 	<pre class="propdef">
 		Name: corner-shape
-		Value: <<corner-shape-value>>{1,2} / [ <<corner-shape-value>>{1,2} ]?
+		Value: <<corner-shape-value>>{1,2} [ / <<corner-shape-value>>{1,2} ]?
 		Initial: round
 		Applies to: all elements where 'border-radius' can apply
 		Inherited: no


### PR DESCRIPTION
The grammar of [`corner-shape`](https://drafts.csswg.org/css-borders-4/#propdef-corner-shape) currently allows a trailing slash:

  > `<corner-shape-value>{1,2} / [ <corner-shape-value>{1,2} ]?`