### PR TITLE
[css-color-hdr] Prevent color() links from pointing to CSS Color 5

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -924,7 +924,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 	Specifying Predefined and Custom Color Spaces: the ''color()'' Function
 </h2>
 
-	The ''color()'' function allows a color to be specified
+	The <dfn>color()<dfn> function allows a color to be specified
 	in a particular, given [=color space=]
 	(rather than the implicit sRGB color space that most of the other color functions operate in).
 


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/11713#issuecomment-2752661935. 

 > The extended `<color-function>` production links back to CSS Color 5, which means the extended `<colorspace-params>` becomes invisible.

[`<color-function>`](https://drafts.csswg.org/css-color-hdr-1/#typedef-color-function) actually links to CSS Color HDR. I assume that this comment was about the `color()` production, and the goal is to prevent readers from being directed to CSS Color 5 by clicking on `color()`, and missing that [`<colorspace-params>`](https://drafts.csswg.org/css-color-hdr-1/#typedef-colorspace-params)  is also extended.