### PR TITLE
[css-values-4] A small fix and some tweaks to calc serialization

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5139,78 +5139,82 @@ Serialization</h3>
 			treating the node's children as the function's comma-separated [=calculation=] arguments,
 			and return the result.
 
-		4. If |root| is a Negate node,
-			let |s| be a [=string=]
-			initially containing "(-1 * ".
+		4. If |root| is a Negate node:
+			
+			1. Let |s| be a [=string=]
+			   initially containing "(-1 * ".
 
-			[=serialize a calculation tree|Serialize=] |root|'s child,
-			and append it to |s|.
+			2. [=serialize a calculation tree|Serialize=] |root|'s child,
+			   and append it to |s|.
 
-			Append ")" to |s|,
-			then return it.
+			3. Append ")" to |s|,
+			   then return it.
 
-		5. If |root| is an Invert node,
-			let |s| be a [=string=]
-			initially containing "(1 / ".
+		5. If |root| is an Invert node:
 
-			[=serialize a calculation tree|Serialize=] |root|'s child,
-			and append it to |s|.
+			1. Let |s| be a [=string=]
+			   initially containing "(1 / ".
 
-			Append ")" to |s|,
-			then return it.
+			2. [=serialize a calculation tree|Serialize=] |root|'s child,
+			   and append it to |s|.
 
-		6. If |root| is a Sum node,
-			let |s| be a [=string=]
-			initially containing "(".
+			3. Append ")" to |s|,
+			   then return it.
 
-			[=sort a calculation's children|Sort root's children=].
+		6. If |root| is a Sum node:
 
-			[=serialize a calculation tree|Serialize=] |root|'s first child,
-			and append it to |s|.
+			1. Let |s| be a [=string=]
+				initially containing "(".
 
-			[=list/For each=] |child| of |root| beyond the first:
+			2. [=sort a calculation's children|Sort root's children=].
 
-			1. If |child| is a Negate node,
-				append " - " to |s|,
-				then [=serialize a calculation tree|serialize=] the Negate's child
-				and append the result to |s|.
+			3. [=serialize a calculation tree|Serialize=] |root|'s first child,
+				and append it to |s|.
 
-			3. If |child| is a negative numeric value,
-				append " - " to |s|,
-				then serialize the negation of |child| as normal
-				and append the result to |s|.
+			4. [=list/For each=] |child| of |root| beyond the first:
 
-			2. Otherwise,
-				append " + " to |s|,
-				then [=serialize a calculation tree|serialize=] |child|
-				and append the result to |s|.
+				1. If |child| is a Negate node,
+					append " - " to |s|,
+					then [=serialize a calculation tree|serialize=] the Negate's child
+					and append the result to |s|.
 
-			Finally, append ")" to |s|
-			and return it.
+				3. If |child| is a negative numeric value,
+					append " - " to |s|,
+					then serialize the negation of |child| as normal
+					and append the result to |s|.
 
-		7. If |root| is a Product node,
-			let |s| be a [=string=]
-			initially containing "(".
+				2. Otherwise,
+					append " + " to |s|,
+					then [=serialize a calculation tree|serialize=] |child|
+					and append the result to |s|.
 
-			[=sort a calculation's children|Sort root's children=].
+			5. Append ")" to |s|
+				and return it.
 
-			[=serialize a calculation tree|Serialize=] |root|'s first child,
-			and append it to |s|.
+		7. If |root| is a Product node:
 
-			[=list/For each=] |child| of |root| beyond the first:
+			1. Let |s| be a [=string=]
+				initially containing "(".
 
-			1. If |child| is an Invert node,
-				append " / " to |s|,
-				then [=serialize a calculation tree|serialize=] the Invert's child
-				and append the result to |s|.
+			2. [=sort a calculation's children|Sort root's children=].
 
-			2. Otherwise,
-				append " * " to |s|,
-				then [=serialize a calculation tree|serialize=] |child|
-				and append the result to |s|.
+			3. [=serialize a calculation tree|Serialize=] |root|'s first child,
+				and append it to |s|.
 
