### PR TITLE
[css-values-5] Tweaked attr() syntax, per WG resolution. #11034 #11035

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1649,9 +1649,9 @@ Ian's proposal:
 
 	<div class='note'>
 		Note that the default value need not be of the type given.
-		For instance, if the type required of the attribute by the author is ''&lt;number px>'',
+		For instance, if the type required of the attribute by the author is ''&lt;length>'',
 		the default could still be <css>auto</css>,
-		like in ''width: attr(size &lt;number px>, auto);''.
+		like in ''width: attr(size &lt;length>, auto);''.
 	</div>
 
 	<div class="example">
@@ -1857,7 +1857,7 @@ makes the containing [=declaration=] [=invalid at computed-value time=].
 	</pre>
 </div>
 
-<!-- Big Text: ident() 
+<!-- Big Text: ident()
 
 ████ ████▌  █████▌ █    █▌ █████▌   ██ ██
  ▐▌  █▌  █▌ █▌     █▌   █▌   █▌    █▌   ▐█


### PR DESCRIPTION
This change replaces a leftover of the old syntax for `attr()` in an example by the new one.

Sebastian