### PR TITLE
[css-mixins-1] Let 'inherit' work like 'inherit()'

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -633,8 +633,29 @@ with its [=function parameters=] overriding "inherited" custom properties of the
 			is the [=guaranteed-invalid value=].
 
 		* On custom properties,
-			the [=CSS-wide keywords=] ''initial'' and ''inherit'' have their usual effect;
-			all other [=CSS-wide keywords=] resolve to the [=guaranteed-invalid value=].
+			the [=CSS-wide keywords=] have the following effects:
+
+			<dl>
+				<dt>''initial''</dt>
+				<dd>
+					Resolves to the initial value of the custom property
+					within |registrations|.
+				</dd>
+
+				<dt>''inherit''</dt>
+				<dd>
+					Resolves like an ''inherit()'' function
+					with the custom property name as its one and only argument.
+
+					Note: This ensures that a [=function parameter=] defaulted to ''inherit''
+						is reinterpreted using the local [=parameter type=].
+				</dd>
+
+				<dt>any other [=CSS-wide keyword=]</dt>
+				<dd>
+					Resolves to the [=guaranteed-invalid value=].
+				</dd>
+			</dl>
 
 			Note: ''initial'' references the [=custom property registration=]
 			created from the [=function parameters=],


### PR DESCRIPTION
With `@function`, it becomes possible to have a "type mismatch" between an "outer" custom property and an "inner" custom property:

```
@property --x {
  syntax: "auto | red";
  /* ... */
}

@function --f(--x <color>: inherit) {
  result: var(--x);
}

div {
  --x: red;
  --result: --f(); /* => ? */
}
```

We have to address this somehow, and the obvious way seems to be making 'inherit' behave like "a var(--x) that resolves in the parent stack frame". This is essentially what inherit() does, which already exists in the spec.
