### PR TITLE
Fix typo in description for column in item-track-direction

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -1287,18 +1287,18 @@ Item Flow Axis: 'item-track'/'item-direction'</h3>
 		: <dfn>column</dfn>
 		::
 			<span class="option masonry">Track-oriented Option</span>
-			Represents placement into rows,
-			i.e. tracks or lines parallel to the [=inline axis=].
-			Items are placed in start-to-end order in the inline axis
+			Represents placement into columns,
+			i.e. tracks or lines parallel to the [=block axis=].
+			Items are placed in start-to-end order in the block axis
 			in [=flex layout=] and [=grid layout=],
-			and in start-to-end order in the [=block axis=]
+			and in start-to-end order in the [=inline axis=]
 			in [=masonry layout=].
 
 			<span class="option grid">Flow-oriented Option</span>
-			Represents row-primary item placement,
-			i.e. placing items start-to-end in the [=inline axis=],
-			producing flex row lines in [=flex layout=],
-			and column grid tracks in [=masonry layout=].
+			Represents column-primary item placement,
+			i.e. placing items start-to-end in the [=block axis=],
+			producing flex column lines in [=flex layout=],
+			and row grid tracks in [=masonry layout=].
 
 		: <dfn>row-reverse</dfn>
 		::


### PR DESCRIPTION
Just  flipped all the related values in the text for `column`.