### PR TITLE
[css-borders-4] Accept 1-2 / 1-4 whitespace separated values in corner-shape shorthands

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -448,7 +448,7 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	<pre class=propdef>
 		Name: corner-top-shape, corner-right-shape, corner-bottom-shape, corner-left-shape,
 			corner-block-start-shape, corner-block-end-shape, corner-inline-start-shape, corner-inline-end-shape
-		Value: <<corner-shape-value>>
+		Value: <<corner-shape-value>>{1,2}
 		Initial: round
 		Applies to: all elements where 'border-radius' can apply
 		Inherited: no

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -410,7 +410,7 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 
 	<pre class="propdef">
 		Name: corner-shape
-		Value: <<corner-shape-value>>{1,2} [ / <<corner-shape-value>>{1,2} ]?
+		Value: <<corner-shape-value>>{1,4}
 		Initial: round
 		Applies to: all elements where 'border-radius' can apply
 		Inherited: no

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -457,10 +457,8 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	</pre>
 
 	<p>The 'corner-*-shape' shorthands set the two 'corner-*-*-shape'
-	longhand properties of the related side. If values are given before
-	and after the slash, then the values before the slash set the
-	horizontal radius and the values after the slash set the vertical radius.
-	If there is no slash, then the values set both radii equally.
+	longhand properties of the related side.
+	If a single value is specified, it sets both longhands equally.
 	The two values for the radii are given in the order
 	top-left, top-right for 'corner-top-shape',
 	top-right, bottom-right for 'corner-right-shape',

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -405,19 +405,8 @@ Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: che
 		|x/a|^k + |y/b|^k = 1
 	</pre>
 
-<h4 id=corner-shape-shorthand>
-Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
-
-	<pre class="propdef">
-		Name: corner-shape
-		Value: <<corner-shape-value>>{1,4}
-		Initial: round
-		Applies to: all elements where 'border-radius' can apply
-		Inherited: no
-		Animation type: see individual properties
-	</pre>
-
-	Applies the shape to all corners, following the same rules as ''border-radius''.
+<h4 id=corner-shape-longhands>
+Corner Shaping: the 'corner-*-shape' properties</h4>
 
 	<pre class=propdef>
 	Name: corner-top-left-shape, corner-top-right-shape, corner-bottom-right-shape, corner-bottom-left-shape, corner-start-start-shape, corner-start-end-shape, corner-end-start-shape, corner-end-end-shape
@@ -445,6 +434,9 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	and the second the inline-axis side
 	(i.e. patterned as 'corner-<var>block</var>-<var>inline</var>-shape').
 
+<h4 id=corner-shape-shorthands>
+Corner Shaping: the 'corner-shape' and 'corner-*-shape' shorthand properties</h4>
+
 	<pre class=propdef>
 		Name: corner-top-shape, corner-right-shape, corner-bottom-shape, corner-left-shape,
 			corner-block-start-shape, corner-block-end-shape, corner-inline-start-shape, corner-inline-end-shape
@@ -469,6 +461,17 @@ Corner Shaping: the 'corner-shape' and 'corner-*-shape' properties</h4>
 	start-start, end-start for 'corner-inline-start-shape',
 	and start-end, end-end for 'corner-inline-end-shape'.
 	If the second value is omitted it is copied from the first.
+
+	<pre class="propdef">
+		Name: corner-shape
+		Value: <<corner-shape-value>>{1,4}
+		Initial: round
+		Applies to: all elements where 'border-radius' can apply
+		Inherited: no
+		Animation type: see individual properties
+	</pre>
+
+	Applies the shape to all corners, following the same rules as ''border-radius''.
 
 
 <h4 id=corner-shape-interpolation>


### PR DESCRIPTION
Fixes #11650.

There must have been some misunderstanding in this issue with #11651. Please forgive me to directly express what would make sense to me. Feel free to reject it if I am missing something, or to add your own changes.

- `corner-<side>-shape` accepts 1-2 values (with no `/`)
- `corner-shape` accept 1-4 values (with no `/`)
- longhands are moved into their own section before shorthands