### PR TITLE
[css-images] Allow specifying any angle as a bare zero in gradients

### DIFF
--- a/css-images-3/Overview.bs
+++ b/css-images-3/Overview.bs
@@ -334,7 +334,7 @@ Linear Gradients: the ''linear-gradient()'' notation {#linear-gradients}
 	<pre class=prod>
 		<<linear-gradient()>> = linear-gradient( [ <<linear-gradient-syntax>> ] )
 
-		<dfn>&lt;linear-gradient-syntax></dfn> = [ <<angle>> | to <<side-or-corner>> ]? , <<color-stop-list>>
+		<dfn>&lt;linear-gradient-syntax></dfn> = [ <<angle>> | <<zero>> | to <<side-or-corner>> ]? , <<color-stop-list>>
 
 		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]
 	</pre>

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1271,7 +1271,7 @@ Linear Gradients: the ''linear-gradient()'' notation {#linear-gradients}
 
 	<pre class=prod>
 		<dfn>&lt;linear-gradient-syntax></dfn> =
-			[ [ <<angle>> | to <<side-or-corner>> ] || <<color-interpolation-method>> ]? ,
+			[ [ <<angle>> | <<zero>> | to <<side-or-corner>> ] || <<color-interpolation-method>> ]? ,
 			<<color-stop-list>>
 		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]
 	</pre>
@@ -1560,14 +1560,14 @@ Conic Gradients: the ''conic-gradient()'' notation</h3>
 	<pre class='prod'>
 		<dfn>conic-gradient()</dfn> = conic-gradient( [ <<conic-gradient-syntax>> ] )
 		<dfn>&lt;conic-gradient-syntax></dfn> =
-			[ [ [ from <<angle>> ]? [ at <<position>> ]? ] || <<color-interpolation-method>> ]? ,
+			[ [ [ from [ <<angle>> | <<zero>> ] ]? [ at <<position>> ]? ] || <<color-interpolation-method>> ]? ,
 			<<angular-color-stop-list>>
 	</pre>
 
 	The arguments are defined as follows:
 
 	<dl dfn-type=value dfn-for="conic-gradient(), repeating-conic-gradient()">
-		<dt><dfn><<angle>></dfn>
+		<dt><dfn><<angle>> | <<zero>></dfn>
 		<dd>
 			The entire gradient is rotated by this angle.
 			If omitted, defaults to ''0deg''.

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1843,8 +1843,8 @@ Color Stop Lists</h4>
 		<dfn>&lt;angular-color-stop-list></dfn> =
 			<<angular-color-stop>> , [ <<angular-color-hint>>? , <<angular-color-stop>> ]#?
 		<dfn>&lt;angular-color-stop></dfn> = <<color>> <<color-stop-angle>>?
-		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>>
-		<dfn>&lt;color-stop-angle></dfn> = <<angle-percentage>>{1,2}
+		<dfn>&lt;angular-color-hint></dfn> = <<angle-percentage>> | <<zero>>
+		<dfn>&lt;color-stop-angle></dfn> = [ <<angle-percentage>> | <<zero>> ]{1,2}
 
 		<dfn>&lt;color-stop></dfn> = <<color-stop-length>> | <<color-stop-angle>>
 	</pre>


### PR DESCRIPTION
Fixes #8346.

It explicitly allows declaring a conic/linear gradient rotation with `<zero>` in the grammar, which is already defined in prose.

It allows declaring an angular color stop/hint with `<zero>`, which matches the output in Chrome and Firefox but is currently undefined, so this change is substantive.

As noted in the issue, I believe that this change allows these lines to be removed from CSS V&U [3](https://github.com/w3c/csswg-drafts/blob/2e37f85c673df18fb79998c96124aab9d87e321f/css-values-3/Overview.bs#L1590-L1593) and [4](https://github.com/w3c/csswg-drafts/blob/2e37f85c673df18fb79998c96124aab9d87e321f/css-values-4/Overview.bs#L2635-L2638), because all uses `<angle>` with a bare `0` would now be explicitly allowed in the grammar:

  > Note: For legacy reasons,
  > some uses of `<<angle>>` allow a bare ''0'' to mean ''0deg''.
  > This is not true in general, however,
  > and will not occur in future uses of the `<<angle>>` type.