### PR TITLE
Editorial: fixed naming mistake - changed start time to current time

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2429,7 +2429,7 @@ which can be one of the following:
   <dt><dfn>idle</dfn>
   <dd>
     The [=animation effect=] associated |animation| remains in
-    its [=animation effect/before phase=] and stays at zero [=animation/start time=].
+    its [=animation effect/before phase=] and stays at zero [=animation/current time=].
 
   <dt><dfn>primary</dfn>
   <dd>


### PR DESCRIPTION
When state of AnimationTrigger is `idle` it should stay at zero `animation/current time` and not `start time`.

/cc @DavMila 