### PR TITLE
[web-animations-2] Use `dfn` type for animation trigger values

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2379,19 +2379,19 @@ Issue: Should there be any effect of triggers on scroll-driven animations?
 The behavior an [=animation trigger=] applies to its associated [=animation=]’s
 playback is defined by its <dfn export>animation trigger type</dfn>, and
 depending on its [=animation trigger state|state=] can apply one of two
-distinct behavior types: ''primary'' or ''inverse''.
+distinct behavior types: [=animation trigger state/primary=] or [=animation trigger state/inverse=].
 Given an internal |did trigger| flag, the values of [=animation trigger type=]
 can be one of the following:
 
-<dl dfn-type=value dfn-for='animation trigger type'>
+<dl dfn-for='animation trigger type'>
   <dt><dfn>once</dfn>
   <dd>
-    The ''primary'' behavior is [=play an animation|triggering=] the associated animation.
+    The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
 
   <dt><dfn>repeat</dfn>
   <dd>
-    The ''primary'' behavior is [=play an animation|triggering=] the associated animation.
-    The ''inverse'' behavior is resetting the associated [=animation effect=] back to
+    The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
+    The [=animation trigger state/inverse=] behavior is resetting the associated [=animation effect=] back to
     its [=animation effect/before phase=] and its associated animation’s [=animation/start time=] to zero.
 
   <dt><dfn>alternate</dfn>
@@ -2399,20 +2399,20 @@ can be one of the following:
     <dl class=switch>
       : if the |did trigger| flag is false,
       ::
-        The ''primary'' behavior is [=play an animation|triggering=] the associated animation.
+        The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
 
       : Otherwise,
       ::
-        The ''primary'' behavior is [=reverse an animation|reversing=] the associated animation.
+        The [=animation trigger state/primary=] behavior is [=reverse an animation|reversing=] the associated animation.
 
     </dl>
 
-    The ''inverse'' behavior is [=reverse an animation|reversing=] the associated animation.
+    The [=animation trigger state/inverse=] behavior is [=reverse an animation|reversing=] the associated animation.
 
   <dt><dfn>state</dfn>
   <dd>
-    The ''primary'' behavior is [=play an animation|triggering or resuming=] the associated animation.
-    The ''inverse'' behavior is [=pause an animation|pausing=] the associated animation.
+    The [=animation trigger state/primary=] behavior is [=play an animation|triggering or resuming=] the associated animation.
+    The [=animation trigger state/inverse=] behavior is [=pause an animation|pausing=] the associated animation.
 </dl>
 
 Issue: Need to bike-shed the name for type "state" type.
@@ -2427,7 +2427,7 @@ has an internal <dfn export lt="animation trigger state">state</dfn> which
 controls the applied behavior type. This state has discrete values
 which can be one of the following:
 
-<dl dfn-for="animation trigger state" dfn-type=value>
+<dl dfn-for="animation trigger state">
   <dt><dfn>idle</dfn>
   <dd>
     The [=animation effect=] associated |animation| remains in
@@ -2435,11 +2435,11 @@ which can be one of the following:
 
   <dt><dfn>primary</dfn>
   <dd>
-    When switched to this value the ''primary'' behavior type defined by |type| is applied to |animation|.
+    When switched to this value the [=animation trigger state/primary=] behavior type defined by |type| is applied to |animation|.
 
   <dt><dfn>inverse</dfn>
   <dd>
-    When switched to this value the ''inverse'' behavior type defined by |type| is applied to |animation|.
+    When switched to this value the [=animation trigger state/inverse=] behavior type defined by |type| is applied to |animation|.
 
 </dl>
 
@@ -2449,7 +2449,7 @@ Issue: Do we need a formal resolution on the spec of the idle state?
 
 Each [=animation trigger=] defines an <dfn for="animation trigger">active interval</dfn>
 and only one such interval. This interval is the segment of the timeline’s progress
-during which the trigger’s [=animation trigger state|state=] is set to ''primary''.
+during which the trigger’s [=animation trigger state|state=] is set to [=animation trigger state/primary=].
 
 ### Animation Trigger Ranges ### {#trigger-ranges}
 
@@ -2464,7 +2464,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
 [=animation trigger/active interval|active interval=] is defined as follows:
 
 <dl class=switch>
-  : If |state| is ''animation trigger state/primary'',
+  : If |state| is [=animation trigger state/primary=],
   ::
     Then |interval| is set to [=exit range=].
 
@@ -2515,7 +2515,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
   1. Let |did trigger| be a boolean flag that is initially false.
 
   1. Let |state| be the current [=animation trigger state|state=]
-    of |trigger| that is initially ''animation trigger state/idle''.
+    of |trigger| that is initially [=animation trigger state/idle=].
 
   1. Set |state| as follows:
     <dl class=switch>
@@ -2527,7 +2527,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
       ::
 
         <dl class=switch>
