### PR TITLE
[css-view-transitions-1] Minor edits

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -1291,14 +1291,15 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 			Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
-		1. Set [=document/rendering suppression for view transitions=] to false.
+		1. Set |transition|'s [=relevant global object's=] [=associated document=]'s [=document/rendering suppression for view transitions=] to false.
 
 		1. If |transition|'s [=ViewTransition/initial snapshot containing block size=] is not equal to the [=snapshot containing block size=],
-			then [=skip the view transition=] for |transition|, and return.
+			then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
 
 		1. [=Capture the new state=] for |transition|.
 
-			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			If failure is returned, then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
 			and return.
 
 		1. [=list/For each=] |capturedElement| of |transition|'s [=ViewTransition/named elements=]' [=map/values=]:
@@ -1895,7 +1896,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 					Note: Other rendering constraints are enforced via |capturedElement|'s [=new element=] being [=captured in a view transition=].
 
-				1. Let |newRect| be [=snapshot containing block=] if |capturedElement| is the [=document element=],
+				1. Let |newRect| be the [=snapshot containing block=] if |capturedElement|'s [=new element=] is the [=document element=],
 					otherwise, |capturedElement|'s [=border box=].
 
 				1. Set |width| to the current width of |newRect|.


### PR DESCRIPTION
- Specify which documents is used for rendering supression
- Specify reason for skipping transition when capture fails
- Specify the correct document element in new capture

Closes #11721
Closes #11723
Closes #11725

