### PR TITLE
[css-borders-4][editorial] Remove range of k parameter from superellipse()

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -473,7 +473,7 @@ The 'corner-shape' Shorthand</h4>
 	<pre class=prod>
 		<dfn><<corner-shape-value>></dfn> = <l>''round''</l> | <l>''scoop''</l> | <l>''bevel''</l> | <l>''notch''</l> | <l>''<corner-shape-value>/square''</l> | <l>''squircle''</l> |
 		                       <<superellipse()>>
-		<dfn>superellipse()</dfn> = superellipse(<<number [-&infin;,&infin;]>> | infinity | -infinity)
+		<dfn>superellipse()</dfn> = superellipse(<<number>> | infinity | -infinity)
 	</pre>
 
 	<dl dfn-type="value" dfn-for="<corner-shape-value>, corner-shape">


### PR DESCRIPTION
Replaces `<number [-∞,∞]>` with `<number>`, since the range includes the infinity values.