### PR TITLE
[css-backgrounds-4] Drop duplicate `background-position` logical property group

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -263,7 +263,6 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to width of background positioning area <em>minus</em> width of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
-		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's horizontal component.
@@ -278,7 +277,6 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to height of background positioning area <em>minus</em> height of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
-		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's vertical component.
@@ -293,7 +291,6 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to inline-size of background positioning area <em>minus</em> inline-size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
-		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's inline-axis component.
@@ -308,7 +305,6 @@ Background Positioning Longhands: the 'background-position-x', 'background-posit
 		Percentages: refer to size of background positioning area <em>minus</em> size of background image
 		Computed value: A list, each item consisting of: an offset given as a computed <<length-percentage>> value, plus an origin keyword
 		Animation type: repeatable list
-		Logical property group: background-position
 	</pre>
 
 	This property specifies the background position's block-axis component.


### PR DESCRIPTION
The `background-position` longhands were already defined with `background-position` as a logical property group. #11139 duplicated the "Logical property group" line in the property definition table, leading to `background-position background-position` as logical property group in the rendered spec.

