### PR TITLE
[css-borders-4] Define border/shadow rendering for `corner-shape`

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -375,6 +375,9 @@ To compute the <dfn>adjusted untrimmed inner top-left corner starting point</dfn
 	1. Let |w| be the [=used value=] of the element's 'border-left-width'.
 	1. If |s| is equal or greater than 1, return <code>|w|, 0</code>.
 	1. If |s| is equal or less than -1, return <code>0, -|w|</code>.
+
+		Note: Because of the above clamping, when the shape is more convex than a ''corner-shape/round'' or more concave than a ''corner-shape-scoop'',
+		the inner curve cannot would appear to have a "belly" towards the middle, as it cannot remain constant while maintaining the same curvature.
 	1. Let |k| be <code>0.5<sup>|s|</sup></code>.
 	1. Let |normalizedHalfCorner| be <code>0.5<sup>|k|</sup></code>.
 	1. Let |offset| be <code>2 - &radic;2</code>.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -428,7 +428,7 @@ To compute the <dfn>corner path</dfn> given a rectangle |cornerRect|, a rectangl
 		1. Swap between |startThickness| and |endThickness|.
 		1. Set |orientation| to (|orientation| + 2) % 4.
 	1. Let |cornerPath| be a path that begins at <code>(0, 1)</code>.
-	1. Switch on|curvature|:
+	1. Switch on |curvature|:
 		<dl class=switch>
 			: 0
 			:: Extend |cornerPath| by adding a straight line to <code>(1, 0)</code>.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -361,7 +361,74 @@ as well as account for sharp edges and overlaps.
 Issue: 'border-radius' already handles *adjacent* corners overlapping by shrinking the radiuses proportionally.
 A negative ''superellipse()'' parameter allows for *opposite* corners to sometimes overlap, and needs additional restrictions defined.
 
-Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: check if we need additional rendering restrictions.
+<h5 id=corner-shape-border-rendering>
+Effect of 'corner-shape' on border rendering</h5>
+
+When rendering a [=border=] for a box that has a 'border-radius' and a 'corner-shape'
+the inner border follows the curve of the outer shape, with a nearly consistent distance from the outer path throughout,
+or a linearly increasing distance if the 'border-width' at the different edges is different.
+
+<div algorithm="adjust-border-inner-path-for-corner-shape">
+To compute the <dfn>adjusted untrimmed inner top-left corner starting point</dfn>:
+
+	1. Let |s| be the [=superellipse parameter=] of the element's 'corner-top-left-shape'.
+	1. Let |w| be the [=used value=] of the element's 'border-left-width'.
+	1. If |s| is equal or greater than 1, return <code>|w|, 0</code>.
+	1. If |s| is equal or less than -1, return <code>0, -|w|</code>.
+	1. Let |k| be <code>0.5<sup>|s|</sup></code>.
+	1. Let |normalizedHalfCorner| be <code>0.5<sup>|k|</sup></code>.
+	1. Let |offset| be <code>2 - &radic;2</code>.
+	1. Let |adjustedX| be <code>max(0, 2 * |normalizedHalfCorner| - |offset|)</code>.
+	1. Let |adjustedY| be <code>max(0, 2 * (1 - |normalizedHalfCorner|) - |offset|)</code>.
+	1. Return <code>|adjustedX|, |adjustedY|</code>.
+</div>
+
+<div algorithm="corner-shape-path">
+To compute the inner path of a corner:
+
+	1. Let |adjustedX|, |adjustedY| be the result of the [=adjusted untrimmed inner top-left corner starting point=] steps,
+		modified to consider the corresponding 'border-width' and 'corner-shape' values at the start and end of a path`.
+	1. Create a path based on the [=canonical superellipse formula=], with the outer corner as the center, starting from |adjustedX| and ending at |adjustedY|.
+		User agents MAY create an approximation of this path rather than try to follow the formula precisely, for performance reasons.
+	1. Trim the resulting path so that it starts at a point that has a 'border-width' distance from the outer.
+</div>
+
+<div class=note>
+The superellipse quadrant is scaled so that:
+	* Its center stays at the outer corner.
+	* Its start and end point are perpendicular to the outer starting point.
+	* Its distance from the outer curve is the corresponding 'border-width'.
+
+This is illustrated in the following chart:
+<figure>
+	<img src="images/corner-shape-border.svg"
+		width="840" height="840"
+		style="background: white; padding: 8px;"
+		title="Border rendering with corner-shape"
+		alt="Border rendering with corner-shape">
+	<figcaption>Illustration of border path computation based on 'corner-shape'.
+	</figcaption>
+</figure>
+
+</div>
+
+<h5 id=corner-shape-border-rendering>
+Effect of 'corner-shape' on 'box-shadow' rendering</h5>
+
+When rendering the 'box-shadow' of an element that has a 'corner-shape', the 'border-radius' of the rendered shadow is adjusted to account for the spread.
+The resulting shape looks like a scaled version of the original shape, as if the shadow is at a distance in the z direction.
+This is accomplished by computing the per-dimension scale given the spread, and applying that scale on each of radii separately.
+
+<div algorithm="corner-shape-box-shadow-adjustment">
+To scale the 'border-radius' value based on the 'box-shadow' |spread|:
+	1. Let |width| be the element's [=border box=]'s width.
+	1. Let |height| be the element's [=border box=]'s height.
+	1. Let |newWidth| be <code>|width| + |spread| * 2</code>.
+	1. Let |newHeight| be <code>|height| + |spread| * 2</code>.
+	1. Let |horizontalScale| be |newWidth|/|width|.
+	1. Let |verticalScale| be |newHeight|/|height|.
+	1. Scale the 'border-radius' values by |horizontalScale|, |verticalScale|.
+</div>
 
 <h4 id=corner-shape-value>
 'corner-shape' values</h4>
@@ -415,10 +482,10 @@ Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: che
 
 		<figure>
 			<img src="images/superellipse-param.svg"
-			     width="320" height="240"
-			     style="background: white; padding: 8px;"
-			     title="rendering of different superellipse parameter values"
-			     alt="Rendering of different superellipse parameter values.">
+				width="320" height="240"
+				style="background: white; padding: 8px;"
+				title="rendering of different superellipse parameter values"
+				alt="Rendering of different superellipse parameter values.">
 			<figcaption>
 				Rendering examples of different ''superellipse()'' values.
 			</figcaption>

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -20,6 +20,12 @@ Warning: Not Ready
 spec:css-text-4; type:value; text:collapse
 spec:css-shapes-2; type:function; text:path()
 spec:css-shapes-2; type:property; text:shape-inside
+spec:geometry-1; type: dfn; text: width dimension
+spec:geometry-1; type: dfn; text: height dimension
+spec:geometry-1; type: dfn; text: x coordinate; for: rectangle
+spec:geometry-1; type: dfn; text: y coordinate; for: rectangle
+spec:geometry-1; type: dfn; text: rectangle
+spec:dom; type: dfn; text: element;
 </pre>
 
 <link rel="stylesheet" href="style.css" />
@@ -358,79 +364,143 @@ Like 'border-radius', 'corner-shape' clips elements according to the [=overflow=
 Since stroking a superellipse accurately may be computationally intensive, user agents may approximate the path using bezier curves,
 as well as account for sharp edges and overlaps.
 
-Issue: 'border-radius' already handles *adjacent* corners overlapping by shrinking the radiuses proportionally.
-A negative ''superellipse()'' parameter allows for *opposite* corners to sometimes overlap, and needs additional restrictions defined.
-
-<h5 id=corner-shape-border-rendering>
-Effect of 'corner-shape' on border rendering</h5>
-
-When rendering a [=border=] for a box that has a 'border-radius' and a 'corner-shape'
+When rendering a [=border=] for a box that has a 'border-radius' and a 'corner-shape',
 the inner border follows the curve of the outer shape, with a nearly consistent distance from the outer path throughout,
-or a linearly increasing distance if the 'border-width' at the different edges is different.
+or a linearly increasing distance if the 'border-width' of the two edges of the corner is not uniform.
 
-<div algorithm="adjust-border-inner-path-for-corner-shape">
-To compute the <dfn>adjusted untrimmed inner top-left corner starting point</dfn>:
+In contrast, when rendering a 'box shadow' or when extending the [=overflow clip edge=], the resulting path does not trace border contour.
+Instead, it preserves the original shape and scales it in an axis-aligned manner.
 
-	1. Let |s| be the [=superellipse parameter=] of the element's 'corner-top-left-shape'.
-	1. Let |w| be the [=used value=] of the element's 'border-left-width'.
-	1. If |s| is equal or greater than 1, return <code>|w|, 0</code>.
-	1. If |s| is equal or less than -1, return <code>0, -|w|</code>.
-
-		Note: Because of the above clamping, when the shape is more convex than a ''corner-shape/round'' or more concave than a ''corner-shape-scoop'',
-		the inner curve cannot would appear to have a "belly" towards the middle, as it cannot remain constant while maintaining the same curvature.
-	1. Let |k| be <code>0.5<sup>|s|</sup></code>.
-	1. Let |normalizedHalfCorner| be <code>0.5<sup>|k|</sup></code>.
-	1. Let |offset| be <code>2 - &radic;2</code>.
-	1. Let |adjustedX| be <code>max(0, 2 * |normalizedHalfCorner| - |offset|)</code>.
-	1. Let |adjustedY| be <code>max(0, 2 * (1 - |normalizedHalfCorner|) - |offset|)</code>.
-	1. Return <code>|adjustedX|, |adjustedY|</code>.
-</div>
-
-<div algorithm="corner-shape-path">
-To compute the inner path of a corner:
-
-	1. Let |adjustedX|, |adjustedY| be the result of the [=adjusted untrimmed inner top-left corner starting point=] steps,
-		modified to consider the corresponding 'border-width' and 'corner-shape' values at the start and end of a path`.
-	1. Create a path based on the [=canonical superellipse formula=], with the outer corner as the center, starting from |adjustedX| and ending at |adjustedY|.
-		User agents MAY create an approximation of this path rather than try to follow the formula precisely, for performance reasons.
-	1. Trim the resulting path so that it starts at a point that has a 'border-width' distance from the outer.
-</div>
-
-<div class=note>
-The superellipse quadrant is scaled so that:
-	* Its center stays at the outer corner.
-	* Its start and end point are perpendicular to the outer starting point.
-	* Its distance from the outer curve is the corresponding 'border-width'.
-
-This is illustrated in the following chart:
 <figure>
-	<img src="images/corner-shape-border.svg"
-		width="840" height="840"
-		style="background: white; padding: 8px;"
-		title="Border rendering with corner-shape"
-		alt="Border rendering with corner-shape">
-	<figcaption>Illustration of border path computation based on 'corner-shape'.
-	</figcaption>
+	<img src="images/corner-shape-adjusting.svg"
+		style="background: white;"
+		alt="Adjusting corner shapes">
+	<figcaption>Borders are aligned to the curve, shadows and clip are aligned to the axis.</figcaption>
 </figure>
 
-</div>
 
-<h5 id=corner-shape-border-rendering>
-Effect of 'corner-shape' on 'box-shadow' rendering</h5>
+An [=/element=] |element|'s <dfn>outer contour</dfn> is the [=border contour path=] given |element| and |element|'s [=border edge=].
 
-When rendering the 'box-shadow' of an element that has a 'corner-shape', the 'border-radius' of the rendered shadow is adjusted to account for the spread.
-The resulting shape looks like a scaled version of the original shape, as if the shadow is at a distance in the z direction.
-This is accomplished by computing the per-dimension scale given the spread, and applying that scale on each of radii separately.
+An [=/element=] |element|'s <dfn>inner contour</dfn> is the [=border contour path=] given |element| and |element|'s [=padding edge=].
 
