### PR TITLE
[css-shapes-1] Typo

### DIFF
--- a/css-shapes-1/Overview.bs
+++ b/css-shapes-1/Overview.bs
@@ -828,7 +828,7 @@ The ''shape()'' Function</h4>
 			the command's starting point, the command's end point, or the [=reference box=], respectively.
 			If such component is not provided, the <<coordinate-pair>> is relative to the segment's start.
 
-		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] && <<arc-sweep>>? && <<arc-size>>? && rotate <<angle>>? ]
+		<dt><dfn><<arc-command>></dfn> = <dfn value>arc</dfn> <<command-end-point>> [[of <<length-percentage>>{1,2}] && <<arc-sweep>>? && <<arc-size>>? && [ rotate <<angle>> ]? ]
 		<dd>
 			Add an <a href="https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands">elliptical arc</a> command
 			to the list of path data commands,


### PR DESCRIPTION
The ["detailed" definition of `<arc-command>`](https://drafts.csswg.org/css-shapes-1/#typedef-shape-arc-command) syntax allows omitting `<angle>` after `rotate`. The "main" definition does not.

I guess that is a typo in the former definition.

`<arc-command> = arc <command-end-point> [ [ of <length-percentage>{1,2} ] && <arc-sweep>? && <arc-size>? && [rotate <angle>]? ]`

`<arc-command> = arc <command-end-point> [[of <length-percentage>{1,2}] && <arc-sweep>? && <arc-size>? && rotate <angle>? ]`