### PR TITLE
[pointer-animations-1] Prefix `pointer()` definition types

### DIFF
--- a/pointer-animations-1/Overview.bs
+++ b/pointer-animations-1/Overview.bs
@@ -222,9 +222,9 @@ spec:selectors-4; type:dfn; text:selector
 	Its syntax is
 
 	<pre class="prod">
-		<<pointer()>> = pointer( [ <<source>> || <<axis>> ]? )
-		<dfn noexport><<axis>></dfn> = block | inline | x | y
-		<dfn noexport><<source>></dfn> = root | nearest | self
+		<<pointer()>> = pointer( [ <<pointer-source>> || <<pointer-axis>> ]? )
+		<dfn noexport><<pointer-axis>></dfn> = block | inline | x | y
+		<dfn noexport><<pointer-source>></dfn> = root | nearest | self
 	</pre>
 
 	By default,
@@ -308,7 +308,7 @@ spec:selectors-4; type:dfn; text:selector
 
 		:   <dfn>axis</dfn>
 		::  The axis that drives the progress of the timeline.
-			See value definitions for <<axis>>, above.
+			See value definitions for <<pointer-axis>>, above.
 	</dl>
 
 	Inherited attributes:


### PR DESCRIPTION
Type definitions share a common namespace and the `<axis>` type is already defined in Scroll-driven Animations:
https://drafts.csswg.org/scroll-animations-1/#typedef-axis

This update prefixes the `<axis>` type (and `<source>` for consistency) with `pointer-` to disambiguate. Feel free to adjust the name as you see fit!

Note: As in Scroll-driven Animations, the spec defines the types with a `noexport` attribute. That seems fine to avoid accidental references from other modules. If that is also meant to create a module-specific namespace for type definitions, we may have a problem as editing tools and validators that I'm aware of and that leverage CSS syntax definitions do not expect that to be possible ;)