-<div algorithm="corner-shape-box-shadow-adjustment">
-To scale the 'border-radius' value based on the 'box-shadow' |spread|:
-	1. Let |width| be the element's [=border box=]'s width.
-	1. Let |height| be the element's [=border box=]'s height.
-	1. Let |newWidth| be <code>|width| + |spread| * 2</code>.
-	1. Let |newHeight| be <code>|height| + |spread| * 2</code>.
-	1. Let |horizontalScale| be |newWidth|/|width|.
-	1. Let |verticalScale| be |newHeight|/|height|.
-	1. Scale the 'border-radius' values by |horizontalScale|, |verticalScale|.
+An [=/element=]'s [=border=] is rendered in the area between its [=outer contour=] and its [=inner contour=].
+
+An [=/element=]'s [=overflow=] area is shaped by its [=inner contour=].
+An [=/element=]'s [=overflow clip edge=] is shaped by the [=border contour path=] given |element|, and |element|'s [=padding edge=], and |element|'s [=used value|used=] 'overflow-clip-margin'.
+
+Each shadow of [=/element=]'s 'box shadow' is shaped by the [=border contour path=] given |element|, and |element|'s [=border edge=], and the shadow's [=used value|used=] 'box-shadow-spread'.
+
+<div algorithm="adjust-border-inner-path-for-corner-shape">
+To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given an an [=edge=] |targetEdge| and an optional number |spread| (default 0):
+	1. Let |outerLeft|, |outerTop|, |outerRight|, |outerBottom| be |element|'s [=unshaped edge|unshaped=] [=border edge=].
+	1. Let |topLeftHorizontalRadius|, |topLeftVericalRadius|, |topRightHorizontalRadius|, |topRightVerticalRadius|, |bottomRightHorizontalRadius|,
+		|bottomRightVerticalRadius|, |bottomLeftHorizontalRadius|, and |bottomLeftVerticalRadius| be |element| [=border edge=]'s radii.
+	1. Let |topLeftShape|, |topRightShape|, |bottomRightShape|, and |bottomLeftShape| be |element|'s [=computed value|computed=] 'corner-*-shape' values.
+	1. Let |targetLeft|, |targetTop|, |targetRight|, |targetBottom| [=unshaped edge|unshaped=] |targetEdge|.
+	1. Let |path| be a new path [[SVG2]].
+	1. Compute a [=corner path=] given
+		the [=rectangle=] <code>(|outerRight| - |topRightHorizontalRadius|, |outerTop|, |topRightHorizontalRadius|, |topRightVerticalRadius|)</code>,
+		0, |targetTop| - |outerTop|, |outerRight| - |targetRight|, and |topRightShape|,
+		and append it to |path|.
+	1. Compute a [=corner path=] given
+		the rectangle <code>(|outerRight| - |bottomRightHorizontalRadius|, |outerBottom| - |bottomRightVerticalRadius|, |bottomRightHorizontalRadius|, |bottomRightVerticalRadius|)</code>, |targetEdge|,
+		1, |outerRight| - |targetRight|, |outerBottom| - |targetBottom|, and |bottomRightShape|,
+		and append it to |path|.
+	1. Compute a [=corner path=] given
+		the rectangle <code>(|outerLeft|, |outerBottom| - |bottomLeftVerticalRadius|, |bottomLeftHorizontalRadius|, |bottomLeftVerticalRadius|)</code>, |targetEdge|,
+		2, |outerBottom| - |targetBottom|, |targetLeft| - |outerLeft|, and |bottomLeftShape|,
+		and append it to |path|.
+	1. Compute a [=corner path=] given
+		the rectangle <code>(|outerLeft|, |outerTop|, |topLeftHorizontalRadius|, |topLeftVericalRadius|)</code>, |targetEdge|,
+		3, |targetLeft| - |outerLeft|, |targetTop| - |outerTop|, and |topLeftShape|,
+		and append it to |path|.
+	1. If |spread| is not 0, then:
+		1. Scale |path| by <code>1 + (|spread| * 2) / (|targetRect|'s [=width dimension|width=]), 1 + (|spread| * 2) / (|targetEdge|'s [=height dimension|height=])</code>.
+		1. Translate |path| by <code>-|spread|, -|spread|</code>.
+
+		Note: this creates an effect where the resulting path has the same shape as the original path, but scaled to fit the given spread.
+	1. Return |path|.
+
+To compute the <dfn>corner path</dfn> given a rectangle |cornerRect|, a rectangle |trimRect|, and numbers |startThickness|, |endThickness|, |orientation|, and |curvature|:
+	1. Assert: |orientation| is 0, 1, 2, or 3.
+	1. If |curvature| is less than zero, then:
+		1. Set |curvature| to <code>-|curvature|</code>.
+		1. Swap between |startThickness| and |endThickness|.
+		1. Set |orientation| to (|orientation| + 2) % 4.
+	1. Let |cornerPath| be a path that begins at <code>(0, 1)</code>.
+	1. Switch on|curvature|:
+		<dl class=switch>
+			: 0
+			:: Extend |cornerPath| by adding a straight line to <code>(1, 0)</code>.
+
+			: &infin;
+			::
+				1. Extend |cornerPath| by adding a straight line to <code>(1, 1)</code>.
+				1. Extend |cornerPath| by adding a straight line to <code>(1, 0)</code>.
+
+			: Otherwise
+			::
+				1. Let |K| be <code>0.5<sup>|curvature|</sup></code>.
+				1. For each |T| between 0 and 1, extend |cornerPath| through <code>(|T|<sup>|K|</sup>, (1−|T|)<sup>|K|</sup>)</code>.
+
+				User agents may approximate this path, for instance, by using concatenated Bezier curves, to balance between performance and rendering accuracy.
+		</dl>
+
+	1. Let (|x|, |y|, |width|, |height|) be |targetRect|.
+	1. Let |clockwiseRectQuad| be « (|x|, |y|), (|x| + |width|, |y|), (|x| + |width|, |y| + |height|), (|x|, |y| + height|) ».
+	1. Let |curveStartPoint| be |clockwiseRectQuad|[|orientation|].
+	1. Let |curveEndPoint| be |clockwiseRectQuad|[(|orientation| + 2) % 4].
+	1. If either |startThickness| or |endThickness| is greater than 0, then:
+
+		Note: the following substeps compute a new |curveStartPoint| and |curveEndPoint|, based on the thickness and |curvature|.
+		The start and end points are offset inwards, perpendicular to the direction of the curve, with the corresponding |startThickness| or |endThickness|.
+
+		1. Let |tangentUnitVector| be <code>(1, 0)</code>.
+
+			Note: |tangentUnitVector| is a unit vector (length of 1 pixel) that points along a curve with both positive X and Y components
+			(like a top-right corner) and reflects the given |curvature|. This base vector can then be rotated to align with the specific corner's orientation
+			and scaled to match the required border thickness.
+			For round curvatures, or for hyperellipses (|curvature| greater than 1), the tangent is a horizontal line to the right.
+
+			<figure>
+				<img src="images/corner-shape-target-unit-vector-round.svg"
+					style="background: white; padding: 8px;"
+					alt="Tangent unit vector with round (s=1)">
+				<figcaption>When the 'corner-shape' is ''corner-shape/round'' or more convex (<code>>= 1</code>), the unit vector is <code>1, 0</code>.
+				</figcaption>
+			</figure>
+
+		1. If |curvature| is less than 1:
+			1. Let |halfCorner| be the [=normalized superellipse half corner=] given |curvature|.
+			1. Let |offsetX| be <code>max(0, (|halfCorner| - 1) * 2 + &Sqrt;2)</code>.
+			1. Let |offsetY| be <code>max(0, &Sqrt;2 - |halfCorner| * 2)</code>.
+
+				Note: This formula defines the tangent of a quadratic Bezier curve that's equivalent to a superellipse quadrant.
+				Notably, convex hypoellipses (superellipses with a [=superellipse parameter|parameter=] between 0 and 1) can be very precisely represented by quadratic curves.
+
+			1. Let |length| be <code>hypot(|offsetX|, |offsetY|)</code>.
+			1. Set |tangentUnitVector| to <code>(|offsetX| / |length|, |offsetY| / |length|)</code>.
+
+				At this point |curvature| is guaranteed to be convex (>=1), so ther resulting |tangentUnitVector| would be in the range between <code>(1, 0)</code> and <code>(&Sqrt;2/2, &Sqrt;2/2)</code>.
+
+				<figure>
+					<img src="images/corner-shape-target-unit-vector-bevel.svg"
+						style="background: white; padding: 8px;"
+						alt="Tangent unit vector with bevel (s=0)">
+					<figcaption>When the 'corner-shape' is ''corner-shape/bevel'' (<code>0</code>), the unit vector is <code>&Sqrt;2/2, &Sqrt;2/2</code>.
+					</figcaption>
+				</figure>
+
+		1. Let |startOffset| be |tangentUnitVector|, scaled by |startThickness| and rotated <code>90° * ((|orientation| + 1) % 4)</code> clockwise.
+		1. Let |endOffset| be |tangentUnitVector|, scaled by |endThickness| and rotated by <code>90° * ((|orientation| + 2) % 4)</code> clockwise.
+		1. Translate |curveStartPoint| by |startOffset|.
+		1. Translate |curveEndPoint| by |endOffset|.
+		1. Set |cornerRect| to a rectangle that contains |curveStartPoint| and |curveEndPoint|.
+	1. Rotate |cornerPath| by <code>90° * |orientation|</code>, with <code>(0.5, 0.5)</code> as the origin, as described [=transformation matrix|here=].
+	1. Scale |cornerPath| by <code>|cornerRect|'s [=width dimension|width=], |cornerRect|'s [=width dimension|height=]</code>.
+	1. translate |cornerPath| by<code> |cornerRect|'s [=x coordinate|x=], |cornerRect|'s [=y coordinate|y=]</code>.
+	1. Trim |cornerPath| to |trimRect|.
+	1. Return |cornerPath|.
 </div>
 
 <h4 id=corner-shape-value>
