### PR TITLE
[css-ui-4] switch from using :focus to :focus-visible in the example on outlines

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -393,11 +393,11 @@ Outline properties</h2>
 	(e.g. for entering text or selecting a button).
 
 	<div class="example">
-		For example, to draw a thick black line around an element when it has the focus,
-		and a thick red line when it is active,
-		the following rules can be used:
+		For example, to draw a thick black line around elements in the 
+		'':focus-visible'' state, and a thick red line when it is in the 
+		'':active'' state, the following rules can be used:
 		<pre><code class="lang-css">
-		:focus  { outline: thick solid black }
+		:focus-visible  { outline: thick solid black }
 		:active { outline: thick solid red }
 		</code></pre>
 	</div>


### PR DESCRIPTION
[css-ui-4] closes #12538 

Note, given that I changed this to use 'state' I also changed active to mention the state. If this is problematic I guess it could also be something like

> For example, to draw a thick black line around elements when the UA
> would draw a native focus outline, and a thick red line when it is active, 
> the following rules can be used:

But to me, what I sent is clearer.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
