### PR TITLE
[css-forms-1] Add field-sizing to base select styles

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -695,6 +695,11 @@ input[type=radio]::checkmark {
 ## Selects & buttons
 
 ```css
+select {
+  /* Base appearance select always sizes based on its contents. */
+  field-sizing: content !important;
+}
+
 button,
 ::file-selector-button,
 select,


### PR DESCRIPTION
Base select is always sized based on its content size rather than using the legacy fixed styling, so we set field-sizing to content !important.

See https://github.com/w3c/csswg-drafts/issues/11838#issuecomment-2708823023