### PR TITLE
[css-viewport-1] number / percentage should be alternates, not optionals 

### DIFF
--- a/css-viewport-1/Overview.bs
+++ b/css-viewport-1/Overview.bs
@@ -419,7 +419,7 @@ Note: 'zoom' does not affect or prevent 'transform' scaling.
 
 <pre class="propdef">
 	Name: zoom
-	Value: <<number [0,∞]>> || <<percentage [0,∞]>>
+	Value: <<number [0,∞]>> | <<percentage [0,∞]>>
 	Initial: 1
 	Applies to: all <<length>> property values of all elements
 	Inherited: no


### PR DESCRIPTION
The viewport spec's `zoom` style value has the following grammar:

`<number [0,∞]> || <percentage [0,∞]>`

I'm _sure_ this is not correct, this would allow for values such as `zoom: 100% 0.5`, `zoom: 0.75 50%`, and so on. AFAICT no browser supports such values and the spec does not describe what would happen if both values were supplied. I'm sure it is meant to be:

`<number [0,∞]> | <percentage [0,∞]>`

Which would mean _either_ a number _or_ a percentage, but not both. Please let me know if I'm wrong though.