### PR TITLE
[css-values-5] Refer to attr-type argument, not syntax

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1646,7 +1646,7 @@ Ian's proposal:
 		if the attribute is missing
 		or fails to parse as the specified type.
 
-		If the <<syntax>> argument is omitted,
+		If the <<attr-type>> argument is omitted,
 		the fallback defaults to the empty string if omitted;
 		otherwise, it defaults to the [=guaranteed-invalid value=] if omitted.
 


### PR DESCRIPTION
There is no `<syntax>` argument to attr() anymore; refer to `<attr-type>` instead.