@@ -466,7 +536,7 @@ To scale the 'border-radius' value based on the 'box-shadow' |spread|:
 	It is a number between <css>-infinity</css> and <css>infinity</css>, with <css>-infinity</css> corresponding to a straight concave corner,
 	<css>infinity</css> corresponding to a square convex corner.
 
-	The <dfn>canonical superellipse formula</dfn> can be described in Cartesian coordinates, as follows,
+	The <dfn export>canonical superellipse formula</dfn> can be described in Cartesian coordinates, as follows,
 	where <code>s</code> is the [=superellipse parameter=]:
 
 	<pre>
@@ -574,7 +644,7 @@ Since it uses a <code>log2</code>, interpolating it linearly would result in an 
 To balance that, the <dfn>superellipse interpolation</dfn> formula describes how a [=superellipse parameter=] is converted to a value between 0 and 1, and vice versa:
 
 <div algorithm="superellipse-param-to-interpolation-value">
-To interpolate a <<number [-&infin;,&infin;]>> |s| to an interpolation value between 0 and 1, return the first matching statement, switch on |s|:
+To compute the <dfn>normalized superellipse half corner</dfn> given a [=superellipse parameter=] |s|, return the first matching statement, switching on |s|:
 <dl class=switch>
 	: -&infin;
 	:: Return 0.
@@ -588,8 +658,9 @@ To interpolate a <<number [-&infin;,&infin;]>> |s| to an interpolation value bet
 		1. Let |convexHalfCorner| be <code>0.5<sup>|k|</sup></code>.
 		1. If |param| is less than 0, return <code>1 - |convexHalfCorner|</code>.
 		1. Return |convexHalfCorner|.
-
 </dl>
+
+To interpolate a [=superellipse parameter=] |s| to an interpolation value between 0 and 1, return the [=normalized superellipse half corner=] given |s|.
 
 To convert a <<number [0,1]>> |interpolationValue| back to a [=superellipse parameter=], switch on |interpolationValue|:
 <dl class=switch>

