### PR TITLE
[css-values-5] Fix syntax references for functions

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -837,7 +837,7 @@ Calculated Progress Values: the ''progress()'' notation</h3>
 	The syntax of ''progress()'' is defined as follows:
 
 	<pre class=prod>
-		<dfn id=typedef-progress-fn><<progress()>></dfn> = progress(<<calc-sum>>, <<calc-sum>>, <<calc-sum>>)
+		<<progress()>> = progress(<<calc-sum>>, <<calc-sum>>, <<calc-sum>>)
 	</pre>
 
 	where the first, second, and third <<calc-sum>> values represent
@@ -874,7 +874,7 @@ Media Query Progress Values: the ''media-progress()'' notation</h3>
 	The syntax of ''media-progress()'' is defined as follows:
 
 	<pre class=prod>
-		<dfn><<media-progress()>></dfn> = media-progress(<<mf-name>>, <<calc-sum>>, <<calc-sum>>)
+		<<media-progress()>> = media-progress(<<mf-name>>, <<calc-sum>>, <<calc-sum>>)
 	</pre>
 
 	where the value of the [=media feature=] corresponding to <<mf-name>>
@@ -910,7 +910,7 @@ Container Query Progress Values: the ''container-progress()'' notation</h3>
 	The syntax of ''container-progress()'' is defined as follows:
 
 	<pre class=prod>
-		<dfn><<container-progress()>></dfn> = container-progress(<<mf-name>> [ of <<container-name>> ]?, <<calc-sum>>, <<calc-sum>>)
+		<<container-progress()>> = container-progress(<<mf-name>> [ of <<container-name>> ]?, <<calc-sum>>, <<calc-sum>>)
 	</pre>
 
 	where <<mf-name>> represents a [=size feature=]
@@ -1083,7 +1083,7 @@ Interpolated Numeric and Dimensional Values: the ''calc-mix()'' notation</h3>
 	with the following syntactic form:
 
 	<pre class=prod>
-		<dfn><<calc-mix()>></dfn> = calc-mix( <<progress>>, <<calc-sum>>, <<calc-sum>> )
+		<<calc-mix()>> = calc-mix( <<progress>>, <<calc-sum>>, <<calc-sum>> )
 	</pre>
 
 	The <<calc-sum>> arguments can resolve
@@ -1154,7 +1154,7 @@ Interpolated Transform Values: the ''transform-mix()'' notation</h3>
 	with the following syntactic form:
 
 	<pre class=prod>
-		<dfn><<transform-mix()>></dfn> = transform-mix( <<progress>>, <<transform-list>>, <<transform-list>> )
+		<<transform-mix()>> = transform-mix( <<progress>>, <<transform-list>>, <<transform-list>> )
 	</pre>
 
 	The [=used value=] of a valid ''transform-mix()'' is
@@ -1179,7 +1179,7 @@ Interpolated Property Values: the ''mix()'' notation</h3>
 	which supports two alternative syntax patterns:
 
 	<pre class="prod">
-		<dfn><<mix()>></dfn> =
+		<<mix()>> =
 		  mix( <<progress>> , <<whole-value>> , <<whole-value>> ) |
 		  mix( <<progress>> && of <<keyframes-name>> )
 	</pre>
@@ -1325,7 +1325,7 @@ Selecting the First Supported Value: the ''first-valid()'' notation</h3>
 	as the whole value of the property it's used in.
 
 	<pre class=prod>
-		<dfn>&lt;first-valid()></dfn> = first-valid( <<declaration-value>># )
+		<<first-valid()>> = first-valid( <<declaration-value>># )
 	</pre>
 
 	If none of the arguments represent a valid value for the property,
@@ -1372,7 +1372,7 @@ Conditional Value Selection: the ''if()'' notation</h3>
 	The ''if()'' function's syntax is defined as follows:
 
 	<pre class=prod>
-	<dfn><<if()>></dfn> = if( [ <<if-branch>> ; ]* <<if-branch>> ;? )
+	<<if()>> = if( [ <<if-branch>> ; ]* <<if-branch>> ;? )
 	<dfn><<if-branch>></dfn> = <<if-condition>> : <<declaration-value>>?
 	<dfn><<if-condition>></dfn> = <<boolean-expr[ <<if-test>> ]>> | else
 	<dfn><<if-test>></dfn> =
@@ -1469,7 +1469,7 @@ Toggling Between Values: the ''toggle()'' notation</h3>
 	The syntax of the ''toggle()'' expression is:
 
 	<pre class=prod>
-		<dfn><<toggle()>></dfn> = toggle( <<whole-value>># )
+		<<toggle()>> = toggle( <<whole-value>># )
 	</pre>
 
 	The ''toggle()'' notation is a <<whole-value>>.
@@ -1581,7 +1581,7 @@ Inherited Value References: the ''inherit()'' notation</h3>
 	whose syntax is defined as:
 
 	<pre class=prod>
-		<dfn><<inherit()>></dfn> = inherit( <<custom-property-name>>, <<declaration-value>>? )
+		<<inherit()>> = inherit( <<custom-property-name>>, <<declaration-value>>? )
 	</pre>
 
 	The ''inherit()'' function's [=argument grammar=] is:


### PR DESCRIPTION
The spec defines functional notations in prose through `<dfn>`, then details the syntax of these notations. The syntaxes were incorrectly wrapped in another `<dfn>`, making Bikeshed think that these were new type definitions instead of references to the functional notation definitions.

In other words, this update gets things back to usual spec text, e.g., as in:
https://drafts.csswg.org/css-values-4/#ref-for-funcdef-abs%E2%91%A1
(which correctly links back to the definition in prose of `abs()`).
