### PR TITLE
[web-animations-2] s/animation-trigger-type/animation-trigger-behavior/

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -723,14 +723,14 @@ Declaring Animation Triggers</h2>
     The 'animation-trigger' properties
     are [=reset-only sub-properties=] of the 'animation' [=shorthand=].
 
-## The 'animation-trigger-type' property ## {#animation-trigger-type}
+## The 'animation-trigger-behavior' property ## {#animation-trigger-behavior}
 
-The 'animation-trigger-type' property specifies the [=animation trigger type=]
+The 'animation-trigger-behavior' property specifies the [=animation trigger behavior=]
 of the [=animation trigger=].
 
 <pre class='propdef'>
-Name: animation-trigger-type
-Value: <<single-animation-trigger-type>>#
+Name: animation-trigger-behavior
+Value: <<single-animation-trigger-behavior>>#
 Initial: once
 Applies to: all elements
 Inherited: no
@@ -740,12 +740,12 @@ Animation type: not animatable
 Canonical order: per grammar
 </pre>
 
-<span class=prod><dfn>&lt;single-animation-trigger-type></dfn> = once | repeat | alternate | state</span>
+<span class=prod><dfn>&lt;single-animation-trigger-behavior></dfn> = once | repeat | alternate | state</span>
 
-The values of 'animation-trigger-type' have the following meaning
+The values of 'animation-trigger-behavior' have the following meaning
 for an [=animation trigger=] that enters its [=animation trigger/active interval|active interval=]:
 
-<dl dfn-type=value dfn-for=animation-trigger-type>
+<dl dfn-type=value dfn-for=animation-trigger-behavior>
 	<dt><dfn>once</dfn>
 	<dd>
 		The animation is triggered and played once and only once.
