### PR TITLE
[css-view-transitions-2] Generated strings start with -ua-

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -815,14 +815,12 @@ To resolve the [=used value=] of 'view-transition-name' for |element|:
 	1. If |computed| is <css>none</css>, return null.
 	1. If |computed| is a <<custom-ident>>, return |computed|.
 	1. Assert: |computed| is <css>auto</css> or <css>match-element</css>.
-	1. If |computed| is <css>auto</css>, |element| has an associated [=Element/id=], and |computed| is associated with the same [=tree/root=] as |element|'s [=tree/root=], then return a unique string.
+	1. If |computed| is <css>auto</css>, |element| has an associated [=Element/id=], and |computed| is associated with the same [=tree/root=] as |element|'s [=tree/root=], then return a unique string starting with "<code>-ua-</code>".
 		Two elements with the same [=Element/id=] must return the same string, regardless of their [=node document=].
 
 		Note: this means that a ''::part()'' pseudo-element wouldn't resolve to its matching element's [=Element/id=].
 
-	1. Return a unique string. The string should remain consistent and unique for this element and {{Document}}, at least for the lifetime of |element|'s [=node document=]'s [=active view transition=].
-
-		Note: this string is not web-observable, and is used for addressing the element in internal algorithms.
+	1. Return a unique string starting with "<code>-ua-</code>". The string should remain consistent and unique for this element and {{Document}}, at least for the lifetime of |element|'s [=node document=]'s [=active view transition=].
 
 		Note: When used in a cross-document view transition, generated <css>auto</css> values never match, resulting in separate ''::view-transition-group()'' pseudo-elements, one exiting and one entering.
 


### PR DESCRIPTION
Resolution:
https://github.com/w3c/csswg-drafts/issues/12004#issuecomment-2910779457

Closes #12004
