### PR TITLE
[css-spec-grid-1] Fixes a small typo

### DIFF
--- a/css-grid-1/Overview.bs
+++ b/css-grid-1/Overview.bs
@@ -2628,7 +2628,7 @@ Grid Definition Shorthand: the 'grid' property</h3>
 	<dl dfn-for=grid dfn-type=value>
 		<dt><<'grid-template'>>
 		<dd>
-			Sets the 'grid-template' longhands as as for 'grid-template',
+			Sets the 'grid-template' longhands as for 'grid-template',
 			and the 'grid-auto-*' longhands to their initial values.
 
 		<dt><dfn id='grid-s-auto-row'><<'grid-template-rows'>> / [ auto-flow && dense? ] <<'grid-auto-columns'>>?</dfn>


### PR DESCRIPTION
I think there's a typo going on here. "as" is written twice.