### PR TITLE
[css-view-transitions-2] Fix Typo in `view-transition-name: auto` example

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -785,9 +785,9 @@ Ordinarily, each of these items would have to receive a unique 'view-transition-
 
 ```css
 li:nth-child(1) { view-transition-name: item1; }
-li:nth-child(2) { view-transition-name: item1; }
-li:nth-child(3) { view-transition-name: item1; }
-li:nth-child(4) { view-transition-name: item1; }
+li:nth-child(2) { view-transition-name: item2; }
+li:nth-child(3) { view-transition-name: item3; }
+li:nth-child(4) { view-transition-name: item4; }
 ...
 ```
 


### PR DESCRIPTION
These names were intended to be unique.
