### PR TITLE
[css-mixins-1] Don't erase the result type

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -589,7 +589,8 @@ with its [=function parameters=] overriding "inherited" custom properties of the
 		Let |argument styles| be the result.
 	10. Let |body rule| be the [=function body=] of |custom function|,
 		as a [=style rule=].
-	11. For each [=custom property registration=] of |registrations|,
+	11. For each [=custom property registration=] of |registrations|
+		except the registration with the name "result",
 		set its initial value
 		to the corresponding value in |argument styles|,
 		set its syntax


### PR DESCRIPTION
The "result" registration got caught in the blast radius when resetting the types for the local variables.

#12256