### PR TITLE
[css-mixins-1] Fix minor bikeshed errors

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -427,8 +427,8 @@ is the real element at the root of the [=calling context=] stack.
 			the |dashed function|'s name as a [=tree-scoped reference=].
 			If no such name exists, return the [=guaranteed-invalid value=].
 		2. For each |arg| in |arguments|, 
-		[=substitute arbitrary subsitution functions=] in |arg|,
-		and replace |arg| with the result.
+			[=substitute arbitrary substitution functions=] in |arg|,
+			and replace |arg| with the result.
 
 			Note: This may leave some (or all) arguments as the [=guaranteed-invalid value=],
 				triggering [=default values=] (if any).


### PR DESCRIPTION
 - Two lines were not indented enough.
 - "substitute arbitrary subsitution functions" was missing an "s".
