### PR TITLE
[css-flexbox-1] Make non-replaced elements consult the transferred size for their automatic minimum. #6069 #6794

### DIFF
--- a/css-flexbox-1/Overview.bs
+++ b/css-flexbox-1/Overview.bs
@@ -960,14 +960,27 @@ Automatic Minimum Size of Flex Items</h3>
 	for <a>scroll containers</a> the <a>automatic minimum size</a> is zero, as usual.
 
 	The <dfn>content-based minimum size</dfn> of a [=flex item=]
-	is the smaller of its [=specified size suggestion=] and its [=content size suggestion=]
-	if its [=specified size suggestion=] exists;
-	otherwise, the smaller of its [=transferred size suggestion=] and its [=content size suggestion=]
-	if the element is [=replaced element|replaced=]
-	<!-- https://github.com/w3c/csswg-drafts/issues/6069 -->
-	and its [=transferred size suggestion=] exists;
-	otherwise its [=content size suggestion=].
-	In all cases, the size is clamped by the [=maximum size|maximum=] [=main size=] if it's <a>definite</a>.
+	differs depending on whether the [=flex item=] is [=replaced element|replaced=] or not:
+
+	: For [=replaced elements=]
+	::
+		Use the smaller of the [=content size suggestion=]
+		and the [=transferred size suggestion=]
+		(if one exists),
+		capped by the [=specified size suggestion=]
+		(if one exists).
+
+	: For [=non-replaced elements=]
+	::
+		Use the larger of the [=content size suggestion=]
+		and the [=transferred size suggestion=]
+		(if one exists),
+		capped by the [=specified size suggestion=]
+		(if one exists).
+
+	In either case,
+	the size is clamped by the [=maximum size|maximum=] [=main size=]
+	if it's <a>definite</a>.
 
 <!-- This differs from Grid's definition
 (which just consults the first of specified,transferred,content that exists)


### PR DESCRIPTION
* <https://github.com/w3c/csswg-drafts/issues/6069>
* <https://github.com/w3c/csswg-drafts/issues/6794>

Ping @bfgeek for review, merge if you're happy.