--- a/css-borders-4/images/corner-shape-adjusting.svg
+++ b/css-borders-4/images/corner-shape-adjusting.svg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="76.724533mm"
+   height="67.854446mm"
+   viewBox="0 0 76.724533 67.854447"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   sodipodi:docname="corner-shape-target-unit-vector-scoop.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showguides="false"
+     inkscape:zoom="1.5144501"
+     inkscape:cx="10.895044"
+     inkscape:cy="122.15655"
+     inkscape:window-width="2000"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <linearGradient
+       id="swatch5"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9-1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-129.62674,-12.133553)">
+    <path
+       style="fill:none;fill-opacity:1;stroke:#44a53e;stroke-width:3.48543;stroke-dasharray:none;stroke-opacity:1"
+       d="M 198.06245,73.544621 C 137.01385,63.877494 134.30976,11.669043 134.30976,11.669043"
+       id="path1-2"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#6f6f6f;stroke-width:3.00188;stroke-dasharray:none;stroke-opacity:1"
+       d="M 195.48426,75.052153 C 144.76022,66.421714 133.36838,16.380666 133.36838,16.380666"
+       id="path1"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:0.4;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#2aac39;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1"
+       x="174.28171"
+       y="36.048309"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="fill:#2aac39;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="174.28171"
+         y="36.048309"
+         id="tspan4">Shadow/clip Spread direction</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#2aac39;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="174.28171"
+         y="37.31831"
+         id="tspan10"></tspan><tspan
+         sodipodi:role="line"
+         style="fill:#2aac39;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="174.83981"
+         y="38.58831"
+         id="tspan11"> </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:0.4;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#7ede88;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1"
+       x="145.83183"
+       y="16.129513"
+       id="text3-9"><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="145.83183"
+         y="16.129513"
+         id="tspan4-5">Border</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="145.83183"
+         y="17.399513"
+         id="tspan6"></tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="145.83183"
+         y="18.669514"
+         id="tspan7">width</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="145.83183"
+         y="19.939512"
+         id="tspan8"></tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="145.83183"
+         y="21.209513"
+         id="tspan9">direction</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;line-height:0.4;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#7ede88;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none;stroke-opacity:1"
+       x="195.03636"
+       y="64.481644"
+       id="text3-9-7"><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="195.03636"
+         y="64.481644"
+         id="tspan4-5-3">Border</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="195.03636"
+         y="65.751648"
+         id="tspan6-4" /><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="195.03636"
+         y="67.021645"
+         id="tspan7-3">width</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="195.03636"
+         y="68.291649"
+         id="tspan8-0" /><tspan
+         sodipodi:role="line"
+         style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-dasharray:none"
+         x="195.03636"
+         y="69.561646"
+         id="tspan9-4">direction</tspan></text>
+    <path
+       style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 133.67503,22.661827 -1.69767,-5.861307 6.52678,1.067376 z"
+       id="path14-8"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="1.0482353" />
+    <path
+       style="fill:#c87ede;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 193.98171,76.13758 -6.67679,-1.318955 4.51766,-3.300271 z"
+       id="path14-8-1"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="1.0482353" />
+    <path
+       style="fill:#45cf4d;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 170.86286,47.074533 -4.29039,-1.756081 4.34785,-2.252814 z"
+       id="path14-8-8"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="1.9575957"
+       inkscape:transform-center-y="0.30635793" />
+    <path
+       style="fill:#45cf4d;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 175.12486,43.337186 4.3478,1.608693 -4.26846,2.399829 z"
+       id="path14-8-8-8"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="-1.9362893"
+       inkscape:transform-center-y="-0.29977958" />
+    <path
+       style="fill:#45cf4d;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 171.13191,43.051564 1.85434,-4.248847 2.15217,4.398535 z"
+       id="path14-8-8-1"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="0.31059569"
+       inkscape:transform-center-y="-1.9439231" />
+    <path
+       style="fill:#45cf4d;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 175.15575,47.577566 -1.70831,4.309633 -2.30098,-4.322549 z"
+       id="path14-8-8-8-1"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="-0.30425242"
+       inkscape:transform-center-y="1.9638262" />
+  </g>
+</svg>

