### PR TITLE
[css-view-transitions-1] Flush the callback queue before performing other view-transition operations

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1235,6 +1235,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 		To <dfn>perform pending transition operations</dfn> given a {{Document}} |document|, perform the following steps:
 
+		1. [=Flush the update callback queue=].
+
+			Note: this ensures that any changes to the DOM scheduled by other skipped transitions are done before the old state for this transition is captured.
+
 		1. If |document|'s [=document/active view transition=] is not null, then:
 
 			1. If |document|'s [=document/active view transition=]'s [=ViewTransition/phase=] is "`pending-capture`",
@@ -1255,10 +1259,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		then captures the new state of the document.
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
-
-		1. [=Flush the update callback queue=].
-
-			Note: this ensures that any changes to the DOM scheduled by other skipped transitions are done before the old state for this transition is captured.
 
 		1. [=Capture the old state=] for |transition|.
 


### PR DESCRIPTION
This ensures that a DOM update callback that skips the active transition would take effect.

Closes #11943

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
