### PR TITLE
[css-values-5] Allow omitting position options in color-interpolate()

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1295,7 +1295,7 @@ Interpolated Color Values: the ''color-interpolate()'' notation</h3>
 				&& <<easing-function>>? && <<color-interpolation-method>>?
 			] ,
 			<<input-position>>{1,2} : <<color>>,
-			[ [ <<easing-function>> || <<color-interpolation-method>> ],
+			[ [ <<easing-function>> || <<color-interpolation-method>> ]?,
 			  <<input-position>>{1,2} : <<color>> ]# )
 	</pre>
 


### PR DESCRIPTION
The current syntax does not allow omitting stop options in color-interpolate(), which is an obvious oversight. (I am pretty sure this is the only one left.)