--- a/css-borders-4/images/corner-shape-border.svg
+++ b/css-borders-4/images/corner-shape-border.svg
@@ -1,0 +1,382 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="210mm"
+   viewBox="0 0 210 210"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   sodipodi:docname="corner-shape-border.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showguides="false"
+     inkscape:zoom="1.5144501"
+     inkscape:cx="500.84187"
+     inkscape:cy="141.30542"
+     inkscape:window-width="2000"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <linearGradient
+       id="swatch5"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9-1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern6-7-3-8"
+       preserveAspectRatio="xMidYMid"
+       id="pattern5-7-2"
+       patternTransform="matrix(0,3.7555143,-2.4515703,0,-607.78726,595.86181)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="29"
+       height="20"
+       patternTransform="translate(190,350)"
+       preserveAspectRatio="xMidYMid"
+       style="fill:#000000"
+       id="pattern6-7-3-8"
+       inkscape:label=""
+       inkscape:collect="always"
+       inkscape:isstock="true">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="M 0,5 C 19,5 10,15 29,15"
+         id="path4-2-7-5"
+         sodipodi:nodetypes="cc" />
+    </pattern>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern6-7-3-8-5"
+       preserveAspectRatio="xMidYMid"
+       id="pattern5-7-2-0"
+       patternTransform="matrix(3.7555143,0,0,2.4515703,591.22601,828.35725)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="29"
+       height="20"
+       patternTransform="translate(190,350)"
+       preserveAspectRatio="xMidYMid"
+       style="fill:#000000"
+       id="pattern6-7-3-8-5"
+       inkscape:label=""
+       inkscape:collect="always"
+       inkscape:isstock="true">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="M 0,5 C 19,5 10,15 29,15"
+         id="path4-2-7-5-6"
+         sodipodi:nodetypes="cc" />
+    </pattern>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern6-7-4"
+       preserveAspectRatio="xMidYMid"
+       id="pattern5-4"
+       patternTransform="matrix(0,-0.46339159,-2.5161728,0,-629.66706,96.85952)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="29"
+       height="20"
+       patternTransform="translate(190,350)"
+       preserveAspectRatio="xMidYMid"
+       style="fill:#000000"
+       id="pattern6-7-4"
+       inkscape:label=""
+       inkscape:collect="always"
+       inkscape:isstock="true">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="M 0,5 C 19,5 10,15 29,15"
+         id="path4-2-7"
+         sodipodi:nodetypes="cc" />
+    </pattern>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern6-7-4-5"
+       preserveAspectRatio="xMidYMid"
+       id="pattern5-4-9"
+       patternTransform="matrix(-0.46339159,0,0,2.5161728,82.274394,855.53298)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="29"
+       height="20"
+       patternTransform="translate(190,350)"
+       preserveAspectRatio="xMidYMid"
+       style="fill:#000000"
+       id="pattern6-7-4-5"
+       inkscape:label=""
+       inkscape:collect="always"
+       inkscape:isstock="true">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="M 0,5 C 19,5 10,15 29,15"
+         id="path4-2-7-1"
+         sodipodi:nodetypes="cc" />
+    </pattern>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#000000;stroke-width:0.32431"
+       d="m 105.30612,23.167361 -1.21575,85.269769 v 0"
+       id="path1" />
+    <path
+       style="fill:#000000;stroke-width:0.32431"
+       d="m 98.416867,19.349311 -2.02625,81.451719 v 0"
+       id="path2" />
+    <path
+       style="fill:none;stroke-width:0.32431"
+       d="m 52.218375,53.287526 85.507725,0.424228 h -2.02624 z"
+       id="path3" />
+    <path
+       style="fill:none;stroke-width:0.32431"
+       d="M 94.364367,15.107034 112.19536,105.89176 92.743367,117.77014 140.9681,18.925083 Z"
+       id="path4" />
+    <path
+       style="fill:url(#pattern5-4);fill-opacity:1;stroke:#b4b4b4;stroke-width:0.285698;stroke-opacity:1"
+       d="M 6.7154184,165.62355 208.43624,165.4668"
+       id="path5-5" />
+    <path
+       style="fill:url(#pattern5-4-9);fill-opacity:1;stroke:#b4b4b4;stroke-width:0.285698;stroke-opacity:1"
+       d="M 151.03842,219.15051 150.88167,17.429679"
+       id="path5-5-4" />
+    <path
+       style="fill:url(#pattern5-7-2);fill-opacity:1;stroke:#000000;stroke-width:0.802821;stroke-opacity:1"
+       d="m 12.256221,38.570003 196.541669,1.27038"
+       id="path5-0-4" />
+    <path
+       style="fill:url(#pattern5-7-2-0);fill-opacity:1;stroke:#000000;stroke-width:0.802821;stroke-opacity:1"
+       d="M 33.934195,208.31377 35.204575,11.772102"
+       id="path5-0-4-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       d="M 5.0740317,54.799544 C 8.6822318,46.004556 12.290433,37.209565 18.379356,30.838797 24.46828,24.46803 33.037584,20.52164 41.607062,16.575171"
+       id="path9"
+       inkscape:path-effect="#path-effect9"
+       inkscape:original-d="M 5.0740317,54.799544 C 8.6822321,46.004556 12.290433,37.209565 15.898633,28.414577 24.46828,24.46803 33.037584,20.52164 41.607062,16.575171"
+       transform="matrix(3.9395522,0,0,3.8643277,-13.062885,-46.51075)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       d="M 5.0740317,54.799544 C 8.6822318,46.004556 12.290433,37.209565 18.379356,30.838797 24.46828,24.46803 33.037584,20.52164 41.607062,16.575171"
+       id="path9-7"
+       transform="matrix(3.5015674,0,0,3.6223394,14.823061,-22.698454)"
+       inkscape:original-d="M 5.0740317,54.799544 C 8.6822321,46.004556 12.290433,37.209565 15.898633,28.414577 24.46828,24.46803 33.037584,20.52164 41.607062,16.575171"
+       inkscape:path-effect="#path-effect9-1" />
+    <text
+       xml:space="preserve"
+       style="font-size:2.55249px;line-height:0.4;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#2c17e1;stroke-width:0.273585;stroke-opacity:1"
+       x="97.484924"
+       y="135.79584"
+       id="text10-1"
+       transform="matrix(0.81930244,0.30417124,-0.45235461,1.052611,0,0)"><tspan
+         id="tspan10-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.55249px;line-height:0.4;font-family:'Courier New';-inkscape-font-specification:'Courier New';text-align:center;text-anchor:middle;stroke:#2c17e1;stroke-width:0.273585;stroke-opacity:1"
+         x="97.484924"
+         y="135.79584"
+         sodipodi:role="line">&lt; border-left-width &gt;</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.68244px;line-height:0.4;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#2c17e1;stroke-width:0.287514;stroke-opacity:1"
+       x="36.831066"
+       y="151.9312"
+       id="text10-1-4"
+       transform="matrix(0.80899998,0.00819997,-0.07025009,1.2353819,0,0)"><tspan
+         id="tspan10-5-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.68244px;line-height:0.4;font-family:'Courier New';-inkscape-font-specification:'Courier New';text-align:center;text-anchor:middle;stroke:#2c17e1;stroke-width:0.287514;stroke-opacity:1"
+         x="36.831066"
+         y="151.9312"
+         sodipodi:role="line">&lt; border-left-width &gt;</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.341px;line-height:0.4;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#2c17e1;stroke-width:0.250917;stroke-opacity:1"
+       x="73.223145"
+       y="-107.50817"
+       id="text10-1-4-0"
+       transform="matrix(0.34081544,0.74718906,-1.2207767,0.25776119,0,0)"
+       inkscape:transform-center-x="-2.9953319"
+       inkscape:transform-center-y="0.39912927"><tspan
+         id="tspan10-5-9-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.341px;line-height:0.4;font-family:'Courier New';-inkscape-font-specification:'Courier New';text-align:center;text-anchor:middle;stroke:#2c17e1;stroke-width:0.250917;stroke-opacity:1"
+         x="73.223145"
+         y="-107.50817"
+         sodipodi:role="line">&lt; border-top-width &gt;</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:2.341px;line-height:0.4;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#2c17e1;stroke-width:0.250917;stroke-opacity:1"
+       x="-19.258831"
+       y="-144.30482"
+       id="text10-1-4-0-7"
+       transform="matrix(-0.01460429,0.82111714,-1.2126291,-0.29371305,0,0)"
+       inkscape:transform-center-x="-2.4735787"
+       inkscape:transform-center-y="1.6514585"><tspan
+         id="tspan10-5-9-8-4"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.341px;line-height:0.4;font-family:'Courier New';-inkscape-font-specification:'Courier New';text-align:center;text-anchor:middle;stroke:#2c17e1;stroke-width:0.250917;stroke-opacity:1"
+         x="-19.258831"
+         y="-144.30482"
+         sodipodi:role="line">&lt; border-top-width &gt;</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.315485;stroke-opacity:1"
+       d="M 6.8831191,165.2597 47.931036,62.359105 151.50748,17.648002"
+       id="path11"
+       sodipodi:nodetypes="ccc" />
+    <text
+       xml:space="preserve"
+       style="font-size:4.18024px;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#7f7f7f;stroke-width:0.348353;stroke-opacity:1"
+       x="10.654659"
+       y="69.022209"
+       id="text11"
+       transform="matrix(0.76679664,-0.59196469,0.49045853,0.92549423,0,0)"><tspan
+         sodipodi:role="line"
+         id="tspan11"
+         style="stroke-width:0.348353;stroke:#7f7f7f;stroke-opacity:1"
+         x="10.654659"
+         y="69.022209">Hull of</tspan><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.348353;stroke:#7f7f7f;stroke-opacity:1"
+         x="10.654659"
+         y="74.24752"
+         id="tspan12">superellipse</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       x="80.272339"
+       y="137.92538"
+       id="text13"
+       transform="rotate(26.178723)"><tspan
+         sodipodi:role="line"
+         id="tspan13"
+         style="stroke-width:0.264583;stroke:#7f7f7f;stroke-opacity:1"
+         x="80.272339"
+         y="137.92538">90°</tspan><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.264583;stroke:#7f7f7f;stroke-opacity:1"
+         x="80.272339"
+         y="141.89413"
+         id="tspan14">from hull</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#7a832b;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       x="77.788658"
+       y="-125.25896"
+       id="text13-1"
+       transform="rotate(66.418425)"><tspan
+         sodipodi:role="line"
+         id="tspan13-5"
+         style="fill:#7a832b;fill-opacity:0.703297;stroke-width:0.264583;stroke:#7f7f7f;stroke-opacity:1"
+         x="77.788658"
+         y="-125.25896">90°</tspan><tspan
+         sodipodi:role="line"
+         style="fill:#7a832b;fill-opacity:0.703297;stroke-width:0.264583;stroke:#7f7f7f;stroke-opacity:1"
+         x="77.788658"
+         y="-121.29021"
+         id="tspan14-5">from hull</tspan></text>
+    <ellipse
+       style="fill:#85297e;fill-opacity:0.703297;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       id="path14"
+       cx="34.097622"
+       cy="171.50122"
+       rx="3.144706"
+       ry="2.795294" />
+    <ellipse
+       style="fill:#85297e;fill-opacity:0.703297;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       id="path14-9"
+       cx="155.82854"
+       cy="39.813652"
+       rx="3.144706"
+       ry="2.795294" />
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ccd783;fill-opacity:0.703297;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       x="39.134117"
+       y="170.51294"
+       id="text15"><tspan
+         sodipodi:role="line"
+         id="tspan15"
+         style="stroke-width:0.264583" /></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:#ccd783;fill-opacity:0.703297;stroke:#000000;stroke-width:0.264583;stroke-opacity:1"
+       x="40.531765"
+       y="168.41646"
+       id="text16"><tspan
+         sodipodi:role="line"
+         id="tspan16"
+         style="stroke-width:0.264583"
+         x="40.531765"
+         y="168.41646" /></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:37.3981;fill:#ce83d7;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       x="39.483532"
+       y="170.16353"
+       id="text17"><tspan
+         x="39.483532"
+         y="170.16353"
+         id="tspan2">Meeting point of the </tspan><tspan
+         x="39.483532"
+         y="174.13227"
+         id="tspan3">border and the corner</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:40.1934;fill:#ccd783;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       x="133.14908"
+       y="52.029648"
+       id="text17-3"
+       transform="translate(22.012941,-5.94)"><tspan
+         x="133.14908"
+         y="52.029648"
+         id="tspan4">Meeting point of the </tspan><tspan
+         x="133.14908"
+         y="55.998398"
+         id="tspan5">border and the corner</tspan></text>
+  </g>
+</svg>

