### PR TITLE
[css-color][editorial] Minor syntax adjustments

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4743,7 +4743,7 @@ Color Space for Interpolation</h3>
 
 	<pre class='prod'>
 		<dfn export>&lt;color-space></dfn> = &lt;rectangular-color-space> | &lt;polar-color-space>
-		<dfn export>&lt;rectangular-color-space></dfn> = <l>''srgb''</l> | <l>''srgb-linear''</l> | <l>''display-p3''</l> | <l>''a98-rgb''</l> | <l>''prophoto-rgb''</l> | <l>''rec2020''</l> | <l>''lab''</l> | <l>''oklab''</l> | <l>''xyz''</l> | <l>''xyz-d50''</l> | <l>''xyz-d65''</l>
+		<dfn export>&lt;rectangular-color-space></dfn> = <l>''srgb''</l> | <l>''srgb-linear''</l> | <l>''display-p3''</l> | <l>''a98-rgb''</l> | <l>''prophoto-rgb''</l> | <l>''rec2020''</l> | <l>''lab''</l> | <l>''oklab''</l> | <<xyz-space>>
 		<dfn export>&lt;polar-color-space></dfn> = <l>''hsl''</l> | <l>''hwb''</l> | <l>''lch''</l> | <l>''oklch''</l>
 		<dfn export>&lt;hue-interpolation-method></dfn> = [ shorter | longer | increasing | decreasing ] hue
 		<dfn export id="color-interpolation-method">&lt;color-interpolation-method></dfn> = in [ <<rectangular-color-space>> | <<polar-color-space>> <<hue-interpolation-method>>? ]

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1734,8 +1734,7 @@ The OkLCh chroma has dropped from 0.251 to 0.117.
 		<dfn>&lt;custom-params></dfn> = <<dashed-ident>> [ <<number>> | <<percentage>> | none ]+
 		<dfn>&lt;predefined-rgb-params></dfn> = <<predefined-rgb>> [ <<number>> | <<percentage>> | none ]{3}
 		<dfn>&lt;predefined-rgb></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020
-		<dfn>&lt;xyz-params></dfn> = <<xyz>> [ <<number>> | <<percentage>> | none ]{3}
-		<dfn>&lt;xyz></dfn> = xyz | xyz-d50 | xyz-d65
+		<dfn>&lt;xyz-params></dfn> = <<xyz-space>> [ <<number>> | <<percentage>> | none ]{3}
 	</pre>
 
 
@@ -2755,7 +2754,7 @@ or any other color or monochrome output device which has been characterized.
 
 	<pre class='prod'>
 		<dfn export>&lt;color-space></dfn> = <<rectangular-color-space>> | <<polar-color-space>> | <<custom-color-space>>
-		<dfn export>&lt;rectangular-color-space></dfn> = <l>''srgb''</l> | <l>''srgb-linear''</l> | <l>''display-p3''</l> | <l>''a98-rgb''</l> | <l>''prophoto-rgb''</l> | <l>''rec2020''</l> | <l>''lab''</l> | <l>''oklab''</l> | <l>''xyz''</l> | <l>''xyz-d50''</l> | <l>''xyz-d65''</l>
+		<dfn export>&lt;rectangular-color-space></dfn> = <l>''srgb''</l> | <l>''srgb-linear''</l> | <l>''display-p3''</l> | <l>''a98-rgb''</l> | <l>''prophoto-rgb''</l> | <l>''rec2020''</l> | <l>''lab''</l> | <l>''oklab''</l> | <<xyz-space>>
 		<dfn export>&lt;polar-color-space></dfn> = <l>''hsl''</l> | <l>''hwb''</l> | <l>''lch''</l> | <l>''oklch''</l>
 		<dfn export>&lt;custom-color-space></dfn> = <<dashed-ident>>
 		<dfn export>&lt;hue-interpolation-method></dfn> = [ shorter | longer | increasing | decreasing ] hue


### PR DESCRIPTION
- align CSS Color 4 and 5 by renaming `<xyz>` to `<xyz-space>`
- refer to `<xyz-space>` instead of inlining its value