### PR TITLE
[css-values-5] Fix dfn of `<input-position>` and `<output-value>`

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -1185,16 +1185,17 @@ Defining the Interpolation Map</h4>
 	The [=interpolation map=] values are defined as follows:
 
 	<dl dfn-for="calc-interpolate(), transform-interpolate(), color-interpolate(), interpolate()">
-		<dt><dfn type lt="<input-position>|<output-value>"><<input-position>>{1,2} : <<output-value>></dfn>
+		<dt><dfn value><<input-position>>{1,2} : <<output-value>></dfn>
 		<dd>
 			Represents an [=interpolation stop=]
 			associating the specified [=input position=](s) with the specified [=output values=].
 			As with the [=gradient functions=],
 			if two <<input-position>>s are specified,
-			it is treated the same as two stops with the same <<output-value>>.
+			it is treated the same as two stops with the same
+			<dfn><<output-value>></dfn>.
 
 			<pre class=prod>
-				<<input-position>> = <<percentage>> | <<number>> | <<dimension>>
+				<dfn><<input-position>></dfn> = <<percentage>> | <<number>> | <<dimension>>
 			</pre>
 
 			Note: <<output-value>> is not given a grammar here,


### PR DESCRIPTION
A `<dfn>` of type `type` should only enclose a basic data type (something between `<` and `>`). At least, that's been the case across specs until now. The spec was using the dfn to describe a more complex `value`. More likely, the spec was trying to combine the definition of the two types with the definition of the value pattern that uses them in one single dfn.

This update changes the value pattern definition type to `value` and creates additional `type` dfns for the individual types so that they can be referenced from other constructs.
