### PR TITLE
[selectors-5] fix typo in :heading() syntax

### DIFF
--- a/selectors-5/Overview.bs
+++ b/selectors-5/Overview.bs
@@ -177,7 +177,7 @@ Heading Structures: the heading pseudo-classes '':heading'', and '':heading()''<
 	The syntax is:
 
 	<pre class=prod>
-		::heading() = ::heading( <<An+B>># )
+		:heading() = :heading( <<An+B>># )
 	</pre>
 
 	The [=specificity=] of '':heading()'' is that of a class.


### PR DESCRIPTION
This fixes a small typo from #12404 