### PR TITLE
[media-5] Add more discussion of fingerprinting risks with `prefers-*`, per  #12282

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -151,17 +151,24 @@ Units</h3>
 <h3 id='mq-prefers-security'>
 Prefers-* Media Features Security and Privacy</h3>
 
-	<div class=issue>
-	Information about a user can be used as an active fingerprinting vector.
-	Analysis of impact pending, more information to be provided before spec
-	is published.
+	Media features that reflect operating system preferences are a fingerprinting risk
+	because difference users have different preferences and these are observable to origins.
 
-	User agents and developers implementing this
-	specification need to be aware of this vector and take it
-	into consideration when deciding whether to use the feature.
-	Specifically `prefers-reduced-motion`, `prefers-color-scheme`, `prefers-reduced-transparency` and
-	`prefers-reduced-data` are currently of concern for exploitation.
-	</div>
+	* The 'prefers-reduced-data' media feature may be correlated with low income and limited data.
+	* The `prefers-reduced-motion`, `prefers-color-scheme`, `prefers-reduced-transparency` and
+	  `forced-colors` reflect affordances for a range of special needs,
+	
+	Properties dependent on one of the above media queries
+	may be read by embedded iframe content using several methods:
+
+	* Colors and other property values may be directly accessed through computed style.
+	* Layout affecting properties influence lengths, positions and sizes available to script.
+	* Images may be rendered into a canvas element and pixels value read by script.
+
+	Authors should use these media features only when the benefit is clear,
+	particularly when embedded third party content.
+	Combining these queries increases the fingerprinting risk,
+	allowing users to be sorted into smaller buckets.
 
 <!--
 ██     ██  ███████
@@ -3692,9 +3699,8 @@ Appendix B: Privacy Considerations</h2>
 
 	Issue: this section is <a href="https://github.com/w3c/csswg-drafts/issues?q=is%3Aopen+is%3Aissue+label%3Amediaqueries-5+label%3Aprivacy-tracker">incomplete</a> 
 
-	The 'prefers-reduced-data' media feature
-	may be an undesired source of fingerprinting,
-	with a bias towards low income with limited data.
+	<a href="#mq-prefers-security">Section 1.4</a> discusses fingerprinting via
+	the 'prefers-*' and 'forced-colors' media features.
 
 	The {{PreferenceManager}} object allows querying some user-preference [=media features=]. This
 	is not a privacy leak, as that information is already trivially
@@ -3745,6 +3751,7 @@ the following changes and additions were made to this module since the
 * Establish a normative reference for [[Display-P3]]
 * Disallow use of ''layer'' as a media type, rather than merely treat it as an unknown one, for compatibility with [=cascade layers=].
 * Clarify intent of 'prefers-reduced-motion'
+* Added further discussion of fingerprinting vectors
 
 <h3 id="changes-since-2020-07-31"
 oldids="video-width, descdef-media-video-width, video-height, descdef-media-video-height, video-resolution, descdef-media-video-resolution">
@@ -3908,6 +3915,7 @@ Comments from
  Sigurd Lerstad,
  Simon Kissane,
  Simon Pieters,
+ Stephen Chenney,
  Steven Pemberton,
  Susan Lesch,
  Tantek Çelik,


### PR DESCRIPTION
Explicitly address fingerprinting concerns with media queries. Also goes some way to addressing [#10076](https://github.com/w3c/csswg-drafts/issues/10076) and  #9119 and #3488.