### PR TITLE
[css-values-5] Move "exploratory draft" issue from *progress() to *mix()

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -760,8 +760,6 @@ Combination of <<position>></h4>
 <h2 id="progress">
 Interpolation Progress Functional Notations</h2>
 
-	ISSUE(6245): This section is an exploratory draft, and not yet approved by the CSSWG.
-
 	The ''progress()'', ''media-progress()'', and ''container-progress()'' [=functional notations=]
 	represent the proportional distance
 	of a given value (the <dfn noexport>progress value</dfn>)
@@ -936,6 +934,8 @@ Container Query Progress Values: the ''container-progress()'' notation</h3>
 
 <h2 id="mixing">
 Mixing and Interpolation Notations: the *-mix() family</h2>
+
+	ISSUE(6245): This section is an exploratory draft, and not yet approved by the CSSWG.
 
 	ISSUE(6245): This feature <a href="https://css.typetura.com/ruleset-interpolation/explainer/">does not handle multiple breakpoints very well</a>,
 	and <a href="https://github.com/w3c/csswg-drafts/issues/6245#issuecomment-2469190377">might need to be redesigned</a>.


### PR DESCRIPTION
Since there haven't been any discussions about *progress() for a long time, and both WebKit and Blink have implemented it, I suggest to move this warning to *mix() functions section that's currently under heavy discussion.