### PR TITLE
[css-view-transitions-1] Fix mistake in setup transition pseudo-elements algorithm

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1456,7 +1456,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		and generates initial styles.
 		The structure of the pseudo-tree is covered at a higher level in [[#view-transition-pseudos]].
 
-		1. Let |document| be [=this's=] [=relevant global object's=] [=associated document=].
+		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
 
 		1. Set |document|'s [=show view transition tree=] to true.
 


### PR DESCRIPTION
The [setup transition pseudo-elements algorithm](https://drafts.csswg.org/css-view-transitions-1/#setup-transition-pseudo-elements) has no [this](https://webidl.spec.whatwg.org/#this) value, because it is not defined on an IDL interface.
It gets its ViewTransition passed in as a parameter.

This fixes the incorrect syntax for accessing the relevant global object.