### PR TITLE
[css-mixins-1] Make locals untyped again

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -520,6 +520,8 @@ with its [=function parameters=] overriding "inherited" custom properties of the
 	9. For each [=custom property registration=] of |registrations|,
 		set its initial value
 		to the corresponding value in |argument styles|,
+		set its syntax
+		to the [=universal syntax definition=],
 		and prepend a [=custom property=] to |body rule|
 		with the property name and value in |argument styles|.
 	10. [=Resolve function styles=] using |body rule|, |registrations|, and |calling context|.


### PR DESCRIPTION
7efac5a8ab7204b6b34d1b1d41b9ecf56623e408 accidentally made local variables "inherit" any type specified by a shadowed parameter. This simply restores the old behavior of locals being untyped.
