### PR TITLE
[cssom-view-1] Minor corrections to scrolling algorithms

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -159,8 +159,7 @@ Initial scroll target</h4>
 		1. Let |target| be the <a>initial scroll target</a> for |scrollcontainer|.
 		1. Let |position| be the result of running the steps to
 			<a spec="cssom-view-1">determine the scroll-into-view position</a> of |target|
-			with <var ignore>behavior</var> set to "auto",
-			<var ignore>block</var> set to "start",
+			with <var ignore>block</var> set to "start",
 			<var ignore>inline</var> set to "nearest",
 			and <var ignore>scrolling box</var> set to |scrollcontainer|.
 		1. Set |scrollcontainer|'s <a>initial scroll position</a> to |position|.

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1511,7 +1511,7 @@ run the following steps:
             <dt>If <var>element edge D</var> is outside <var>scrolling box edge D</var> and <var>element width</var> is less than <var>scrolling box width</var>
             <dd>Align <var>element edge D</var> with <var>scrolling box edge D</var>.
         </dl>
-    1. Return <var>position</var>.
+1. Return <var>position</var>.
 
 </div>
 

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1299,7 +1299,7 @@ The <dfn method for=Element caniuse=scrollintoview>scrollIntoView(<var>arg</var>
     1. Set <var>behavior</var> to the {{ScrollOptions/behavior}} dictionary member of <var>options</var>.
     1. Set <var>block</var> to the {{ScrollIntoViewOptions/block}} dictionary member of <var>options</var>.
     1. Set <var>inline</var> to the {{ScrollIntoViewOptions/inline}} dictionary member of <var>options</var>.
-    1. If the {{ScrollIntoViewOptions/container}} dictionary member of <var>options</var>,
+    1. If the {{ScrollIntoViewOptions/container}} dictionary member of <var>options</var> is "nearest",
         set <var>container</var> to this element.
 1. Otherwise, if <var>arg</var> is false, then set <var>block</var> to "<code>end</code>".
 1. If the element does not have any associated [=CSS/box=],

--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1462,7 +1462,6 @@ The <dfn attribute for=Element>currentCSSZoom</dfn> attribute must return the
 <div algorithm>
 
 To <dfn export>determine the scroll-into-view position</dfn> of a <var>target</var>, which is an <a for="/">Element</a>, [=pseudo-element=], or <a>Range</a>,
-with a scroll behavior <var>behavior</var>,
 a block flow direction position <var>block</var>,
 an inline base direction position <var>inline</var>,
 and a <a>scrolling box</a> <var>scrolling box</var>,
@@ -1526,7 +1525,7 @@ means to run these steps:
 1. For each ancestor element or <a>viewport</a> that establishes a <a>scrolling box</a> <var>scrolling box</var>,
     in order of innermost to outermost <a>scrolling box</a>, run these substeps:
     1. If the {{Document}} associated with <var>target</var> is not <a>same origin</a> with the {{Document}} associated with the element or <a>viewport</a> associated with <var>scrolling box</var>, terminate these steps.
-    1. Let <var>position</var> be the scroll position resulting from running the steps to <a>determine the scroll-into-view position</a> of <var>target</var> with <var>behavior</var> as the |scroll behavior|,
+    1. Let <var>position</var> be the scroll position resulting from running the steps to <a>determine the scroll-into-view position</a> of <var>target</var> with
         <var>block</var> as the |block flow position|, <var>inline</var> as the |inline base direction position| and <var>scrolling box</var> as the |scrolling box|.
     1. If <var>position</var> is not the same as <var>scrolling box</var>'s current scroll position, or <var>scrolling box</var> has an ongoing <a>smooth scroll</a>,
         1. <dl class=switch>


### PR DESCRIPTION
3 small corrections to the scrolling-related algorithms that came up while implementing them:

1. The "Return _position_." step in "determine the scroll-into-view position" makes more sense at the top level.
2. The `behavior` parameter to "determine the scroll-into-view position" is not used and seems to be a leftover from before it was split up.
3. Say what value to check `container` against in `scrollIntoView()`. I'm not 100% sure on this but out of the two options, "nearest" makes the most sense.