### PR TITLE
[css-forms-1] Add `::file-selector-button` to selectors for buttons

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -696,6 +696,7 @@ input[type=radio]::checkmark {
 
 ```css
 button,
+::file-selector-button,
 select,
 input[type="color"] {
   border: 1px solid currentColor;
@@ -726,13 +727,16 @@ input[type="color"] {
   display: inline-flex;
   gap: 1em;
 }
-:is(button, select, input[type="color"]):enabled:hover {
+:is(button, select, input[type="color"]):enabled:hover,
+:enabled::file-selector-button:hover {
   background-color: color-mix(in lab, currentColor 10%, transparent);
 }
-:is(button, select, input[type="color"]):enabled:active {
+:is(button, select, input[type="color"]):enabled:active,
+:enabled::file-selector-button:active {
   background-color: color-mix(in lab, currentColor 20%, transparent);
 }
-:is(button, select, input[type="color"]):disabled {
+:is(button, select, input[type="color"]):disabled,
+:disabled::file-selector-button {
   color: color-mix(in srgb, currentColor 50%, transparent);
 }
 


### PR DESCRIPTION
Previously `::file-selector-button` would be missing many of the styles associated with button-like UI.