### PR TITLE
[css-overflow-5] Specify that root ::scroll-marker-group is a child.

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -248,13 +248,17 @@ The 'scroll-marker-group' property</h4>
 
 		<dt><dfn>before</dfn>
 		<dd>
-			The [=scroll container=] generates a ''::scroll-marker-group'' pseudo-element
-			whose box is an immediate preceding sibling to its [=originating element=].
+			The [=scroll container=] generates a ''::scroll-marker-group'' pseudo-element.
+			When originating from the root element,
+			the generated pseudo-element's box is the first child of the [=originating element=].
+			Otherwise, its box is an immediate preceding sibling to its [=originating element=].
 
 		<dt><dfn>after</dfn>
 		<dd>
-			The [=scroll container=] generates a ''::scroll-marker-group'' pseudo-element
-			whose box is an immediate following sibling to its [=originating element=].
+			The [=scroll container=] generates a ''::scroll-marker-group'' pseudo-element.
+			When originating from the root element,
+			the generated pseudo-element's box is the last child of the [=originating element=].
+			Otherwise, its box is an immediate following sibling to its [=originating element=].
 
 	</dl>
 


### PR DESCRIPTION
Generating a ::scroll-marker-group for the root element should create a pseudo-element as a child of the root, which otherwise has all the usual scroll marker behaviors, as resolved in #11802.