### PR TITLE
[css-viewport-1] Make sure to always return one segment

### DIFF
--- a/css-viewport-1/Overview.bs
+++ b/css-viewport-1/Overview.bs
@@ -572,13 +572,13 @@ interface Viewport {
 The {{segments}} property is an array of {{DOMRect}} that represent the dimensions of each existing viewport segment.
 Each {{DOMRect}} contains the geometry of the segment (x, y, width, height) in CSS ''<length>/px''.
 
-Additonal details about the definition of a viewport segment can be found here: [[css-env-1#viewport-segments]].
+Additional details about the definition of a viewport segment can be found here: [[css-env-1#viewport-segments]].
 
 The {{segments}} attribute getter steps are:
 1. If the {{Viewport}}'s associated {{Document}} is not <a>fully active</a>, return null.
 2. Let |topLevelTraversable| be |document|'s [=relevant global object=]'s [=/navigable=]'s [=browsing context/top-level traversable=].
 3. If |topLevelTraversable|.[=[[DisplayFeaturesOverride]]=] is non-null, return {{Viewport}}'s [[css-env-1#viewport-segments|segments]] array calculated from |topLevelTraversable|.[=[[DisplayFeaturesOverride]]=].
-4. Returns null if there is only a single viewport segment and abort these steps.
+4. If there is only a single viewport segment (typically the size of the {{Viewport}}) return an array with that single segment.
 5. Otherwise, return the {{Viewport}}'s [[css-env-1#viewport-segments|segments]] array calculated from the hardware features.
 
 <div class=non-normative>


### PR DESCRIPTION
When the device is not folded (flat) or it's a regular device always return one segment (typically the size of the viewport). This is to follow developer feedback and consistency with the rest of the platform.

#11957
