### PR TITLE
[css-fonts-4] Add additional whitespace in font-variation-settings grammaer

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -7196,7 +7196,7 @@ Low-level font variation settings control: the 'font-variation-settings' propert
 
 <pre class="propdef">
 Name: font-variation-settings
-Value: normal | [ <<opentype-tag>> <<number>>]#
+Value: normal | [ <<opentype-tag>> <<number>> ]#
 Initial: normal
 Applies to: all elements and text
 Inherited: yes


### PR DESCRIPTION
This was a little cramped, so I've added a space character between the `>` and `]`.