### PR TITLE
[css-color-adjust-1] Create section for forced colors mode emulation color palettes

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -871,8 +871,10 @@ Forced Colors Mode Color Palettes {#forced-color-palettes}
 	For the purposes of user agent automation and application testing, this document
 	defines the below <dfn>forced colors mode emulation color palettes</dfn>.
 
-	[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/light}}":
 		<table class="data">
+			<caption>
+				[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/light}}"
+			</caption>
 			<thead>
 			<tr>
 				<th><<system-color>> keyword</th>
@@ -1014,8 +1016,10 @@ Forced Colors Mode Color Palettes {#forced-color-palettes}
 			</tbody>
 		</table>
 
-	[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/dark}}":
 		<table class="data">
+			<caption>
+				[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/dark}}"
+			</caption>
 			<thead>
 				<tr>
 					<th><<system-color>> keyword</th>

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -499,300 +499,10 @@ Forced Color Palettes {#forced}
 	If [=get emulated forced colors theme data=]
 	is not "{{ForcedColorsModeAutomationTheme/none}}",
 	the user agent should bypass the above operating system color themes,
-	and instead do the following based on the resulting value of
-	[=emulated forced colors theme data=]:
-
-	: "{{ForcedColorsModeAutomationTheme/light}}"
-	:: Act as if the user has enabled <a>forced colors mode</a> with the
-		following color mappings:
-
-		<table class="data">
-			<thead>
-			<tr>
-				<th><<system-color>> keyword</th>
-				<th>Value</th>
-			</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>''AccentColor''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''AccentColorText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''ActiveText''</td>
-					<td>
-						<span class="swatch" style="--color: #00009F"></span>
-						&nbsp;#00009F
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonBorder''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonFace''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''Canvas''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''CanvasText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''Field''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''FieldText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''GrayText''</td>
-					<td>
-						<span class="swatch" style="--color: #600000"></span>
-						&nbsp;#600000
-					</td>
-				</tr>
-				<tr>
-					<td>''Highlight''</td>
-					<td>
-						<span class="swatch" style="--color: #37006E"></span>
-						&nbsp;#37006E
-					</td>
-				</tr>
-				<tr>
-					<td>''HighlightText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''LinkText''</td>
-					<td>
-						<span class="swatch" style="--color: #00009F"></span>
-						&nbsp;#00009F
-					</td>
-				</tr>
-				<tr>
-					<td>''Mark''</td>
-					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
-					</td>
-				</tr>
-				<tr>
-					<td>''MarkText''</td>
-					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
-					</td>
-				</tr>
-				<tr>
-					<td>''SelectedItem''</td>
-					<td>
-						<span class="swatch" style="--color: #37006E"></span>
-						&nbsp;#37006E
-					</td>
-				</tr>
-				<tr>
-					<td>''SelectedItemText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''VisitedText''</td>
-					<td>
-						<span class="swatch" style="--color: #00009F"></span>
-						&nbsp;#00009F
-					</td>
-				</tr>
-			</tbody>
-		</table>
-
-	: "{{ForcedColorsModeAutomationTheme/dark}}"
-	:: Act as if the user has enabled <a>forced colors mode</a> with the
-		following color mappings:
-		<table class="data">
-			<thead>
-				<tr>
-					<th><<system-color>> keyword</th>
-					<th>Value</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td>''AccentColor''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''AccentColorText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''ActiveText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFF00"></span>
-						&nbsp;#FFFF00
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonBorder''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonFace''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''ButtonText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''Canvas''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''CanvasText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-				</tr>
-				<tr>
-					<td>''Field''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''FieldText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFFFF"></span>
-						&nbsp;#FFFFFF
-					</td>
-					<td></td>
-				</tr>
-				<tr>
-					<td>''GrayText''</td>
-					<td>
-						<span class="swatch" style="--color: #3FF23F"></span>
-						&nbsp;#3FF23F
-					</td>
-				</tr>
-				<tr>
-					<td>''Highlight''</td>
-					<td>
-						<span class="swatch" style="--color: #1AEBFF"></span>
-						&nbsp;#1AEBFF
-					</td>
-				</tr>
-				<tr>
-					<td>''HighlightText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''LinkText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFF00"></span>
-						&nbsp;#FFFF00
-					</td>
-				</tr>
-				<tr>
-					<td>''Mark''</td>
-					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
-					</td>
-				</tr>
-				<tr>
-					<td>''MarkText''</td>
-					<td>
-						N/A - this [=system color=] keyword should not be adjusted.
-					</td>
-				</tr>
-				<tr>
-					<td>''SelectedItem''</td>
-					<td>
-						<span class="swatch" style="--color: #1AEBFF"></span>
-						&nbsp;#1AEBFF
-					</td>
-				</tr>
-				<tr>
-					<td>''SelectedItemText''</td>
-					<td>
-						<span class="swatch" style="--color: #000000"></span>
-						&nbsp;#000000
-					</td>
-				</tr>
-				<tr>
-					<td>''VisitedText''</td>
-					<td>
-						<span class="swatch" style="--color: #FFFF00"></span>
-						&nbsp;#FFFF00
-					</td>
-				</tr>
-			</tbody>
-		</table>
+	and instead act as if the user has enabled <a>forced colors mode</a>
+	with the [=forced colors mode emulation color palette=] defined for
+	the resulting value of [=emulated forced colors theme data=].
+		
 
 <!--THOUGHTS
 	This advice (below) maybe makes sense for (prefers-contrast),
@@ -1156,7 +866,297 @@ Emulation {#color-adjust-emulation}
 
 	5. Return |traversable|'s associated [=emulated forced colors theme data=].
 
+Forced Colors Mode Color Palettes {#forced-color-palettes}
+----------------------------------------------
+	For the purposes of user agent automation and application testing, this document
+	defines the below <dfn>forced colors mode emulation color palettes</dfn>.
 
+	[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/light}}":
+		<table class="data">
+			<thead>
+			<tr>
+				<th><<system-color>> keyword</th>
+				<th>Value</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>''AccentColor''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''AccentColorText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ActiveText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonBorder''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonFace''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''Canvas''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''CanvasText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''Field''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''FieldText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''GrayText''</td>
+					<td>
+						<span class="swatch" style="--color: #600000"></span>
+						&nbsp;#600000
+					</td>
+				</tr>
+				<tr>
+					<td>''Highlight''</td>
+					<td>
+						<span class="swatch" style="--color: #37006E"></span>
+						&nbsp;#37006E
+					</td>
+				</tr>
+				<tr>
+					<td>''HighlightText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''LinkText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+				<tr>
+					<td>''Mark''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''MarkText''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItem''</td>
+					<td>
+						<span class="swatch" style="--color: #37006E"></span>
+						&nbsp;#37006E
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItemText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''VisitedText''</td>
+					<td>
+						<span class="swatch" style="--color: #00009F"></span>
+						&nbsp;#00009F
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+	[=System color=] mappings for "{{ForcedColorsModeAutomationTheme/dark}}":
+		<table class="data">
+			<thead>
+				<tr>
+					<th><<system-color>> keyword</th>
+					<th>Value</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>''AccentColor''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''AccentColorText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''ActiveText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonBorder''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonFace''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''ButtonText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''Canvas''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''CanvasText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+				</tr>
+				<tr>
+					<td>''Field''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''FieldText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFFFF"></span>
+						&nbsp;#FFFFFF
+					</td>
+					<td></td>
+				</tr>
+				<tr>
+					<td>''GrayText''</td>
+					<td>
+						<span class="swatch" style="--color: #3FF23F"></span>
+						&nbsp;#3FF23F
+					</td>
+				</tr>
+				<tr>
+					<td>''Highlight''</td>
+					<td>
+						<span class="swatch" style="--color: #1AEBFF"></span>
+						&nbsp;#1AEBFF
+					</td>
+				</tr>
+				<tr>
+					<td>''HighlightText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''LinkText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+				<tr>
+					<td>''Mark''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''MarkText''</td>
+					<td>
+						N/A - this [=system color=] keyword should not be adjusted.
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItem''</td>
+					<td>
+						<span class="swatch" style="--color: #1AEBFF"></span>
+						&nbsp;#1AEBFF
+					</td>
+				</tr>
+				<tr>
+					<td>''SelectedItemText''</td>
+					<td>
+						<span class="swatch" style="--color: #000000"></span>
+						&nbsp;#000000
+					</td>
+				</tr>
+				<tr>
+					<td>''VisitedText''</td>
+					<td>
+						<span class="swatch" style="--color: #FFFF00"></span>
+						&nbsp;#FFFF00
+					</td>
+				</tr>
+			</tbody>
+		</table>
 
 
 Privacy Considerations {#privacy}


### PR DESCRIPTION
As suggested by @fantasai, move the system color mappings for the forced colors mode emulation added in https://github.com/w3c/csswg-drafts/pull/11823 to a new subsection of the "Emulation" section to keep the main forced colors mode section simpler.

Checkout https://alisonmaher.github.io/alisonmaher/css-color-adjust-1/Overview.html#forced-color-palettes for a preview of the updates.

