### PR TITLE
[css-shapes-1] Missing comma between shape() parameters

### DIFF
--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -389,7 +389,7 @@ Supported Shapes</h3>
 
 		<<shape()>> = shape(
 			<<'fill-rule'>>?
-			from <<position>>
+			from <<position>> ,
 			<<shape-command>>#
 		)
 	</pre>


### PR DESCRIPTION
The comma between the position and command parameters was dropped when `shape()` was moved from CSS Shapes 2 to CSS Shapes 1. 

https://github.com/w3c/csswg-drafts/commit/eb013231cb01bb4d024e40f95f13fac12ba31c7c#diff-8456ef5bba8c9386e8c499974f617d442407c3404ff7bb0b19fee3d1f9671ef6L162

I guess that is a typo.