### PR TITLE
[css-values-5] Make the progress() result consistent with its arguments

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -795,8 +795,9 @@ Interpolation Progress Calculations: the ''progress()'' notation</h2>
 	or a [=mix notation=].
 
 	<div algorithm>
-		The ''progress()'' notation resolves to a <<number>>
-		by <dfn noexport lt="calculate a progress function">calculating a progress function</dfn> as follows:
+		The result of ''progress()'' is a <<number>>
+		[=made consistent=] with the [=consistent type=] of its arguments,
+		resolved by <dfn noexport lt="calculate a progress function">calculating a progress function</dfn> as follows:
 
 		: If the [=progress start value=] and [=progress end value=] are different values
 		:: <code>([=progress value=] - [=progress start value=]) / ([=progress end value=] - [=progress start value=])</code>.


### PR DESCRIPTION
640e1c0, which was intended to drop `container-progress()` and `media-progress()`, also dropped the requirement on the result type of `progress()`, to make it consistent with its arguments.