### PR TITLE
[css-view-transitions-1] Added authoring guidance re image-pair vs group

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -731,7 +731,10 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		This element exists to provide ''isolation: isolate'' for its children,
 		and is always present as a [=tree/child=] of each ''::view-transition-group()''.
 		This isolation allows the image pair to be blended with non-normal blend modes
-		without affecting other visual outputs.
+		without affecting other visual outputs. As such, the developer would typically not
+		need to add custom styles to the ''::view-transition-image-pair()'' pseudo-element.
+		Instead, a typical design would involve styling either the ''::view-transition-group()'',
+		''::view-transition-old()'', or ''::view-transition-new()'' elements.
 	</div>
 
 ### View Transition Old State Image: the ''::view-transition-old()'' pseudo-element ### {#::view-transition-old}
@@ -1989,6 +1992,10 @@ This should be feasible since access to this data should already be prevented in
 <h2 class="no-num non-normative" id="changes">Appendix A. Changes</h2>
 
 This appendix is <em>informative</em>.
+
+<h3 id="changes-since-2024-03-28">
+Changes from <a href="https://www.w3.org/TR/2024/CRD-css-view-transitions-1-20240328/">2024-03-28 Candidate Recommendation Draft</a>
+* Add a non-normative note to explain that ''::view-transition-image-pair()'' would typically not need custom styling. See <a href="https://github.com/w3c/csswg-drafts/issues/11926#issuecomment-2916977161">issue 11926</a>
 
 <h3 id="changes-since-2023-05-30">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230530/">2023-05-30 Working Draft</a>

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -734,7 +734,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		without affecting other visual outputs. As such, the developer would typically not
 		need to add custom styles to the ''::view-transition-image-pair()'' pseudo-element.
 		Instead, a typical design would involve styling the ''::view-transition-group()'',
-		''::view-transition-old()'', and ''::view-transition-new()'' elements.
+		''::view-transition-old()'', and ''::view-transition-new()'' pseudo-elements.
 	</div>
 
 ### View Transition Old State Image: the ''::view-transition-old()'' pseudo-element ### {#::view-transition-old}

--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -733,8 +733,8 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		This isolation allows the image pair to be blended with non-normal blend modes
 		without affecting other visual outputs. As such, the developer would typically not
 		need to add custom styles to the ''::view-transition-image-pair()'' pseudo-element.
-		Instead, a typical design would involve styling either the ''::view-transition-group()'',
-		''::view-transition-old()'', or ''::view-transition-new()'' elements.
+		Instead, a typical design would involve styling the ''::view-transition-group()'',
+		''::view-transition-old()'', and ''::view-transition-new()'' elements.
 	</div>
 
 ### View Transition Old State Image: the ''::view-transition-old()'' pseudo-element ### {#::view-transition-old}


### PR DESCRIPTION
[css-view-transitions-1] Added authoring guidance re image-pair vs group

Addresses action item
https://github.com/w3c/csswg-drafts/issues/11926#issuecomment-2916977161