### PR TITLE
[css-view-transitions-1] Inherit more animation properties in the pseudo-element tree

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -873,10 +873,6 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	:root::view-transition-image-pair(*) {
 		position: absolute;
 		inset: 0;
-
-		animation-duration: inherit;
-		animation-fill-mode: inherit;
-		animation-delay: inherit;
 	}
 
 	:root::view-transition-old(*),
@@ -885,11 +881,19 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 		inset-block-start: 0;
 		inline-size: 100%;
 		block-size: auto;
+	}
 
+	:root::view-transition-image-pair(*),
+        :root::view-transition-old(*),
+	:root::view-transition-new(*) {
 		animation-duration: inherit;
 		animation-fill-mode: inherit;
 		animation-delay: inherit;
-	}
+		animation-timing-function: inherit;
+		animation-iteration-count: inherit;
+		animation-direction: inherit;
+		animation-play-state: inherit;
+        }
 
 	/* Default cross-fade transition */
 	@keyframes -ua-view-transition-fade-out {


### PR DESCRIPTION
Fixes #11546
