### PR TITLE
[cssom] Return CSSStyleProperties from `element.style` and getComputedStyle

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -3052,11 +3052,11 @@ The <code>ElementCSSInlineStyle</code> mixin provides access to inline style pro
 
 <pre class=idl>
 interface mixin ElementCSSInlineStyle {
-  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleProperties style;
 };
 </pre>
 
-The <dfn attribute for=ElementCSSInlineStyle>style</dfn> attribute must return a <a>CSS declaration block</a> object whose
+The <dfn attribute for=ElementCSSInlineStyle>style</dfn> attribute must return a <a>CSSStyleProperties</a> object whose
 <a for="CSSStyleDeclaration">readonly flag</a> is unset, whose <a for="CSSStyleDeclaration">parent CSS rule</a> is null, and
 whose <a for="CSSStyleDeclaration">owner node</a> is [=this=].
 
@@ -3083,7 +3083,7 @@ Extensions to the {{Window}} Interface {#extensions-to-the-window-interface}
 
 <pre class=idl>
 partial interface Window {
-  [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
+  [NewObject] CSSStyleProperties getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
 };
 </pre>
 


### PR DESCRIPTION
Followup for #9686.

1. getComputedStyle already says it returns a CSSStyleProperties in step 6, and the IDL change fits that.
2. Copied the same change into ElementCSSInlineStyle.style. (fwiw, [WebKit has the same change](https://searchfox.org/wubkat/rev/3d577b31337b13acd2b569e59d863f8fd8505724/Source/WebCore/css/ElementCSSInlineStyle.idl#29).)

@emilio