### PR TITLE
[css-mixins-1] Allow omitting custom function arguments

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -388,7 +388,7 @@ whose function name starts with two dashes (U+002D HYPHEN-MINUS).
 Its syntax is:
 
 <pre class="prod informative" nohighlight>
-	&lt;dashed-function> = --*( <<declaration-value>># )
+	&lt;dashed-function> = --*( <<declaration-value>>#? )
 </pre>
 
 A <<dashed-function>> can only be used where ''var()'' is allowed.


### PR DESCRIPTION
[`@function`](https://drafts.csswg.org/css-mixins-1/#at-ruledef-function) parameters are optional. So I think one or more custom function arguments (`#`) is an oversight.