### PR TITLE
[css-pseudo-4] Add a note explaining Element.pseudo() behaviour #12159

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1829,6 +1829,12 @@ Additions to the CSS Object Model</h2>
   (The UA may drop or regenerate the object for convenience or performance
   if this is not observable.)
 
+  Note: {{CSSPseudoElement}} is returned even when this method is invoked on elements
+  that can't have the requested pseudo type (e.g. ''::before'' on <{input}>).
+  See <a href="https://github.com/w3c/csswg-drafts/issues/12159#issuecomment-3005238286">resolution</a> for more details.
+  Discussion in <a href="https://github.com/w3c/csswg-drafts/issues/12158">Issue 12158</a> will clarify how to
+  determine that the requested pseudo doesn't really "exist".
+
   ISSUE: The identity, lifetime, and nullness of the return value
   (and potential error cases)
   of the {{pseudo()}} method is still under discussion.


### PR DESCRIPTION
As per resolution in #12159, Element.pseudo() returns CSSPseudoElement even when invoked on Element that can't generate the requested type.