### PR TITLE
[css-forms-1] Fix ::checkmark styles to apply when input is checked

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -677,17 +677,21 @@ input:is([type=checkbox]:not([switch]), [type=radio]) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    content: '';
 }
 
-input[type=checkbox]:not([switch])::checkmark {
+input[type=radio] {
+    border-radius: 100%;
+}
+
+input[type=checkbox]:not([switch]):checked::checkmark {
     content: '\2713' / '';
 }
 
-input[type=radio]::checkmark {
-    content: '';
+input[type=radio]:checked::checkmark {
     background-color: currentColor;
     display: inline-block;
-    border-radius: 100%;
+    border-radius: inherit;
     height: 100%;
     width: 100%;
 }


### PR DESCRIPTION
 Fix ::checkmark styles to apply when input is checked

Also apply a border-radius to radio inputs.

With this you now end up with the below rendering:

<img width="32" alt="image" src="https://github.com/user-attachments/assets/81ab9d8e-ed29-467b-a432-130db83515b6" />

<img width="33" alt="image" src="https://github.com/user-attachments/assets/747c5796-e57d-495c-854a-de4bdeaaf702" />

