### PR TITLE
[css-overflow-4] Remove request to not expose line-clamp longhands

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -823,14 +823,6 @@ Limiting Visible Lines: the 'line-clamp' shorthand property</h3>
 	The 'line-clamp' property is a <a>shorthand</a>
 	for the 'max-lines', 'block-ellipsis', and 'continue' properties.
 
-	Issue: For the time being,
-	experimental implementations are encouraged
-	to follow the full behavior defined by this shorthand and its longhands,
-	but to only expose the shorthand to authors.
-	This is in order to facilitate further tweaking,
-	and in particular potential renaming,
-	of the longhand properties and their values.
-
 	It allows limiting the contents of a block container
 	to the specified number of lines;
 	remaining content is fragmented away


### PR DESCRIPTION
The request in the spec not to expose the longhands of line-clamp to authors was only intended as a temporary warning while we figured the syntax space, but the design has been stable for years at this point, and the notion of unexposed longhands brings its own set of complexity.

See https://github.com/w3c/csswg-drafts/issues/10439

@emilio, in https://github.com/w3c/csswg-drafts/issues/10439, we resolved on doing this, but you were not on the call, and we wanted to run this by you to make sure you had no objection, so I'm doing this as a PR rather than as a direct commit, so that you get a chance to pull the breaks if for some reason that's not something you're OK with.