### PR TITLE
[css-contain-2] Fix typo in closing tag.

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -707,7 +707,7 @@ Size Containment</h3>
 
 				<wpt>
 				contain-size-064.html
-				<wpt>
+				</wpt>
 		</dl>
 
 		Note: [=Size containment=] does not suppress baseline alignment.


### PR DESCRIPTION
This prevents bikeshed from generating the spec locally.