### PR TITLE
[css-overflow-4] phrasing tweak in setting clamp points

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -982,7 +982,8 @@ Forcing a Break After a Set Number of Lines: the 'max-lines' property</h3>
 		its <var>N</var>th
 		descendant <a>in-flow</a> <a>line box</a>.
 		If fewer than <var>N</var> line boxes exist,
-		or if there are no clamp points after it,
+		or if there are no possible clamp points
+		after the <var>N</var>th descendant <a>in-flow</a> <a>line box</a>,
 		then that line-clamp container has no clamp point.
 
 


### PR DESCRIPTION
Adjust the phrasing of the sentence describing the case when you cannot set a clamp point. In the original phrasing:
* it wasn't clear what "it" referred to
* the reference to other clamp points without a qualifier like "possible" or "potential" made the logic seem circular.

@andreubotella, can you confirm that my rephrasing does not change the intended meaning?