### PR TITLE
[css-color-adjust-1] Emojis in forced colors mode

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -888,6 +888,8 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	* 'color-scheme' computes to ''light dark''
 	* 'scrollbar-color' computes to ''scrollbar-color/auto''
 	* 'accent-color' computes to ''accent-color/auto''
+	* If 'font-variant-emoji' computes to ''font-variant-emoji/normal'' or ''font-variant-emoji/unicode'',
+		UAs should force any emoji on the page to its monochrome variant, if available.
 
 	UAs may further tweak these <a>forced colors mode</a> heuristics
 	to provide better user experience.


### PR DESCRIPTION
This change adds text to the Color Adjust spec per resolution in https://github.com/w3c/csswg-drafts/issues/8064. This change notes that UAs should force emojis to their monochrome variant depending on the value of `font-variant-emoji` and if a monochrome variant exists.

Updated spec text can be found hosted at https://alisonmaher.github.io/alisonmaher/css-color-adjust-1/Overview.html#forced-colors-properties
