### PR TITLE
Forced Colors Mode WebDriver Emulation

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -24,19 +24,14 @@ spec:css-color-4; type:property; text:color
 spec:fill-stroke-3; type:property;
 	text:fill
 	text:stroke
-spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#; type: dfn;
-	text: error; url: dfn-error
-	text: getting a property; url: dfn-getting-properties
-	text: remote end steps; url: dfn-remote-end-steps
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/; type: dfn;
+	text: navigable; for:Window; url: nav-history-apis.html#window-navigable
+	text: top-level traversable; for:/; url: document-sequences.html#top-level-traversable
 </pre>
 
 <pre class=anchors>
 url: https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme;
 	type: attr-value; for: meta/name; spec: html; text: color-scheme;
-</pre>
-<pre class=anchors>
-url: https://262.ecma-international.org/5.1/#sec-4.3.11; type: dfn;
-	spec: ecmascript; text: null;
 </pre>
 
 <link rel="stylesheet" href="style.css" />
@@ -492,12 +487,11 @@ Forced Color Palettes {#forced}
 	''prefers-color-scheme/light'' or ''prefers-color-scheme/dark''
 	as the user’s preferred color scheme.
 
-	If the [=current forced colors mode automation theme=] is not
-	"{{ForcedColorsModeAutomationTheme/none}}", the user agent should first verify that
-	it is in an automation context (see [[WebDriver#security|WebDriver's Security
-	considerations]]). The user agent should then bypass the above operating system
-	color themes, and instead do the following based on the value of the
-	[=current forced colors mode automation theme=]:
+	If [=get emulated forced colors theme data=]
+	is not "{{ForcedColorsModeAutomationTheme/none}}",
+	the user agent should bypass the above operating system color themes,
+	and instead do the following based on the resulting value of
+	[=emulated forced colors theme data=]:
 
 	: "{{ForcedColorsModeAutomationTheme/light}}"
 	:: Act as if the user has enabled <a>forced colors mode</a> with the
@@ -1096,20 +1090,17 @@ The 'color-adjust' Shorthand {#color-adjust}
 	inheritance.html
 </wpt>
 
-Automation {#color-adjust-automation}
+Emulation {#color-adjust-emulation}
 ===================================
-	For the purposes of user agent automation and website testing, this document
-	defines the below [[WebDriver]] [=extension commands=].
+	For the purposes of user agent automation and application testing, this document
+	defines the below emulations.
 
-	<dfn>Emulate Forced Colors Mode</dfn> {#emualte-forced-colors-mode}
+	<dfn export>Emulate Forced Colors Mode</dfn> {#emualte-forced-colors-mode}
 	--------------------------------------------
 
-	The [=Emulate Forced Colors Mode=] [=extension command=] simulates
-	[=Forced Colors Mode=] for the purposes of testing.
-
-	The <dfn>current forced colors mode automation theme</dfn> tracks what
-	{{ForcedColorsModeAutomationTheme}} is currently active. It defaults to
-	"{{ForcedColorsModeAutomationTheme/none}}".
+	Each [=top-level traversable=] has an associated
+	<dfn>emulated forced colors theme data</dfn>, which is data representing
+	{{ForcedColorsModeAutomationTheme}}, initially "{{ForcedColorsModeAutomationTheme/none}}".
 
 	<xmp class="idl">
 		enum ForcedColorsModeAutomationTheme {
@@ -1119,42 +1110,34 @@ Automation {#color-adjust-automation}
 		};
 	</xmp>
 
-	<figure id="table-setForcedColorsModeAutomationTheme" class="table">
-		<table class="data">
-			<thead>
-				<tr>
-					<th>HTTP Method</th>
-					<th>URI Template</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>POST</td>
-					<td>/session/<em>{session id}</em>/emulate/forced-colors-mode/<em>{theme}</em></td>
-				</tr>
-			</tbody>
-		</table>
-	</figure>
+	To <dfn export>set emulated forced colors theme data</dfn>, given
+    [=navigable=] |navigable| and an |emulatedThemeData|:
 
-The [=remote end steps=], given <em>session</em>, <em>URL
-variables</em> and <em>parameters</em> are:
+	1. Assert |emulatedThemeData| is {{ForcedColorsModeAutomationTheme}}.
 
-1. If <em>parameters</em> is not a JSON [=Object=], return a WebDriver [=error=]	
-	with WebDriver [=error code=] [=invalid argument=].
+	2. Let |traversable| be |navigable|’s [=navigable/top-level traversable=].
 
-2. Let <em>theme</em> be the result of [=getting a property=] named
-	<code>"theme"</code> from <em>parameters</em>.
+	3. If |traversable| is not null:
+		1. Set |traversable|'s associated [=emulated forced colors theme data=] to
+			|emulatedThemeData|.
+		
+		2. UAs must consider this a change that requires style recalculation.
+	
+	To <dfn>get emulated forced colors theme data</dfn>, given {{ForcedColorsModeAutomationTheme}}
+		|theme|:
 
-3. If <em>theme</em> is {{globalThis/undefined}} or is not a member of
-	{{ForcedColorsModeAutomationTheme}}, return a WebDriver [=error=] with
-	WebDriver [=error code=] [=invalid argument=].
+	1. Let |navigable| be |theme|'s [=relevant global object=]'s
+		[=associated Document=]'s [=node navigable=].
 
-4. Set the [=current forced colors mode automation theme=] to <em>theme</em>.
+	2. If |navigable| is null, return null.
 
-5. Signal to the browser that styles need to be recalculated.
+	3. Let |traversable| be |navigable|’s [=navigable/top-level traversable=].
 
-6. Return [=success=] with data 
-	<a href="https://262.ecma-international.org/5.1/#sec-4.3.11">null</a>.
+	4. If |traversable| is null, return null.
+
+	5. Return |traversable|'s associated [=emulated forced colors theme data=].
+
+
 
 
 Privacy Considerations {#privacy}

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -26,21 +26,17 @@ spec:fill-stroke-3; type:property;
 	text:stroke
 spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#; type: dfn;
 	text: error; url: dfn-error
-	text: error code; url: dfn-error-code
-	text: extension command; url: dfn-extension-commands
-	text: extension commands; url: dfn-extension-commands
 	text: getting a property; url: dfn-getting-properties
-	text: invalid argument; url: dfn-invalid-argument
-	text: null; url: dfn-null
 	text: remote end steps; url: dfn-remote-end-steps
-	text: session; url: dfn-session
-	text: success; url: dfn-success
-	text: undefined; url: dfn-undefined
 </pre>
 
 <pre class=anchors>
 url: https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme;
 	type: attr-value; for: meta/name; spec: html; text: color-scheme;
+</pre>
+<pre class=anchors>
+url: https://262.ecma-international.org/5.1/#sec-4.3.11; type: dfn;
+	spec: ecmascript; text: null;
 </pre>
 
 <link rel="stylesheet" href="style.css" />
@@ -1149,7 +1145,7 @@ variables</em> and <em>parameters</em> are:
 2. Let <em>theme</em> be the result of [=getting a property=] named
 	<code>"theme"</code> from <em>parameters</em>.
 
-3. If <em>theme</em> is [=undefined=] or is not a member of
+3. If <em>theme</em> is {{globalThis/undefined}} or is not a member of
 	{{ForcedColorsModeAutomationTheme}}, return a WebDriver [=error=] with
 	WebDriver [=error code=] [=invalid argument=].
 
@@ -1157,7 +1153,8 @@ variables</em> and <em>parameters</em> are:
 
 5. Signal to the browser that styles need to be recalculated.
 
-6. Return [=success=] with data [=null=].
+6. Return [=success=] with data 
+	<a href="https://262.ecma-international.org/5.1/#sec-4.3.11">null</a>.
 
 
 Privacy Considerations {#privacy}

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -1143,14 +1143,15 @@ Automation {#color-adjust-automation}
 The [=remote end steps=], given <em>session</em>, <em>URL
 variables</em> and <em>parameters</em> are:
 
-1. If <em>parameters</em> is not a JSON [=Object=], return a WebDriver [=error=] with
+1. If <em>parameters</em> is not a JSON [=Object=], return a WebDriver [=error=]	
+	with WebDriver [=error code=] [=invalid argument=].
+
+2. Let <em>theme</em> be the result of [=getting a property=] named
+	<code>"theme"</code> from <em>parameters</em>.
+
+3. If <em>theme</em> is [=undefined=] or is not a member of
+	{{ForcedColorsModeAutomationTheme}}, return a WebDriver [=error=] with
 	WebDriver [=error code=] [=invalid argument=].
-
-2. Let <em>theme</em> be the result of [=getting a property=] named <code>"theme"</code> from
-	<em>parameters</em>.
-
-3. If <em>theme</em> is [=undefined=] or is not a member of {{ForcedColorsModeAutomationTheme}},
-	return a WebDriver [=error=] with WebDriver [=error code=] [=invalid argument=].
 
 4. Set the [=current forced colors mode automation theme=] to <em>theme</em>.
 

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -1111,7 +1111,7 @@ Emulation {#color-adjust-emulation}
 	</xmp>
 
 	To <dfn export>set emulated forced colors theme data</dfn>, given
-    [=navigable=] |navigable| and an |emulatedThemeData|:
+	[=navigable=] |navigable| and an |emulatedThemeData|:
 
 	1. Assert |emulatedThemeData| is {{ForcedColorsModeAutomationTheme}}.
 

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -24,12 +24,26 @@ spec:css-color-4; type:property; text:color
 spec:fill-stroke-3; type:property;
 	text:fill
 	text:stroke
+spec: webdriver; urlPrefix: https://w3c.github.io/webdriver/#; type: dfn;
+	text: error; url: dfn-error
+	text: error code; url: dfn-error-code
+	text: extension command; url: dfn-extension-commands
+	text: extension commands; url: dfn-extension-commands
+	text: getting a property; url: dfn-getting-properties
+	text: invalid argument; url: dfn-invalid-argument
+	text: null; url: dfn-null
+	text: remote end steps; url: dfn-remote-end-steps
+	text: session; url: dfn-session
+	text: success; url: dfn-success
+	text: undefined; url: dfn-undefined
 </pre>
 
 <pre class=anchors>
 url: https://html.spec.whatwg.org/multipage/semantics.html#meta-color-scheme;
 	type: attr-value; for: meta/name; spec: html; text: color-scheme;
 </pre>
+
+<link rel="stylesheet" href="style.css" />
 
 Introduction {#intro}
 =====================
@@ -408,21 +422,21 @@ only to force all colors on the page
 to conform to either a [=dark=] or [=light=] color scheme.
 
 <div class="example">
-  For example, a UA might have a “dark room” mode,
-  which forces all pages into a [=dark=] color scheme.
+	For example, a UA might have a “dark room” mode,
+	which forces all pages into a [=dark=] color scheme.
 
-  For pages that already support [=dark=] color schemes,
-  and have indicated so using the 'color-scheme' property
-  or <{meta/name/color-scheme}> <{meta}> name,
-  this has no effect other than reporting a ''@media/prefers-color-scheme/dark'' value
-  for the 'prefers-color-scheme' [=media query=]
-  and selecting a [=dark=] [=used color scheme=].
+	For pages that already support [=dark=] color schemes,
+	and have indicated so using the 'color-scheme' property
+	or <{meta/name/color-scheme}> <{meta}> name,
+	this has no effect other than reporting a ''@media/prefers-color-scheme/dark'' value
+	for the 'prefers-color-scheme' [=media query=]
+	and selecting a [=dark=] [=used color scheme=].
 
-  But for pages that do not explicitly support a [=dark=] color scheme,
-  and have not explicitly forbidden this auto-adjustment
-  by specifying ''color-scheme: only light'',
-  this mode triggers auto-adjustment of the page’s colors
-  to <em>force</em> the page to conform to the desired [=dark=] color scheme.
+	But for pages that do not explicitly support a [=dark=] color scheme,
+	and have not explicitly forbidden this auto-adjustment
+	by specifying ''color-scheme: only light'',
+	this mode triggers auto-adjustment of the page’s colors
+	to <em>force</em> the page to conform to the desired [=dark=] color scheme.
 </div>
 
 
@@ -481,6 +495,305 @@ Forced Color Palettes {#forced}
 	and may result in assuming either
 	''prefers-color-scheme/light'' or ''prefers-color-scheme/dark''
 	as the user’s preferred color scheme.
+
+	If the [=current forced colors mode automation theme=] is not
+	"{{ForcedColorsModeAutomationTheme/none}}", the user agent should first verify that
+	it is in an automation context (see [[WebDriver#security|WebDriver's Security
+	considerations]]). The user agent should then bypass the above operating system
+	color themes, and instead do the following based on the value of the
+	[=current forced colors mode automation theme=]:
+
+	: "{{ForcedColorsModeAutomationTheme/light}}"
+	:: Act as if the user has enabled <a>forced colors mode</a> with the
+		following color mappings:
+
+		<table class="data">
+			<thead>
+			<tr>
+				<th><<system-color>> keyword</th>
+				<th>Value</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>''AccentColor''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''AccentColorText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ActiveText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonBorder''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonFace''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''Canvas''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''CanvasText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''Field''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''FieldText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''GrayText''</td>
+					<td>
+						<span class="swatch" style="--color: #600000"></span>
+						&nbsp;#600000
+					</td>
+				</tr>
+				<tr>
+					<td>''Highlight''</td>
+					<td>
+						<span class="swatch" style="--color: #37006E"></span>
+						&nbsp;#37006E
+					</td>
+				</tr>
+				<tr>
+					<td>''HighlightText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''LinkText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+				<tr>
+					<td>''Mark''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''MarkText''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItem''</td>
+					<td>
+						<span class="swatch" style="--color: #37006E"></span>
+						&nbsp;#37006E
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItemText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''VisitedText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+	: "{{ForcedColorsModeAutomationTheme/dark}}"
+	:: Act as if the user has enabled <a>forced colors mode</a> with the
+		following color mappings:
+		<table class="data">
+			<thead>
+				<tr>
+					<th><<system-color>> keyword</th>
+					<th>Value</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>''AccentColor''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''AccentColorText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''ActiveText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonBorder''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonFace''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''Canvas''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''CanvasText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''Field''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''FieldText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td>''GrayText''</td>
+					<td>
+						<span class="swatch" style="--color: #3FF23F"></span>
+						&nbsp;#3FF23F
+					</td>
+				</tr>
+				<tr>
+					<td>''Highlight''</td>
+					<td>
+						<span class="swatch" style="--color: #1AEBFF"></span>
+						&nbsp;#1AEBFF
+					</td>
+				</tr>
+				<tr>
+					<td>''HighlightText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''LinkText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+				<tr>
+					<td>''Mark''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''MarkText''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItem''</td>
+					<td>
+						<span class="swatch" style="--color: #1AEBFF"></span>
+						&nbsp;#1AEBFF
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItemText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''VisitedText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+			</tbody>
+		</table>
 
 <!--THOUGHTS
 	This advice (below) maybe makes sense for (prefers-contrast),
@@ -787,6 +1100,64 @@ The 'color-adjust' Shorthand {#color-adjust}
 	inheritance.html
 </wpt>
 
+Automation {#color-adjust-automation}
+===================================
+	For the purposes of user agent automation and website testing, this document
+	defines the below [[WebDriver]] [=extension commands=].
+
+	<dfn>Emulate Forced Colors Mode</dfn> {#emualte-forced-colors-mode}
+	--------------------------------------------
+
+	The [=Emulate Forced Colors Mode=] [=extension command=] simulates
+	[=Forced Colors Mode=] for the purposes of testing.
+
+	The <dfn>current forced colors mode automation theme</dfn> tracks what
+	{{ForcedColorsModeAutomationTheme}} is currently active. It defaults to
+	"{{ForcedColorsModeAutomationTheme/none}}".
+
+	<xmp class="idl">
+		enum ForcedColorsModeAutomationTheme {
+			"none",
+			"light",
+			"dark"
+		};
+	</xmp>
+
+	<figure id="table-setForcedColorsModeAutomationTheme" class="table">
+		<table class="data">
+			<thead>
+				<tr>
+					<th>HTTP Method</th>
+					<th>URI Template</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>POST</td>
+					<td>/session/<em>{session id}</em>/emulate/forced-colors-mode/<em>{theme}</em></td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+
+The [=remote end steps=], given <em>session</em>, <em>URL
+variables</em> and <em>parameters</em> are:
+
+1. If <em>parameters</em> is not a JSON [=Object=], return a WebDriver [=error=] with
+	WebDriver [=error code=] [=invalid argument=].
+
+2. Let <em>theme</em> be the result of [=getting a property=] named <code>"theme"</code> from
+	<em>parameters</em>.
+
+3. If <em>theme</em> is [=undefined=] or is not a member of {{ForcedColorsModeAutomationTheme}},
+	return a WebDriver [=error=] with WebDriver [=error code=] [=invalid argument=].
+
+4. Set the [=current forced colors mode automation theme=] to <em>theme</em>.
+
+5. Signal to the browser that styles need to be recalculated.
+
+6. Return [=success=] with data [=null=].
+
 
 Privacy Considerations {#privacy}
 ===================================
@@ -845,4 +1216,4 @@ Changes {#changes}
 			(<a href="https://github.com/w3c/csswg-drafts/issues/7007">Issue 7007</a>)
 	</ul>
 
-  <strong>See also <a href="https://www.w3.org/TR/2022/CR-css-color-adjust-1-20220210/#changes">Changes prior to Candidate Recommendation</a>.</strong>
+	<strong>See also <a href="https://www.w3.org/TR/2022/CR-css-color-adjust-1-20220210/#changes">Changes prior to Candidate Recommendation</a>.</strong>

--- a/css-color-adjust-1/style.css
+++ b/css-color-adjust-1/style.css
@@ -1,0 +1,24 @@
+.swatch {
+	position: relative;
+	z-index: 1;
+	display: inline-block;
+	vertical-align: calc(-.1em - 3px);
+	padding: .6em;
+	background-color: var(--color);
+	border: 3px solid white;
+	border-radius: 3px;
+	box-shadow: 1px 1px 1px rgba(0,0,0,.15);
+    forced-color-adjust: none;
+}
+
+.swatch.oog {
+	border: 2px solid red;
+}
+
+.swatch:hover,
+.swatch:focus {
+	transform: scale(3);
+	border-radius: 2px;
+	transition: .4s;
+	z-index: 2;
+}

--- a/css-color-adjust-1/style.css
+++ b/css-color-adjust-1/style.css
@@ -8,7 +8,7 @@
 	border: 3px solid white;
 	border-radius: 3px;
 	box-shadow: 1px 1px 1px rgba(0,0,0,.15);
-    forced-color-adjust: none;
+	forced-color-adjust: none;
 }
 
 .swatch.oog {


### PR DESCRIPTION
Forced Colors Mode is difficult to test via WPT because it is dependent on OS state (Window High Contrast) to trigger the feature to light up.

This change builds on a drafted [webdriver-bidi emulation command](https://www.w3.org/TR/webdriver-bidi/#module-emulation) (see https://github.com/w3c/webdriver-bidi/pull/905) to define a new forced colors emulation (https://alisonmaher.github.io/alisonmaher/css-color-adjust-1/Overview.html#emualte-forced-colors-mode) that keeps track of the current forced colors mode emulation state.

The change also updates the forced colors mode algorithm (https://alisonmaher.github.io/alisonmaher/css-color-adjust-1/Overview.html#forced) to inform the UA what to do when the forced colors mode emulation state is either `"light"` or `"dark"`.

CSSWG resolution for this change: https://github.com/w3c/csswg-drafts/issues/11824#issuecomment-2769343959

This change also fixes a few unrelated tabbing issues in the CSS Color Adjust 1 spec.
