### PR TITLE
[css-mixins-1] Typo: default return type is `type(*)`

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -213,7 +213,7 @@ the optional [=function parameters=]
 are given by the <<function-parameter>> values
 (defaulting to an empty set),
 and the optional [=custom function/return type=] is given by the <<css-type>> following the <css>returns</css> keyword
-(defaulting to ''*'').
+(defaulting to ''type(*)'').
 
 <div class='example'>
 	If the <<css-type>> of a [=function parameter=] or [=custom function/return type=]


### PR DESCRIPTION
The default return type of [`@function`](https://drafts.csswg.org/css-mixins-1/#at-ruledef-function) is `*` but is not allowed by the grammar ([`<css-type>`](https://drafts.csswg.org/css-mixins-1/#typedef-css-type)).

This PR adds it as an alternative of `<css-type>`.