### PR TITLE
[css-forms-1][css-pseudo-4] Drop element-backed status from `::file-selector-button` pseudo element

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -312,7 +312,6 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
   The <dfn>::file-selector-button</dfn> pseudo-element represents the button used to open a file picker, if the UA renders such a button.
 
   It typically targets the <{button}> inside an <{input}> element with `type=file`.
-  It is an [=element-backed pseudo-element=].
 
   <div class="example" id="file-selector-button-example">
     For example, the following example should show a green border around the

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1625,7 +1625,6 @@ File Selector Button: the ''::file-selector-button'' pseudo-element</h3>
   targets the ''&lt;button>''
   inside an ''&lt;input>'' element with <code>type=file</code>,
   if the UA renders such a button.
-  It is an [=element-backed pseudo-element=].
 
   <wpt>
     file-selector-button-001.html


### PR DESCRIPTION
Per decision in https://github.com/whatwg/html/issues/11130#issuecomment-2919842021