@@ -767,7 +767,7 @@ for an [=animation trigger=] that enters its [=animation trigger/active interval
 		When the trigger’s [=animation trigger/active interval=] is re-entered the animation is resumed.
 </dl>
 
-The behavior of each value is defined in [[web-animations-2#trigger-types]].
+The behavior of each value is defined in [[web-animations-2#trigger-behaviors]].
 
 ## The 'animation-trigger-timeline' property ## {#animation-trigger-timeline}
 
@@ -964,7 +964,7 @@ The values of 'animation-trigger-exit-range-start' have the following meaning:
 ## The 'animation-trigger' property ## {#animation-trigger}
 
 The 'animation-trigger' property is a [=shorthand property|shorthand=]
-that sets 'animation-trigger-type', 'animation-trigger-timeline',
+that sets 'animation-trigger-behavior', 'animation-trigger-timeline',
 'animation-trigger-range-start', 'animation-trigger-range-end',
 'animation-trigger-exit-range-start', and 'animation-trigger-exit-range-end'
 together in a single declaration,
@@ -983,7 +983,7 @@ Animation Type: not animatable
 </pre>
 
 <pre class=prod>
-<dfn>&lt;single-animation-trigger></dfn> = <<single-animation-trigger-type>> || [ none | auto | [ [ <<dashed-ident>> | <<scroll()>> | <<view()>> ] [ normal | <<length-percentage>> | <<timeline-range-name>> <<length-percentage>>? ]{0,4} ] ]
+<dfn>&lt;single-animation-trigger></dfn> = <<single-animation-trigger-behavior>> || [ none | auto | [ [ <<dashed-ident>> | <<scroll()>> | <<view()>> ] [ normal | <<length-percentage>> | <<timeline-range-name>> <<length-percentage>>? ]{0,4} ] ]
 </pre>
 
 # Animation Events # {#events}

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2394,14 +2394,14 @@ Issue: Do we need a formal resolution on the spec of the idle state?
 
 An [=animation trigger=] has an associated <dfn export>animation trigger behavior</dfn>
 which, along with [=did trigger=] and [=animation trigger state|state=],
-determines the [=animation trigger|trigger=]&bs';s effect on its
-associated [=animation=]&bs';s playback.
+determines the [=animation trigger|trigger=]'s effect on its
+associated [=animation=]'s playback.
 
 The [=animation effect=] associated with an [=animation trigger=]
 in the [=animation trigger state/idle=] state
 remains in its [=animation effect/before phase=] and
 stays at zero [=animation/current time=],
-regardless of the trigger&bs';s [=did trigger=] flag or [=animation trigger state|state=].
+regardless of the trigger's [=did trigger=] flag or [=animation trigger state|state=].
 Otherwise, the effect on playback is as follows for
 given values of <var ignore=''>behavior</var>:
 
@@ -2525,9 +2525,9 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
   The procedure of <dfn>updating animation trigger state</dfn>
   of an [=animation trigger=] |trigger| is as follows:
 
-  1. Let |did trigger| be the current value of |trigger|&bs';s [=did trigger=] flag.
+  1. Let |did trigger| be the current value of |trigger|'s [=did trigger=] flag.
 
-  1. Let |behavior| be |trigger|&bs';s associated [=animation trigger behavior=].
+  1. Let |behavior| be |trigger|'s associated [=animation trigger behavior=].
 
   1. Set |trigger|.[=animation trigger state|state=] as follows:
     <dl class=switch>
@@ -3721,7 +3721,7 @@ dictionary AnimationTriggerOptions {
   : <dfn>behavior</dfn>
   ::
       The behavior of the trigger.
-      If not specified, the trigger&bs';s behavior is ''animation-trigger-type/once''.
+      If not specified, the trigger's behavior is ''animation-trigger-type/once''.
 
   : <dfn>rangeStart</dfn>
   ::

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2372,76 +2372,93 @@ and are attached to an [=animation attachment range|attachment range=].
 
 Issue: Should there be any effect of triggers on scroll-driven animations?
 
-### Animation Trigger Types ### {#trigger-types}
+### Animation Trigger Internal State ### {#trigger-state}
 
-The behavior an [=animation trigger=] applies to its associated [=animation=]’s
-playback is defined by its <dfn export>animation trigger type</dfn>, and
-depending on its [=animation trigger state|state=] can apply one of two
-distinct behavior types: [=animation trigger state/primary=] or [=animation trigger state/inverse=].
-Given an internal |did trigger| flag, the values of [=animation trigger type=]
-can be one of the following:
-
-<dl>
-  <dt>''animation-trigger-type/once''
-  <dd>
-    The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
-
-  <dt>''animation-trigger-type/repeat''
-  <dd>
-    The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
-    The [=animation trigger state/inverse=] behavior is resetting the associated [=animation effect=] back to
-    its [=animation effect/before phase=] and its associated animation’s [=animation/start time=] to zero.
-
-  <dt>''animation-trigger-type/alternate''
-  <dd>
-    <dl class=switch>
-      : if the |did trigger| flag is false,
-      ::
-        The [=animation trigger state/primary=] behavior is [=play an animation|triggering=] the associated animation.
-
-      : Otherwise,
-      ::
-        The [=animation trigger state/primary=] behavior is [=reverse an animation|reversing=] the associated animation.
-
-    </dl>
-
-    The [=animation trigger state/inverse=] behavior is [=reverse an animation|reversing=] the associated animation.
-
-  <dt>''animation-trigger-type/state''
-  <dd>
-    The [=animation trigger state/primary=] behavior is [=play an animation|triggering or resuming=] the associated animation.
-    The [=animation trigger state/inverse=] behavior is [=pause an animation|pausing=] the associated animation.
-</dl>
-
-Issue: Need to bike-shed the name for type "state" type.
-
-Issue: Do we need a proper definition for "behavior types primary/inverse"?
-
-### Animation Trigger State ### {#trigger-state}
-
-An [=animation trigger=] |trigger| with [=animation trigger type=] |type|
-and an associated [=animation=] |animation|
-has an internal <dfn export lt="animation trigger state">state</dfn> which
-controls the applied behavior type. This state has discrete values
-which can be one of the following:
+An [=animation trigger=] |trigger|
+has an internal boolean <dfn export>did trigger</dfn> flag, which is initially false,
+and an internal <dfn export lt="animation trigger state">state</dfn> with
+these possible values:
 
 <dl dfn-for="animation trigger state">
   <dt><dfn>idle</dfn>
-  <dd>
-    The [=animation effect=] associated |animation| remains in
-    its [=animation effect/before phase=] and stays at zero [=animation/current time=].
-
   <dt><dfn>primary</dfn>
-  <dd>
-    When switched to this value the [=animation trigger state/primary=] behavior type defined by |type| is applied to |animation|.
-
   <dt><dfn>inverse</dfn>
-  <dd>
-    When switched to this value the [=animation trigger state/inverse=] behavior type defined by |type| is applied to |animation|.
-
 </dl>
 
+The values of [=animation trigger state|state=] and [=did trigger=] are
+updated by the [=updating animation trigger state=] procedure, described below.
+
 Issue: Do we need a formal resolution on the spec of the idle state?
+
+### Animation Trigger Behavior ### {#trigger-behaviors}
+
+An [=animation trigger=] has an associated <dfn export>animation trigger behavior</dfn>
+which, along with [=did trigger=] and [=animation trigger state|state=],
+determines the [=animation trigger|trigger=]&bs';s effect on its
+associated [=animation=]&bs';s playback.
+
+The [=animation effect=] associated with an [=animation trigger=]
+in the [=animation trigger state/idle=] state
+remains in its [=animation effect/before phase=] and
+stays at zero [=animation/current time=],
+regardless of the trigger&bs';s [=did trigger=] flag or [=animation trigger state|state=].
+Otherwise, the effect on playback is as follows for
+given values of <var ignore=''>behavior</var>:
+
+<dl>
+  <dt>''animation-trigger-behavior/once''</dt>
+  <dd>
+    <dl class=switch>
+      : If [=animation trigger state|state=] is [=animation trigger state/primary=],
+      :: the effect is to [=play an animation|trigger=] the associated animation.
+
+      : Otherwise,
+      :: the trigger has no effect.
+  </dl>
+  </dd>
+
+  <dt>''animation-trigger-behavior/repeat''</dt>
+  <dd>
+    <dl class=switch>
+      : If [=animation trigger state|state=] is [=animation trigger state/primary=],
+      :: the effect is to [=play an animation|trigger=] the associated animation.
+
+      : If [=animation trigger state|state=] is [=animation trigger state/inverse=],
+      :: the effect is to reset the associated [=animation effect=] back to
+         its [=animation effect/before phase=] and its associated [=animation=]’s
+         [=animation/start time=] to zero.
+  </dl>
+  </dd>
+
+  <dt>''animation-trigger-behavior/alternate''
+  <dd>
+    <dl class=switch>
+      : If [=animation trigger state|state=] is [=animation trigger state/primary=]
+        and [=did trigger=] is false,
+      :: the effect is to [=play an animation|trigger=] the associated animation.
+
+      : If [=animation trigger state|state=] is [=animation trigger state/primary=]
+        and [=did trigger=] is true,
+      :: the effect is to [=reverse an animation|reverse=] the associated animation.
+
+      : If [=animation trigger state|state=] is [=animation trigger state/inverse=]
+      :: the effect is to [=reverse an animation|reverse=] the associated animation.
+  </dl>
+  </dd>
+
+  <dt>''animation-trigger-behavior/state''
+  <dd>
+    <dl class=switch>
+      : If [=animation trigger state|state=] is [=animation trigger state/primary=]
+      :: the effect is to [=play an animation|trigger or resume=] the associated animation.
+
+      : If [=animation trigger state|state=] is [=animation trigger state/inverse=]
+      :: the effect is to [=pause an animation|pause=] the associated animation.
+  </dl>
+  </dd>
+</dl>
+
+Issue: Do we need a proper definition for "behavior types primary/inverse"?
 
 ### Animation Trigger Active Interval ### {#trigger-active-interval}
 
@@ -2493,29 +2510,26 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
     The procedure of <dfn>setting timeline of animation trigger</dfn> |trigger|,
     to |new timeline| which may be <code>null</code>, is as follows:
 
-    1. Let |old timeline| be the current [=timeline=] of |trigger|, if any.
+    1. Let |old timeline| be the current value of |trigger|.{{AnimationTrigger/timeline}}, if any.
 
     1. If |new timeline| is the same object as |old timeline|, abort this procedure.
 
-    1. Let the [=timeline=] of |trigger| be |new timeline|.
+    1. Set |trigger|.{{AnimationTrigger/timeline}} to |new timeline|.
 
-    1. Run the procedure to [=updating animation trigger state=] for |trigger|.
+    1. Run the [=updating animation trigger state=] procedure for |trigger|.
   </div>
 
 ### Updating Animation Trigger State ### {#updating-trigger-state}
 
 <div algorithm="updating animation trigger state">
-  The procedure of <dfn>updating animation trigger state</dfn> |state|
-  of an [=animation trigger=] |trigger|,
-  with a given a flag |did trigger|, and an [=animation trigger type=] |type|,
-  is as follows:
+  The procedure of <dfn>updating animation trigger state</dfn>
+  of an [=animation trigger=] |trigger| is as follows:
 
-  1. Let |did trigger| be a boolean flag that is initially false.
+  1. Let |did trigger| be the current value of |trigger|&bs';s [=did trigger=] flag.
 
-  1. Let |state| be the current [=animation trigger state|state=]
-    of |trigger| that is initially [=animation trigger state/idle=].
+  1. Let |behavior| be |trigger|&bs';s associated [=animation trigger behavior=].
 
-  1. Set |state| as follows:
+  1. Set |trigger|.[=animation trigger state|state=] as follows:
     <dl class=switch>
       : If |trigger|’s [=local time=] is [=unresolved=],
       ::
@@ -2525,7 +2539,7 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
       ::
 
         <dl class=switch>
-          : If |type| is ''animation-trigger-type/once'' and |did trigger| flag is true,
+          : If |behavior| is ''animation-trigger-behavior/once'' and |did trigger| is true,
           ::
             Then abort this procedure.
 
@@ -2535,16 +2549,16 @@ Depending on its most recent [=animation trigger state|state=] |state|, the
             <dl class=switch>
               : If |trigger| is inside its [=animation trigger/active interval|active interval=],
               ::
-                  1. Set |state| to [=animation trigger state/primary=].
-                  1. Set |did trigger| to true.
+                  1. Set |trigger|.[=animation trigger state|state=] to [=animation trigger state/primary=].
+                  1. Set |trigger|.[=did trigger=] to true.
 
               : Otherwise,
               ::
 
                 <dl class=switch>
-                  : If |did trigger| flag is true,
+                  : If |did trigger| is true,
                   ::
-                      Set |state| to [=animation trigger state/inverse=].
+                      Set |trigger|.[=animation trigger state|state=] to [=animation trigger state/inverse=].
 
                 </dl>
 
@@ -3609,7 +3623,7 @@ Update the type for the AnimationPlaybackEventInit members.
 interface AnimationTrigger {
   constructor(optional AnimationTriggerOptions options = {});
   attribute AnimationTimeline timeline;
-  attribute AnimationTriggerType type;
+  attribute AnimationTriggerBehavior behavior;
   attribute any rangeStart;
   attribute any rangeEnd;
   attribute any exitRangeStart;
@@ -3624,30 +3638,24 @@ interface AnimationTrigger {
 
       1. Create a new {{AnimationTrigger}} object, |trigger|.
 
-      1. Let |type| be the {{AnimationTriggerOptions/type}} property.
+      1. Set |trigger|.[=did trigger=] to false.
 
-      1. Let |timeline| be the {{AnimationTriggerOptions/timeline}} property.
+      1. Set |trigger|.[=animation trigger state|state=] to [=animation trigger state/idle=].
 
-      1. Let |range start| be the {{AnimationTriggerOptions/rangeStart}} property.
+      1. Set |trigger|.{{AnimationTrigger/behavior}} to |options|.{{AnimationTriggerOptions/behavior}}.
 
-      1. Let |range end| be the {{AnimationTriggerOptions/rangeEnd}} property.
-
-      1. Set [=default range=] of |trigger| using |range start| and |range end|,
+      1. Set [=default range=] of |trigger| using |options|.{{AnimationTriggerOptions/rangeStart}} and |options|.{{AnimationTriggerOptions/rangeEnd}},
           following the same rules as the KeyframeAnimationOption
           <a href="#dom-keyframeanimationoptions-rangestart">rangeStart</a> and
           <a href="#dom-keyframeanimationoptions-rangeend">rangeEnd</a> respectively.
 
-      1. Let |exit range start| be the {{AnimationTriggerOptions/exitRangeStart}} property.
-
-      1. Let |exit range end| be the {{AnimationTriggerOptions/exitRangeEnd}} property.
-
-      1. Set [=exit range=] of |trigger| using |exit range start| and |exit range end|,
+      1. Set [=exit range=] of |trigger| using |options|.{{AnimationTriggerOptions/exitRangeStart}} and |options|.{{AnimationTriggerOptions/exitRangeEnd}},
           following the same rules above for [=default range=], unless they are set to
           "auto", in which case they are set to their corresponding side
           of the [=default range=].
 
       1. Run the procedure for [=setting timeline of animation trigger=]
-          on |trigger| passing |timeline| as the <var ignore>new timeline</var>.
+          on |trigger| passing |options|.{{AnimationTriggerOptions/timeline}} as the <var ignore>new timeline</var>.
 
       <div dfn-type=argument class=parameters
            dfn-for="AnimationTrigger/AnimationTrigger(options)">
@@ -3667,9 +3675,9 @@ interface AnimationTrigger {
       Returns the [=timeline=] for this trigger
       or `null` if this timeline is [=inactive timeline|inactive=].
 
-  : <dfn>type</dfn>
+  : <dfn>behavior</dfn>
   ::
-      Returns the [=animation trigger type|type=] of this trigger.
+      Returns the [=animation trigger behavior|behavior=] of this trigger.
 
   : <dfn>rangeStart</dfn>
   ::
@@ -3694,7 +3702,7 @@ interface AnimationTrigger {
 <pre class='idl'>
 dictionary AnimationTriggerOptions {
   AnimationTimeline? timeline;
-  AnimationTriggerType? type = "once";
+  AnimationTriggerBehavior? behavior = "once";
   (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeStart = "normal";
   (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) rangeEnd = "normal";
   (TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) exitRangeStart = "auto";
@@ -3710,10 +3718,10 @@ dictionary AnimationTriggerOptions {
       The timeline to which the trigger is associated.
       If not specified, the trigger is associated with [=default document timeline=].
 
-  : <dfn>type</dfn>
+  : <dfn>behavior</dfn>
   ::
-      The type of trigger to create.
-      If not specified, the trigger is of type ''animation-trigger-type/once''.
+      The behavior of the trigger.
+      If not specified, the trigger&bs';s behavior is ''animation-trigger-type/once''.
 
   : <dfn>rangeStart</dfn>
   ::
@@ -3737,30 +3745,30 @@ dictionary AnimationTriggerOptions {
 
 </div>
 
-<h3 id="the-animationtriggertype-enumeration">The <code>AnimationTriggerType</code> enumeration</h3>
+<h3 id="the-animationtriggerbehavior-enumeration">The <code>AnimationTriggerBehavior</code> enumeration</h3>
 
 <pre class='idl'>
-enum AnimationTriggerType { "once", "repeat", "alternate", "state" };
+enum AnimationTriggerBehavior { "once", "repeat", "alternate", "state" };
 </pre>
 
 <dl dfn-type=enum-value
-      dfn-for="AnimationTriggerType">
+      dfn-for="AnimationTriggerBehavior">
 
   : <dfn>once</dfn>
   ::
-      Type ''animation-trigger-type/once''.
+      ''animation-trigger-behavior/once''.
 
   : <dfn>repeat</dfn>
   ::
-      Type ''animation-trigger-type/repeat''.
+      ''animation-trigger-behavior/repeat''.
 
   : <dfn>alternate</dfn>
   ::
-      Type ''animation-trigger-type/alternate''.
+      ''animation-trigger-behavior/alternate''.
 
   : <dfn>state</dfn>
   ::
-      Type ''animation-trigger-type/state''.
+      ''animation-trigger-behavior/state''.
 
 </dl>
 

--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2980,9 +2980,9 @@ enum FillMode { "none", "forwards", "backwards", "both", "auto" };
 :   <code>auto</code>
 ::  Update the description as:
 
-    > Fill backwards and forwards when applied to an
-    > {{GroupEffect}} and no fill when applied to an
-    > {{KeyframeEffect}}.
+    > Fill backwards and forwards when applied to a
+    > {{GroupEffect}} and no fill when applied to a
+    > {{KeyframeEffect!!interface}}.
 
 <h3 id="the-groupeffect-interface">The <code>GroupEffect</code> interface</h3>
 
@@ -3273,7 +3273,7 @@ interface SequenceEffect : GroupEffect {
 
 <h3 id="the-keyframeeffect-interface">The <code>KeyframeEffect</code> interfaces</h3>
 
-The {{KeyframeEffect}} interface is modified to add the following:
+The {{KeyframeEffect!!interface}} interface is modified to add the following:
 
 <pre class='idl'>
 partial interface KeyframeEffect {
@@ -3286,7 +3286,7 @@ partial interface KeyframeEffect {
 :   <dfn constructor for=KeyframeEffect
      lt="KeyframeEffect(target, keyframes, options)">
     KeyframeEffect (target, keyframes, options)</dfn>
-::  Amend step 5 of the procedure to create a new {{KeyframeEffect}} object as
+::  Amend step 5 of the procedure to create a new {{KeyframeEffect!!interface}} object as
     follows:
 
     5.  If <var>options</var> is a {{KeyframeEffectOptions}} object,
@@ -3295,13 +3295,13 @@ partial interface KeyframeEffect {
         corresponding value from <var>options</var>.
 
         When assigning these properties, the error-handling defined for the
-        corresponding setters on the {{KeyframeEffect}} interface is applied.
+        corresponding setters on the {{KeyframeEffect!!interface}} interface is applied.
         If any of those setters require an exception to be thrown
         for the values specified by <var>options</var>, this procedure must
         <a>throw</a> the same exception and abort all further steps.
 
 :   <dfn constructor for=KeyframeEffect lt="KeyframeEffect(source)">KeyframeEffect (source)</dfn>
-::  Amend the procedure to create a new {{KeyframeEffect}} object with the
+::  Amend the procedure to create a new {{KeyframeEffect!!interface}} object with the
     same properties as {{KeyframeEffect/KeyframeEffect(source)/source}} to include setting the
     <a>iteration composite operation</a> from <var>source</var> on <var>effect</var>.
 
@@ -3422,7 +3422,7 @@ callback EffectCallback = undefined (double? progress,
                                 Animation animation);
 </pre>
 
-An {{EffectCallback}} is called each time an {{KeyframeEffect}} object
+An {{EffectCallback}} is called each time an {{KeyframeEffect!!interface}} object
 with which it is associated is updated.
 
 <div class="parameters">
@@ -3484,7 +3484,7 @@ is modified to add the following members:
 <div dfn-type=method class=methods
        dfn-for="Animatable">
 
-  : <dfn lt="animate(keyframes, options)">Animation animate(|keyframes|, |options|)</dfn>
+  : <dfn lt="animate(keyframes, options)">Animation animate(<var ignore=''>keyframes</var>, <var>options</var>)</dfn>
   ::  Amend step 6 of the procedure as follows:
 
     6. If |options| is a {{KeyframeAnimationOptions}} object,


### PR DESCRIPTION
`Behavior` is a more accurate and intuitive term than `type`.

Also rewrites the explanations of `state`, `did trigger`, and `behavior` for clarity.

Also fixes some bikeshed linking syntax to point to IDL attributes where appropriate.