### PR TITLE
Update to color properties in Forced Colors Mode

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -803,7 +803,8 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 
 	When <a>forced colors mode</a> is active
 	and 'forced-color-adjust' is ''forced-color-adjust/auto'' (see below) on an element,
-	colors on the element are force-adjusted to the user’s preferred color palette.
+	the <<color>> components of all properties on the element
+	are force-adjusted to the user’s preferred color palette.
 
 	<div class="note">
 		Specifically, <a>forced colors mode</a> applies to the following color properties,
@@ -812,6 +813,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		but it may not be an exhaustive list as more properties get added over time:
 
 		<ul>
+			<li>'accent-color'
 			<li>'background-color'
 			<li>'border-color'
 			<li>'caret-color'
@@ -830,7 +832,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 		</ul>
 	</div>
 
-	For each relevant color property,
+	For each <<color>> component of a property,
 	if its [=computed value=] is a color other than a [=system color=],
 	its [=used value=] is instead forced to a [=system color=] as follows:
 

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -877,8 +877,8 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	* 'background-image' computes to ''background-image/none''
 		unless the original value contains a ''url()'' function
 	* 'color-scheme' computes to ''light dark''
-	* 'scrollbar-color' computed to ''scrollbar-color/auto''
-	* 'accent-color' computed to ''accent-color/auto''
+	* 'scrollbar-color' computes to ''scrollbar-color/auto''
+	* 'accent-color' computes to ''accent-color/auto''
 
 	UAs may further tweak these <a>forced colors mode</a> heuristics
 	to provide better user experience.

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -805,26 +805,32 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	and 'forced-color-adjust' is ''forced-color-adjust/auto'' (see below) on an element,
 	colors on the element are force-adjusted to the user’s preferred color palette.
 
-	Specifically, for each of the following properties:
+	<div class="note">
+		Specifically, <a>forced colors mode</a> applies to the following color properties,
+		along with their shorthands.
+		This is the list of color properties existing at the time of writing,
+		but it may not be an exhaustive list as more properties get added over time:
 
-	<ul>
-		<li>'color'
-		<li>'fill'
-		<li>'stroke'
-		<li>'text-decoration-color'
-		<li>'text-emphasis-color'
-		<li>'border-color'
-		<li>'outline-color'
-		<li>'column-rule-color'
-		<li>'scrollbar-color'
-		<li>'-webkit-tap-highlight-color'
-		<li>'background-color'
-		<li>'caret-color'
-		<li>'flood-color'
-		<li>'lighting-color'
-		<li>'stop-color'
-	</ul>
+		<ul>
+			<li>'background-color'
+			<li>'border-color'
+			<li>'caret-color'
+			<li>'color'
+			<li>'flood-color'
+			<li>'fill'
+			<li>'lighting-color'
+			<li>'outline-color'
+			<li>'rule-color'
+			<li>'scrollbar-color'
+			<li>'stop-color'
+			<li>'stroke'
+			<li>'text-decoration-color'
+			<li>'text-emphasis-color'
+			<li>'-webkit-tap-highlight-color'
+		</ul>
+	</div>
 
+	For each relevant color property,
 	if its [=computed value=] is a color other than a [=system color=],
 	its [=used value=] is instead forced to a [=system color=] as follows:
 


### PR DESCRIPTION
[css-color-adjust-1] This change makes the updates per resolutions taken in https://github.com/w3c/csswg-drafts/issues/11857.

More specifically, it moves the color properties that forced colors applies to within a note, mentions that this is the list at the time of writing and may not be exhaustive as other color properties are added over time, and notes that forced colors mode applies to any shorthand properties, as well.

It updates normative text referencing color properties to note that forced colors applies to the `<color>` components of all properties.

This change also updates `column-rule-color` to `rule-color` to ensure that full support exits for the new color properties added in the Gaps specification.

It adds `accent-color` to the list of color properties (it is mentioned lower down in the algorithm (along with `scrollbar-color`) but it wasn't mentioned in the color properties list).

I also updated some minor inconsistencies in using "computed" vs "computes" within the forced color mode rules.

Lastly, I updated the order of the color properties to be in alphabetical order.

The updates can be found hosted at https://alisonmaher.github.io/alisonmaher/css-color-adjust-1/Overview.html#forced-colors-properties.
