### PR TITLE
[css-color-hdr] Clarification on the grammar / spec text for dynamic-range-limit-mix() #11672

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -382,7 +382,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 
 
 <pre class='prod'>
-	<dfn>dynamic-range-limit-mix()</dfn> = dynamic-range-limit-mix( [ <<ident>> && <<percentage [0,100]>> ]#)
+	<dfn>dynamic-range-limit-mix()</dfn> = dynamic-range-limit-mix( [ <<'dynamic-range-limit'>> && <<percentage [0,100]>> ]#{2,} )
 </pre>
 
 <wpt>


### PR DESCRIPTION
Fixes the grammar to match examples and text.