### PR TITLE
[css-overflow-5] Define scroll-target-group property for element scroll marker groups

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -217,12 +217,38 @@ Issue: Add images representing these examples.
 <h4 id="scroll-marker-grouping">
 Scroll marker grouping</h4>
 
-An element with a <a href="https://open-ui.org/components/focusgroup.explainer/">focusgroup</a> attribute defines a <dfn>scroll marker group container</dfn>
-having a <dfn>scroll marker group</dfn> containing all of the [=scroll marker=] elements for which this is the nearest ancestor [=scroll marker group container=].
-
-Issue: The grouping of markers for scroll progress tracking should be separated from opting into focusgroup focus behavior.
+The 'scroll-target-group' property determines whether an element establishes a <dfn>scroll marker group container</dfn> containing [=scroll marker=] elements forming a [=scroll marker group=].
 
 A ''::scroll-marker-group'' pseudo-element is the [=scroll marker group container=] for its contained ''::scroll-marker'' pseudo-elements, which form a [=scroll marker group=] together.
+
+<h4 id="scroll-target-group">
+The 'scroll target group' property</h4>
+
+	<pre class=propdef>
+	Name: scroll-target-group
+	Value: none | auto
+	Initial: none
+	Applies to: all elements
+	Inherited: no
+	Computed value: specified value
+	Animation Type: discrete
+	Canonical Order: per grammar
+	</pre>
+
+	The 'scroll-target-group' property specifies whether the element is a [=scroll marker group container=].
+
+	<dl dfn-type=value dfn-for=scroll-target-group>
+		<dt><dfn>none</dfn>
+		<dd>
+			The element does not establish a [=scroll marker group container=].
+
+		<dt><dfn>auto</dfn>
+		<dd>
+			The element establishes a [=scroll marker group container=]
+			forming a [=scroll marker group=] containing all of the [=scroll marker=] elements
+			for which this is the nearest ancestor [=scroll marker group container=].
+
+	</dl>
 
 <h4 id="scroll-marker-group-property">
 The 'scroll-marker-group' property</h4>


### PR DESCRIPTION
Defines the scroll-target-group property for establishing element scroll marker groups #10916 using proposed naming in #12191.