-          : If |type| is ''animation trigger type/once'' and |did trigger| flag is true,
+          : If |type| is [=animation trigger type/once=] and |did trigger| flag is true,
           ::
             Then abort this procedure.
 
@@ -2537,7 +2537,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
             <dl class=switch>
               : If |trigger| is inside its [=animation trigger/active interval|active interval=],
               ::
-                  1. Set |state| to ''animation trigger state/primary''.
+                  1. Set |state| to [=animation trigger state/primary=].
                   1. Set |did trigger| to true.
 
               : Otherwise,
@@ -2546,7 +2546,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
                 <dl class=switch>
                   : If |did trigger| flag is true,
                   ::
-                      Set |state| to ''animation trigger state/inverse''.
+                      Set |state| to [=animation trigger state/inverse=].
 
                 </dl>
 
@@ -3713,7 +3713,7 @@ dictionary AnimationTriggerOptions {
   : <dfn>type</dfn>
   ::
       The type of trigger to create.
-      If not specified, the trigger is of type ''animation trigger type/once''.
+      If not specified, the trigger is of type [=animation trigger type/once=].
 
   : <dfn>rangeStart</dfn>
   ::
@@ -3748,19 +3748,19 @@ enum AnimationTriggerType { "once", "repeat", "alternate", "state" };
 
   : <dfn>once</dfn>
   ::
-      Type ''animation trigger type/once''.
+      Type [=animation trigger type/once=].
 
   : <dfn>repeat</dfn>
   ::
-      Type ''animation trigger type/repeat''.
+      Type [=animation trigger type/repeat=].
 
   : <dfn>alternate</dfn>
   ::
-      Type ''animation trigger type/alternate''.
+      Type [=animation trigger type/alternate=].
 
   : <dfn>state</dfn>
   ::
-      Type ''animation trigger type/state''.
+      Type [=animation trigger type/state=].
 
 </dl>
 

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2383,18 +2383,18 @@ distinct behavior types: [=animation trigger state/primary=] or [=animation trig
 Given an internal |did trigger| flag, the values of [=animation trigger type=]
 can be one of the following:
 
-<dl dfn-for='animation trigger type'>
-  <dt><dfn>once</dfn>
+<dl>
+  <dt>''animation-trigger-type/once''
   <dd>
     The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
 
-  <dt><dfn>repeat</dfn>
+  <dt>''animation-trigger-type/repeat''
   <dd>
     The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
     The [=animation trigger state/inverse=] behavior is resetting the associated [=animation effect=] back to
     its [=animation effect/before phase=] and its associated animation’s [=animation/start time=] to zero.
 
-  <dt><dfn>alternate</dfn>
+  <dt>''animation-trigger-type/alternate''
   <dd>
     <dl class=switch>
       : if the |did trigger| flag is false,
@@ -2409,7 +2409,7 @@ can be one of the following:
 
     The [=animation trigger state/inverse=] behavior is [=reverse an animation|reversing=] the associated animation.
 
-  <dt><dfn>state</dfn>
+  <dt>''animation-trigger-type/state''
   <dd>
     The [=animation trigger state/primary=] behavior is [=play an animation|triggering or resuming=] the associated animation.
     The [=animation trigger state/inverse=] behavior is [=pause an animation|pausing=] the associated animation.
@@ -2527,7 +2527,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
       ::
 
         <dl class=switch>
-          : If |type| is [=animation trigger type/once=] and |did trigger| flag is true,
+          : If |type| is 'animation-trigger-type/once'' and |did trigger| flag is true,
           ::
             Then abort this procedure.
 
@@ -3713,7 +3713,7 @@ dictionary AnimationTriggerOptions {
   : <dfn>type</dfn>
   ::
       The type of trigger to create.
-      If not specified, the trigger is of type [=animation trigger type/once=].
+      If not specified, the trigger is of type ''animation-trigger-type/once''.
 
   : <dfn>rangeStart</dfn>
   ::
@@ -3748,19 +3748,19 @@ enum AnimationTriggerType { "once", "repeat", "alternate", "state" };
 
   : <dfn>once</dfn>
   ::
-      Type [=animation trigger type/once=].
+      Type ''animation-trigger-type/once''.
 
   : <dfn>repeat</dfn>
   ::
-      Type [=animation trigger type/repeat=].
+      Type ''animation-trigger-type/repeat''.
 
   : <dfn>alternate</dfn>
   ::
-      Type [=animation trigger type/alternate=].
+      Type ''animation-trigger-type/alternate''.
 
   : <dfn>state</dfn>
   ::
-      Type [=animation trigger type/state=].
+      Type ''animation-trigger-type/state''.
 
 </dl>
 


### PR DESCRIPTION
The values for "animation trigger state" and "animation trigger type" were defined with a `value` definition type. That type is reserved for CSS values: https://speced.github.io/bikeshed/#dfn-types

This makes tools that crawl specs to extract machine-readable information wrongly assume that the spec introduces new CSS values.

There is no specific definition type available for generic values. This update uses a regular `dfn` and updates references to these values accordingly.

