### PR TITLE
[css-lists-3] Correct markup for nested lists example

### DIFF
--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -1326,8 +1326,8 @@ The Implicit ''list-item'' Counter</h3>
 								<li>Third third-level item in reversed list
 								<li>Fourth third-level item in reversed list
 							</ol>
+						<li>Third second-level item, list start=3
 					</ol>
-				<li>Third second-level item, list start=3
 				<li>Third top-level item
 			</ol>
 		</xmp>


### PR DESCRIPTION
Non-substantive contribution.

Before:
- Markup for css-lists-3/Example 19 (nested lists) does not render the expected layout
- The body of the line item "Third second-level item, list start=3" indicates the intention of the authors

After:
- Minor correction to the markup matches likely author intent