-			Finally, append ")" to |s|
-			and return it.
+			4. [=list/For each=] |child| of |root| beyond the first:
+
+				1. If |child| is an Invert node,
+					append " / " to |s|,
+					then [=serialize a calculation tree|serialize=] the Invert's child
+					and append the result to |s|.
+
+				2. Otherwise,
+					append " * " to |s|,
+					then [=serialize a calculation tree|serialize=] |child|
+					and append the result to |s|.
+
+			5. Append ")" to |s|
+				and return it.
 	</div>
 
 	<div algorithm>

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5145,7 +5145,7 @@ Serialization</h3>
 				initially containing "(-1 * ".
 
 			2. [=serialize a calculation tree|Serialize=] |root|'s child,
-			   and append it to |s|.
+				and append it to |s|.
 
 			3. Append ")" to |s|,
 			   then return it.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5148,7 +5148,7 @@ Serialization</h3>
 				and append it to |s|.
 
 			3. Append ")" to |s|,
-			   then return it.
+				then return it.
 
 		5. If |root| is an Invert node:
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5092,7 +5092,7 @@ Serialization</h3>
 				with a value of 1.
 				Serialize this numeric value
 				and append it to |s|.
-			3. Return |s|.
+			4. Append ")" to |s|, then return it.
 
 		3. If the [=calculation tree’s=] root node is a numeric value,
 			or a [=calc-operator node=],

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5153,7 +5153,7 @@ Serialization</h3>
 		5. If |root| is an Invert node:
 
 			1. Let |s| be a [=string=]
-			   initially containing "(1 / ".
+			initially containing "(1 / ".
 
 			2. [=serialize a calculation tree|Serialize=] |root|'s child,
 			   and append it to |s|.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5178,7 +5178,7 @@ Serialization</h3>
 					then [=serialize a calculation tree|serialize=] the Negate's child
 					and append the result to |s|.
 
-				3. If |child| is a negative numeric value,
+				2. If |child| is a negative numeric value,
 					append " - " to |s|,
 					then serialize the negation of |child| as normal
 					and append the result to |s|.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5156,7 +5156,7 @@ Serialization</h3>
 			initially containing "(1 / ".
 
 			2. [=serialize a calculation tree|Serialize=] |root|'s child,
-			   and append it to |s|.
+				and append it to |s|.
 
 			3. Append ")" to |s|,
 			   then return it.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5159,7 +5159,7 @@ Serialization</h3>
 				and append it to |s|.
 
 			3. Append ")" to |s|,
-			   then return it.
+				then return it.
 
 		6. If |root| is a Sum node:
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5142,7 +5142,7 @@ Serialization</h3>
 		4. If |root| is a Negate node:
 			
 			1. Let |s| be a [=string=]
-			   initially containing "(-1 * ".
+				initially containing "(-1 * ".
 
 			2. [=serialize a calculation tree|Serialize=] |root|'s child,
 			   and append it to |s|.

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5066,8 +5066,6 @@ Range Checking</h3>
 <h3 id='calc-serialize'>
 Serialization</h3>
 
-	Issue: This section is still <a href="https://lists.w3.org/Archives/Member/w3c-css-wg/2016AprJun/0239.html">under discussion</a>.
-
 	<div algorithm>
 		To <dfn export>serialize a math function</dfn> |fn|:
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -5183,7 +5183,7 @@ Serialization</h3>
 					then serialize the negation of |child| as normal
 					and append the result to |s|.
 
-				2. Otherwise,
+				3. Otherwise,
 					append " + " to |s|,
 					then [=serialize a calculation tree|serialize=] |child|
 					and append the result to |s|.


### PR DESCRIPTION
Hopefully these are self-explanatory. I think they all count as editorial.

The numbering change is because it felt awkward to have non-numbered sequential steps in between an outer numbered list and an inner numbered list for Sum and Product nodes. But while I was at it, it made sense to also do that for Negate and Invert. Steps 2 and 3 feel simple enough that it's not necessary.

Closes #11781.