### PR TITLE
[css-forms-1] Include textarea in list of elements.

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -80,7 +80,7 @@ Markup Shorthands: css yes, markdown yes
   To apply the [=basic appearance=] on individual controls, the following code is used:
 
   <pre class="lang-css">
-    input, meter, progress, button, select {
+    input, textarea, meter, progress, button, select {
       appearance: base;
     }
   </pre>
@@ -105,7 +105,7 @@ Markup Shorthands: css yes, markdown yes
       color: rgb(131, 17, 0);
     }
 
-    input, meter, progress, button, select {
+    input, textarea, meter, progress, button, select {
       appearance: base;
     }
     </pre>
@@ -122,7 +122,7 @@ Markup Shorthands: css yes, markdown yes
       color: rgb(0, 249, 0);
     }
 
-    input, meter, progress, button, select {
+    input, textarea, meter, progress, button, select {
       appearance: base;
     }
     </pre>


### PR DESCRIPTION
This fixes three cases where `<textarea>` was omitted from the list of elements that `appearance: base` can be applied to.

I think `textarea` should be included in this list, unless I'm missing something.