### PR TITLE
[css-values-4] Use "include" when fetching cross-origin CSS resources

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1169,7 +1169,7 @@ URL Processing Model</h4>
 			whose [=request/destination=] is |destination|,
 			[=request/mode=] is |corsMode|,
 			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
-			[=request/credentials mode=] is "same-origin",
+			[=request/credentials mode=] is "include",
 			[=request/use-url-credentials flag=] is set,
 			[=request/client=] is |environmentSettings|,
 			and whose [=request/referrer=] is |environmentSettings|'s [=API base URL=].

--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1169,23 +1169,25 @@ URL Processing Model</h4>
 			whose [=request/destination=] is |destination|,
 			[=request/mode=] is |corsMode|,
 			[=request/origin=] is |environmentSettings|'s [=environment settings object/origin=],
-			[=request/credentials mode=] is "include",
+			[=request/credentials mode=] is "same-origin",
 			[=request/use-url-credentials flag=] is set,
 			[=request/client=] is |environmentSettings|,
 			and whose [=request/referrer=] is |environmentSettings|'s [=API base URL=].
 
-		5. Apply any <dfn export>URL request modifier steps</dfn> that apply to this request.
+		5. If |corsMode| is "no-cors", set |req|'s [=request/credentials mode=] to "include".
+
+		6. Apply any <dfn export>URL request modifier steps</dfn> that apply to this request.
 
 			Note: This specification does not define any URL request modification steps,
 			but other specs may do so.
 
-		6. If |req|'s [=request/mode=] is "cors",
+		7. If |req|'s [=request/mode=] is "cors",
 			set |req|'s [=request/referrer=] to |sheet|'s <a spec=cssom>location</a>. [[CSSOM]]
 
-		7. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
+		8. If |sheet|'s <a spec=cssom>origin-clean flag</a> is set,
 			set |req|'s [=request/initiator type=] to "css". [[CSSOM]]
 
-		8. [=/Fetch=] |req|,
+		9. [=/Fetch=] |req|,
 			with [=fetch/processresponseconsumebody=] set to |processResponse|.
 	</div>
 

--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -464,10 +464,12 @@ Request URL Modifiers</h4>
 		<dd>
 			The [=URL request modifier steps=] for this modifier given [=/request=] |req| are:
 
-			1. Set [=/request=]'s [=request/mode=] to "cors".
+			1. Set |req|'s [=request/mode=] to "cors".
 
 			2. If the given value is ''use-credentials'',
-				set [=/request=]'s [=request/credentials mode=] to "include".
+				set |req|'s [=request/credentials mode=] to "include".
+
+			3. Otherwise, set |req|'s [=request/credentials mode=] to "same-origin".
 
 		<dt><dfn><<integrity-modifier>></dfn> = <dfn function lt="integrity()">integrity</dfn>(<<string>>)
 		<dd>


### PR DESCRIPTION
This matches existing implementation, and was a bug in the existing spec.

Closes #12073

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
