### PR TITLE
[css-counter-styles] Define extended CJK longhand counter styles range

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2367,7 +2367,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 
 	This entire section is normative, but <strong>optional</strong>. User-agents may ignore it and still be conformant. If a user-agent implements some of the extended forms described in this section, they must be implemented as described here.
 
-	The Chinese longhand styles are defined out to 10k with a [=Chinese|specialized algorithm=], while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles. However, these styles are defined out to 10<sup>16</sup> in common usage. The following section describes an alternative algorithm for these styles.
+	The Chinese longhand styles are defined out to 10k with a [[#limited-chinese|specialized algorithm]], while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles. However, these styles are defined out to 10<sup>16</sup> in common usage. The following section describes an alternative algorithm for these styles.
 
 	All of the Chinese, Japanese, and Korean styles are defined for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive. For numbers outside this range, the ''cjk-decimal'' style is used. All of the styles are defined by almost identical algorithms (specified as a single algorithm here, with the differences called out when relevant), but use different sets of characters. The list following the algorithm gives the name of each counter style using this algorithm, and the individual character sets used by each style.
 

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2041,7 +2041,7 @@ Longhand East Asian Counter Styles</h3>
 	The Korean and Japanese variants of these counter styles can,
 	if limited to the range of -9999 to 9999,
 	be expressed as ''@counter-style'' rules.
-	The Chinese variants use a [=Chinese|specialized algorithm=],
+	The Chinese variants use a [[#limited-chinese|specialized algorithm]],
 	regardless of range.
 	The required implementation is described in [[#limited-range-required]],
 	which defines the styles over these limited ranges,

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -1914,7 +1914,8 @@ Longhand East Asian Counter Styles</h3>
 	as their characters are more difficult to alter into each other.
 
 	<div class="example">
-		The following table shows examples of these styles, particularly some ways in which they differ.
+		The following table shows examples of these styles,
+		particularly some ways in which they differ.
 
 		<table class="data">
 			<thead>
@@ -2034,15 +2035,19 @@ Longhand East Asian Counter Styles</h3>
 		</table>
 	</div>
 
-	Because opinions differ on how best to represent numbers 10,000 or greater 
-	using the longhand CJK styles, the implementation details are split into two sections. 
-	The Korean and Japanese variants of these counter styles can, if limited to the range 
-	of -9999 to 9999, be expressed as ''@counter-style'' rules. 
-	The Chinese variants use a [=Chinese|specialized algorithm=], regardless of range. 
-	The required implementation is described in [[#limited-range-required]], which defines 
-	the styles over these limited ranges, and the optional implementation is described in 
-	[[#extended-range-optional]], which defines them over a larger range following custom algorithms. 
-	Outside the implementation-supported range, 
+	Because opinions differ on how best to represent numbers 10,000 or greater
+	using the longhand CJK styles,
+	the implementation details are split into two sections.
+	The Korean and Japanese variants of these counter styles can,
+	if limited to the range of -9999 to 9999,
+	be expressed as ''@counter-style'' rules.
+	The Chinese variants use a [=Chinese|specialized algorithm=],
+	regardless of range.
+	The required implementation is described in [[#limited-range-required]],
+	which defines the styles over these limited ranges,
+	and the optional implementation is described in [[#extended-range-optional]],
+	which defines them over a larger range following custom algorithms.
+	Outside the implementation-supported range,
 	the fallback is ''cjk-decimal''.
 
 <!--
@@ -2185,30 +2190,35 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 	</dl>
 
 	The Chinese longhand styles are defined by almost identical algorithms
-	(specified as a single algorithm here, with the differences called out when relevant),
+	(specified as a single algorithm here,
+	with the differences called out when relevant),
 	but use different sets of characters,
 	as specified by the table following the algorithm.
 
 	<ol>
-		<li>If the counter value is 0, the representation is the character for 0
-		specified for the given counter style.  Skip the rest of this algorithm.
+		<li>If the counter value is 0,
+		the representation is the character for 0 specified for the given counter style.
+		Skip the rest of this algorithm.
 
-		<li>Initially represent the counter value as a decimal number.  For each
-		digit that is not 0, append the appropriate digit marker to the digit.
+		<li>Initially represent the counter value as a decimal number.
+		For each digit that is not 0,
+		append the appropriate digit marker to the digit.
 		The ones digit has no marker.
 
-		<li>For the informal styles, if the counter value is between ten and
-		nineteen, remove the tens digit (leave the digit marker).
+		<li>For the informal styles,
+		if the counter value is between ten and nineteen,
+		remove the tens digit (leave the digit marker).
 
-		<li>Drop any trailing zeros and collapse any remaining zeros into a single
-		zero digit.
+		<li>Drop any trailing zeros
+		and collapse any remaining zeros into a single zero digit.
 
-		<li>Replace the digits 0-9 with the appropriate character for the given
-		counter style.  Return the resultant string as the representation of the
-		counter value.
+		<li>Replace the digits 0-9 with the appropriate character
+		for the given counter style.
+		Return the resultant string as the representation of the counter value.
 	</ol>
 
-	For all of these counter styles, the '@counter-style/suffix' is "、" U+3001,
+	For all of these counter styles,
+	the '@counter-style/suffix' is "、" U+3001,
 	the '@counter-style/fallback' is ''cjk-decimal'',
 	the '@counter-style/range' is ''-9999 9999'',
 	and the '@counter-style/negative' value is given in the table of symbols for each style.
@@ -2363,58 +2373,85 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 
 <h4 id='extended-range-optional'>Extended Implementation (optional)</h4>
 
-	Some counter styles described in earlier chapters have been limited to an artifically small (though still useful) range to reduce the overall complexity of the spec and the task of implementing those styles. However, some implementations might consider the extra complexity worthwhile for the additional range it offers to authors. To accomodate this, this section describes how to extend the limited counter-styles to a larger range.
+	Some counter styles described in earlier chapters have been limited to an artifically small (though still useful) range
+	to reduce the overall complexity of the spec and the task of implementing those styles.
+	However, some implementations might consider the extra complexity worthwhile
+	for the additional range it offers to authors.
+	To accomodate this,
+	this section describes how to extend the limited counter-styles to a larger range.
 
-	This entire section is normative, but <strong>optional</strong>. User-agents may ignore it and still be conformant. If a user-agent implements some of the extended forms described in this section, they must be implemented as described here.
+	This entire section is normative, but <strong>optional</strong>.
+	User-agents may ignore it and still be conformant.
+	If a user-agent implements some of the extended forms described in this section,
+	they must be implemented as described here.
 
-	The Chinese longhand styles are defined out to 10k with a [[#limited-chinese|specialized algorithm]], while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles. However, these styles are defined out to 10<sup>16</sup> in common usage. The following section describes an alternative algorithm for these styles.
+	The Chinese longhand styles are defined out to 10k with a [[#limited-chinese|specialized algorithm]],
+	while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles.
+	However, these styles are defined out to 10<sup>16</sup> in common usage.
+	The following section describes an alternative algorithm for these styles.
 
-	All of the Chinese, Japanese, and Korean styles are defined for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive. For numbers outside this range, the ''cjk-decimal'' style is used. All of the styles are defined by almost identical algorithms (specified as a single algorithm here, with the differences called out when relevant), but use different sets of characters. The list following the algorithm gives the name of each counter style using this algorithm, and the individual character sets used by each style.
+	All of the Chinese, Japanese, and Korean styles are defined
+	for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive.
+	For numbers outside this range, the ''cjk-decimal'' style is used.
+	All of the styles are defined by almost identical algorithms
+	(specified as a single algorithm here,
+	with the differences called out when relevant),
+	but use different sets of characters.
+	The list following the algorithm gives the name of each counter style using this algorithm,
+	and the individual character sets used by each style.
 
 	<ol>
-		<li>If the counter value is 0, the representation is the character for 0
-		specified for the given counter style.  Skip the rest of this algorithm.
+		<li>If the counter value is 0,
+		the representation is the character for 0 specified for the given counter style.
+		Skip the rest of this algorithm.
 
-		<li>Initially represent the counter value as a decimal number.  Starting
-		from the right (ones place), split the decimal number into groups of
-		four digits.
+		<li>Initially represent the counter value as a decimal number.
+		Starting from the right (ones place),
+		split the decimal number into groups of four digits.
 
-		<li>For each group with a non-zero value, append the appropriate group
-		marker to the group.  The ones group has no marker.
+		<li>For each group with a non-zero value,
+		append the appropriate group marker to the group.
+		The ones group has no marker.
 
-		<li>Within each group, for each digit that is not 0, append the appropriate
-		digit marker to the digit.  The ones digit of each group has no marker.
+		<li>Within each group,
+		for each digit that is not 0,
+		append the appropriate digit marker to the digit.
+		The ones digit of each group has no marker.
 
 		<li>Drop ones:
 			<ul>
-				<li>For the Chinese informal styles, for any group with a value
-				between ten and nineteen, remove the tens digit (leave the digit
-				marker).
+				<li>For the Chinese informal styles,
+				for any group with a value between ten and nineteen,
+				remove the tens digit (leave the digit marker).
 
-				<li>For the Japanese informal and Korean informal styles, if any
-				of the digit markers are preceded by the digit 1, and that digit
-				is not the first digit of the group, remove the digit (leave the
-				digit marker).
+				<li>For the Japanese informal and Korean informal styles,
+				if any of the digit markers are preceded by the digit 1,
+				and that digit is not the first digit of the group,
+				remove the digit (leave the digit marker).
 
-				<li>For Korean informal styles, if the value of the ten-thousands
-				group is 1, drop the digit (leave the digit marker).
+				<li>For Korean informal styles,
+				if the value of the ten-thousands group is 1,
+				drop the digit (leave the digit marker).
 			</ul>
 		
 
 		<li>Drop zeros:
 			<ul>
-				<li>For the Japanese and Korean styles, drop all zero digits.
+				<li>For the Japanese and Korean styles,
+				drop all zero digits.
 
-				<li>For the Chinese styles, drop any trailing zeros for all
-				non-zero groups and collapse (across groups) each remaining
-				consecutive group of zeros into a single zero digit.
+				<li>For the Chinese styles,
+				drop any trailing zeros for all non-zero groups
+				and collapse (across groups) each remaining consecutive group of zeros
+				into a single zero digit.
 			</ul>
 
-		<li>For the Korean styles, insert a space (" " U+0020) between each group.
+		<li>For the Korean styles,
+		insert a space (" " U+0020) between each group.
 
-		<li>Replace the digits 0-9 with the appropriate character for the given
-		counter style.  Return the resultant string as the representation of the
-		counter value.
+		<li>Replace the digits 0-9 with the appropriate character
+		for the given counter style.
+		Return the resultant string as the representation of the counter value.
 	</ol>
 
 	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]], except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2184,7 +2184,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 			(It exists for legacy reasons.)
 	</dl>
 
-	The <dfn dfn>Chinese</dfn> longhand styles are defined by almost identical algorithms
+	The Chinese longhand styles are defined by almost identical algorithms
 	(specified as a single algorithm here, with the differences called out when relevant),
 	but use different sets of characters,
 	as specified by the table following the algorithm.
@@ -2417,7 +2417,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		counter value.
 	</li></ol>
 
-	For all of these counter styles, the '@counter-style/suffix' is "、" U+3001, the '@counter-style/fallback' is ''cjk-decimal'', and the '@counter-style/negative' is given in the tables below, or else is the initial value of the descriptor. The '@counter-style/range' is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
+	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]], except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
 
 	The following tables define the characters used in these styles:
 	<table class="data">

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -1929,7 +1929,7 @@ Longhand East Asian Counter Styles</h3>
 				    <th>100
 				    <th>101
 				    <th>6001
-			</thead>
+			
 			<tbody>
 				<tr><th scope="row">''japanese-informal''
 				    <td>〇
@@ -2030,7 +2030,7 @@ Longhand East Asian Counter Styles</h3>
 				    <td>壹佰
 				    <td>壹佰零壹
 				    <td>陸仟零壹
-			</tbody>
+			
 		</table>
 	</div>
 
@@ -2225,7 +2225,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 				<th>simp-chinese-formal
 				<th>trad-chinese-informal
 				<th>trad-chinese-formal
-		</thead>
+		
 		<tbody>
 			<tr>
 				<th scope=row>Digit 0
@@ -2311,7 +2311,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 				<td>负 U+8D1F
 				<td>負 U+8CA0
 				<td>負 U+8CA0
-		</tbody>
+		
 	</table>
 
 	<div class='note'>
@@ -2375,47 +2375,47 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		<li>If the counter value is 0, the representation is the character for 0
 		specified for the given counter style.  Skip the rest of this algorithm.
 
-		</li><li>Initially represent the counter value as a decimal number.  Starting
+		<li>Initially represent the counter value as a decimal number.  Starting
 		from the right (ones place), split the decimal number into groups of
 		four digits.
 
-		</li><li>For each group with a non-zero value, append the appropriate group
+		<li>For each group with a non-zero value, append the appropriate group
 		marker to the group.  The ones group has no marker.
 
-		</li><li>Within each group, for each digit that is not 0, append the appropriate
+		<li>Within each group, for each digit that is not 0, append the appropriate
 		digit marker to the digit.  The ones digit of each group has no marker.
 
-		</li><li>Drop ones:
+		<li>Drop ones:
 			<ul>
 				<li>For the Chinese informal styles, for any group with a value
 				between ten and nineteen, remove the tens digit (leave the digit
 				marker).
 
-				</li><li>For the Japanese informal and Korean informal styles, if any
+				<li>For the Japanese informal and Korean informal styles, if any
 				of the digit markers are preceded by the digit 1, and that digit
 				is not the first digit of the group, remove the digit (leave the
 				digit marker).
 
-				</li><li>For Korean informal styles, if the value of the ten-thousands
+				<li>For Korean informal styles, if the value of the ten-thousands
 				group is 1, drop the digit (leave the digit marker).
-			</li></ul>
+			</ul>
 		
 
-		</li><li>Drop zeros:
+		<li>Drop zeros:
 			<ul>
 				<li>For the Japanese and Korean styles, drop all zero digits.
 
-				</li><li>For the Chinese styles, drop any trailing zeros for all
+				<li>For the Chinese styles, drop any trailing zeros for all
 				non-zero groups and collapse (across groups) each remaining
 				consecutive group of zeros into a single zero digit.
-			</li></ul>
+			</ul>
 
-		</li><li>For the Korean styles, insert a space (" " U+0020) between each group.
+		<li>For the Korean styles, insert a space (" " U+0020) between each group.
 
-		</li><li>Replace the digits 0-9 with the appropriate character for the given
+		<li>Replace the digits 0-9 with the appropriate character for the given
 		counter style.  Return the resultant string as the representation of the
 		counter value.
-	</li></ol>
+	</ol>
 
 	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]], except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
 
@@ -2425,116 +2425,115 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 			<tr>
 				<th rowspan="2" scope="col">Values
 				</th><th colspan="4" scope="col">Codepoints
-			</th></tr><tr>
+			</th><tr>
 				<th>simp-chinese-informal
 				</th><th>simp-chinese-formal
 				</th><th>trad-chinese-informal
 				</th><th>trad-chinese-formal
-		</th></tr></thead>
-		<tbody>
+				<tbody>
 			<tr>
 				<th scope="row">Digit 0
 				</th><td>零 U+96F6
-				</td><td>零 U+96F6
-				</td><td>零 U+96F6
-				</td><td>零 U+96F6
-			</td></tr><tr>
+				<td>零 U+96F6
+				<td>零 U+96F6
+				<td>零 U+96F6
+			<tr>
 				<th scope="row">Digit 1
 				</th><td>一 U+4E00
-				</td><td>壹 U+58F9
-				</td><td>一 U+4E00
-				</td><td>壹 U+58F9
-			</td></tr><tr>
+				<td>壹 U+58F9
+				<td>一 U+4E00
+				<td>壹 U+58F9
+			<tr>
 				<th scope="row">Digit 2
 				</th><td>二 U+4E8C
-				</td><td>贰 U+8D30
-				</td><td>二 U+4E8C
-				</td><td>貳 U+8CB3
-			</td></tr><tr>
+				<td>贰 U+8D30
+				<td>二 U+4E8C
+				<td>貳 U+8CB3
+			<tr>
 				<th scope="row">Digit 3
 				</th><td>三 U+4E09
-				</td><td>叁 U+53C1
-				</td><td>三 U+4E09
-				</td><td>參 U+53C3
-			</td></tr><tr>
+				<td>叁 U+53C1
+				<td>三 U+4E09
+				<td>參 U+53C3
+			<tr>
 				<th scope="row">Digit 4
 				</th><td>四 U+56DB
-				</td><td>肆 U+8086
-				</td><td>四 U+56DB
-				</td><td>肆 U+8086
-			</td></tr><tr>
+				<td>肆 U+8086
+				<td>四 U+56DB
+				<td>肆 U+8086
+			<tr>
 				<th scope="row">Digit 5
 				</th><td>五 U+4E94
-				</td><td>伍 U+4F0D
-				</td><td>五 U+4E94
-				</td><td>伍 U+4F0D
-			</td></tr><tr>
+				<td>伍 U+4F0D
+				<td>五 U+4E94
+				<td>伍 U+4F0D
+			<tr>
 				<th scope="row">Digit 6
 				</th><td>六 U+516D
-				</td><td>陆 U+9646
-				</td><td>六 U+516D
-				</td><td>陸 U+9678
-			</td></tr><tr>
+				<td>陆 U+9646
+				<td>六 U+516D
+				<td>陸 U+9678
+			<tr>
 				<th scope="row">Digit 7
 				</th><td>七 U+4E03
-				</td><td>柒 U+67D2
-				</td><td>七 U+4E03
-				</td><td>柒 U+67D2
-			</td></tr><tr>
+				<td>柒 U+67D2
+				<td>七 U+4E03
+				<td>柒 U+67D2
+			<tr>
 				<th scope="row">Digit 8
 				</th><td>八 U+516B
-				</td><td>捌 U+634C
-				</td><td>八 U+516B
-				</td><td>捌 U+634C
-			</td></tr><tr>
+				<td>捌 U+634C
+				<td>八 U+516B
+				<td>捌 U+634C
+			<tr>
 				<th scope="row">Digit 9
 				</th><td>九 U+4E5D
-				</td><td>玖 U+7396
-				</td><td>九 U+4E5D
-				</td><td>玖 U+7396
-			</td></tr><tr>
+				<td>玖 U+7396
+				<td>九 U+4E5D
+				<td>玖 U+7396
+			<tr>
 				<th scope="row">Second Digit Marker
 				</th><td>十 U+5341
-				</td><td>拾 U+62FE
-				</td><td>十 U+5341
-				</td><td>拾 U+62FE
-			</td></tr><tr>
+				<td>拾 U+62FE
+				<td>十 U+5341
+				<td>拾 U+62FE
+			<tr>
 				<th scope="row">Third Digit Marker
 				</th><td>百 U+767E
-				</td><td>佰 U+4F70
-				</td><td>百 U+767E 
-				</td><td>佰 U+4F70
-			</td></tr><tr>
+				<td>佰 U+4F70
+				<td>百 U+767E 
+				<td>佰 U+4F70
+			<tr>
 				<th scope="row">Fourth Digit Marker
 				</th><td>千 U+5343
-				</td><td>仟 U+4EDF
-				</td><td>千 U+5343
-				</td><td>仟 U+4EDF
-			</td></tr><tr>
+				<td>仟 U+4EDF
+				<td>千 U+5343
+				<td>仟 U+4EDF
+			<tr>
 				<th scope="row">Second Group Marker
 				</th><td>万 U+4E07
-				</td><td>万 U+4E07
-				</td><td>萬 U+842C
-				</td><td>萬 U+842C
-			</td></tr><tr>
+				<td>万 U+4E07
+				<td>萬 U+842C
+				<td>萬 U+842C
+			<tr>
 				<th scope="row">Third Group Marker
 				</th><td>亿 U+4EBF
-				</td><td>亿 U+4EBF
-				</td><td>億 U+5104
-				</td><td>億 U+5104
-			</td></tr><tr>
+				<td>亿 U+4EBF
+				<td>億 U+5104
+				<td>億 U+5104
+			<tr>
 				<th scope="row">Fourth Group Marker
 				</th><td>万亿 U+4E07 U+4EBF
-				</td><td>万亿 U+4E07 U+4EBF
-				</td><td>兆 U+5146
-				</td><td>兆 U+5146
-			</td></tr><tr>
+				<td>万亿 U+4E07 U+4EBF
+				<td>兆 U+5146
+				<td>兆 U+5146
+			<tr>
 				<th scope="row">Negative Sign
 				</th><td>负 U+8D1F
-				</td><td>负 U+8D1F
-				</td><td>負 U+8CA0
-				</td><td>負 U+8CA0
-		</td></tr></tbody>
+				<td>负 U+8D1F
+				<td>負 U+8CA0
+				<td>負 U+8CA0
+		
 	</table>
 
 	<table class="data">
@@ -2542,79 +2541,78 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 			<tr>
 				<th rowspan="2" scope="col">Values
 				</th><th colspan="2" scope="col">Codepoints
-			</th></tr><tr>
+			</th><tr>
 				<th>japanese-informal
 				</th><th>japanese-formal
-		</th></tr></thead>
-		<tbody>
+				<tbody>
 			<tr>
 				<th scope="row">Digit 0
 				</th><td>〇 U+3007
-				</td><td>零 U+96F6
-			</td></tr><tr>
+				<td>零 U+96F6
+			<tr>
 				<th scope="row">Digit 1
 				</th><td>一 U+4E00
-				</td><td>壱 U+58F1
-			</td></tr><tr>
+				<td>壱 U+58F1
+			<tr>
 				<th scope="row">Digit 2
 				</th><td>二 U+4E8C
-				</td><td>弐 U+5F10
-			</td></tr><tr>
+				<td>弐 U+5F10
+			<tr>
 				<th scope="row">Digit 3
 				</th><td>三 U+4E09
-				</td><td>参 U+53C2
-			</td></tr><tr>
+				<td>参 U+53C2
+			<tr>
 				<th scope="row">Digit 4
 				</th><td>四 U+56DB
-				</td><td>四 U+56DB
-			</td></tr><tr>
+				<td>四 U+56DB
+			<tr>
 				<th scope="row">Digit 5
 				</th><td>五 U+4E94
-				</td><td>伍 U+4f0D
-			</td></tr><tr>
+				<td>伍 U+4f0D
+			<tr>
 				<th scope="row">Digit 6
 				</th><td>六 U+516D
-				</td><td>六 U+516D
-			</td></tr><tr>
+				<td>六 U+516D
+			<tr>
 				<th scope="row">Digit 7
 				</th><td>七 U+4E03
-				</td><td>七 U+4E03
-			</td></tr><tr>
+				<td>七 U+4E03
+			<tr>
 				<th scope="row">Digit 8
 				</th><td>八 U+516B
-				</td><td>八 U+516B
-			</td></tr><tr>
+				<td>八 U+516B
+			<tr>
 				<th scope="row">Digit 9
 				</th><td>九 U+4E5D
-				</td><td>九 U+4E5D
-			</td></tr><tr>
+				<td>九 U+4E5D
+			<tr>
 				<th scope="row">Second Digit Marker
 				</th><td>十 U+5341
-				</td><td>拾 U+62FE
-			</td></tr><tr>
+				<td>拾 U+62FE
+			<tr>
 				<th scope="row">Third Digit Marker
 				</th><td>百 U+767E
-				</td><td>百 U+767E
-			</td></tr><tr>
+				<td>百 U+767E
+			<tr>
 				<th scope="row">Fourth Digit Marker
 				</th><td>千 U+5343
-				</td><td>阡 U+9621
-			</td></tr><tr>
+				<td>阡 U+9621
+			<tr>
 				<th scope="row">Second Group Marker
 				</th><td>万 U+4E07
-				</td><td>萬 U+842C
-			</td></tr><tr>
+				<td>萬 U+842C
+			<tr>
 				<th scope="row">Third Group Marker
 				</th><td>億 U+5104
-				</td><td>億 U+5104
-			</td></tr><tr>
+				<td>億 U+5104
+			<tr>
 				<th scope="row">Fourth Group Marker
 				</th><td>兆 U+5146
-				</td><td>兆 U+5146
-			</td></tr><tr>
+				<td>兆 U+5146
+			<tr>
 				<th scope="row">Negative Sign
 				</th><td colspan="2">マイナス U+30DE U+30A4 U+30CA U+30B9
-		</td></tr></tbody>
+		
 	</table>
 
 	<table class="data">
@@ -2622,96 +2620,95 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 			<tr>
 				<th rowspan="2" scope="col">Values
 				</th><th colspan="3" scope="col">Codepoints
-			</th></tr><tr>
+			</th><tr>
 				<th>korean-hangul-formal
 				</th><th>korean-hanja-informal
 				</th><th>korean-hanja-formal
-		</th></tr></thead>
-		<tbody>
+				<tbody>
 			<tr>
 				<th scope="row">Digit 0
 				</th><td>영 U+C601
-				</td><td>零 U+96F6
-				</td><td>零 U+96F6
-			</td></tr><tr>
+				<td>零 U+96F6
+				<td>零 U+96F6
+			<tr>
 				<th scope="row">Digit 1
 				</th><td>일 U+C77C
-				</td><td>一 U+4E00
-				</td><td>壹 U+58F9
-			</td></tr><tr>
+				<td>一 U+4E00
+				<td>壹 U+58F9
+			<tr>
 				<th scope="row">Digit 2
 				</th><td>이 U+C774
-				</td><td>二 U+4E8C
-				</td><td>貳 U+8CB3
-			</td></tr><tr>
+				<td>二 U+4E8C
+				<td>貳 U+8CB3
+			<tr>
 				<th scope="row">Digit 3
 				</th><td>삼 U+C0BC
-				</td><td>三 U+4E09
-				</td><td>參 U+53C3
-			</td></tr><tr>
+				<td>三 U+4E09
+				<td>參 U+53C3
+			<tr>
 				<th scope="row">Digit 4
 				</th><td>사 U+C0AC
-				</td><td>四 U+56DB
-				</td><td>四 U+56DB
-			</td></tr><tr>
+				<td>四 U+56DB
+				<td>四 U+56DB
+			<tr>
 				<th scope="row">Digit 5
 				</th><td>오 U+C624
-				</td><td>五 U+4E94
-				</td><td>五 U+4E94
-			</td></tr><tr>
+				<td>五 U+4E94
+				<td>五 U+4E94
+			<tr>
 				<th scope="row">Digit 6
 				</th><td>육 U+C721
-				</td><td>六 U+516D
-				</td><td>六 U+516D
-			</td></tr><tr>
+				<td>六 U+516D
+				<td>六 U+516D
+			<tr>
 				<th scope="row">Digit 7
 				</th><td>칠 U+CE60
-				</td><td>七 U+4E03
-				</td><td>七 U+4E03
-			</td></tr><tr>
+				<td>七 U+4E03
+				<td>七 U+4E03
+			<tr>
 				<th scope="row">Digit 8
 				</th><td>팔 U+D314
-				</td><td>八 U+516B
-				</td><td>八 U+516B
-			</td></tr><tr>
+				<td>八 U+516B
+				<td>八 U+516B
+			<tr>
 				<th scope="row">Digit 9
 				</th><td>구 U+AD6C
-				</td><td>九 U+4E5D
-				</td><td>九 U+4E5D
-			</td></tr><tr>
+				<td>九 U+4E5D
+				<td>九 U+4E5D
+			<tr>
 				<th scope="row">Second Digit Marker
 				</th><td>십 U+C2ED
-				</td><td>十 U+5341
-				</td><td>拾 U+62FE
-			</td></tr><tr>
+				<td>十 U+5341
+				<td>拾 U+62FE
+			<tr>
 				<th scope="row">Third Digit Marker
 				</th><td>백 U+BC31
-				</td><td>百 U+767E
-				</td><td>百 U+767E
-			</td></tr><tr>
+				<td>百 U+767E
+				<td>百 U+767E
+			<tr>
 				<th scope="row">Fourth Digit Marker
 				</th><td>천 U+CC9C
-				</td><td>千 U+5343
-				</td><td>仟 U+4EDF
-			</td></tr><tr>
+				<td>千 U+5343
+				<td>仟 U+4EDF
+			<tr>
 				<th scope="row">Second Group Marker
 				</th><td>만 U+B9CC
-				</td><td>萬 U+842C
-				</td><td>萬 U+842C
-			</td></tr><tr>
+				<td>萬 U+842C
+				<td>萬 U+842C
+			<tr>
 				<th scope="row">Third Group Marker
 				</th><td>억 U+C5B5
-				</td><td>億 U+5104
-				</td><td>億 U+5104
-			</td></tr><tr>
+				<td>億 U+5104
+				<td>億 U+5104
+			<tr>
 				<th scope="row">Fourth Group Marker
 				</th><td>조 U+C870
-				</td><td>兆 U+5146
-				</td><td>兆 U+5146
-		</td></tr><tr>
+				<td>兆 U+5146
+				<td>兆 U+5146
+		<tr>
 				<th scope="row">Negative Sign
 				</th><td colspan="2">마이너스 U+B9C8 U+C774 U+B108 U+C2A4
-		</td></tr></tbody>
+		
 	</table>
 
 <!--

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2451,7 +2451,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 	</ol>
 
 	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]],
-	except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
+	except for the '@counter-style/range', which is ''calc(-1 * pow(10, 16) + 1) calc(pow(10, 16) - 1)''.
 
 	The following tables define the characters used in these styles:
 	<table class="data">

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2037,13 +2037,13 @@ Longhand East Asian Counter Styles</h3>
 	Because opinions differ on how best to represent numbers 10,000 or greater 
 	using the longhand CJK styles, the implementation details are split into two sections. 
 	The Korean and Japanese variants of these counter styles can, if limited to the range 
-	of -9999 to 9999, be expressed as <code>@counter-style</code> rules. 
+	of -9999 to 9999, be expressed as ''@counter-style'' rules. 
 	The Chinese variants use a [=Chinese|specialized algorithm=], regardless of range. 
 	The required implementation is described in [[#limited-range-required]], which defines 
 	the styles over these limited ranges, and the optional implementation is described in 
 	[[#extended-range-optional]], which defines them over a larger range following custom algorithms. 
 	Outside the implementation-supported range, 
-	the fallback is 'cjk-decimal'.
+	the fallback is ''cjk-decimal''.
 
 <!--
 ██       ████ ██     ██ ████ ████████ ████████ ████████         ██████        ██ ██    ██

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2385,10 +2385,6 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 	If a user-agent implements some of the extended forms described in this section,
 	they must be implemented as described here.
 
-	The Chinese longhand styles are defined out to 10k with a [[#limited-chinese|specialized algorithm]],
-	while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles.
-	However, these styles are defined out to 10<sup>16</sup> in common usage.
-	The following section describes an alternative algorithm for these styles.
 
 	All of the Chinese, Japanese, and Korean styles are defined
 	for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive.

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2056,8 +2056,9 @@ Longhand East Asian Counter Styles</h3>
 ████████ ████ ██     ██ ████    ██    ████████ ████████         ██████   ██████  ██    ██
 -->
 
-<h4 id='limited-japanese'>
-Japanese: ''japanese-informal'' and ''japanese-formal''</h4>
+<h4 id='limited-range-required'>Limited-range Implementation (required)</h4>
+<h5 id='limited-japanese'>
+Japanese: ''japanese-informal'' and ''japanese-formal''</h5>
 
 	<dl dfn-type="value" dfn-for="<counter-style-name>">
 		<dt><dfn id="japanese-informal">japanese-informal</dfn>
@@ -2098,8 +2099,8 @@ Japanese: ''japanese-informal'' and ''japanese-formal''</h4>
 	</pre>
 
 
-<h4 id=limited-korean>
-Korean: ''korean-hangul-formal'', ''korean-hanja-informal'', and ''korean-hanja-formal''</h4>
+<h5 id=limited-korean>
+Korean: ''korean-hangul-formal'', ''korean-hanja-informal'', and ''korean-hanja-formal''</h5>
 
 	<dl dfn-for="<counter-style-name>" dfn-type="value">
 		<dt><dfn id="korean-hangul-formal">korean-hangul-formal</dfn>
@@ -2154,8 +2155,8 @@ Korean: ''korean-hangul-formal'', ''korean-hanja-informal'', and ''korean-hanja-
 	</pre>
 
 
-<h4 id='limited-chinese'>
-Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-informal'', and ''trad-chinese-formal''</h4>
+<h5 id='limited-chinese'>
+Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-informal'', and ''trad-chinese-formal''</h5>
 
 	<dl dfn-type="value" dfn-for="<counter-style>">
 		<dt><dfn id="simp-chinese-informal">simp-chinese-informal</dfn>
@@ -2184,7 +2185,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 			(It exists for legacy reasons.)
 	</dl>
 
-	The Chinese longhand styles are defined by almost identical algorithms
+	The <dfn dfn>Chinese</dfn> longhand styles are defined by almost identical algorithms
 	(specified as a single algorithm here, with the differences called out when relevant),
 	but use different sets of characters,
 	as specified by the table following the algorithm.
@@ -2360,6 +2361,356 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		 40　　　 四十    80　　　 八十   120　 一百二十
 		</pre>
 	</div>
+
+<h4 id='extended-range-optional'>Extended Implementation (optional)</h4>
+
+	Some counter styles described in earlier chapters have been limited to an artifically small (though still useful) range to reduce the overall complexity of the spec and the task of implementing those styles. However, some implementations might consider the extra complexity worthwhile for the additional range it offers to authors. To accomodate this, this section describes how to extend the limited counter-styles to a larger range.
+
+	This entire section is normative, but <strong>optional</strong>. User-agents may ignore it and still be conformant. If a user-agent implements some of the extended forms described in this section, they must be implemented as described here.
+
+	The Chinese longhand styles are defined out to 10k with a [=Chinese|specialized algorithm=], while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles. However, these styles are defined out to 10<sup>16</sup> in common usage. The following section describes an alternative algorithm for these styles.
+
+	The Chinese and Japanese styles are defined for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive; the Korean styles are defined for all non-negative numbers less than 10<sup>16</sup>. For numbers outside this range, the ''cjk-decimal'' style is used. All of the styles are defined by almost identical algorithms (specified as a single algorithm here, with the differences called out when relevant), but use different sets of characters. The list following the algorithm gives the name of each counter style using this algorithm, and the individual character sets used by each style.
+
+	<ol>
+		<li>If the counter value is 0, the representation is the character for 0
+		specified for the given counter style.  Skip the rest of this algorithm.
+
+		</li><li>Initially represent the counter value as a decimal number.  Starting
+		from the right (ones place), split the decimal number into groups of
+		four digits.
+
+		</li><li>For each group with a non-zero value, append the appropriate group
+		marker to the group.  The ones group has no marker.
+
+		</li><li>Within each group, for each digit that is not 0, append the appropriate
+		digit marker to the digit.  The ones digit of each group has no marker.
+
+		</li><li>Drop ones:
+			<ul>
+				<li>For the Chinese informal styles, for any group with a value
+				between ten and nineteen, remove the tens digit (leave the digit
+				marker).
+
+				</li><li>For the Japanese informal and Korean informal styles, if any
+				of the digit markers are preceded by the digit 1, and that digit
+				is not the first digit of the group, remove the digit (leave the
+				digit marker).
+
+				</li><li>For Korean informal styles, if the value of the ten-thousands
+				group is 1, drop the digit (leave the digit marker).
+			</li></ul>
+		
+
+		</li><li>Drop zeros:
+			<ul>
+				<li>For the Japanese and Korean styles, drop all zero digits.
+
+				</li><li>For the Chinese styles, drop any trailing zeros for all
+				non-zero groups and collapse (across groups) each remaining
+				consecutive group of zeros into a single zero digit.
+			</li></ul>
+
+		</li><li>For the Korean styles, insert a space (" " U+0020) between each group.
+
+		</li><li>Replace the digits 0-9 with the appropriate character for the given
+		counter style.  Return the resultant string as the representation of the
+		counter value.
+	</li></ol>
+
+	For all of these counter styles, the '@counter-style/suffix' is "、" U+3001, the '@counter-style/fallback' is ''cjk-decimal'', and the '@counter-style/negative' is given in the tables below, or else is the initial value of the descriptor. For Chinese and Japanese, the '@counter-style/range' is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1), while for Korean it's ''0 9999999999999999'' (again, 10<sup>16</sup>-1).
+
+	The following tables define the characters used in these styles:
+	<table class="data">
+		<thead>
+			<tr>
+				<th rowspan="2" scope="col">Values
+				</th><th colspan="4" scope="col">Codepoints
+			</th></tr><tr>
+				<th>simp-chinese-informal
+				</th><th>simp-chinese-formal
+				</th><th>trad-chinese-informal
+				</th><th>trad-chinese-formal
+		</th></tr></thead>
+		<tbody>
+			<tr>
+				<th scope="row">Digit 0
+				</th><td>零 U+96F6
+				</td><td>零 U+96F6
+				</td><td>零 U+96F6
+				</td><td>零 U+96F6
+			</td></tr><tr>
+				<th scope="row">Digit 1
+				</th><td>一 U+4E00
+				</td><td>壹 U+58F9
+				</td><td>一 U+4E00
+				</td><td>壹 U+58F9
+			</td></tr><tr>
+				<th scope="row">Digit 2
+				</th><td>二 U+4E8C
+				</td><td>贰 U+8D30
+				</td><td>二 U+4E8C
+				</td><td>貳 U+8CB3
+			</td></tr><tr>
+				<th scope="row">Digit 3
+				</th><td>三 U+4E09
+				</td><td>叁 U+53C1
+				</td><td>三 U+4E09
+				</td><td>參 U+53C3
+			</td></tr><tr>
+				<th scope="row">Digit 4
+				</th><td>四 U+56DB
+				</td><td>肆 U+8086
+				</td><td>四 U+56DB
+				</td><td>肆 U+8086
+			</td></tr><tr>
+				<th scope="row">Digit 5
+				</th><td>五 U+4E94
+				</td><td>伍 U+4F0D
+				</td><td>五 U+4E94
+				</td><td>伍 U+4F0D
+			</td></tr><tr>
+				<th scope="row">Digit 6
+				</th><td>六 U+516D
+				</td><td>陆 U+9646
+				</td><td>六 U+516D
+				</td><td>陸 U+9678
+			</td></tr><tr>
+				<th scope="row">Digit 7
+				</th><td>七 U+4E03
+				</td><td>柒 U+67D2
+				</td><td>七 U+4E03
+				</td><td>柒 U+67D2
+			</td></tr><tr>
+				<th scope="row">Digit 8
+				</th><td>八 U+516B
+				</td><td>捌 U+634C
+				</td><td>八 U+516B
+				</td><td>捌 U+634C
+			</td></tr><tr>
+				<th scope="row">Digit 9
+				</th><td>九 U+4E5D
+				</td><td>玖 U+7396
+				</td><td>九 U+4E5D
+				</td><td>玖 U+7396
+			</td></tr><tr>
+				<th scope="row">Second Digit Marker
+				</th><td>十 U+5341
+				</td><td>拾 U+62FE
+				</td><td>十 U+5341
+				</td><td>拾 U+62FE
+			</td></tr><tr>
+				<th scope="row">Third Digit Marker
+				</th><td>百 U+767E
+				</td><td>佰 U+4F70
+				</td><td>百 U+767E 
+				</td><td>佰 U+4F70
+			</td></tr><tr>
+				<th scope="row">Fourth Digit Marker
+				</th><td>千 U+5343
+				</td><td>仟 U+4EDF
+				</td><td>千 U+5343
+				</td><td>仟 U+4EDF
+			</td></tr><tr>
+				<th scope="row">Second Group Marker
+				</th><td>万 U+4E07
+				</td><td>万 U+4E07
+				</td><td>萬 U+842C
+				</td><td>萬 U+842C
+			</td></tr><tr>
+				<th scope="row">Third Group Marker
+				</th><td>亿 U+4EBF
+				</td><td>亿 U+4EBF
+				</td><td>億 U+5104
+				</td><td>億 U+5104
+			</td></tr><tr>
+				<th scope="row">Fourth Group Marker
+				</th><td>万亿 U+4E07 U+4EBF
+				</td><td>万亿 U+4E07 U+4EBF
+				</td><td>兆 U+5146
+				</td><td>兆 U+5146
+			</td></tr><tr>
+				<th scope="row">Negative Sign
+				</th><td>负 U+8D1F
+				</td><td>负 U+8D1F
+				</td><td>負 U+8CA0
+				</td><td>負 U+8CA0
+		</td></tr></tbody>
+	</table>
+
+	<table class="data">
+		<thead>
+			<tr>
+				<th rowspan="2" scope="col">Values
+				</th><th colspan="2" scope="col">Codepoints
+			</th></tr><tr>
+				<th>japanese-informal
+				</th><th>japanese-formal
+		</th></tr></thead>
+		<tbody>
+			<tr>
+				<th scope="row">Digit 0
+				</th><td>〇 U+3007
+				</td><td>零 U+96F6
+			</td></tr><tr>
+				<th scope="row">Digit 1
+				</th><td>一 U+4E00
+				</td><td>壱 U+58F1
+			</td></tr><tr>
+				<th scope="row">Digit 2
+				</th><td>二 U+4E8C
+				</td><td>弐 U+5F10
+			</td></tr><tr>
+				<th scope="row">Digit 3
+				</th><td>三 U+4E09
+				</td><td>参 U+53C2
+			</td></tr><tr>
+				<th scope="row">Digit 4
+				</th><td>四 U+56DB
+				</td><td>四 U+56DB
+			</td></tr><tr>
+				<th scope="row">Digit 5
+				</th><td>五 U+4E94
+				</td><td>伍 U+4f0D
+			</td></tr><tr>
+				<th scope="row">Digit 6
+				</th><td>六 U+516D
+				</td><td>六 U+516D
+			</td></tr><tr>
+				<th scope="row">Digit 7
+				</th><td>七 U+4E03
+				</td><td>七 U+4E03
+			</td></tr><tr>
+				<th scope="row">Digit 8
+				</th><td>八 U+516B
+				</td><td>八 U+516B
+			</td></tr><tr>
+				<th scope="row">Digit 9
+				</th><td>九 U+4E5D
+				</td><td>九 U+4E5D
+			</td></tr><tr>
+				<th scope="row">Second Digit Marker
+				</th><td>十 U+5341
+				</td><td>拾 U+62FE
+			</td></tr><tr>
+				<th scope="row">Third Digit Marker
+				</th><td>百 U+767E
+				</td><td>百 U+767E
+			</td></tr><tr>
+				<th scope="row">Fourth Digit Marker
+				</th><td>千 U+5343
+				</td><td>阡 U+9621
+			</td></tr><tr>
+				<th scope="row">Second Group Marker
+				</th><td>万 U+4E07
+				</td><td>萬 U+842C
+			</td></tr><tr>
+				<th scope="row">Third Group Marker
+				</th><td>億 U+5104
+				</td><td>億 U+5104
+			</td></tr><tr>
+				<th scope="row">Fourth Group Marker
+				</th><td>兆 U+5146
+				</td><td>兆 U+5146
+			</td></tr><tr>
+				<th scope="row">Negative Sign
+				</th><td colspan="2">マイナス U+30DE U+30A4 U+30CA U+30B9
+		</td></tr></tbody>
+	</table>
+
+	<table class="data">
+		<thead>
+			<tr>
+				<th rowspan="2" scope="col">Values
+				</th><th colspan="3" scope="col">Codepoints
+			</th></tr><tr>
+				<th>korean-hangul-formal
+				</th><th>korean-hanja-informal
+				</th><th>korean-hanja-formal
+		</th></tr></thead>
+		<tbody>
+			<tr>
+				<th scope="row">Digit 0
+				</th><td>영 U+C601
+				</td><td>零 U+96F6
+				</td><td>零 U+96F6
+			</td></tr><tr>
+				<th scope="row">Digit 1
+				</th><td>일 U+C77C
+				</td><td>一 U+4E00
+				</td><td>壹 U+58F9
+			</td></tr><tr>
+				<th scope="row">Digit 2
+				</th><td>이 U+C774
+				</td><td>二 U+4E8C
+				</td><td>貳 U+8CB3
+			</td></tr><tr>
+				<th scope="row">Digit 3
+				</th><td>삼 U+C0BC
+				</td><td>三 U+4E09
+				</td><td>參 U+53C3
+			</td></tr><tr>
+				<th scope="row">Digit 4
+				</th><td>사 U+C0AC
+				</td><td>四 U+56DB
+				</td><td>四 U+56DB
+			</td></tr><tr>
+				<th scope="row">Digit 5
+				</th><td>오 U+C624
+				</td><td>五 U+4E94
+				</td><td>五 U+4E94
+			</td></tr><tr>
+				<th scope="row">Digit 6
+				</th><td>육 U+C721
+				</td><td>六 U+516D
+				</td><td>六 U+516D
+			</td></tr><tr>
+				<th scope="row">Digit 7
+				</th><td>칠 U+CE60
+				</td><td>七 U+4E03
+				</td><td>七 U+4E03
+			</td></tr><tr>
+				<th scope="row">Digit 8
+				</th><td>팔 U+D314
+				</td><td>八 U+516B
+				</td><td>八 U+516B
+			</td></tr><tr>
+				<th scope="row">Digit 9
+				</th><td>구 U+AD6C
+				</td><td>九 U+4E5D
+				</td><td>九 U+4E5D
+			</td></tr><tr>
+				<th scope="row">Second Digit Marker
+				</th><td>십 U+C2ED
+				</td><td>十 U+5341
+				</td><td>拾 U+62FE
+			</td></tr><tr>
+				<th scope="row">Third Digit Marker
+				</th><td>백 U+BC31
+				</td><td>百 U+767E
+				</td><td>百 U+767E
+			</td></tr><tr>
+				<th scope="row">Fourth Digit Marker
+				</th><td>천 U+CC9C
+				</td><td>千 U+5343
+				</td><td>仟 U+4EDF
+			</td></tr><tr>
+				<th scope="row">Second Group Marker
+				</th><td>만 U+B9CC
+				</td><td>萬 U+842C
+				</td><td>萬 U+842C
+			</td></tr><tr>
+				<th scope="row">Third Group Marker
+				</th><td>억 U+C5B5
+				</td><td>億 U+5104
+				</td><td>億 U+5104
+			</td></tr><tr>
+				<th scope="row">Fourth Group Marker
+				</th><td>조 U+C870
+				</td><td>兆 U+5146
+				</td><td>兆 U+5146
+		</td></tr></tbody>
+	</table>
 
 <!--
 ████████ ████████ ██     ██ ████  ███████  ████████  ████  ██████

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2369,7 +2369,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 
 	The Chinese longhand styles are defined out to 10k with a [=Chinese|specialized algorithm=], while the Japanese and Korean longhand styles are defined similarly as ''additive'' styles. However, these styles are defined out to 10<sup>16</sup> in common usage. The following section describes an alternative algorithm for these styles.
 
-	The Chinese and Japanese styles are defined for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive; the Korean styles are defined for all non-negative numbers less than 10<sup>16</sup>. For numbers outside this range, the ''cjk-decimal'' style is used. All of the styles are defined by almost identical algorithms (specified as a single algorithm here, with the differences called out when relevant), but use different sets of characters. The list following the algorithm gives the name of each counter style using this algorithm, and the individual character sets used by each style.
+	All of the Chinese, Japanese, and Korean styles are defined for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive. For numbers outside this range, the ''cjk-decimal'' style is used. All of the styles are defined by almost identical algorithms (specified as a single algorithm here, with the differences called out when relevant), but use different sets of characters. The list following the algorithm gives the name of each counter style using this algorithm, and the individual character sets used by each style.
 
 	<ol>
 		<li>If the counter value is 0, the representation is the character for 0
@@ -2417,7 +2417,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		counter value.
 	</li></ol>
 
-	For all of these counter styles, the '@counter-style/suffix' is "、" U+3001, the '@counter-style/fallback' is ''cjk-decimal'', and the '@counter-style/negative' is given in the tables below, or else is the initial value of the descriptor. For Chinese and Japanese, the '@counter-style/range' is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1), while for Korean it's ''0 9999999999999999'' (again, 10<sup>16</sup>-1).
+	For all of these counter styles, the '@counter-style/suffix' is "、" U+3001, the '@counter-style/fallback' is ''cjk-decimal'', and the '@counter-style/negative' is given in the tables below, or else is the initial value of the descriptor. The '@counter-style/range' is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
 
 	The following tables define the characters used in these styles:
 	<table class="data">
@@ -2708,6 +2708,9 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 				</th><td>조 U+C870
 				</td><td>兆 U+5146
 				</td><td>兆 U+5146
+		</td></tr><tr>
+				<th scope="row">Negative Sign
+				</th><td colspan="2">마이너스 U+B9C8 U+C774 U+B108 U+C2A4
 		</td></tr></tbody>
 	</table>
 

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2450,7 +2450,8 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		Return the resultant string as the representation of the counter value.
 	</ol>
 
-	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]], except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
+	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]],
+	except for the '@counter-style/range', which is ''-9999999999999999 9999999999999999'' (-10<sup>16</sup>+1 and 10<sup>16</sup>-1).
 
 	The following tables define the characters used in these styles:
 	<table class="data">

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2386,7 +2386,7 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 	they must be implemented as described here.
 
 
-	All of the Chinese, Japanese, and Korean styles are defined
+	All of the Chinese, Japanese, and Korean styles are defined here
 	for all numbers between -10<sup>16</sup> and 10<sup>16</sup>, exclusive.
 	For numbers outside this range, the ''cjk-decimal'' style is used.
 	All of the styles are defined by almost identical algorithms

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2046,7 +2046,7 @@ Longhand East Asian Counter Styles</h3>
 	The required implementation is described in [[#limited-range-required]],
 	which defines the styles over these limited ranges,
 	and the optional implementation is described in [[#extended-range-optional]],
-	which defines them over a larger range following custom algorithms.
+	which defines them over a larger range using custom algorithms.
 	Outside the implementation-supported range,
 	the fallback is ''cjk-decimal''.
 

--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2034,17 +2034,16 @@ Longhand East Asian Counter Styles</h3>
 		</table>
 	</div>
 
-	Because opinions differ on how best to represent numbers 10k or greater
-	using the longhand CJK styles,
-	all of the counter styles defined in this section are defined to have a range of -9999 to 9999,
-	but implementations may support a larger range.
-	Outside the implementation-supported range,
-	the fallback is ''cjk-decimal''.
-
-	Note: Implementations are encouraged to research and implement counter representations beyond 10k
-	and report back to the CSS Working Group with data
-	when a generally-accepted answer is discovered.
-	Some previous research on this topic is contained in an <a href="https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130718/#extended-cjk">earlier draft</a>.
+	Because opinions differ on how best to represent numbers 10,000 or greater 
+	using the longhand CJK styles, the implementation details are split into two sections. 
+	The Korean and Japanese variants of these counter styles can, if limited to the range 
+	of -9999 to 9999, be expressed as <code>@counter-style</code> rules. 
+	The Chinese variants use a [=Chinese|specialized algorithm=], regardless of range. 
+	The required implementation is described in [[#limited-range-required]], which defines 
+	the styles over these limited ranges, and the optional implementation is described in 
+	[[#extended-range-optional]], which defines them over a larger range following custom algorithms. 
+	Outside the implementation-supported range, 
+	the fallback is 'cjk-decimal'.
 
 <!--
 ██       ████ ██     ██ ████ ████████ ████████ ████████         ██████        ██ ██    ██


### PR DESCRIPTION
This attempts to define extended CJK longhand counter styles with clear implementation separation as discussed in #12300.

Closes #12300.

## Change

This is mainly copy/pasted from an older version of the spec, which defined counter values outside this limited range and clearly separated required/optional implementations.
https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130718/#extended-cjk

However, I made a slight change for the Korean range.
The former version of the spec [defines a range between 0 and 10^16](https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130718/#extended-cjk:~:text=the%20Korean%20styles%20are%20defined%20for%20all%20non%2Dnegative%20numbers%20less%20than%201016.), yet the new version defines it down to a negative range because the current ED spec already defines the Korean negative range. See: 
https://drafts.csswg.org/css-counter-styles/#limited-korean

## The current browser behaviour

The cross-browser implementation for the *limited* one is consistent, but the *extended* one is inconsistent.
The new version of spec makes a clear difference between limited and optional, so that implementation and test separation makes sense.
The current implementation status that I could observe is as follows:

- ✅ Gecko: Partially supports extended ranges beyond the spec, but not fully up to 10^16
- ❌ WebKit: Supports spec limited range and fails tests for values > 9999
- ❌ Chromium: Supports spec limited range and fails tests for values > 9999

The Korean negative range is also supported in all 3 browsers.
FWIW, here's a Chromium implementation, according to the current ED spec (not the former one).
https://chromium.googlesource.com/chromium/src/+/d0be3bc63c34b2a904be717bfa3bf0be4e71eb45

## WPT

WPT test will also be updated with:
- Clear separation between limited(*required*) and extended(*optional*) range.
  -  limited(*required*) : counter-[cjk]-*.html
      - e.g; [counter-japanese-formal.html](https://github.com/web-platform-tests/wpt/pull/53312/files#diff-7d745ba2f9bb8db4ac70496aebed2c743cdace9f3d3425a4edc28c18bf872939)
  - extended(*optional*): counter-[cjk]-extended-*.html
    - e.g; [counter-japanese-formal-extended.html](https://github.com/web-platform-tests/wpt/pull/53312/files#diff-dfce9b315a420779230d69863af53804dbff3e23563d918aa91213be813f52b1)
- Addition of extended CJK longhand range support which covers its algorithm
  - https://www.w3.org/TR/2013/WD-css-counter-styles-3-20130718/#extended-cjk

ref: https://github.com/web-platform-tests/wpt/pull/53312/

cc: @nt1m
