### PR TITLE
[css-ui][editorial] Markup <x> and <y> productions with <dfn> element

### DIFF
--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -1043,7 +1043,7 @@ cursors larger than that size must be shrunk to within
 the OS-supported size bounds,
 while maintaining the cursor image's [=natural aspect ratio=], if any.
 
-The optional &lt;x&gt; and &lt;y&gt; coordinates
+The optional <<x>>; and <<y>>; coordinates
 identify the exact position within the image which is the pointer position (i.e., the hotspot).
 </dd>
 <dt><dfn type><<x>></dfn></dt>
@@ -1065,7 +1065,7 @@ the effect is as if a value of "0 0" were specified.
 
 If the coordinates of the hotspot,
 as specified either inside the image resource or
-by &lt;x&gt; and &lt;y&gt; values,
+by <<x>> and <<y>> values,
 fall outside of the cursor image,
 they must be clamped (independently) to fit.
 </dd>

--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -933,7 +933,7 @@ While the content is being scrolled, implementations may adjust their rendering 
 <h4 id="cursor" caniuse="css3-cursors">Styling the Cursor: the 'cursor' property</h4>
 <pre class="propdef">
 Name: cursor
-Value: [ [<<url>> [&lt;x&gt; &lt;y&gt;]?,]* <br>
+Value: [ [<<url>> [<<x>>; <<y>>]?,]* <br>
  [ auto | default | none |<br>
  context-menu | help | pointer | progress | wait | <br>
  cell | crosshair | text | vertical-text | <br>
@@ -1046,8 +1046,8 @@ while maintaining the cursor image's [=natural aspect ratio=], if any.
 The optional &lt;x&gt; and &lt;y&gt; coordinates
 identify the exact position within the image which is the pointer position (i.e., the hotspot).
 </dd>
-<dt>&lt;x&gt;</dt>
-<dt>&lt;y&gt;</dt>
+<dt><dfn type><<x>></dfn></dt>
+<dt><dfn type><<y>></dfn></dt>
 <dd>
 Each is a <<number>>.
 The x-coordinate and y-coordinate of the position

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -683,7 +683,7 @@ Styling the Cursor: the 'cursor' property</h4>
 
 	<pre class="propdef">
 	Name: cursor
-	Value: [ [ <<url>> | <<url-set>> ] [&lt;x&gt; &lt;y&gt;]? ]#? <br>
+	Value: [ [ <<url>> | <<url-set>> ] [<<x>> <<y>>]? ]#? <br>
 	 [ auto | default | none |<br>
 	 context-menu | help | pointer | progress | wait | <br>
 	 cell | crosshair | text | vertical-text | <br>
@@ -827,8 +827,8 @@ Styling the Cursor: the 'cursor' property</h4>
 					The optional &lt;x&gt; and &lt;y&gt; coordinates
 					identify the exact position within the image which is the pointer position (i.e., the hotspot).
 
-				<dt>&lt;x&gt;
-				<dt>&lt;y&gt;
+				<dt><dfn><<x>></dfn>
+				<dt><dfn><<y>></dfn>
 				<dd>
 					Each is a <<number>>.
 					The x-coordinate and y-coordinate of the position

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -827,8 +827,8 @@ Styling the Cursor: the 'cursor' property</h4>
 					The optional &lt;x&gt; and &lt;y&gt; coordinates
 					identify the exact position within the image which is the pointer position (i.e., the hotspot).
 
-				<dt><dfn><<x>></dfn>
-				<dt><dfn><<y>></dfn>
+				<dt><dfn type><<x>></dfn>
+				<dt><dfn type><<y>></dfn>
 				<dd>
 					Each is a <<number>>.
 					The x-coordinate and y-coordinate of the position

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -824,7 +824,7 @@ Styling the Cursor: the 'cursor' property</h4>
 					the OS-supported size bounds,
 					while maintaining the cursor image's [=natural aspect ratio=], if any.
 
-					The optional &lt;x&gt; and &lt;y&gt; coordinates
+					The optional <<x>> and <<y>> coordinates
 					identify the exact position within the image which is the pointer position (i.e., the hotspot).
 
 				<dt><dfn type><<x>></dfn>
@@ -846,7 +846,7 @@ Styling the Cursor: the 'cursor' property</h4>
 
 					If the coordinates of the hotspot,
 					as specified either inside the image resource or
-					by &lt;x&gt; and &lt;y&gt; values,
+					by <<x>> and <<y>> values,
 					fall outside of the cursor image,
 					they must be clamped (independently) to fit.
 			</dl>


### PR DESCRIPTION
I could not find the issues mentioned in the message of 9b8f394 in the archives, so I may be missing the reason not to do this change. But it would allow `w3c/reffy` to extract these CSS types.