### PR TITLE
[css-values-5] Fix progress-function() definition to use commas #10489

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -773,7 +773,7 @@ Interpolation Progress Functional Notations</h2>
 	following a common syntactic pattern:
 
 	<pre class=prod>
-		<var ignore>progress-function</var>() = <var ignore>progress-function</var>( <var ignore>progress value</var> from <var ignore>start value</var> to <var ignore>end value</var> )
+		<var ignore>progress-function</var>() = <var ignore>progress-function</var>( <var ignore>progress value</var>, <var ignore>start value</var>, <var ignore>end value</var> )
 	</pre>
 
 	Each resolves to a <<number>>


### PR DESCRIPTION
As per #10489, the progress notation functions don't use `from` and `to` anymore and go with commas instead, but this progress-function() definition hasn't been changed in 5666cec, hence the fix.
