### PR TITLE
[css-borders-4] Remove the second value from the corner-*-shape variant

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -445,34 +445,6 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	and the second the inline-axis side
 	(i.e. patterned as 'corner-<var>block</var>-<var>inline</var>-shape').
 
-	<pre class=propdef>
-		Name: corner-top-shape, corner-right-shape, corner-bottom-shape, corner-left-shape,
-			corner-block-start-shape, corner-block-end-shape, corner-inline-start-shape, corner-inline-end-shape
-		Value: <<corner-shape-value>> [ / <<corner-shape-value>> ]
-		Initial: round
-		Applies to: all elements where 'border-radius' can apply
-		Inherited: no
-		Computed value: see individual properties
-		Animation type: see individual properties
-	</pre>
-
-	<p>The 'corner-*-shape' shorthands set the two 'corner-*-*-shape'
-	longhand properties of the related side. If values are given before
-	and after the slash, then the values before the slash set the
-	horizontal radius and the values after the slash set the vertical radius.
-	If there is no slash, then the values set both radii equally.
-	The two values for the radii are given in the order
-	top-left, top-right for 'corner-top-shape',
-	top-right, bottom-right for 'corner-right-shape',
-	bottom-left, bottom-right for 'corner-bottom-shape',
-	top-left, bottom-left for 'corner-left-shape',
-	start-start, start-end for 'corner-block-start-shape',
-	end-start, end-end for 'corner-block-end-shape'
-	start-start, end-start for 'corner-inline-start-shape',
-	and start-end, end-end for 'corner-inline-end-shape'.
-	If the second value is omitted it is copied from the first.
-
-
 <h4 id=corner-shape-interpolation>
 Interpolating corner shapes</h4>
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -445,6 +445,34 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	and the second the inline-axis side
 	(i.e. patterned as 'corner-<var>block</var>-<var>inline</var>-shape').
 
+	<pre class=propdef>
+		Name: corner-top-shape, corner-right-shape, corner-bottom-shape, corner-left-shape,
+			corner-block-start-shape, corner-block-end-shape, corner-inline-start-shape, corner-inline-end-shape
+		Value: <<corner-shape-value>>
+		Initial: round
+		Applies to: all elements where 'border-radius' can apply
+		Inherited: no
+		Computed value: see individual properties
+		Animation type: see individual properties
+	</pre>
+
+	<p>The 'corner-*-shape' shorthands set the two 'corner-*-*-shape'
+	longhand properties of the related side. If values are given before
+	and after the slash, then the values before the slash set the
+	horizontal radius and the values after the slash set the vertical radius.
+	If there is no slash, then the values set both radii equally.
+	The two values for the radii are given in the order
+	top-left, top-right for 'corner-top-shape',
+	top-right, bottom-right for 'corner-right-shape',
+	bottom-left, bottom-right for 'corner-bottom-shape',
+	top-left, bottom-left for 'corner-left-shape',
+	start-start, start-end for 'corner-block-start-shape',
+	end-start, end-end for 'corner-block-end-shape'
+	start-start, end-start for 'corner-inline-start-shape',
+	and start-end, end-end for 'corner-inline-end-shape'.
+	If the second value is omitted it is copied from the first.
+
+
 <h4 id=corner-shape-interpolation>
 Interpolating corner shapes</h4>
 


### PR DESCRIPTION
`corner-shape` has only one value, there is no point in providing two values for each side, it was a copy-paste mistake from `border-radius`.

Closes #11650

