### PR TITLE
[mediaqueries-5] Drop non standard `[RuntimeEnabled]` extended attribute

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -2715,7 +2715,7 @@ The {{CSSCustomMediaRule}} interface represents a ''@custom-media'' rule.
 <pre class="idl" export>
 typedef (MediaList or boolean) CustomMediaQuery;
 
-[Exposed=Window, RuntimeEnabled=CSSCustomMedia]
+[Exposed=Window]
 interface CSSCustomMediaRule : CSSRule {
     readonly attribute CSSOMString name;
     readonly attribute CustomMediaQuery query;


### PR DESCRIPTION
The `[RuntimeEnabled]` extended attribute is [specific to Blink](https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/bindings/IDLExtendedAttributes.md#RuntimeEnabled).
