### PR TITLE
[css-values-5] Allow re-ordering calc-mix() item values

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -920,7 +920,7 @@ Weighted Average of Numeric and Dimensional Values: the ''calc-mix()'' notation<
 	with the following syntactic form:
 
 	<pre class=prod>
-		<<calc-mix()>> = calc-mix( [ <<calc-sum>> <<percentage [0,100]>>? ]# )
+		<<calc-mix()>> = calc-mix( [ <<calc-sum>> && <<percentage [0,100]>>? ]# )
 	</pre>
 
 	The <<calc-sum>> arguments can resolve


### PR DESCRIPTION
All functions in the `*-mix()` family allow declaring `<percentage>` before the mixed item value, except `calc-mix()`.