### PR TITLE
[css-forms-1] Add user-select: none to button-like stylesheet

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -725,6 +725,8 @@ input[type="color"] {
    * in between it and the text. */
   display: inline-flex;
   gap: 1em;
+
+  user-select: none;
 }
 :is(button, select, input[type="color"]):enabled:hover {
   background-color: color-mix(in lab, currentColor 10%, transparent);


### PR DESCRIPTION
This is implemented by Chromium for base appearance select, and by Firefox for auto appearance selects and other button-like elements.