### PR TITLE
[css-animations-2] setting `effect` should not prevent the timeline to set set via `animation-timeline`

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -142,7 +142,7 @@ the changes from the programming interface take precedence as follows:
     to <code>null</code>
     or some {{AnimationEffect}} other than the original {{KeyframeEffect}},
     all subsequent changes to animation properties other than
-    'animation-name', 'animation-play-state' or 'animation-timeline
+    'animation-name', 'animation-play-state', or 'animation-timeline'
     will not be reflected in that animation.
     Similarly, any change to matching ''@keyframes'' rules will not be reflected
     in that animation.

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -142,7 +142,7 @@ the changes from the programming interface take precedence as follows:
     to <code>null</code>
     or some {{AnimationEffect}} other than the original {{KeyframeEffect}},
     all subsequent changes to animation properties other than
-    'animation-name' or 'animation-play-state'
+    'animation-name', 'animation-play-state' or 'animation-timeline
     will not be reflected in that animation.
     Similarly, any change to matching ''@keyframes'' rules will not be reflected
     in that animation.


### PR DESCRIPTION
While most `animation-*` CSS properties should _not_ have an effect once a `CSSAnimation` object has had its `effect` property set via the bindings, the `animation-timeline` property, like the `animation-play-state` and `animation-name` properties, should not follow that pattern since it is relevant to the _animation_ and not the animation _effect_.

The relevant WPT test is updated in https://github.com/web-platform-tests/wpt/pull/51057.