### PR TITLE
[css-values-4] Allow `{A}` and `?` multipliers to be stacked

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -335,7 +335,7 @@ Component Value Multipliers</h3>
 	</ul>
 
 	The <css>+</css> and <css>#</css> multipliers may be stacked as ''+#'';
-	similarly, the <css>#</css> and <css>?</css> multipliers may be stacked as ''#?''.
+	similarly, the <css>#</css> and <css>?</css> multipliers, <css>{A}</css> and <css>?</css> multipliers, and <css>{A,B}</css> and <css>?</css> multipliers may be stacked as ''#?'', ''{A}?'', and ''{A,B}?'', respectively.
 	These stacks each represent the later multiplier
 	applied to the result of the earlier multiplier.
 	(These same stacks can be represented using grouping,


### PR DESCRIPTION
Via https://github.com/csstree/csstree/issues/346

The Value Definition Syntax defines the list of multipliers that can be stacked. The syntax definition of [`<cursor-image>`](https://drafts.csswg.org/css-ui-4/#typedef-cursor-cursor-image) in css-ui-4 has started to use `<number>{2}?` but the `{A}?` stack isn't explicitly allowed for now.

I'm assuming that the new syntax definition in css-ui-4 is intended. If not, well, it needs fixing ;)

This update completes the list of multipliers that can be stacked with `{A}?` and `{A,B}?`. Feel free to discard and re-create with adjusted wording as you see fit.
