### PR TITLE
[css-animations-2] Set `animation-trigger-type`  as the coordinating list base property

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -716,7 +716,7 @@ Declaring Animation Triggers</h2>
     These list-valued properties,
     which are all [=longhands=] of the 'animation-trigger' [=shorthand=],
     form a [=coordinating list property group=]
-    with 'animation-name' as the [=coordinating list base property=]
+    with 'animation-trigger-type' as the [=coordinating list base property=]
     and each item in the [=coordinated value list=]
     defining the properties of a single animation trigger.
 


### PR DESCRIPTION
`animation-name`  is currently defined as the coordinating list base property for [`animation-trigger`](https://drafts.csswg.org/css-animations-2/#animation-triggers). I presume this is an oversight and should be `animation-trigger-type`.