### PR TITLE
[css-borders-4] Improve definition of superellipse()

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -367,8 +367,7 @@ Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: che
 'corner-shape' values</h4>
 
 	<pre class=prod>
-		<dfn><<corner-shape-value>></dfn> = <l>''round''</l> | <l>''scoop''</l> | <l>''bevel''</l> | <l>''notch''</l> | <l>''<corner-shape-value>/square''</l> | <l>''squircle''</l> |
-											superellipse(<<number [-&infin;,&infin;]>> | infinity | -infinity)
+		<dfn><<corner-shape-value>></dfn> = <l>''round''</l> | <l>''scoop''</l> | <l>''bevel''</l> | <l>''notch''</l> | <l>''<corner-shape-value>/square''</l> | <l>''squircle''</l> | <<superellipse()>>
 	</pre>
 
 	<dl dfn-type="value" dfn-for="<corner-shape-value>">
@@ -392,7 +391,12 @@ Issue <a href="https://github.com/w3c/csswg-drafts/issues/11610">#11610</a>: che
 		<dd>Border radii define a convex curve between an ellipse and an convex angle, equivalent to <css>superellipse(2)</css>.
 	</dl>
 
-	The <dfn>superellipse( <<number>> | infinity | -infinity )</dfn> function describes the <dfn>superellipse parameter</dfn> of the corner.
+	The <dfn>superellipse()</dfn> function describes the <dfn>superellipse parameter</dfn> of the corner. Its syntax is as follows:
+
+	<pre class=prod>
+		<<superellipse()>> = superellipse( <<number>> | infinity | -infinity )
+	</pre>
+
 	It is a number between <css>-infinity</css> and <css>infinity</css>, with <css>-infinity</css> corresponding to a straight concave corner,
 	<css>infinity</css> corresponding to a square convex corner.
 


### PR DESCRIPTION
`superellipse()` is currently used in [`<corner-shape-value>`](https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value) with an inline value definition that does not link to its definition. Besides, this value definition uses `<number [-∞,∞]>`, which is just `<number>`.

This definition also includes its parameters, which are different than in `<corner-shape-value>`. Its syntax is not properly defined in a production rule.

This PR fixes all these problems.