### PR TITLE
[css-2025] Initial version based on last version of CSS 2024

### DIFF
--- a/css-2025/Overview.bs
+++ b/css-2025/Overview.bs
@@ -1,0 +1,1189 @@
+<pre class='metadata'>
+Title: CSS Snapshot 2025
+Shortname: css-2025
+Level: none
+Status: NOTE
+Prepare for TR: no
+Group: CSSWG
+Work Status: revising
+URL: https://drafts.csswg.org/css-2025/
+Editor: Tab Atkins Jr., Google, http://xanthir.com/, w3cid 42199
+Editor: Elika J. Etemad / fantasai, Apple, http://fantasai.inkedblade.net/contact, w3cid 35400
+Editor: Florian Rivoal, Invited Expert, https://florian.rivoal.net, w3cid 43241
+Editor: Chris Lilley, W3C, https://svgees.us/, w3cid 1438
+Editor: Sebastian Zartner, Invited Expert, sebastianzartner@gmail.com, w3cid 64937
+Abstract: This document collects together into one definition all the specs that
+	together form the current state of Cascading Style Sheets (CSS) as of 2025.
+	The primary audience is CSS implementers, not CSS authors, as this definition
+	includes modules by specification stability, not Web browser adoption rate.
+Status Text:
+	<!-- This document is a work in progress,
+	aimed at representing the state of CSS as of 2025.
+	It should become a Working Group Note when completed.
+
+	Replace the above with this when publishing to TR: -->
+	This document represents the state of CSS as of 2025.
+	<!-- The CSS Working Group does not expect any further changes to this document:
+	new snapshots will be published at
+	<a href="https://www.w3.org/TR/CSS/">https://www.w3.org/TR/CSS/</a> as CSS advances. -->
+Boilerplate: index no
+</pre>
+<pre class=link-defaults>
+spec:selectors-4; type:dfn; text:document language
+spec:css-ui-3; type:property; text:cursor
+spec:css-ui-3; type:property; text:outline
+spec:css-display-3; type:property; text:display
+</pre>
+
+
+
+</div>
+
+Introduction {#intro}
+=====================
+
+	When the first CSS specification was published,
+	all of CSS was contained in one document that defined CSS Level 1.
+	CSS Level 2 was defined also by a single, multi-chapter document.
+	However for CSS beyond Level 2,
+	the CSS Working Group chose to adopt a modular approach,
+	where each module defines a part of CSS,
+	rather than to define a single monolithic specification.
+	This breaks the specification into more manageable chunks
+	and allows more immediate, incremental improvement to CSS.
+
+	Since different CSS modules are at different levels of stability,
+	the CSS Working Group has chosen to publish this profile
+	to define the current scope and state of Cascading Style Sheets as of 2025.
+
+<h3 id="css-glossary">
+What is CSS?</h3>
+
+	<dl export>
+		<dt><dfn lt="CSS | Cascading Style Sheets">Cascading Style Sheets (CSS)</dfn>
+		<dd>
+			CSS is a language for writing [=style sheets=],
+			and is designed to describe the rendering of structured documents
+			(such as HTML and XML)
+			on a variety of media.
+			CSS is used to describe the presentation of a [=source document=],
+			and usually does not change the underlying semantics
+			expressed by its [=document language=].
+
+		<dt><dfn>Style sheet</dfn>
+		<dd>
+			A set of rules that specify the presentation of a document.
+			Style sheets are written by an [=Author=],
+			and interpreted by a [=User Agent=],
+			to present the document to the [=User=].
+
+		<dt><dfn>Source document</dfn>
+		<dd>
+			The document to which one or more style sheets apply.
+			A source document’s structure and semantics are encoded
+			using a [=document language=] (e.g., HTML, XHTML, or SVG).
+
+		<dt><dfn>Author</dfn>
+		<dd>
+			An author is a person who writes documents and associated style sheets.
+			An <dfn>authoring tool</dfn> is a [=User Agent=] that generates style sheets.
+
+		<dt><dfn>User</dfn>
+		<dd>
+			A user is a person who interacts with a user agent
+			to view, hear, or otherwise use the document.
+
+		<dt><dfn noexport lt="user agent | UA">User Agent (UA)</dfn>
+		<dd>
+			A user agent is any program that interprets a document
+			and its associated [=style sheets=]
+			on behalf of a [=user=].
+			A [=user agent=] may display a document, read it aloud,
+			cause it to be printed, convert it to another format, etc.
+			For the purposes of the CSS specifications,
+			a [=User Agent=] is one that supports and interprets [=Cascading Style Sheets=]
+			as defined in these specifications.
+	</dl>
+
+<h3 id="w3c-process">
+Background: The W3C Process and CSS</h3>
+
+	<em>This section is non-normative.</em>
+
+	In the <a href="http://www.w3.org/Consortium/Process/">W3C Process</a>,
+	a Recommendation-track document passes through three levels of stability,
+	summarized below:
+
+	<dl>
+		<dt>Working Draft (WD)
+		<dd>
+
+			This is the design phase of a W3C spec.
+			The WG iterates the spec in response to internal and external feedback.
+
+			The first official Working Draft is designated the “First Public Working Draft” (FPWD).
+			In the CSSWG, publishing FPWD indicates that the Working Group as a whole has agreed to work on the module,
+			roughly as scoped out and proposed in the editor's draft.
+
+			The transition to the next stage is sometimes called “Last Call Working Draft” (LCWD) phase.
+			The CSSWG transitions Working Drafts once we have resolved all known issues,
+			and can make no further progress without feedback from building tests and implementations.
+
+			This “Last Call for Comments” sets a deadline for reporting any outstanding issues,
+			and requires the WG to specially track and address incoming feedback.
+			The comment-tracking document is the Disposition of Comments (DoC).
+			It is submitted along with an updated draft for the Director's approval,
+			to demonstrate wide review and acceptance.
+
+		<dt>Candidate Recommendation (CR)
+		<dd>
+			This is the testing phase of a W3C spec.
+			Notably, this phase is about using tests and implementations to test the specification:
+			it is not about testing the implementations.
+			This process often reveals more problems with the spec,
+			and so a Candidate Recommendation will morph over time in response to implementation and testing feedback,
+			though usually less so than during the design phase (WD).
+
+			Demonstration of two correct, independent implementations of each feature is required to exit CR,
+			so in this phase the WG builds a test suite and generates implementation reports.
+
+			The transition to the next stage is “Proposed Recommendation” (PR).
+			During this phase the W3C Advisory Committee must approve the transition to REC.
+
+		<dt>Recommendation (REC)
+		<dd>
+			This is the completed state of a W3C spec and represents a maintenance phase.
+			At this point the WG only maintains an errata document
+			and occasionally publishes an updated edition that incorporates the errata back into the spec.
+	</dl>
+
+	An <dfn export>Editor's Draft</dfn> is effectively a live copy of the editors’ own working copy.
+	It may or may not reflect Working Group consensus,
+	and can at times be in a self-inconsistent state.
+	(Because the publishing process at W3C is time-consuming and onerous,
+	the <a>Editor's Draft</a> is usually the best (most up-to-date) reference for a spec.
+	Efforts are currently underway to reduce the friction of publishing,
+	so that official drafts will be regularly up-to-date
+	and <a>Editor's Drafts</a> can return to their original function as scratch space.)
+
+
+<h2 id=module-classification>
+Classification of CSS Specifications</h2>
+
+	Advisement:
+	A list of all CSS modules, stable and in-progress,
+	and their statuses
+	can be found at the <a href="http://www.w3.org/Style/CSS/current-work">CSS Current Work page</a>.
+
+
+<h3 id=css-official>Cascading Style Sheets (CSS) &mdash; The Official Definition</h3>
+
+	This profile includes only specifications that we consider stable
+	<em>and</em> for which we have enough implementation experience that we are sure of that stability.
+
+	Note: This is not intended to be a CSS Desktop Browser Profile:
+	inclusion in this profile is based on feature stability only
+	and not on expected use or Web browser adoption.
+	This profile defines CSS in its most complete form.
+
+	As of 2025,
+	<dfn export>Cascading Style Sheets (CSS)</dfn> is defined by the following
+	specifications.
+
+	<dl>
+		<dt><a href="https://www.w3.org/TR/CSS2/">CSS Level 2, latest revision</a> (including errata)
+		[[!CSS2]]
+		<dd>
+			This defines the core of CSS, parts of which are overridden by later specifications.
+			We recommend in particular reading <a href="https://www.w3.org/TR/CSS2/intro.html">Chapter 2</a>,
+			which introduces some of the basic concepts of CSS
+			and its design principles.
+
+		<dt><a href="https://www.w3.org/TR/css-syntax-3/">CSS Syntax Level 3</a>
+		[[!CSS-SYNTAX-3]]
+		<dd>
+			Replaces CSS2&sect;4.1, CSS2&sect;4.2, CSS2&sect;4.4, and CSS2&sect;G,
+			redefining how CSS is parsed.
+
+		<dt><a href="https://www.w3.org/TR/css-style-attr/">CSS Style Attributes</a>
+		[[!CSS-STYLE-ATTR]]
+		<dd>
+			Defines how CSS declarations can be embedded in markup attributes.
+
+		<dt><a href="https://www.w3.org/TR/css3-mediaqueries/">Media Queries Level 3</a>
+		[[!CSS3-MEDIAQUERIES]]
+		<dd>
+			Replaces CSS2&sect;7.3 and expands on the syntax for media-specific styles.
+
+		<dt><a href="https://www.w3.org/TR/css-conditional-3/">CSS Conditional Rules Level 3</a>
+		[[!CSS-CONDITIONAL-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;7.2,
+			updating the definition of ''@media'' rules to allow nesting
+			and introducing the ''@supports'' rule for feature-support queries.
+
+		<dt><a href="https://www.w3.org/TR/selectors-3/">Selectors Level 3</a>
+		[[!SELECTORS-3]]
+		<dd>
+			Replaces CSS2&sect;5 and CSS2&sect;6.4.3, defining an extended range of selectors.
+
+		<dt><a href="https://www.w3.org/TR/css-namespaces/">CSS Namespaces</a>
+		[[!CSS3-NAMESPACE]]
+		<dd>
+			Introduces an ''@namespace'' rule to allow namespace-prefixed selectors.
+
+		<dt><a href="https://www.w3.org/TR/css-cascade-4/">CSS Cascading and Inheritance Level 4</a>
+		[[!CSS-CASCADE-4]]
+		<dd>
+			Extends and supersedes CSS2&sect;1.4.3 and CSS2&sect;6, as well as [[CSS-CASCADE-3]].
+			Describes how to collate style rules and assign values to all properties on all elements.
+			By way of cascading and inheritance, values are propagated for all properties on all elements.
+
+		<dt><a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Level 3</a>
+		[[!CSS-VALUES-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;1.4.2.1, CSS2&sect;4.3, and CSS2&sect;A.2.1&ndash;3,
+			defining CSS's property definition syntax
+			and expanding its set of units.
+
+		<dt><a href="https://www.w3.org/TR/css-variables-1/">CSS Custom Properties for Cascading Variables Module Level 1</a>
+		[[!CSS-VARIABLES-1]]
+		<dd>
+			Introduces cascading variables as a new primitive value type that is accepted by all CSS properties,
+			and custom properties for defining them.
+
+		<dt><a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Level 3</a>
+		[[!CSS-BOX-3]]
+		<dd>
+			Replaces CSS2&sect;8.1, &sect;8.2, &sect;8.3 (but not &sect;8.3.1), and &sect;8.4.
+
+		<dt><a href="https://www.w3.org/TR/css-color-4/">CSS Color Level 4</a>
+		[[!CSS-COLOR-4]]
+		<dd>
+			Extends and supersedes CSS2&sect;4.3.6, CSS2&sect;14.1, and CSS2&sect;18.2,
+			also extends and supersedes [[CSS-COLOR-3]],
+			introducing an extended range of color spaces beyond sRGB,
+			extended color values,
+			and CSS Object Model extensions for color.
+			Also defines the 'opacity' property.
+
+		<dt><a href="https://www.w3.org/TR/css-backgrounds-3/">CSS Backgrounds and Borders Level 3</a>
+		[[!CSS-BACKGROUNDS-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;8.5 and CSS2&sect;14.2,
+			providing more control of backgrounds and borders,
+			including layered background images,
+			image borders,
+			and drop shadows.
+
+		<dt><a href="https://www.w3.org/TR/css-images-3/">CSS Images Level 3</a>
+		[[!CSS-IMAGES-3]]
+		<dd>
+			Redefines and incorporates the external 2D image value type,
+			introduces native 2D gradients,
+			and adds additional controls for replaced element sizing and rendering.
+
+		<dt><a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Level 3</a>
+		[[!CSS-FONTS-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;15
+			and provides more control over font choice and feature selection.
+
+		<dt><a href="https://www.w3.org/TR/css-writing-modes-3/">CSS Writing Modes Level 3</a>
+		[[!CSS-WRITING-MODES-3]]
+		<dd>
+			Defines CSS support for various international writing modes,
+			such as left-to-right (e.g. Latin or Indic),
+			right-to-left (e.g. Hebrew or Arabic),
+			bidirectional (e.g. mixed Latin and Arabic) and vertical (e.g. Asian scripts).
+			Replaces and extends CSS2&sect;8.6 and &sect;9.10.
+
+		<dt><a href="https://www.w3.org/TR/css-multicol-1/">CSS Multi-column Layout Level 1</a>
+		[[!CSS-MULTICOL-1]]
+		<dd>
+			Introduces multi-column flows to CSS layout.
+
+		<dt><a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Module Level 1</a>
+		[[!CSS-FLEXBOX-1]]
+		<dd>
+			Introduces a flexible linear layout model for CSS.
+
+		<dt><a href="https://www.w3.org/TR/css-ui-3/">CSS Basic User Interface Module Level 3</a>
+		[[!CSS-UI-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;18.1 and CSS2&sect;18.4,
+			defining 'cursor', 'outline', and several new CSS features that also enhance the user interface.
+
+		<dt><a href="https://www.w3.org/TR/css-contain-1/">CSS Containment Module Level 1</a>
+		[[!CSS-CONTAIN-1]]
+		<dd>
+			Introduces the 'contain' property,
+			which enforces the independent CSS processing of an element’s subtree
+			in order to enable heavy optimizations by user agents when used well.
+
+		<dt><a href="https://www.w3.org/TR/css-transforms-1/">CSS Transforms Level 1</a>
+		[[!CSS-TRANSFORMS-1]]
+		<dd>
+			Introduces coordinate-based graphical transformations to CSS.
+
+		<dt><a href="https://www.w3.org/TR/compositing-1/">CSS Compositing and Blending Level 1</a>
+		[[!COMPOSITING]]
+		<dd>
+			Defines the compositing and blending of overlaid content
+			and introduces features to control their modes.
+
+		<dt><a href="https://www.w3.org/TR/css-easing-1/">CSS Easing Functions Level 1</a>
+		[[!CSS-EASING-1]].
+		<dd>
+			Describes a way for authors to define a transformation
+			that controls the rate of change of some value.
+			Applied to animations,
+			such transformations can be used to produce animations
+			that mimic physical phenomena such as momentum
+			or to cause the animation to move in discrete steps producing robot-like movement.
+
+		<dt><a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a>
+		[[!CSS-COUNTER-STYLES-3]]
+		<dd>
+			Introduces the ''@counter-style'' rule,
+			which allows authors to define their own custom counter styles
+			for use with CSS list-marker and generated-content counters [[CSS-LISTS-3]].
+			It also predefines a set of common counter styles,
+			including the ones present in CSS2 and CSS2.1.
+	</dl>
+
+	Note: Although we don't anticipate significant changes to the specifications that form this snapshot,
+	their inclusion does not mean they are frozen.
+	The Working Group will continue to address problems as they are found in these specs.
+	Implementers should monitor <a href="http://lists.w3.org/Archives/Public/www-style/">www-style</a>
+	and/or the <a href="http://www.w3.org/blog/CSS">CSS Working Group Blog</a>
+	for any resulting changes, corrections, or clarifications.
+
+<h3 id="reliable-cr">
+Reliable Candidate Recommendations</h3>
+
+The following specifications are considered to be in a reliable state, meaning they have largely stable implementations and specifications, but are not yet at the Recommendation level due to minor issues or the need for additional implementation reports.
+
+<dl>
+	<dt><a href="https://www.w3.org/TR/mediaqueries-4/">Media Queries Level 4</a>
+	[[MEDIAQUERIES-4]]
+	<dd>
+		Extends and supersedes [[CSS3-MEDIAQUERIES]],
+		expanding the syntax,
+		deprecating most media types,
+		and introducing new media features.
+
+	<dt><a href="https://www.w3.org/TR/css-scroll-snap-1/">CSS Scroll Snap Module Level 1</a>
+	[[CSS-SCROLL-SNAP-1]]
+	<dd>
+		Contains features to control panning and scrolling behavior with “snap positions”.
+
+	<dt><a href="https://www.w3.org/TR/css-scrollbars-1/">CSS Scrollbars Styling Module Level 1</a>
+	[[CSS-SCROLLBARS-1]]
+	<dd>
+		Defines properties to influence the visual styling of scrollbars,
+		introducing controls for their color and width.
+
+	<dt><a href="https://www.w3.org/TR/css-grid-1/">CSS Grid Layout Module Level 1</a>
+	[[CSS-GRID-1]]
+	<dd>
+		Introduces a two-dimensional grid-based layout system,
+		optimized for user interface design.
+		In the grid layout model, the children of a grid container
+		can be positioned into arbitrary slots in a predefined flexible or fixed-size layout grid.
+
+	<dt><a href="https://www.w3.org/TR/css-grid-2/">CSS Grid Layout Module Level 2</a>
+	[[CSS-GRID-2]]
+	<dd>
+		Extends and supersedes [[CSS-GRID-1]],
+		introducing “subgrids” for managing nested markup in a shared grid framework.
+</dl>
+
+<h3 id=fairly-stable>
+Fairly Stable Modules with limited implementation experience</h3>
+
+	The following modules have completed design work,
+	and are fairly stable,
+	but have not received much testing and implementation experience yet.
+	We hope to incorporate them into the [[#css-official|official definition of CSS]] in a future snapshot.
+
+	<dl>
+		<dt><a href="https://www.w3.org/TR/mediaqueries-4/">Media Queries Level 4</a>
+		[[MEDIAQUERIES-4]]
+		<dd>
+			Extends and supersedes [[CSS3-MEDIAQUERIES]],
+			expanding the syntax, deprecating most media types,
+			and introducing new media features.
+
+		<dt><a href="https://www.w3.org/TR/css-display-3/">CSS Display Module Level 3</a>
+		[[CSS-DISPLAY-3]]
+		<dd>
+			Replaces CSS2&sect;9.1.2, &sect;9.2.1 (but not &sect;9.2.1.1), &sect;9.2.2 (but not &sect;9.2.2.1), &sect;9.2.3, and &sect;9.2.4 (and lays the foundations for replacing &sect;9.7),
+			defining how the CSS formatting box tree is generated
+			from the document element tree
+			and defining the 'display' property that controls it.
+
+		<dt><a href="https://www.w3.org/TR/css-writing-modes-4/">CSS Writing Modes Level 4</a>
+		[[CSS-WRITING-MODES-4]]
+		<dd>
+			Extends and supersedes [[CSS-WRITING-MODES-3]],
+			adding more options for vertical writing.
+
+		<dt><a href="https://www.w3.org/TR/css-break-3/">CSS Fragmentation Module Level 3</a>
+		[[CSS-BREAK-3]]
+		<dd>
+			Describes the fragmentation model that partitions a flow into pages, columns, or regions
+			and defines properties that control it.
+			Extends and supersedes CSS2&sect;13.3.
+
+		<dt><a href="https://www.w3.org/TR/css-align-3/">CSS Box Alignment Module Level 3</a>
+		[[CSS-ALIGN-3]]
+		<dd>
+			Introduces properties to control the alignment of boxes
+			within their containers in the various CSS box layout models:
+			block layout, table layout, flex layout, and grid layout.
+
+		<dt><a href="https://www.w3.org/TR/css-shapes-1/">CSS Shapes Module Level 1</a>
+		[[CSS-SHAPES-1]]
+		<dd>
+			Extends floats (CSS2&sect;9.5) to effect non-rectangular wrapping shapes.
+
+		<dt><a href="https://www.w3.org/TR/css-text-3/">CSS Text Module Level 3</a>
+		[[CSS-TEXT-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;16 excepting &sect;16.3,
+			defining properties for text manipulation and specifying their processing model.
+			It covers line breaking, justification and alignment, white space handling, and text transformation.
+
+		<dt><a href="https://www.w3.org/TR/css-text-decor-3/">CSS Text Decoration Module Level 3</a>
+		[[CSS-TEXT-DECOR-3]]
+		<dd>
+			Extends and supersedes CSS2&sect;16.3,
+			providing more control over text decoration lines
+			and adding the ability to specify text emphasis marks
+			and text shadows.
+
+		<dt><a href="https://www.w3.org/TR/css-masking-1/">CSS Masking Module Level 1</a>
+		[[CSS-MASKING-1]]
+		<dd>
+			Replaces CSS2&sect;11.1.2
+			and introduces more powerful ways of clipping and masking content.
+
+		<dt><a href="https://www.w3.org/TR/css-scroll-snap-1/">CSS Scroll Snap Module Level 1</a>
+		[[CSS-SCROLL-SNAP-1]]
+		<dd>
+			Contains features to control panning and scrolling behavior with “snap positions”.
+
+		<dt><a href="https://www.w3.org/TR/css-speech-1/">CSS Speech Module Level 1</a>
+		[[CSS-SPEECH-1]]
+		<dd>
+			Replaces CSS2&sect;A,
+			overhauling the (non-normative) speech rendering chapter.
+
+		<dt><a href="https://www.w3.org/TR/css-view-transitions-1/">CSS View Transitions Module Level 1</a>
+		[[CSS-VIEW-TRANSITIONS-1]]</dt>
+		<dd>
+			Defines the View Transition API, along with associated properties and pseudo-elements,
+			which allows developers to create animated visual transitions representing
+			changes in the document state.
+		</dd>
+	</dl>
+
+<h3 id=rough-interop>
+Modules with Rough Interoperability</h3>
+
+	Although the following modules have been widely deployed with <a>rough interoperability</a>,
+	their details are not fully worked out or sufficiently well-specified
+	and they need more testing and bugfixing.
+	We hope to incorporate them into the [[#css-official|official definition of CSS]] in a future snapshot.
+
+	<dl>
+		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>
+		[[CSS-TRANSITIONS-1]]
+		and <a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
+		[[CSS-ANIMATIONS-1]].
+		<dd>
+			Introduces mechanisms for transitioning the computed values of CSS properties over time.
+
+		<dt><a href="https://www.w3.org/TR/css-will-change-1/">CSS Will Change Level 1</a>
+		[[CSS-WILL-CHANGE-1]]
+		<dd>
+			Introduces a performance hint property called 'will-change'.
+
+		<dt><a href="https://www.w3.org/TR/filter-effects-1/">Filter Effects Module Level 1</a>
+		[[FILTER-EFFECTS-1]]
+		<dd>
+			Introduces filter effects as a way of processing an element’s rendering before it is displayed in the document.
+
+		<dt><a href="https://www.w3.org/TR/css-font-loading/">CSS Font Loading Module Level 3</a>
+		[[CSS-FONT-LOADING-3]]
+		<dd>
+			Introduces events and interfaces used for dynamically loading font resources.
+
+		<dt><a href="https://www.w3.org/TR/css-sizing-3/">CSS Box Sizing Level 3</a>
+		[[CSS-SIZING-3]]
+		<dd>
+			Overlays and extends CSS&sect;10.,
+			expanding the value set of the sizing properties,
+			introducing more precise sizing terminology,
+			and defining with more precision and detail
+			various automatic sizing concepts only vaguely defined in CSS2.
+
+
+		<dt><a href="https://www.w3.org/TR/css-transforms-2/">CSS Transforms Level 2</a>
+		[[CSS-TRANSFORMS-2]]
+		<dd>
+			Builds upon [[CSS-TRANSFORMS-1]]
+			to add new transform functions and properties for three-dimensional transforms,
+			and convenience functions for simple transforms.
+
+		<dt><a href="https://www.w3.org/TR/css-lists-3/">CSS Lists and Counters Module Level 3</a>
+		[[CSS-LISTS-3]]
+		<dd>
+			Contains CSS features related to list counters:
+			styling them,
+			positioning them,
+			and manipulating their value.
+
+		<dt><a href="https://www.w3.org/TR/css-logical-1/">CSS Logical Properties and Values Level 1</a>
+		[[CSS-LOGICAL-1]]
+		<dd>
+			Introduces logical properties and values
+			that provide the author with the ability to control layout through logical,
+			rather than physical,
+			direction and dimension mappings.
+			Also defines logical properties and values for the features defined in [[CSS2]].
+			These properties are writing-mode relative equivalents
+			of their corresponding physical properties.
+
+		<dt><a href="https://www.w3.org/TR/css-position-3/">CSS Positioned Layout Module Level 3</a>
+		[[CSS-POSITION-3]]
+		<dd>
+			Contains defines coordinate-based positioning and offsetting schemes of CSS:
+			[=relative positioning=],
+			[=sticky positioning=],
+			[=absolute positioning=],
+			and [=fixed positioning=].
+
+		<dt><a href="https://www.w3.org/TR/resize-observer-1/">Resize Observer</a>
+		[[RESIZE-OBSERVER-1]]
+		<dd>
+			This specification describes an API for observing changes to element’s principal box's size.
+
+		<dt><a href="https://www.w3.org/TR/web-animations-1/">Web Animations</a>
+		[[WEB-ANIMATIONS-1]]
+		<dd>
+			Defines a model for synchronization and timing of changes to the presentation of a Web page.
+			Also defines an application programming interface for interacting with this model.
+
+		<dt><a href="https://www.w3.org/TR/css-fonts-4/">CSS Fonts Module Level 4</a>
+		[[!CSS-FONTS-4]]
+		<dd>
+			Extends and supersedes CSS Fonts 3
+			and provides more control over font choice and feature selection,
+			including support for OpenType variations.
+
+		<dt><a href="https://www.w3.org/TR/css-color-adjust-1/">CSS Color Adjustment Module Level 1</a>
+		[[CSS-COLOR-ADJUST-1]]
+		<dd>
+			This module introduces a model and controls over automatic color adjustment by the user agent to handle user preferences and device output optimizations.
+
+		<dt><a href="https://www.w3.org/TR/css-conditional-4/">CSS Conditional Rules Module Level 4</a>
+		[[CSS-CONDITIONAL-4]]
+		<dd>
+			Extends CSS Conditional 3 to allow testing for supported selectors.</dd>
+
+		<dt><a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Level 5</a>
+		[[CSS-CASCADE-5]]
+		<dd>
+			Extends CSS Cascade 4 to add cascade layers.</dd>
+
+		<dt><a href="https://www.w3.org/TR/motion-1/">Motion Path Module Level 1</a>
+		[[MOTION-1]]
+		<dd>
+			This module allows authors to position any graphical object and animate it along an author specified path.
+
+		<dt><a href="https://www.w3.org/TR/css-scroll-anchoring-1/">CSS Scroll Anchoring Module Level 1</a>
+		[[CSS-SCROLL-ANCHORING-1]]
+		<dd>
+			This module aims to minimize content shifts
+			by locking the scroll position of a scroll container to a particular anchor element.
+
+		<dt><a href="https://www.w3.org/TR/cssom-1/">CSS Object Model (CSSOM)</a>
+		[[CSSOM-1]]
+		<dd>
+			This module defines APIs for parsing, serializing,
+			and manipulating CSS, Media Queries, and Selectors.
+
+		<dt><a href="https://www.w3.org/TR/css-color-5/">CSS Color Module Level 5</a>
+		[[CSS-COLOR-5]]
+		<dd>
+			Extends CSS Color 4 to add color spaces and color modification functions.
+
+		<dt><a href="https://www.w3.org/TR/selectors-4/">Selectors Level 4</a>
+		[[SELECTORS-4]]
+		<dd>
+			Extends Selectors Level 3 by introducing new pseudo-classes,
+			pseudo-elements, and combinators,
+			enhancing the ability to select elements
+			based on more complex criteria and states.
+	</dl>
+
+<h3 id="css-levels">
+CSS Levels</h3>
+
+	Cascading Style Sheets does not have versions in the traditional sense;
+	instead it has <dfn export>levels</dfn>. Each level of CSS builds on the previous,
+	refining definitions and adding features. The feature set of each higher
+	level is a superset of any lower level, and the behavior allowed for a given
+	feature in a higher level is a subset of that allowed in the lower levels.
+	A user agent conforming to a higher level of CSS is thus also conformant to
+	all lower levels.
+
+	<dl>
+		<dt><dfn export>CSS Level 1</dfn>
+		<dd>
+			The CSS Working Group considers the
+			<a href="https://www.w3.org/TR/2008/REC-CSS1-20080411/">CSS1 specification</a> to be
+			obsolete. <a>CSS Level 1</a> is defined as all the features defined
+			in the CSS1 specification (properties, values, at-rules, etc), but using
+			the syntax and definitions in the
+			<a href="https://www.w3.org/TR/CSS2/">CSS2.1 specification</a>.
+			<a href="https://www.w3.org/TR/css-style-attr/">CSS Style Attributes</a>
+			defines its inclusion in element-specific style attributes.
+
+		<dt><dfn export>CSS Level 2</dfn>
+		<dd>
+			Although the <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/">CSS2 specification</a>
+			is technically a W3C Recommendation, it passed into the Recommendation stage
+			before the W3C had defined the Candidate Recommendation stage. Over time
+			implementation experience and further review has brought to light many problems
+			in the CSS2 specification, so instead of expanding an already <a
+			href="http://www.w3.org/Style/css2-updates/REC-CSS2-19980512-errata.html">unwieldy
+			errata list</a>, the CSS Working Group chose to define <cite>CSS Level 2
+			Revision 1</cite> (CSS2.1). In case of any conflict between the two specs
+			CSS2.1 contains the definitive definition.
+
+			Once CSS2.1 became Candidate Recommendation&#8212;effectively though not
+			officially the same level of stability as CSS2&#8212;obsoleted the CSS2
+			Recommendation.  Features in CSS2 that were dropped from CSS2.1 should be
+			considered to be at the Candidate Recommendation stage, but note that many
+			of these have been or will be pulled into a CSS Level 3 working draft, in
+			which case that specification will, once it reaches CR, obsolete the
+			definitions in CSS2.
+
+			The <a href="https://www.w3.org/TR/CSS2/">CSS2.1 specification</a> defines
+			<a>CSS Level 2</a> and the <a href="https://www.w3.org/TR/css-style-attr/">CSS
+			Style Attributes specification</a> defines its inclusion in
+			element-specific style attributes.
+
+		<dt><dfn export>CSS Level 3</dfn>
+		<dd>
+			<a>CSS Level 3</a> builds on CSS Level 2 module by module, using the CSS2.1
+			specification as its core. Each module adds functionality and/or
+			replaces part of the CSS2.1 specification. The CSS Working Group
+			intends that the new CSS modules will not contradict the CSS2.1
+			specification: only that they will add functionality and refine
+			definitions. As each module is completed, it will be plugged in to
+			the existing system of CSS2.1 plus previously-completed modules.
+
+			From this level on modules are levelled independently: for example
+			Selectors Level 4 may well be completed before CSS Line Module Level 3.
+			Modules with no <a>CSS Level 2</a> equivalent start at Level 1;
+			modules that update features that existed in <a>CSS Level 2</a> start at Level 3.
+
+		<dt><dfn export>CSS Level 4</dfn> and beyond
+		<dd>
+			There is no CSS Level 4.
+			Independent modules can reach level 4 or beyond,
+			but CSS the language no longer has levels.
+			("CSS Level 3" as a term is used only to differentiate it from the previous monolithic versions.)
+	</dl>
+
+<h3 id="profiles">
+CSS Profiles</h3>
+
+	Not all implementations will implement all functionality defined in CSS.
+
+	In the past, the Working Group published a few Profiles,
+	which were meant to define the minimal subset of CSS
+	that various classes of user agents were expected to support.
+
+	This effort has been discontinued,
+	as the Working Group was not finding it effective or useful,
+	and the profiles previously defined are now unmaintained.
+
+	Note: Partial implementations of CSS, even if that subset is an official profile,
+	must follow the forward-compatible parsing rules for <a href="#partial">partial implementations</a>.
+
+<h2 id="responsible">
+Requirements for Responsible Implementation of CSS</h2>
+
+	The following sections define several conformance requirements
+	for implementing CSS responsibly,
+	in a way that promotes interoperability in the present and future.
+
+<h3 id="partial">Partial Implementations</h3>
+
+	So that authors can exploit the forward-compatible parsing rules to assign fallback values,
+	<strong>CSS renderers <em>must</em> treat as invalid
+	(and <a href="https://www.w3.org/TR/CSS2/conform.html#ignore">ignore as appropriate</a>)
+	any at-rules, properties, property values, keywords, and other syntactic constructs
+	for which they have no usable level of support</strong>.
+	In particular, user agents <em>must not</em> selectively ignore
+	unsupported property values and honor supported values in a single multi-value property declaration:
+	if any value is considered invalid (as unsupported values must be),
+	CSS requires that the entire declaration be ignored.
+
+<h3 id="future-proofing">Implementations of Unstable and Proprietary Features</h3>
+
+	To avoid clashes with future stable CSS features,
+	the CSSWG recommends the following best practices for the implementation of
+	<a>unstable</a> features and <a>proprietary extensions</a> to CSS:
+
+<h4 id="experimental">
+Experimentation and Unstable Features</h4>
+
+	Implementations of <a>unstable</a> features
+	that are described in W3C specifications
+	but are not interoperable
+	should not be released broadly for general use;
+	but may be released for limited, experimental use in controlled environments.
+
+	<details class=why>
+		<summary>Why?</summary>
+		We want to allow both authors and implementors to experiment with the feature and give feedback,
+		but prevent authors from relying on them in production websites
+		and thereby accidentally "locking in" (through content dependence)
+		certain syntax or behavior that might change later.
+	</details>
+
+	<div class="example">
+		For example,
+		a UA could release an <a>unstable</a> features for experimentation
+		through beta or other testing-stage builds;
+		behind a hidden configuration flag;
+		behind a switch enabled only for specific testing partners;
+		or through some other means of limiting dependent use.
+	</div>
+
+	A CSS feature is considered <dfn>unstable</dfn> until
+	its specification has reached the Candidate Recommendation (CR) stage in the W3C process.
+	In exceptional cases,
+	the CSSWG may additionally, by an officially-recorded resolution,
+	add pre-CR features to the set that are considered safe to release for broad use.
+	See [[#CR-exceptions]].
+
+	Note: Vendors should consult the WG explicitly and not make assumptions on this point,
+	as a pre-CR spec that hasn't changed in awhile is usually more out-of-date than stable.
+
+<h4 id="proprietary">
+Proprietary and Non-standardized Features</h4>
+
+	To avoid clashes with future CSS features,
+	the CSS2.1 specification reserves a
+	<dfn export lt="vendor prefix | vendor-prefixed | prefixed | unprefixed"><a href="https://www.w3.org/TR/CSS2/syndata.html#vendor-keywords">prefixed syntax</a></dfn> [[!CSS2]]
+	for proprietary and experimental extensions to CSS.
+	A CSS feature is a <dfn>proprietary extension</dfn> if it is meant for use
+	in a closed environment accessible only to a single vendor's user agent(s).
+	A UA should support such <a>proprietary extensions</a>
+	only through a vendor-<a>prefixed</a> syntax
+	and not expose them to open (multi-UA) environments such as the World Wide Web.
+
+	<details class=why>
+		<summary>Why?</summary>
+		The prefixing requirement allows shipping specialized features in closed environments
+		without conflicting with future additions to standard CSS.
+		The restriction on exposure to open systems is to prevent
+		accidentally causing the public CSS environment
+		to depend on an unstandardized <a>proprietary extensions</a>.
+	</details>
+
+	<div class="example">
+		For example,
+		Firefox's XUL-based UI, Apple's iTunes UI, and Microsoft's Universal Windows Platform app
+		use extensions to CSS implemented by their respective UAs.
+		So long as these UAs do not allow Web content to access these features,
+		they do not provide an opportunity for such content
+		to become dependent on their <a>proprietary extensions</a>.
+	</div>
+
+	Even if a feature is intended to eventually be used in the Web,
+	if it hasn't yet been standardized
+	it should still not be exposed to the Web.
+
+
+<h4 id="de-facto">
+Market Pressure and De Facto Standards</h4>
+
+	If a feature is <a>unstable</a> (i.e. the spec has not yet stabilized), but
+
+	*	at least three UAs implement the feature
+		(<em>or</em> a UA has broken the other rules and shipped for broad use
+		an <a>unstable</a> or otherwise non-standard feature in a production release),
+	*	<em>and</em> the implementations have rough interoperability,
+	*	<em>and</em> the CSS Working Group has recorded consensus
+		that this feature should exist and be released,
+
+	implementers may ship that feature <a>unprefixed</a> in broad-release builds.
+	<dfn>Rough interoperability</dfn> is satisfied by a subjective judgment
+	that even though there may be differences,
+	the implementations are sufficiently similar
+	to be used in production websites for a substantial number of use cases.
+
+	<p class="note">Note that the CSSWG must still be consulted to ensure coordination across vendors
+		and to ensure coherency review by the CSS experts from each vendor.
+		Note also that <a>rough interoperability</a> still usually means
+		painful lack of interop in edge (or not-so-edge) cases,
+		particularly because details have not been ironed out through the standards review process.
+
+	<details class=why>
+		<summary>Why?</summary>
+		If a feature is sufficiently popular that three or more browsers have implemented it before it's finished standardization,
+		this clause allows releasing the pressure to ship.
+		Also, if a feature has already escaped into the wild and sites have started depending on it,
+		pretending it's still “experimental” doesn't help anyone.
+		Allowing others to ship unprefixed recognizes that the feature is now de facto standardized
+		and encourages authors to write cross-platform code.
+	</details>
+
+<h5 id="unstable-syntax" class="no-toc">
+Vendor-prefixing Unstable Features</h5>
+
+	<p>When exposing such a standards-track <a>unstable</a> feature to the Web in a production release,
+	implementations should support <em>both</em> <a>vendor-prefixed</a> and unprefixed syntaxes
+	for the feature.
+	Once the feature has stabilized and the implementation is updated to match interoperable behavior,
+	support for the <a>vendor-prefixed</a> syntax should be removed.
+
+	<details class=why>
+		<summary>Why?</summary>
+		This is recommended so that authors can use the unprefixed syntax to target all implementations,
+		but when necessary, can target specific implementations
+		to work around incompatibilities among implementations
+		as they get ironed out through the standards/bugfixing process.
+
+		The lack of a phase
+		where only the prefixed syntax is supported
+		greatly reduces the risk of stylesheets
+		being written with only the vendor-prefixed syntax.
+		This in turn allows UA vendors to retire
+		their prefixed syntax once the feature is stable,
+		with a lower risk of breaking existing content.
+		It also reduces the need occasionally felt by some vendors
+		to support a feature with the prefix of another vendor,
+		due to content depending on that syntax.
+	</details>
+
+	Anyone promoting <a>unstable</a> features to authors
+	should document them using their standard unprefixed syntax,
+	and avoid encouraging the use of the <a>vendor-prefixed</a> syntax
+	for any purpose other than working around implementation differences.
+
+<h5 id="open-technology" class="no-toc">
+Preserving the Openness of CSS</h5>
+
+	In order to preserve the open nature of CSS as a technology,
+	vendors should make it possible for other implementors
+	to freely implement any features that they do ship.
+	To this end, they should provide spec-editing and testing resources
+	to complete standardization of such features,
+	and avoid other obstacles (e.g., platform dependency, licensing restrictions)
+	to their competitors shipping the feature.
+
+<h3 id="testing">Implementations of CR-level Features</h3>
+
+	Once a specification reaches the Candidate Recommendation stage,
+	implementers should release an <a>unprefixed</a> implementation
+	of any CR-level feature they can demonstrate
+	to be correctly implemented according to spec,
+	and should avoid exposing a prefixed variant of that feature.
+
+	To establish and maintain the interoperability of CSS across
+	implementations, the CSS Working Group requests that non-experimental
+	CSS renderers submit an implementation report (and, if necessary, the
+	testcases used for that implementation report) to the W3C before
+	releasing an unprefixed implementation of any CSS features. Testcases
+	submitted to W3C are subject to review and correction by the CSS
+	Working Group.
+
+	Further information on submitting testcases and implementation reports
+	can be found from on the CSS Working Group's website at
+	<a href="http://www.w3.org/Style/CSS/Test/">http://www.w3.org/Style/CSS/Test/</a>.
+	Questions should be directed to the
+	<a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a>
+	mailing list.
+
+<h2 id="CR-exceptions">
+Safe to Release pre-CR Exceptions</h2>
+
+	The following features have been explicitly and proactively cleared
+	by the CSS Working Group for broad release
+	prior to the spec reaching Candidate Recommendation.
+	See [[#experimental]].
+
+	<ul>
+		<li>The flow-relative equivalents of
+		the sizing properties ('width', 'height', etc.),
+		the border properties,
+		the margin and padding properties.
+		See <a href="https://lists.w3.org/Archives/Public/www-style/2015Jul/0040.html">explanation</a>
+		and <a href="https://www.w3.org/TR/css-logical-1/">specification</a>.
+
+		<li>The ''width/min-content'' and ''width/max-content'' keywords of the sizing properties.
+		See <a href="https://lists.w3.org/Archives/Public/www-style/2015Aug/0109.html">decision</a>
+		and <a href="https://www.w3.org/TR/css-sizing-3/#sizing-values">specification</a>.
+		<li>The ''conic-gradient()'' gradient notation. See <a href="https://github.com/w3c/csswg-drafts/issues/2383#issuecomment-371340088">decision</a>.
+
+		<li>The <a spec=css-sizing-4 property>aspect-ratio</a> property. [[!CSS-SIZING-4]]
+
+		<li>The 'translate', 'rotate', and 'scale' properties. [[!CSS-TRANSFORMS-2]]
+
+		<li>The 'hyphenate-character' property. [[!CSS-TEXT-4]]
+
+		<li>The <a>color-mix()</a> function. [[!CSS-COLOR-5]]
+
+		<li>The <<color-interpolation-method>>, defined in [[!CSS-COLOR-4]] and used for interpolation of linear, radial and conic gradients. [[!CSS-IMAGES-4]]
+
+		<li>The [=relative color=] syntax, defined in [[!CSS-COLOR-5]]</li>
+	</ul>
+
+	The following features have been explicitly and retroactively cleared
+	by the CSS Working Group for broad release
+	prior to the spec reaching Candidate Recommendation:
+	<ul>
+		<li>Everything in
+		<a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
+		and
+		<a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>.
+	</ul>
+
+<h2 id="indices">Indices</h2>
+
+<em>These sections are non-normative.</em>
+
+<h3 id="terms">Terms Index</h3>
+
+<index type="dfn" status="TR" spec="
+	css21,
+	css-syntax-3,
+	css-style-attr,
+	mediaqueries-3,
+	mediaqueries-4,
+	css-conditional-3,
+	css-namespaces-3,
+	selectors-3,
+	css-cascade-4,
+	css-values-3,
+	css-color-3,
+	css-backgrounds-3,
+	css-images-3,
+	css-fonts-4,
+	css-multicol-1,
+	css-ui-3,
+	compositing-1,
+	css-writing-modes-3,
+	css-writing-modes-4,
+	css-transitions-1,
+	css-animations-1,
+	css-easing-1,
+	css-flexbox-1,
+	css-transforms-1,
+	css-variables-1,
+	css-text-3,
+	css-counter-styles-3,
+	css-masking-1,
+	css-shapes-1,
+	css-text-decor-3,
+	css-will-change-1,
+	css-speech-1,
+	css-align-3,
+	css-grid-1,
+	filter-effects-1,
+	css-break-3,
+	css-contain-1,
+	css-scroll-snap-1,
+	css-display-3,
+	css-font-loading-3"></index>
+
+<h3 id="selectors">Selector Index</h3>
+
+<index type="selector" status="TR" spec="
+	css21,
+	css-syntax-3,
+	css-style-attr,
+	mediaqueries-3,
+	mediaqueries-4,
+	css-conditional-3,
+	css-namespaces-3,
+	selectors-3,
+	css-cascade-4,
+	css-values-3,
+	css-color-3,
+	css-backgrounds-3,
+	css-images-3,
+	css-fonts-4,
+	css-multicol-1,
+	css-ui-3,
+	compositing-1,
+	css-writing-modes-3,
+	css-writing-modes-4,
+	css-transitions-1,
+	css-animations-1,
+	css-easing-1,
+	css-flexbox-1,
+	css-transforms-1,
+	css-variables-1,
+	css-text-3,
+	css-counter-styles-3,
+	css-masking-1,
+	css-shapes-1,
+	css-text-decor-3,
+	css-will-change-1,
+	css-speech-1,
+	css-align-3,
+	css-grid-1,
+	filter-effects-1,
+	css-break-3,
+	css-contain-1,
+	css-scroll-snap-1,
+	css-display-3,
+	css-font-loading-3"></index>
+
+<h3 id="at-rules">
+At-Rule Index</h3>
+
+<index type="at-rule" status="TR" spec="
+	css21,
+	css-syntax-3,
+	css-style-attr,
+	mediaqueries-3,
+	mediaqueries-4,
+	css-conditional-3,
+	css-namespaces-3,
+	selectors-3,
+	css-cascade-4,
+	css-values-3,
+	css-color-3,
+	css-backgrounds-3,
+	css-images-3,
+	css-fonts-4,
+	css-multicol-1,
+	css-ui-3,
+	compositing-1,
+	css-writing-modes-3,
+	css-writing-modes-4,
+	css-transitions-1,
+	css-animations-1,
+	css-easing-1,
+	css-flexbox-1,
+	css-transforms-1,
+	css-variables-1,
+	css-text-3,
+	css-counter-styles-3,
+	css-masking-1,
+	css-shapes-1,
+	css-text-decor-3,
+	css-will-change-1,
+	css-speech-1,
+	css-align-3,
+	css-grid-1,
+	filter-effects-1,
+	css-break-3,
+	css-contain-1,
+	css-scroll-snap-1,
+	css-display-3,
+	css-font-loading-3"></index>
+
+<h3 id="properties">Property Index</h3>
+
+<index type="property" status="TR" spec="
+	css21,
+	css-syntax-3,
+	css-style-attr,
+	mediaqueries-3,
+	mediaqueries-4,
+	css-conditional-3,
+	css-namespaces-3,
+	selectors-3,
+	css-cascade-4,
+	css-values-3,
+	css-color-3,
+	css-backgrounds-3,
+	css-images-3,
+	css-fonts-4,
+	css-multicol-1,
+	css-ui-3,
+	compositing-1,
+	css-writing-modes-3,
+	css-writing-modes-4,
+	css-transitions-1,
+	css-animations-1,
+	css-easing-1,
+	css-flexbox-1,
+	css-transforms-1,
+	css-variables-1,
+	css-text-3,
+	css-counter-styles-3,
+	css-masking-1,
+	css-shapes-1,
+	css-text-decor-3,
+	css-will-change-1,
+	css-speech-1,
+	css-align-3,
+	css-grid-1,
+	filter-effects-1,
+	css-break-3,
+	css-contain-1,
+	css-scroll-snap-1,
+	css-display-3,
+	css-font-loading-3"></index>
+
+<h3 id="values">Values Index</h3>
+
+<index type="value" status="TR" spec="
+	css21,
+	css-syntax-3,
+	css-style-attr,
+	mediaqueries-3,
+	mediaqueries-4,
+	css-conditional-3,
+	css-namespaces-3,
+	selectors-3,
+	css-cascade-4,
+	css-values-3,
+	css-color-3,
+	css-backgrounds-3,
+	css-images-3,
+	css-fonts-4,
+	css-multicol-1,
+	css-ui-3,
+	compositing-1,
+	css-writing-modes-3,
+	css-writing-modes-4,
+	css-transitions-1,
+	css-animations-1,
+	css-easing-1,
+	css-flexbox-1,
+	css-transforms-1,
+	css-variables-1,
+	css-text-3,
+	css-counter-styles-3,
+	css-masking-1,
+	css-shapes-1,
+	css-text-decor-3,
+	css-will-change-1,
+	css-speech-1,
+	css-align-3,
+	css-grid-1,
+	filter-effects-1,
+	css-break-3,
+	css-contain-1,
+	css-scroll-snap-1,
+	css-display-3,
+	css-font-loading-3"></index>
+
+Acknowledgements {#acks}
+========================
+
+Special thanks to Florian Rivoal for creating the initial draft of the [[#experimental]] recommendations.


### PR DESCRIPTION
This is meant to be the initial version of the CSS 2025 Group Note.

It's based on the latest version of the CSS 2024 Group Note (pending any possible last changes from #11696).

I kept everything as is including the authors and only updated the year.

@svgeesus As you helped a lot with the 2024 snapshot, I thought you're the right person to add as reviewer.

Sebastian