### PR TITLE
[css-values-5] Editorial: fix scope of random() values

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2101,7 +2101,7 @@ Generating a Random Numeric Value: the ''random()'' function</h3>
 		in the styles across several elements,
 		via the ''random()/match-element'' value (or its absence)
 
-	<dl dfn-type=value dfn-for="random()|<random-value-sharing>">
+	<dl dfn-type=value dfn-for="random(),<random-value-sharing>">
 		: <dfn>auto</dfn>
 		::	Each [=random function=] in an element's styles
 			will use a distinct [=random base value=].


### PR DESCRIPTION
According to the definitions data model, `dfn-for` needs to a contain a "comma-separated list" of definitions. A recent commit used `|` to separate values definitions for `random()` and `<random-value-sharing>`. References back to the scoped definitions did not work as a result.
