### PR TITLE
[css-color-hdr-1] Use definition of `color()` from css-color-5

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -29,6 +29,7 @@ WPT Display: open
 	spec:css-color-5; type:dfn; text:component keywords
 	spec:css-color-5; type:dfn; text:origin color
 	spec:css-color-5; type:dfn; text:required conversion
+	spec:css-color-5; type:function; text:color()
 	spec:css-color-adjust-1; type:value; text:light
 	spec:css-color-adjust-1; type:value; text:dark
 	spec:css-color-4; type:value; text:rec2020
@@ -977,7 +978,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 	Specifying Predefined and Custom Color Spaces: the ''color()'' Function
 </h2>
 
-	The <dfn>color()</dfn> function allows a color to be specified
+	The ''color()'' function allows a color to be specified
 	in a particular, given [=color space=]
 	(rather than the implicit sRGB color space that most of the other color functions operate in).
 


### PR DESCRIPTION
Issue #11954 noted that the spec does not really extend the definition of the `color()` function but rather extends the definition of one of the types that gets used in the definition of `color()`. A previous update dropped duplicated constructs accordingly, but the duplication of the definition itself remained.

Duplication is confusing for tools and readers because there's no longer any direct linnk between the definition of the `color()` function and its syntax.

This replaces the definition with a reference to the actual definition in `css-color-5`, allowing readers to access the actual function syntax. Note the "link default" should only be needed on a temporary basis (and it is needed precisely because the cross-references database currently contains more than one definition of the `color()` function).

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