--- a/css-borders-4/images/corner-shape-border.svg
+++ b/css-borders-4/images/corner-shape-border.svg
@@ -27,7 +27,7 @@
      showguides="false"
      inkscape:zoom="1.5144501"
      inkscape:cx="500.84187"
-     inkscape:cy="141.30542"
+     inkscape:cy="458.25215"
      inkscape:window-width="2000"
      inkscape:window-height="1027"
      inkscape:window-x="0"
@@ -264,8 +264,8 @@
          y="-144.30482"
          sodipodi:role="line">&lt; border-top-width &gt;</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.315485;stroke-opacity:1"
-       d="M 6.8831191,165.2597 47.931036,62.359105 151.50748,17.648002"
+       style="fill:none;stroke:#000000;stroke-width:0.314718;stroke-opacity:1"
+       d="M 7.0573122,165.43471 47.857447,62.411975 150.80867,17.647801"
        id="path11"
        sodipodi:nodetypes="ccc" />
     <text
@@ -355,7 +355,7 @@
          y="168.41646" /></text>
     <text
        xml:space="preserve"
-       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:37.3981;fill:#ce83d7;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:37.3981;display:inline;fill:#ce83d7;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
        x="39.483532"
        y="170.16353"
        id="text17"><tspan
@@ -367,7 +367,7 @@
          id="tspan3">border and the corner</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:40.1934;fill:#ccd783;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
