### PR TITLE
[css-highlight-api] highlightsFromPoint: add support for StaticRanges for #11745

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -668,15 +668,19 @@ method must return the result of running these steps:
 	* <var>x</var> is greater than the <a>viewport</a> width excluding the size of a rendered scroll bar (if any)
 	* <var>y</var> is greater than the <a>viewport</a> height excluding the size of a rendered scroll bar (if any)
 1. Otherwise, return a [=sequence=] of [=custom highlights=] given by ordering the highlights contained in this {{HighlightRegistry}} in descending order of [=priority=],
-	excluding the highlights without at least one [=range=] <var>range</var> that satisfies the following constraints:
-	1. The coordinates <var>x</var>,<var>y</var> fall inside at least one of the {{DOMRect}}s returned by calling {{Range/getClientRects()}} on <var>range</var>.
+	including only those highlights that contain at least one {{AbstractRange}} <var>abstractRange</var> that satisfies the following:
+
+	* Let <var>range</var> be a {{Range}} object whose [=start node=] and [=end node=] are set to <var>abstractRange</var>'s [=start node=] and [=end node=] respectively,
+		and [=start offset=] and [=end offset=] are set to <var>abstractRange</var>'s [=start offset=] and [=end offset=] respectively.
+
+	* The coordinates <var>x</var>,<var>y</var> fall inside at least one of the {{DOMRect}}s returned by calling {{Range/getClientRects()}} on <var>range</var>.
 
 		Note: The specifics of hit testing are out of scope of this
 		specification and therefore the exact details of
 		{{highlightsFromPoint()}} are therefore too. Hit testing
 		will hopefully be defined in a future revision of CSS or HTML.
 
-	1. The <var>range</var>'s {{commonAncestorContainer}} is not in a [=shadow tree=] or is in a [=shadow tree=] whose
+	* The <var>range</var>'s {{commonAncestorContainer}} is not in a [=shadow tree=] or is in a [=shadow tree=] whose
 		[=shadow root=] is [=list/contains|contained by=] by <var>options</var>.<var>shadowRoots</var>.
 
 <h2 id=events>


### PR DESCRIPTION
Add some clarifications to the algorithm for highlightsFromPoint so it includes StaticRanges too.

See issue https://github.com/w3c/csswg-drafts/issues/11745