### PR TITLE
[css-grid-3] Fix typo in html example

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -295,7 +295,7 @@ Reordering and Accessibility</h3>
 			  <div class="item tall">3</div>
 			  <div class="item wide">4</div>
 			  <div class=item>5</div>
-			  <div class=item>6/div>
+			  <div class=item>6</div>
 			  <div class=item>7</div>
 			</section>
 			<style>


### PR DESCRIPTION
Fixes a typo in provided HTML example

This is non-substantial.