### PR TITLE
[css-shadow-parts-1] replace data-x attribute with lt

### DIFF
--- a/css-shadow-parts-1/Overview.bs
+++ b/css-shadow-parts-1/Overview.bs
@@ -442,7 +442,7 @@ The rules for parsing a list of part mappings are as follow:
 
 1. Let <var>input</var> be the string being parsed.
 
-1. <span data-x="split a string on commas">Split the string <var>input</var> on
+1. <span lt="split a string on commas">Split the string <var>input</var> on
     commas</span>. Let <var>unparsed mappings</var> be the resulting list of strings.
 
 1. Let <var>mappings</var> be an initially empty [=list=] of [=pairs=] of tokens.


### PR DESCRIPTION
data-x is used in Wattsi (HTML) but doesn't work in Bikeshed.