### PR TITLE
[css-highlight-api-1] Update Editors

### DIFF
--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -39,6 +39,7 @@ Editor: Dan Clark, Microsoft Corporation https://www.microsoft.com, https://gith
 Editor: Fernando Fiori, Microsoft Corporation https://www.microsoft.com, https://github.com/ffiori, w3cid 129562
 Editor: Florian Rivoal, On behalf of Bloomberg, https://florian.rivoal.net/, w3cid 43241
 Editor: Megan Gardner, Apple Inc. https://apple.com/, w3cid 110930
+Former Editor: Sanket Joshi, Microsoft Corporation https://www.microsoft.com, https://github.com/sanketj, w3cid 115721
 Abstract:
 	This CSS module describes a mechanism
 	for styling arbitrary ranges of a document identified by script.


### PR DESCRIPTION
[css-highlight-api-1] Update Editors

It was resolved in the CSSWG meeting from June 25, 2025 to add Dan Clark and Fernando Fiori (me) as editors of the CSS Custom Highlight API specification since Sanket Joshi no longer works at Microsoft, and Dan and Fernando have been involved with it for a long time now. It was first proposed in this PR discussion thread (https://github.com/w3c/csswg-drafts/pull/12215#issuecomment-2992969941) and then resolved in a live meeting.
