### PR TITLE
Fix bikeshed errors in color adjust spec

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -29,11 +29,11 @@ spec:fill-stroke-3; type:property;
 	text:fill
 	text:stroke
 spec:css-gaps-1; type:property; text:column-rule-color
-spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
+spec: html;
 	text:body; type:element
 	text:meta; type:element
-	text:navigable; type:dfn; for:Window; url:nav-history-apis.html#window-navigable
-	text:top-level traversable; type:dfn; for:/; url:document-sequences.html#top-level-traversable
+	text:navigable; type:dfn; for:Window;
+	text:top-level traversable; type:dfn; for:/;
 </pre>
 
 <pre class=anchors>
@@ -615,13 +615,13 @@ Forced Color Palettes {#forced}
 				<tr>
 					<td>''Mark''</td>
 					<td>
-						N/A - this <<system-color>> keyword should not be adjusted.
+						N/A - this [=system color=] keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
 					<td>''MarkText''</td>
 					<td>
-						N/A - this <<system-color>> keyword should not be adjusted.
+						N/A - this [=system color=] keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
@@ -761,13 +761,13 @@ Forced Color Palettes {#forced}
 				<tr>
 					<td>''Mark''</td>
 					<td>
-						N/A - this <<system-color>> keyword should not be adjusted.
+						N/A - this [=system color=] keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
 					<td>''MarkText''</td>
 					<td>
-						N/A - this <<system-color>> keyword should not be adjusted.
+						N/A - this [=system color=] keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
@@ -834,19 +834,19 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		<li>'stop-color'
 	</ul>
 
-	if its [=computed value=] is a color other than a <<system-color>>,
-	its [=used value=] is instead forced to a <<system-color>> as follows:
+	if its [=computed value=] is a color other than a [=system color=],
+	its [=used value=] is instead forced to a [=system color=] as follows:
 
 	* For 'background-color' in particular,
 		it is forced to
-		the color opposite the 'color' property’s <<system-color>> value
+		the color opposite the 'color' property’s [=system color=] value
 		in the [=system color pairings=],
 		using ''CanvasText'' as the opposite of ''Canvas''.
 		However, its alpha channel is taken from
 		the original 'background-color' value
 		so that transparent backgrounds remain transparent.
 	* In all other cases, the UA determines
-		the appropriate forced <<system-color>>--
+		the appropriate forced [=system color=]--
 		which should match the color that would result
 		from an empty [=author style sheet=]
 		whenever all of the element’s affected properties
@@ -887,7 +887,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	<div class="example">
 		Authors may still use features such as ''color-mix()'' in [=forced colors mode=].
 		In such cases, the [=computed value=] will behave as it would normally,
-		but the [=used value=] will be overridden with an appropriate <<system-color>>.
+		but the [=used value=] will be overridden with an appropriate [=system color=].
 
 		<pre highlight=css>
 		.example {
@@ -895,7 +895,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		}
 		</pre>
 
-		The [=computed value=] for 'color' will be a 50-50 blend of the ''CanvasText'' and ''Canvas'' <<system-color>>s.
+		The [=computed value=] for 'color' will be a 50-50 blend of the ''CanvasText'' and ''Canvas'' [=system colors=].
 		That value will inherit to descendants and be observable via APIs such as {{Element/computedStyleMap()}}.
 
 		The [=used value=] for 'color' will be a system color chosen by the UA, for example ''CanvasText''.

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -31,9 +31,9 @@ spec:fill-stroke-3; type:property;
 spec:css-gaps-1; type:property; text:column-rule-color
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
 	text:body; type:element
-	text: meta; type: element
-	text: navigable; type: dfn; for:Window; url: nav-history-apis.html#window-navigable
-	text: top-level traversable; type: dfn; for:/; url: document-sequences.html#top-level-traversable
+	text:meta; type:element
+	text:navigable; type:dfn; for:Window; url:nav-history-apis.html#window-navigable
+	text:top-level traversable; type:dfn; for:/; url:document-sequences.html#top-level-traversable
 </pre>
 
 <pre class=anchors>

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -20,13 +20,20 @@ WPT Display: open
 </pre>
 <pre class='link-defaults'>
 spec:css2; type:dfn; text:canvas
+spec:css-backgrounds-3; type:property;
+	text:border-color
+	text:box-shadow
 spec:css-color-4; type:property; text:color
+spec:css-color-5; type:function; text:color()
 spec:fill-stroke-3; type:property;
 	text:fill
 	text:stroke
-spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/; type: dfn;
-	text: navigable; for:Window; url: nav-history-apis.html#window-navigable
-	text: top-level traversable; for:/; url: document-sequences.html#top-level-traversable
+spec:css-gaps-1; type:property; text:column-rule-color
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
+	text:body; type:element
+	text: meta; type: element
+	text: navigable; type: dfn; for:Window; url: nav-history-apis.html#window-navigable
+	text: top-level traversable; type: dfn; for:/; url: document-sequences.html#top-level-traversable
 </pre>
 
 <pre class=anchors>
@@ -57,7 +64,9 @@ Introduction {#intro}
 		to automatically adjust colors to the user's assumed performance preferences,
 		such as suppressing background colors when printing to save ink.
 
-	Together with the 'prefers-color-scheme', 'prefers-contrast', and 'forced-colors' [=media queries=] [[!MEDIAQUERIES-5]],
+	Together with the <a descriptor for=@media>prefers-color-scheme</a>,
+	<a descriptor for=@media>prefers-contrast</a>, and
+	<a descriptor for=@media>forced-colors</a> [=media queries=] [[!MEDIAQUERIES-5]],
 	this module allows color scheme negotiation
 	between the author and the user.
 
@@ -171,7 +180,7 @@ Opting Into a Preferred Color Scheme: the 'color-scheme' property {#color-scheme
 		rendering/dark-color-scheme/color-scheme-visited-link-initial.html
 	</wpt>
 
-	While the 'prefers-color-scheme' media feature
+	While the <a descriptor for=@media>prefers-color-scheme</a> media feature
 	allows an author to adapt the page’s colors to the user’s preferred color scheme,
 	many parts of the page are not under the author's control
 	(such as form controls, scrollbars, etc).
@@ -244,7 +253,7 @@ Opting Into a Preferred Color Scheme: the 'color-scheme' property {#color-scheme
 		To <dfn noexport>determine the used color scheme</dfn> of an element:
 
 		1. If the user's [=preferred color scheme=],
-			as indicated by the 'prefers-color-scheme' media feature,
+			as indicated by the <a descriptor for=@media>prefers-color-scheme</a> media feature,
 			is present among the listed [=color schemes=],
 			and is supported by the user agent,
 			that's the element's [=used color scheme=].
@@ -275,7 +284,7 @@ Opting Into a Preferred Color Scheme: the 'color-scheme' property {#color-scheme
 
 	<div class=example>
 		A page that responds to user preferences for light or dark display
-		by using the 'prefers-color-scheme' media feature
+		by using the <a descriptor for=@media>prefers-color-scheme</a> media feature
 		to alter the colors it uses
 		can easily opt the browser-controlled UI
 		(scrollbars, inputs, etc)
@@ -420,7 +429,7 @@ to conform to either a [=dark=] or [=light=] color scheme.
 	and have indicated so using the 'color-scheme' property
 	or <{meta/name/color-scheme}> <{meta}> name,
 	this has no effect other than reporting a ''@media/prefers-color-scheme/dark'' value
-	for the 'prefers-color-scheme' [=media query=]
+	for the <a descriptor for=@media>prefers-color-scheme</a> [=media query=]
 	and selecting a [=dark=] [=used color scheme=].
 
 	But for pages that do not explicitly support a [=dark=] color scheme,
@@ -606,13 +615,13 @@ Forced Color Palettes {#forced}
 				<tr>
 					<td>''Mark''</td>
 					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
+						N/A - this <<system-color>> keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
 					<td>''MarkText''</td>
 					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
+						N/A - this <<system-color>> keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
@@ -752,13 +761,13 @@ Forced Color Palettes {#forced}
 				<tr>
 					<td>''Mark''</td>
 					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
+						N/A - this <<system-color>> keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
 					<td>''MarkText''</td>
 					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
+						N/A - this <<system-color>> keyword should not be adjusted.
 					</td>
 				</tr>
 				<tr>
@@ -788,7 +797,7 @@ Forced Color Palettes {#forced}
 <!--THOUGHTS
 	This advice (below) maybe makes sense for (prefers-contrast),
 	but is it really applicable to forced-colors as well?
-	If so, should forced-colors be instead a 'forced' value on 'prefers-contrast',
+	If so, should forced-colors be instead a 'forced' value on <a descriptor for=@media>prefers-contrast</a>,
 	so that a (prefers-contrast) query will catch all of these cases at once?
 
 	Authors are encouraged to simplify the contrast in their pages
@@ -825,19 +834,19 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		<li>'stop-color'
 	</ul>
 
-	if its [=computed value=] is a color other than a [=system color=],
-	its [=used value=] is instead forced to a [=system color=] as follows:
+	if its [=computed value=] is a color other than a <<system-color>>,
+	its [=used value=] is instead forced to a <<system-color>> as follows:
 
 	* For 'background-color' in particular,
 		it is forced to
-		the color opposite the 'color' property’s [=system color=] value
+		the color opposite the 'color' property’s <<system-color>> value
 		in the [=system color pairings=],
 		using ''CanvasText'' as the opposite of ''Canvas''.
 		However, its alpha channel is taken from
 		the original 'background-color' value
 		so that transparent backgrounds remain transparent.
 	* In all other cases, the UA determines
-		the appropriate forced [=system color=]--
+		the appropriate forced <<system-color>>--
 		which should match the color that would result
 		from an empty [=author style sheet=]
 		whenever all of the element’s affected properties
@@ -878,7 +887,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	<div class="example">
 		Authors may still use features such as ''color-mix()'' in [=forced colors mode=].
 		In such cases, the [=computed value=] will behave as it would normally,
-		but the [=used value=] will be overridden with an appropriate [=system color=].
+		but the [=used value=] will be overridden with an appropriate <<system-color>>.
 
 		<pre highlight=css>
 		.example {
@@ -886,7 +895,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		}
 		</pre>
 
-		The [=computed value=] for 'color' will be a 50-50 blend of the ''CanvasText'' and ''Canvas'' [=system colors=].
+		The [=computed value=] for 'color' will be a 50-50 blend of the ''CanvasText'' and ''Canvas'' <<system-color>>s.
 		That value will inherit to descendants and be observable via APIs such as {{Element/computedStyleMap()}}.
 
 		The [=used value=] for 'color' will be a system color chosen by the UA, for example ''CanvasText''.


### PR DESCRIPTION
[css-color-adjust-1] This change fixes some auto-links that weren't working and adds exact locations for some links that were ambiguous. This cleans up all current bikeshed warnings for the color adjust spec, except for complaints about the "system color" definition not existing as an exportable definition, as this will require a change to the color spec.