### PR TITLE
[css-counter-styles-3] Fix markup

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2053,7 +2053,7 @@ Longhand East Asian Counter Styles</h3>
 <h4 id='limited-japanese'>
 Japanese: ''japanese-informal'' and ''japanese-formal''</h4>
 
-	<dl dfn-type="value" dfn-for="<counter-style>">
+	<dl dfn-type="value" dfn-for="<counter-style-name>">
 		<dt><dfn id="japanese-informal">japanese-informal</dfn>
 		<dd>
 			Informal Japanese Kanji numbering


### PR DESCRIPTION
Fixes #8185.

This PR allows all counter style names to be grouped under the same namespace in CSS tools like `w3c/webref`.

[`japanese-*`](https://drafts.csswg.org/css-counter-styles-3/#limited-japanese) are defined`for="<counter-style>"` whereas other predefined counter style names are defined `for="<counter-style-name>"`. [`<counter-style>`](https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style) produces `<counter-style-name>` and `<symbols()>`.