### PR TITLE
[css-mixins-1] Fix markup

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -179,7 +179,7 @@ The <dfn>@function</dfn> Rule {#function-rule}
 ----------------------------------------------
 
 The ''@function'' rule defines a <dfn>custom function</dfn>,
-and consists of a name (<<function-name>>),
+and consists of a name,
 a list of [=function parameter|parameters=],
 a <dfn for="custom function">function body</dfn>,
 and optionally a <dfn for="custom function">return type</dfn> described by a [=syntax definition=].
@@ -239,8 +239,8 @@ and rules defined later win within the same layer.
 
 The name of a ''@function'' rule is a [=tree-scoped name=].
 
-If the <<function-parameter-list>>
-contains the same <<custom-property-name>> more than once,
+If the [=function parameters=]
+contain the same <<custom-property-name>> more than once,
 then the ''@function'' rule is invalid.
 
 The body of a ''@function'' rule accepts [=conditional group rules=],


### PR DESCRIPTION
Replaces/removes links to `<function-name>` and `<function-parameter-list>`, which are no longer defined.