### PR TITLE
[css-counter-styles-3] Extended @counter-style containing *-symbols are valid

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -709,8 +709,7 @@ Building from Existing Counter Styles: the ''extends'' system
 	rather than taking their initial values.
 
 	If a ''@counter-style'' uses the ''extends'' system,
-	it must not contain a '@counter-style/symbols' or '@counter-style/additive-symbols' descriptor,
-	or else the ''@counter-style'' rule is invalid.
+	it must not contain a '@counter-style/symbols' or '@counter-style/additive-symbols' descriptor.
 
 	If the specified <<counter-style-name>> is an [=ASCII case-insensitive=] match
 	for ''disc'', ''circle'', ''square'', ''disclosure-open'', or ''disclosure-closed''


### PR DESCRIPTION
Fixes #9258. This PR removes this emphasized part:

  > If a `@counter-style` uses the extends `system`, it must not contain a `symbols` or `additive-symbols` descriptor, **or else the `@counter-style` rule is invalid**.

It was reported in #5717 and should have been fixed in ba2a8cb.

They all follow the resolution in #1682.

---

ba2a8cb and this PR leave multiple requirements (*"must [not] contain"*) without explicitly saying what should happen when they are not met. In my opinion, *"otherwise, the `@counter-style` does not define a counter style (but is still a valid at-rule)"* should be added.