### PR TITLE
[*][editorial] Unquote delimiters in value definitions

### DIFF
--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -646,7 +646,7 @@ plus the additional rules noted below:
 	@page = @page <<page-selector-list>>? { <<declaration-rule-list>> }
 	<dfn><<page-selector-list>></dfn> = <<page-selector>>#
 	<dfn><<page-selector>></dfn> = [ <<ident-token>>? <<pseudo-page>>* ]!
-	<dfn><<pseudo-page>></dfn> = ':' [ left | right | first | blank ]
+	<dfn><<pseudo-page>></dfn> = : [ left | right | first | blank ]
 
 	/* Margin rules */
 	<dfn>@top-left-corner</dfn> = @top-left-corner { <<declaration-list>> };

--- a/css-values-3/Overview.bs
+++ b/css-values-3/Overview.bs
@@ -2021,10 +2021,10 @@ Syntax</h4>
 	<pre class='prod'>
 	<<calc()>> = calc( <<calc-sum>> )
 	<dfn>&lt;calc-sum></dfn> = <<calc-product>> [ [ '+' | '-' ] <<calc-product>> ]*
-	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ '*' <<calc-value>> | '/' <<calc-number-value>> ]*
+	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ '*' <<calc-value>> | / <<calc-number-value>> ]*
 	<dfn>&lt;calc-value></dfn> = <<number>> | <<dimension>> | <<percentage>> | ( <<calc-sum>> )
 	<dfn>&lt;calc-number-sum></dfn> = <<calc-number-product>> [ [ '+' | '-' ] <<calc-number-product>> ]*
-	<dfn>&lt;calc-number-product></dfn> = <<calc-number-value>> [ '*' <<calc-number-value>> | '/' <<calc-number-value>> ]*
+	<dfn>&lt;calc-number-product></dfn> = <<calc-number-value>> [ '*' <<calc-number-value>> | / <<calc-number-value>> ]*
 	<dfn>&lt;calc-number-value></dfn> = <<number>> | ( <<calc-number-sum>> )
 	</pre>
 

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -437,7 +437,7 @@ Component Values and White Space</h3>
 		allowing any possibly function name after the initial colon:
 
 		<xmp class=prod>
-			<pseudo-class-selector> = ':' <ident-token> | ':' <function-token> <any-value> ')'
+			<pseudo-class-selector> = : <ident-token> | : <function-token> <any-value> )
 		</xmp>
 
 		This represents <em>any</em> function name,
@@ -4272,7 +4272,7 @@ Syntax</h3>
 	<<abs()>>   = abs( <<calc-sum>> )
 	<<sign()>>  = sign( <<calc-sum>> )
 	<dfn>&lt;calc-sum></dfn> = <<calc-product>> [ [ '+' | '-' ] <<calc-product>> ]*
-	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ [ '*' | '/' ] <<calc-value>> ]*
+	<dfn>&lt;calc-product></dfn> = <<calc-value>> [ [ '*' | / ] <<calc-value>> ]*
 	<dfn>&lt;calc-value></dfn> = <<number>> | <<dimension>> | <<percentage>> |
 	               <<calc-keyword>> | ( <<calc-sum>> )
 	<dfn>&lt;calc-keyword></dfn> = e | pi | infinity | -infinity | NaN

--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -3726,11 +3726,11 @@ Grammar</h2>
 	<dfn noexport>&lt;attr-matcher></dfn> = [ '~' | '|' | '^' | '$' | '*' ]? '='
 	<dfn noexport>&lt;attr-modifier></dfn> = i | s
 
-	<dfn>&lt;pseudo-class-selector></dfn> = ':' <<ident-token>> |
-	                          ':' <<function-token>> <<any-value>> ')'
+	<dfn>&lt;pseudo-class-selector></dfn> = : <<ident-token>> |
+	                          : <<function-token>> <<any-value>> )
 
-	<dfn>&lt;pseudo-element-selector></dfn> = ':' <<pseudo-class-selector>> | <<legacy-pseudo-element-selector>>
-	<dfn>&lt;legacy-pseudo-element-selector></dfn> =  ':' [before | after | first-line | first-letter]
+	<dfn>&lt;pseudo-element-selector></dfn> = : <<pseudo-class-selector>> | <<legacy-pseudo-element-selector>>
+	<dfn>&lt;legacy-pseudo-element-selector></dfn> =  : [before | after | first-line | first-letter]
 	</pre>
 
 	In interpreting the above grammar,


### PR DESCRIPTION
This PR removes the quotes around `:` `/` `)` in value definitions.

Since eab6ac4, the related text of [CSS V&U](https://drafts.csswg.org/css-values-4/#component-types) is:

  > 6. Delimiters, which represent their corresponding tokens. Slashes (`/`), commas (`,`), colons (`:`), semicolons (`;`), parentheses (`(` and `)`), and braces (`{` and `}`) are written literally. Other delimiters must be written enclosed in single quotes (such as `'+'`).

In this paragraph, whether they *can* be or they *must* be written literally is ambiguous.

None are tokenized as `<delim-token>` but as their own token, except `/`. They *are* delimiters, I think, and I guess these tokens only exist for convenience. But a "dumb" CSS value definition parser may interpret `')'` as a `<delim-token>` whose value is `)`, whereas such token cannot exist.

This change would also be appreciated to have simpler implementation of such parsers. MediaQueries and Selectors both define a "general" functional notation: the former with `)`, the second with `')'`.