### PR TITLE
[css-color-adjust-1][editorial] Fix typo in emualte-forced-colors-mode anchor

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -1114,7 +1114,7 @@ Emulation {#color-adjust-emulation}
 	For the purposes of user agent automation and application testing, this document
 	defines the below emulations.
 
-	<dfn export>Emulate Forced Colors Mode</dfn> {#emualte-forced-colors-mode}
+	<dfn export>Emulate Forced Colors Mode</dfn> {#emulate-forced-colors-mode}
 	--------------------------------------------
 
 	Each [=top-level traversable=] has an associated


### PR DESCRIPTION
Typo noticed while reviewing https://github.com/w3c/webdriver-bidi/pull/905