### PR TITLE
[css-values-5] Don't use flat tree for tree-counting #9562

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2755,7 +2755,7 @@ Tree Counting Functions: the ''sibling-count()'' and ''sibling-index()'' notatio
 	as an <<integer>>,
 	the index of the element
 	on which the notation is used
-	among the children of its parent.
+	among its [=inclusive siblings=].
 	Like '':nth-child()'',
 	''sibling-index()'' is 1-indexed.
 
@@ -2803,9 +2803,8 @@ Tree Counting Functions: the ''sibling-count()'' and ''sibling-index()'' notatio
 
 	</div>
 
-	Note: Like the rest of CSS (other than [=selectors=]),
-	''sibling-count()'' and ''sibling-index()''
-	operate on the [=flat tree=].
+	Note: These functions may, in the future, have variants that support counting
+	[=flat tree=] siblings.
 
 	Note: These functions may, in the future,
 	be extended to accept an ''of <<complex-real-selector-list>>'' argument,


### PR DESCRIPTION
Per resolution[1], tree counting functions should not use the flat tree for indexing. Instead use the term 'inclusive siblings' from the DOM spec, which is the same term that :nth-*() selectors use.

[1] https://github.com/w3c/csswg-drafts/issues/9562#issuecomment-2824834068