+       style="font-size:3.175px;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;white-space:pre;inline-size:40.1934;display:inline;fill:#ccd783;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.264583;stroke-opacity:1"
        x="133.14908"
        y="52.029648"
        id="text17-3"
@@ -378,5 +378,13 @@
          x="133.14908"
          y="55.998398"
          id="tspan5">border and the corner</tspan></text>
+    <path
+       style="fill:#ce83d7;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.253439;stroke-opacity:1"
+       d="m 150.76487,17.29169 9.44673,20.099561"
+       id="path5" />
+    <path
+       style="fill:#ce83d7;fill-opacity:0.703297;stroke:#7f7f7f;stroke-width:0.303879;stroke-opacity:1"
+       d="M 6.9253378,165.24809 32.642475,175.86266"
+       id="path5-7" />
   </g>
 </svg>

--- a/css-borders-4/images/corner-shape-target-unit-vector-bevel.svg
+++ b/css-borders-4/images/corner-shape-target-unit-vector-bevel.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="65.920311mm"
+   height="60.872108mm"
+   viewBox="0 0 65.920312 60.872109"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   sodipodi:docname="corner-shape-target-unit-vector-bevel.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showguides="false"
+     inkscape:zoom="1.5144501"
+     inkscape:cx="-18.158406"
+     inkscape:cy="179.60314"
+     inkscape:window-width="2000"
+     inkscape:window-height="989"
+     inkscape:window-x="481"
+     inkscape:window-y="66"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <linearGradient
+       id="swatch5"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9-1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-127.88256,-17.975939)">
+    <path
+       style="fill:none;stroke:#6f6f6f;stroke-width:3.00188;stroke-dasharray:none;stroke-opacity:1"
+       d="M 192.83841,77.697988 C 166.92261,55.964608 130.72253,19.026501 130.72253,19.026501"
+       id="path1"
+       sodipodi:nodetypes="cc" />
+    <rect
+       style="fill:#de7edd;fill-opacity:1;stroke:none;stroke-width:0.556438;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2"
+       width="2.6205802"
+       height="8.5646629"
+       x="77.637993"
+       y="103.45072"
+       transform="matrix(0.72802265,-0.68555307,0.68922275,0.72454951,0,0)" />
+    <ellipse
+       style="fill:#000000;stroke-width:1"
+       id="path2"
+       cx="135.38884"
+       cy="27.429224"
+       rx="2.2711763"
+       ry="2.0964704" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.08071px;line-height:0.4;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.970304;stroke-dasharray:none;stroke-opacity:1"
+       x="133.91901"
+       y="38.565884"
+       id="text2"
+       transform="scale(1.0306053,0.97030356)"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:0.970304"
+         x="133.91901"
+         y="38.565884">Bevel:</tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:0.970304"
+         x="133.91901"
+         y="39.798168"
+         id="tspan1"></tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:0.970304"
+         x="133.91901"
+         y="41.030453"
+         id="tspan3"></tspan><tspan
+         sodipodi:role="line"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:0.970304"
+         x="133.91901"
+         y="42.262737"
+         id="tspan4">√2/2, √2/2</tspan></text>
+  </g>
+</svg>

--- a/css-borders-4/images/corner-shape-target-unit-vector-round.svg
+++ b/css-borders-4/images/corner-shape-target-unit-vector-round.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="65.277016mm"
+   height="61.405281mm"
+   viewBox="0 0 65.277016 61.405281"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   sodipodi:docname="corner-shape-target-unit-vector-round.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showguides="false"
+     inkscape:zoom="1.5144501"
+     inkscape:cx="22.12024"
+     inkscape:cy="174.981"
+     inkscape:window-width="2000"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+    <linearGradient
+       id="swatch5"
+       inkscape:swatch="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect9-1"
+       is_visible="true"
+       lpeversion="1.3"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false"
+       uniform="false" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-126.65789,-19.042942)">
+    <path
+       style="fill:none;stroke:#6f6f6f;stroke-width:2.965;stroke-dasharray:none;stroke-opacity:1"
+       d="m 126.66176,24.808235 c 66.91235,-0.174706 63.76764,55.556468 63.76764,55.556468"
+       id="path1" />
+    <rect
+       style="fill:#de7edd;fill-opacity:1;stroke:none;stroke-width:0.430913;stroke-dasharray:none;stroke-opacity:1"
+       id="rect2"
+       width="8.5605879"
+       height="1.5723531"
+       x="126.48705"
+       y="22.012941" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.08071px;line-height:0.4;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.970304;stroke-dasharray:none;stroke-opacity:1"
+       x="142.22539"
+       y="23.621506"
+       id="text2"
+       transform="scale(1.0306053,0.97030356)"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:0.970304"
+         x="142.22539"
+         y="23.621506">Round: 1,0</tspan></text>
+    <ellipse
+       style="fill:#000000;stroke-width:1"
+       id="path2"
+       cx="135.21848"
+       cy="22.886473"
+       rx="2.2711763"
+       ry="2.0964704" />
+  </g>
+</svg>


### PR DESCRIPTION
Based on [this resolution](https://github.com/w3c/csswg-drafts/issues/11610#issuecomment-2769797194)

- Borders are rendered perpendicular to the outer curve, clamped at corner-shape -1 or 1.
- Shadows are rendered like a scaled version of the original shape, converting the shadow spread to a scale.

Added detailed algorithms, explanation, and a chart.

Closes #11610 
Closes #11767