### PR TITLE
[css-values-5] Typo

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1030,7 +1030,7 @@ Global Syntax of the *-interpolate() family</h3>
 			<<progress-source>> && [ by <<easing-function>> ]?
 			&& <<easing-function>>? && <<segment-options>>?,
 			<<input-position>>{1,2} : <<output-value>> ,
-			[ [ <<easing-function>> || <<segment-options>> , ]? <<input-position>>{1,2} : <<output-value>> ]*
+			[ [ <<easing-function>> || <<segment-options>> ]? , <<input-position>>{1,2} : <<output-value>> ]#?
 		)
 	</pre>
 


### PR DESCRIPTION
The current [definition of the generic interpolation notation](https://drafts.csswg.org/css-values-5/#interpolation-syntax) requires separating interpolation stops by a whitespace:

`[ [ <easing-function> || <segment-options> , ]? <input-position>{1,2} : <output-value> ]*`

The comma should also be hoisted between the optional stop options and the stop.