### PR TITLE
[css-color-hdr] Remove duplicate productions

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -928,8 +928,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 	in a particular, given [=color space=]
 	(rather than the implicit sRGB color space that most of the other color functions operate in).
 
-	In this specification, 
-	the <<colorspace-params>> taken by the ''color()'' function is extended
+	This specification extends the ''color()'' function
 	to allow <a href="#predefined-HDR">predefined color spaces for HDR</a>,
 	in addition to the predefined SDR spaces from [[css-color-4#predefined]]
 	and the relative color syntax from [[css-color-5#relative-colors]].
@@ -937,7 +936,6 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 	Its syntax is now as follows:
 
 	<pre class='prod'>
-		<dfn>&lt;colorspace-params></dfn> = [<<custom-params>> | <<predefined-rgb-params>> | <<xyz-params>>]
 		<dfn>&lt;predefined-rgb></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020 | 
 			rec2100-pq | rec2100-hlg | rec2100-linear
 	</pre>


### PR DESCRIPTION
CSS Color HDR redefines [`<colorspace-params>`](https://drafts.csswg.org/css-color-hdr-1/#typedef-colorspace-params) with the same value definition than in CSS Color 5.

This PR removes it from CSS Color HDR, because duplicate productions are problematic for the tools processing the data extracted from the specs.