### PR TITLE
[css-2025] sections 2.1 and 2.4: matching CSS recommendation names to real names

### DIFF
--- a/css-2025/Overview.bs
+++ b/css-2025/Overview.bs
@@ -199,7 +199,7 @@ Classification of CSS Specifications</h2>
 			which introduces some of the basic concepts of CSS
 			and its design principles.
 
-		<dt><a href="https://www.w3.org/TR/css-syntax-3/">CSS Syntax Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-syntax-3/">CSS Syntax Module Level 3</a>
 		[[!CSS-SYNTAX-3]]
 		<dd>
 			Replaces CSS2&sect;4.1, CSS2&sect;4.2, CSS2&sect;4.4, and CSS2&sect;G,
@@ -215,7 +215,7 @@ Classification of CSS Specifications</h2>
 		<dd>
 			Replaces CSS2&sect;7.3 and expands on the syntax for media-specific styles.
 
-		<dt><a href="https://www.w3.org/TR/css-conditional-3/">CSS Conditional Rules Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-conditional-3/">CSS Conditional Rules Module Level 3</a>
 		[[!CSS-CONDITIONAL-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;7.2,
@@ -227,7 +227,7 @@ Classification of CSS Specifications</h2>
 		<dd>
 			Replaces CSS2&sect;5 and CSS2&sect;6.4.3, defining an extended range of selectors.
 
-		<dt><a href="https://www.w3.org/TR/css-namespaces/">CSS Namespaces</a>
+		<dt><a href="https://www.w3.org/TR/css-namespaces/">CSS Namespaces Module Level 3</a>
 		[[!CSS3-NAMESPACE]]
 		<dd>
 			Introduces an ''@namespace'' rule to allow namespace-prefixed selectors.
@@ -239,7 +239,7 @@ Classification of CSS Specifications</h2>
 			Describes how to collate style rules and assign values to all properties on all elements.
 			By way of cascading and inheritance, values are propagated for all properties on all elements.
 
-		<dt><a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units Module Level 3</a>
 		[[!CSS-VALUES-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;1.4.2.1, CSS2&sect;4.3, and CSS2&sect;A.2.1&ndash;3,
@@ -252,12 +252,12 @@ Classification of CSS Specifications</h2>
 			Introduces cascading variables as a new primitive value type that is accepted by all CSS properties,
 			and custom properties for defining them.
 
-		<dt><a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a>
 		[[!CSS-BOX-3]]
 		<dd>
 			Replaces CSS2&sect;8.1, &sect;8.2, &sect;8.3 (but not &sect;8.3.1), and &sect;8.4.
 
-		<dt><a href="https://www.w3.org/TR/css-color-4/">CSS Color Level 4</a>
+		<dt><a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a>
 		[[!CSS-COLOR-4]]
 		<dd>
 			Extends and supersedes CSS2&sect;4.3.6, CSS2&sect;14.1, and CSS2&sect;18.2,
@@ -267,7 +267,7 @@ Classification of CSS Specifications</h2>
 			and CSS Object Model extensions for color.
 			Also defines the 'opacity' property.
 
-		<dt><a href="https://www.w3.org/TR/css-backgrounds-3/">CSS Backgrounds and Borders Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-backgrounds-3/">CSS Backgrounds and Borders Module Level 3</a>
 		[[!CSS-BACKGROUNDS-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;8.5 and CSS2&sect;14.2,
@@ -276,14 +276,14 @@ Classification of CSS Specifications</h2>
 			image borders,
 			and drop shadows.
 
-		<dt><a href="https://www.w3.org/TR/css-images-3/">CSS Images Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-images-3/">CSS Images Module Level 3</a>
 		[[!CSS-IMAGES-3]]
 		<dd>
 			Redefines and incorporates the external 2D image value type,
 			introduces native 2D gradients,
 			and adds additional controls for replaced element sizing and rendering.
 
-		<dt><a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Module Level 3</a>
 		[[!CSS-FONTS-3]]
 		<dd>
 			Extends and supersedes CSS2&sect;15
@@ -298,12 +298,12 @@ Classification of CSS Specifications</h2>
 			bidirectional (e.g. mixed Latin and Arabic) and vertical (e.g. Asian scripts).
 			Replaces and extends CSS2&sect;8.6 and &sect;9.10.
 
-		<dt><a href="https://www.w3.org/TR/css-multicol-1/">CSS Multi-column Layout Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-multicol-1/">CSS Multi-column Layout Module Level 1</a>
 		[[!CSS-MULTICOL-1]]
 		<dd>
 			Introduces multi-column flows to CSS layout.
 
-		<dt><a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Module Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-flexbox-1/">CSS Flexible Box Layout Module Level 1</a>
 		[[!CSS-FLEXBOX-1]]
 		<dd>
 			Introduces a flexible linear layout model for CSS.
@@ -321,12 +321,12 @@ Classification of CSS Specifications</h2>
 			which enforces the independent CSS processing of an element’s subtree
 			in order to enable heavy optimizations by user agents when used well.
 
-		<dt><a href="https://www.w3.org/TR/css-transforms-1/">CSS Transforms Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-transforms-1/">CSS Transforms Module Level 1</a>
 		[[!CSS-TRANSFORMS-1]]
 		<dd>
 			Introduces coordinate-based graphical transformations to CSS.
 
-		<dt><a href="https://www.w3.org/TR/compositing-1/">CSS Compositing and Blending Level 1</a>
+		<dt><a href="https://www.w3.org/TR/compositing-1/">Compositing and Blending Level 1</a>
 		[[!COMPOSITING]]
 		<dd>
 			Defines the compositing and blending of overlaid content
@@ -487,14 +487,14 @@ Modules with Rough Interoperability</h3>
 	We hope to incorporate them into the [[#css-official|official definition of CSS]] in a future snapshot.
 
 	<dl>
-		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-transitions-1/">CSS Transitions</a>
 		[[CSS-TRANSITIONS-1]]
 		and <a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>
 		[[CSS-ANIMATIONS-1]].
 		<dd>
 			Introduces mechanisms for transitioning the computed values of CSS properties over time.
 
-		<dt><a href="https://www.w3.org/TR/css-will-change-1/">CSS Will Change Level 1</a>
+		<dt><a href="https://www.w3.org/TR/css-will-change-1/">CSS Will Change Module Level 1</a>
 		[[CSS-WILL-CHANGE-1]]
 		<dd>
 			Introduces a performance hint property called 'will-change'.
@@ -509,7 +509,7 @@ Modules with Rough Interoperability</h3>
 		<dd>
 			Introduces events and interfaces used for dynamically loading font resources.
 
-		<dt><a href="https://www.w3.org/TR/css-sizing-3/">CSS Box Sizing Level 3</a>
+		<dt><a href="https://www.w3.org/TR/css-sizing-3/">CSS Box Sizing Module Level 3</a>
 		[[CSS-SIZING-3]]
 		<dd>
 			Overlays and extends CSS&sect;10.,
@@ -519,7 +519,7 @@ Modules with Rough Interoperability</h3>
 			various automatic sizing concepts only vaguely defined in CSS2.
 
 
-		<dt><a href="https://www.w3.org/TR/css-transforms-2/">CSS Transforms Level 2</a>
+		<dt><a href="https://www.w3.org/TR/css-transforms-2/">CSS Transforms Module Level 2</a>
 		[[CSS-TRANSFORMS-2]]
 		<dd>
 			Builds upon [[CSS-TRANSFORMS-1]]


### PR DESCRIPTION
In sections 2.1 and 2.4 the names of several included recommendations do not match the names that appear in the recommendations. Now they are the same.
