### PR TITLE
[css-mixins-1] Consistently return a syntax string

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -822,7 +822,7 @@ interface CSSFunctionRule : CSSGroupingRule {
 		The [=custom function/return type=] of the [=custom function=],
 		represented as a [[css-properties-values-api-1#syntax-strings|syntax string]].
 		If the [=custom function=] has no return type,
-		returns <code>"type(*)"</code>.
+		returns <code>"*"</code>.
 </dl>
 
 
@@ -843,7 +843,7 @@ dictionary FunctionParameter {
 	<dd>
 		The [=parameter type|type=] of the [=function parameter=],
 		represented as a [[css-properties-values-api-1#syntax-strings|syntax string]],
-		or <code>"type(*)"</code> if the [=function parameter|parameter=] has no type.
+		or <code>"*"</code> if the [=function parameter|parameter=] has no type.
 
 	<dt>defaultValue
 	<dd>


### PR DESCRIPTION
Perhaps these functions should indeed return a serialized `<css-type>` (#11908), but until then they should always return a valid syntax string.