### PR TITLE
[cssom-1] Correct typos and grammar in "serialize a CSS declaration block"

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2353,20 +2353,20 @@ To <dfn export>serialize a CSS declaration block</dfn> <var>declaration block</v
    <li><i>Shorthand loop</i>: For each <var>shorthand</var> in <var>shorthands</var>, follow these substeps:
     <ol>
      <li>Let <var>longhands</var> be an array consisting of all <a>CSS declarations</a> in <var>declaration block</var>'s
-     <a for="CSSStyleDeclaration">declarations</a> that that are not in <var>already serialized</var> and have a
+     <a for="CSSStyleDeclaration">declarations</a> that are not in <var>already serialized</var> and have a
      <a for="CSS declaration">property name</a> that
      maps to one of the shorthand properties in <var>shorthands</var>.
-     <li>If all properties that map to <var>shorthand</var> are not present in <var>longhands</var>, continue with the steps labeled <i>shorthand loop</i>.
+     <li>If not all properties that map to <var>shorthand</var> are present in <var>longhands</var>, continue with the steps labeled <i>shorthand loop</i>.
      <li>Let <var>current longhands</var> be an empty array.
      <li>Append all <a>CSS declarations</a> in <var>longhands</var> that have a
      <a for="CSS declaration">property name</a> that maps to <var>shorthand</var> to <var>current longhands</var>.
-     <li>If there is one or more <a>CSS declarations</a> in <var>current longhands</var> have their
+     <li>If there are one or more <a>CSS declarations</a> in <var>current longhands</var> that have their
      <a for="CSS declaration">important flag</a> set and one or more with it unset, continue with
      the steps labeled <i>shorthand loop</i>.
-     <li>If there's any declaration in <var>declaration block</var> in between the first and the last longhand in <var>current longhands</var>
+     <li>If there is any declaration in <var>declaration block</var> in between the first and the last longhand in <var>current longhands</var>
      which belongs to the same [=logical property group=], but has a different [=mapping logic=] as any of the longhands in <var>current longhands</var>,
      and is not in <var>current longhands</var>, continue with the steps labeled <i>shorthand loop</i>.
-     <li>Let <var>value</var> be the result of invoking <a>serialize a CSS value</a> of <var>current longhands</var>.
+     <li>Let <var>value</var> be the result of invoking <a>serialize a CSS value</a> with <var>current longhands</var>.
      <li>If <var>value</var> is the empty string, continue with the steps labeled <i>shorthand loop</i>.
      <li>Let <var>serialized declaration</var> be the result of invoking <a>serialize a CSS declaration</a> with property name
      <var>shorthand</var>, value <var>value</var>, and the <i>important</i> flag set if the <a>CSS declarations</a> in


### PR DESCRIPTION
I noticed the "that that" mistake while implementing this, then identified a couple of other small corrections. Not all of these are "wrong" exactly, they're just not worded the way the specs usually do.