### PR TITLE
[css-forms-1] Add !important to select buttons inertness

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -810,7 +810,7 @@ select > button:first-child {
   display: contents;
 
   /* Prevents button activation behavior so select can handle events */
-  interactivity: inert;
+  interactivity: inert !important;
 }
 select option {
   /* These min-size rules ensure accessibility by following WCAG rules:


### PR DESCRIPTION
This matches recent change to HTML spec PR for select stylesheet. It's undesirable for authors to override the inertness of this button.