### PR TITLE
[css-anchor-position-1][editorial] Clarify validity of anchor-*()

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1251,8 +1251,7 @@ An ''anchor()'' function is a
 <dfn lt="valid anchor function|invalid anchor function">valid anchor function</dfn>
 only if all the following conditions are true:
 
-* It's being used in an [=inset property=]
-	on an [=absolutely positioned box=].
+* It's being used on an [=absolutely positioned box=].
 * If its <<anchor-side>> specifies a physical keyword,
 	it's being used in an [=inset property=] in that axis.
 	(For example, ''anchor()/left'' can only be used in 'left', 'right',
@@ -1401,6 +1400,8 @@ Name: width, height, min-width, min-height, max-width, max-height, top, left, ri
 New values:	<<anchor-size()>>
 </pre>
 
+<div class=note>These are the [=accepted @position-try properties=] that allow lengths.</div>
+
 <pre class=prod>
 anchor-size() = anchor-size( [ <<anchor-name>> || <<anchor-size>> ]? , <<length-percentage>>? )
 <dfn><<anchor-size>></dfn> = width | height | block | inline | self-block | self-inline
@@ -1452,9 +1453,7 @@ An ''anchor-size()'' function is a
 <dfn lt="valid anchor-size function|invalid anchor-size function">valid anchor-size function</dfn>
 only if all the following conditions are true:
 
-* It's being used in a [=sizing property=], an [=inset property=], or a [=margin property=]
-	on an [=absolutely positioned box=].
-	<span class=note>(These are the [=accepted @position-try properties=] that allow lengths.)</span>
+* It's being used on an [=absolutely positioned box=].
 * There is a [=target anchor element=]
 	for the box it's used on,
 	and the <<anchor-name>> value specified in the function.


### PR DESCRIPTION
This PR updates the *Validity* sections for [`anchor()`](https://drafts.csswg.org/css-anchor-position-1/#anchor-valid) and [`anchor-size()`](https://drafts.csswg.org/css-anchor-position-1/#anchor-size-valid), which could [confusingly](https://github.com/w3c/csswg-drafts/issues/11232#issuecomment-2720184752) be interpreted as making these functions invalid *at computed value time* when used in properties other than those for which they are explicitly defined as valid.

These functions are defined as `New values` of these properties. It would not make sense to accept them in all properties (like CSS-wide keywords, arbitrary or whole value substitutions) just to make them invalid at computed value time rather than at parse time.