### PR TITLE
[css-forms-1] Range styles

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -816,19 +816,27 @@ select {
 ISSUE(12267): Refine meter, progress, switch and range input styling.
 
 ```css
-input[type=checkbox][switch] {
+input:is([type=checkbox][switch], [type=range]) {
   display: inline-flex;
   position: relative;
   align-items: center;
+  width: 100%;
+}
+
+input[type=checkbox][switch] {
   width: 2em;
 }
 
 ::slider-track {
   height: 1em;
+  width: 100%;
+}
+
+input[type=range]::slider-track {
+  height: 0.5em;
 }
 
 input[type=checkbox][switch]::slider-track {
-  width: 100%;
   border-radius: 1em;
 }
 
@@ -852,12 +860,8 @@ input[type=checkbox][switch]::slider-fill {
   background-color: currentColor;
   appearance: none;
   width: 1em;
-  height: 100%;
-}
-
-input[type=checkbox][switch]::slider-thumb {
-  border-radius: 100%;
   height: 1em;
+  border-radius: 100%;
   position: absolute;
 }
 


### PR DESCRIPTION
Follow up to #12427 

(Image includes an implementation of sizing and background color for the fill, and positioning of the thumb which aren't included in this PR)

<img width="815" alt="image" src="https://github.com/user-attachments/assets/1dd3bea2-522a-4799-bec2-6bd9b7e25ad0" />
