### PR TITLE
[cssom-view-1] Remove erroneous </li>

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -1090,7 +1090,7 @@ result of running these steps:
     1. Let <var>startNode</var> be the <var>caretPositionNode</var> of the <var>caretPosition</var>, and let <var>startOffset</var> be the <var>caretPositionOffset</var> of the <var>caretPosition</var>.
     1. While <var>startNode</var> is a [=node=], <var>startNode</var>'s [=tree/root=] is a [=shadow root=], and <var>startNode</var>'s [=tree/root=] is not a [=shadow-including inclusive ancestor=] of any of <var>options</var>["{{CaretPositionFromPointOptions/shadowRoots}}"], repeat these steps:
         1. Set <var>startOffset</var> to [=tree/index=] of <var>startNode</var>'s [=tree/root=]'s [=host=].
-        1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].</li>
+        1. Set <var>startNode</var> to <var>startNode</var>'s [=tree/root=]'s [=host=]'s [=tree/parent=].
     1. Return a <a>caret position</a> with its properties set as follows:
         1. <a>caret node</a> is set to <var>startNode</var>.
         1. <a>caret offset</a> is set to <var>startOffset</var>.


### PR DESCRIPTION
cssom-view-1 wasn't building because of this. Removing this erroneous closing tag fixes the build so that the spec is correctly generated.