### PR TITLE
[css-view-transitions-1] Fix typo

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1375,7 +1375,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 			1. Set |capture|'s [=old image=] to the result of [=capturing the image=] of |element|.
 
 			1. Let |originalRect| be [=snapshot containing block=] if |element| is the [=document element=],
-				otherwise, the element|'s [=border box=].
+				otherwise, the |element|'s [=border box=].
 
 			1. Set |capture|'s [=captured element/old width=] to |originalRect|'s {{DOMRect/width}}.
 


### PR DESCRIPTION
Fixes a formatting typo.

This is non-substantial.