### PR TITLE
[css-gaps-1] Define Interpolation behavior for GapDecorations. Issue #12431

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -975,13 +975,6 @@ Lists of values and the ''repeat-line-color/repeat()'' notation</h3>
 		</ol>
 	</div>
 
-	<div algorithm>
-		To <dfn>assign gap decoration values in reverse</dfn>
-		to a list of <var ignore=''>gaps</var> using a list of <var ignore=''>values</var>,
-		follow the same steps as to <a>assign gap decoration values</a>,
-		except that in step 2, change all instances of "first" to "last".
-	</div>
-
 <h4 id="interpolation-behavior">Interpolation behavior</h4>
 When interpolating ''repeat()'' values, or lists of values for 'rule-color' or 'rule-width', the interpolation proceeds in two steps:
 
@@ -992,8 +985,8 @@ When interpolating ''repeat()'' values, or lists of values for 'rule-color' or '
 	<div class="example">
 		<pre class="lang-css">
 		@keyframes example {
-			from { column-rule-width: 10px }
-			to   { column-rule-width: 20px 40px }
+			from { column-rule-width: 10px; }
+			to   { column-rule-width: 20px 40px; }
 		}
 		</pre>
 		Interpolation of the above values would result in expansion of the
@@ -1014,7 +1007,7 @@ When interpolating ''repeat()'' values, or lists of values for 'rule-color' or '
 		Interpolation of the above values would result in expansion of the
 		"from" and "to" values to create lists of equal lengths:
 		<pre>
-		From:   5px 10px 5px 10px
+		From:    5px 10px  5px 10px
 		At 50%: 10px 15px 10px 15px
 		To:     15px 20px 15px 20px
 		</pre>
@@ -1055,87 +1048,87 @@ When interpolating ''repeat()'' values, or lists of values for 'rule-color' or '
 <h5 id="auto-repeaters">Lists with Auto Repeaters</h5>
 	<div algorithm>
 
-		To <dfn>interpolate with auto repeaters</dfn>, when either of the lists we are interpolating between (let's call them |from| and |to|) include an <a>auto repeater</a>, we conceptually split the list into three segments, similar
-		to how we [=assign gap decoration values=]:
-		- |leading gaps|
-		- |auto repeat|
-		- |trailing gaps|
+		To <dfn>interpolate with auto repeaters</dfn>, when either of the lists we are interpolating between (|from| and |to|) include an <a>auto repeater</a>:
 
 			<ol>
-				<li>Let |segment lengths| be the length of the |leading gaps| and |trailing gaps| segments (i.e. the number of items in each list, after <a>expansion</a>).</li>
-				<li>We split |to| and/or |from| into their respective segments.</li>
-				<li>If either of |leading gaps| or |trailing gaps| in |to| or |from| is empty and the other has an <a>auto repeater</a>, we do [=discrete=] interpolation.</li>
+				<li>
+				Split each of |from| and |to| into segments, similar to how we [=assign gap decoration values=]:
+				Let |leading values| be the values before the <a>auto repeater</a>.
+				Let |trailing values| be the values after the <a>auto repeater</a>.
+				Let |auto values| be the values inside the <a>auto repeater</a>.
+				</li>
+				<li>If either of |leading values| or |trailing values| in |from| or |to| is empty and the other has an <a>auto repeater</a>, we fall back to [=discrete=] interpolation.</li>
 				<li>Expand any integer repeaters on each segment.</li>
-				<li>If the |segment lengths| don't match, we fall back to [=discrete=] interpolation.</li>
-				<li>When both |from| and |to| contain auto-repeaters and |segment lengths| match, we apply <a>list interpolation</a> to each segment. Applying <a>list interpolation</a> to the |auto repeat| means applying it to the list of values inside the repeater.</li>
-				<li>If only one of |from| or |to| contains an auto-repeater, we do [=discrete=] interpolation.</li>
+				<li>
+				If the length of |leading values| in |from| and |leading values| in |to| don't match, we fall back to [=discrete=] interpolation.
+				If the length of |trailing values| in |from| and |trailing values| in |to| don't match, we fall back to [=discrete=] interpolation.
+				</li>
+				<li>If only one of |from| or |to| contains an auto-repeater, we fall back to [=discrete=] interpolation.</li>
+				<li>When both |from| and |to| contain auto-repeaters, and the length of their segments match as described above, we apply <a>list interpolation</a> to each segment.
+				Applying <a>list interpolation</a> to the |auto values| means applying it to the list of values inside the repeater.
+				</li>
 			</ol>
-	</div>
-	<div class="example">
-		<pre class="lang-css">
-		@keyframes example {
-			from { column-rule-width: 10px repeat(auto, 20px) 30px }
-			to   { column-rule-width: 20px repeat(auto, 40px) 40px }
-		}
-		</pre>
-		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment.
-		<pre>
-		From:   10px repeat(auto, 20px) 30px
-		At 50%: 15px repeat(auto, 30px) 35px
-		To:     20px repeat(auto, 40px) 40px
-		</pre>
-	</div>
 
-	<div class="example">
-		<pre class="lang-css">
-		@keyframes example {
-			from { column-rule-width: 10px repeat(auto, 20px) 30px }
-			to   { column-rule-width: 20px repeat(auto, 40px 50px) 40px }
-		}
-		</pre>
-		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment,
-		applying <a>list interpolation</a> to list of values in the |auto repeat| segment.
-		<pre>
-		From:   10px repeat(auto, 20px 20px) 30px
-		At 50%: 15px repeat(auto, 30px 35px) 35px
-		To:     20px repeat(auto, 40px 50px) 40px
-		</pre>
-	</div>
+		<div class="example">
+			<pre class="lang-css">
+			@keyframes example {
+				from { column-rule-width: 10px repeat(auto, 20px) 30px }
+				to   { column-rule-width: 20px repeat(auto, 40px) 40px }
+			}
+			</pre>
+			Length of the |leading values| and |trailing values| across |from| and |to| match, so we can apply the [=repeatable list=] algorithm to each segment.
+			<pre>
+			From:   10px repeat(auto, 20px) 30px
+			At 50%: 15px repeat(auto, 30px) 35px
+			To:     20px repeat(auto, 40px) 40px
+			</pre>
+		</div>
 
-	<div class="example">
-		<pre class="lang-css">
-		@keyframes example {
-			from { column-rule-width: 10px repeat(auto, 20px) }
-			to   { column-rule-width: 20px 30px repeat(auto, 40px 50px) }
-		}
-		</pre>
-		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment,
-		applying <a>list interpolation</a> to list of values in the |auto repeat| segment.
-		<pre>
-		From:   10px 10px repeat(auto, 20px 20px)
-		At 50%: 15px 20px repeat(auto, 30px 35px)
-		To:     20px 30px repeat(auto, 40px 50px)
-		</pre>
-	</div>
+		<div class="example">
+			<pre class="lang-css">
+			@keyframes example {
+				from { column-rule-width: 10px 20px repeat(auto, 20px) 30px }
+				to   { column-rule-width: 20px 30px repeat(auto, 40px 50px) 40px }
+			}
+			</pre>
+			Length of the |leading values| and |trailing values| across |from| and |to| match, so we can apply the [=repeatable list=] algorithm to each segment,
+			applying <a>list interpolation</a> to list of values in the |auto repeat| segment.
+			<pre>
+			From:   10px 20px repeat(auto, 20px 20px) 30px
+			At 50%: 15px 25px repeat(auto, 30px 35px) 35px
+			To:     20px 30px repeat(auto, 40px 50px) 40px
+			</pre>
+		</div>
 
-	<div class="example">
-		<pre class="lang-css">
-		@keyframes example {
-			from { column-rule-width: 10px repeat(auto, 20px) 30px }
-			to   { column-rule-width: 20px repeat(auto, 40px) 40px 50px }
-		}
-		</pre>
-		Length of the |trailing gaps| and |leading gaps| in |to| do not match, so we fall back to [=discrete=] interpolation.
-	</div>
+		<div class="example">
+			<pre class="lang-css">
+			@keyframes example {
+				from { column-rule-width: 10px repeat(auto, 20px) }
+				to   { column-rule-width: 20px 30px repeat(auto, 40px 50px) }
+			}
+			</pre>
+			Length of the |from| |leading values| and |to| |leading values| don't match, so we fall back to [=discrete=] interpolation.
+		</div>
 
-	<div class="example">
-		<pre class="lang-css">
-		@keyframes example {
-			from { column-rule-width: 10px repeat(auto, 20px) 30px }
-			to   { column-rule-width: 20px }
-		}
-		</pre>
-		Only |from| contains an <a>auto repeater</a>, so we fall back to [=discrete=] interpolation.
+		<div class="example">
+			<pre class="lang-css">
+			@keyframes example {
+				from { column-rule-width: 10px repeat(auto, 20px) 30px }
+				to   { column-rule-width: 20px repeat(auto, 40px) 40px 50px }
+			}
+			</pre>
+			Length of the |from| |trailing values| and |to| |trailing values| don't match, so we fall back to [=discrete=] interpolation.
+		</div>
+
+		<div class="example">
+			<pre class="lang-css">
+			@keyframes example {
+				from { column-rule-width: 10px repeat(auto, 20px) 30px }
+				to   { column-rule-width: 20px }
+			}
+			</pre>
+			Only |from| contains an <a>auto repeater</a>, so we fall back to [=discrete=] interpolation.
+		</div>
 	</div>
 
 <h3 id="gap-decoration-shorthands">
@@ -1225,6 +1218,6 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Updated 'rule-paint-order' to 'rule-overlap'. (<a href="https://github.com/w3c/csswg-drafts/issues/12540">Issue 12540</a>)
 		<li>Updated the definition for intersections to use 'gutter'. (<a href="https://github.com/w3c/csswg-drafts/issues/12084">Issue 12084</a>)
 		<li>Updated trailing gap decoration assignment to use values in forward order. (<a href="https://github.com/w3c/csswg-drafts/issues/12527">Issue 12527</a>)
-    <li>Specified the interpolation behavior for values which may contain repeaters.
+    	<li>Specified the interpolation behavior for values which may contain repeaters.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/12431">Issue 12431</a>)
 	</ul>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -712,7 +712,7 @@ Gap decoration color: The 'column-rule-color' and 'row-rule-color' properties</h
 		Initial: currentcolor
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>masonry containers</a>
 		Inherited: no
-		Animation type: repeatable list, (see [[#repeat-interpolation]]).
+		Animation type: repeatable list, see [[#interpolation-behavior]].
 	</pre>
 
 	<pre class='prod'>
@@ -807,7 +807,7 @@ Gap decoration width: The 'column-rule-width' and 'row-rule-width' properties</h
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>masonry containers</a>
 		Inherited: no
 		Computed value: list of absolute lengths, <a>snapped as a border width</a>, or ''0'' under conditions described below
-		Animation type: repeatable list, (see [[#repeat-interpolation]]).
+		Animation type: repeatable list, see [[#interpolation-behavior]].
 	</pre>
 
 	<pre class='prod'>
@@ -982,71 +982,161 @@ Lists of values and the ''repeat-line-color/repeat()'' notation</h3>
 		except that in step 2, change all instances of "first" to "last".
 	</div>
 
-<h4 id="repeat-interpolation">Interpolation of ''repeat()''</h4>
-When combining ''repeat()'' values for 'rule-color', and 'rule-width',
+<h4 id="interpolation-behavior">Interpolation behavior</h4>
+When interpolating ''repeat()'' values, or lists of values for 'rule-color' or 'rule-width', the interpolation proceeds in two steps:
 
-When interpolating ''repeat()'' values for 'rule-color' or 'rule-width', the interpolation proceeds in two steps:
+	<ol>
+	<li> <dfn>Expansion</dfn>: Expand any [=integer repeater=] into its equivalent list of values. </li>
+	<li> <dfn>List Interpolation</dfn>: Apply the [=repeatable list=] interpolation algorithm to the expanded lists, interpolating each item against its counterpart.</li>
+	</ol>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px }
+			to   { column-rule-width: 20px 40px }
+		}
+		</pre>
+		Interpolation of the above values would result in expansion of the
+		"from" and "to" values to create lists of equal lengths:
+		<pre>
+		From:   10px 10px
+		At 50%: 15px 25px
+		To:     20px 40px
+		</pre>
+	</div>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: repeat(2, 5px 10px); }
+			to   { column-rule-width: repeat(2, 15px 20px); }
+		}
+		</pre>
+		Interpolation of the above values would result in expansion of the
+		"from" and "to" values to create lists of equal lengths:
+		<pre>
+		From:   5px 10px 5px 10px
+		At 50%: 10px 15px 10px 15px
+		To:     15px 20px 15px 20px
+		</pre>
+	</div>
 
-<ol>
-<li> <dfn>Expansion</dfn>: Expand each ''repeat(n, …)'' into its equivalent list of values. </li>
-<li> <dfn>List Interpolation</dfn>: Apply the [=repeatable list=] interpolation algorithm to the expanded lists, interpolating each item against its counterpart.</li>
-</ol>
-<pre class="example">
-/* Repeater → Repeater */
-from: repeat(2, 5px 10px)
-to:   repeat(2, 15px 20px)
-/* At 50%: 10px 15px 10px 15px */
-</pre>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: repeat(2, 10px 20px); }
+			to   { column-rule-width: 20px; }
+		}
+		</pre>
+		Interpolation of the above values would result in expansion of the
+		"from" and "to" values to create lists of equal lengths:
+		<pre>
+		From:   10px 20px 10px 20px
+		At 50%: 15px 20px 15px 20px
+		To:     20px 20px 20px 20px
+		</pre>
+	</div>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: repeat(2, 10px 20px); }
+			to   { column-rule-width: 20px 30px; }
+		}
+		</pre>
+		Interpolation of the above values would result in expansion of the
+		"from" and "to" values to create lists of equal lengths:
+		<pre>
+		From:   10px 20px 10px 20px
+		At 50%: 15px 25px 15px 25px
+		To:     20px 30px 20px 30px
+		</pre>
+	</div>
 
-<pre class="example">
-/* Repeater → Non-Repeater */
-from: repeat(2, 10px 20px)
-to:   20px
-/* At 50%: 15px 20px 15px 20px */
-</pre>
-
-<pre class="example">
-/* Repeater → Non-Repeater */
-from: repeat(2, 10px 20px)
-to:   20px 30px
-/* At 50%: 15px 25px 15px 25px */
-</pre>
 
 <h5 id="auto-repeaters">Lists with Auto Repeaters</h5>
-When either of the lists we are interpolating between (let's call them |from| and |to|) include an <a>auto repeater</a> (e.g. ''repeat(auto, …)''), we conceptually split the list into three segments, similar
-to how we [=assign gap decoration values=]:
-- |leading gaps|
-- |auto repeat|
-- |trailing gaps|
+	<div algorithm>
 
-Interpolation rules:
-<ol>
-<li>Let |segment lengths| be the length of the |leading gaps| and |trailing gaps| segments (i.e. the number of items in each list, after <a>expansion</a>).</li>
-<li>If either of |leading gaps| or |trailing gaps| is empty and the other has an <a>auto repeater</a>, we do [=discrete=] interpolation.</li>
-<li>If the |segment lengths| match, apply the [=repeatable list=] algorithm separately to the |leading gaps| and |trailing gaps| segments.</li>
- Otherwise, fall back to [=discrete=] interpolation (the value jumps from |from| to |to| with no intermediates).
-<li>When both |from| and |to| contain auto-repeaters and |segment lengths| match, we apply <a>list interpolation</a>.</li>
-</ol>
-<pre class="example">
-/* Auto-Repeater → Auto-Repeater */
-from: 10px repeat(auto, 20px) 30px
-to:   20px repeat(auto, 40px) 40px
-/* At 50%: 15px repeat(auto, 30px) 35px */
-</pre>
+		To <dfn>interpolate with auto repeaters</dfn>, when either of the lists we are interpolating between (let's call them |from| and |to|) include an <a>auto repeater</a>, we conceptually split the list into three segments, similar
+		to how we [=assign gap decoration values=]:
+		- |leading gaps|
+		- |auto repeat|
+		- |trailing gaps|
 
-<pre class="example">
-/* Auto-Repeater → Auto-Repeater (Discrete interpolation, segment lengths don't match) */
-from: 10px repeat(auto, 20px) 30px
-to:   20px repeat(auto, 40px) 40px 50px
-/* At 50%: 15px repeat(auto, 30px) 40px 50px */
-</pre>
+			<ol>
+				<li>Let |segment lengths| be the length of the |leading gaps| and |trailing gaps| segments (i.e. the number of items in each list, after <a>expansion</a>).</li>
+				<li>We split |to| and/or |from| into their respective segments.</li>
+				<li>If either of |leading gaps| or |trailing gaps| in |to| or |from| is empty and the other has an <a>auto repeater</a>, we do [=discrete=] interpolation.</li>
+				<li>Expand any integer repeaters on each segment.</li>
+				<li>If the |segment lengths| don't match, we fall back to [=discrete=] interpolation.</li>
+				<li>When both |from| and |to| contain auto-repeaters and |segment lengths| match, we apply <a>list interpolation</a> to each segment. Applying <a>list interpolation</a> to the |auto repeat| means applying it to the list of values inside the repeater.</li>
+				<li>If only one of |from| or |to| contains an auto-repeater, we do [=discrete=] interpolation.</li>
+			</ol>
+	</div>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px repeat(auto, 20px) 30px }
+			to   { column-rule-width: 20px repeat(auto, 40px) 40px }
+		}
+		</pre>
+		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment.
+		<pre>
+		From:   10px repeat(auto, 20px) 30px
+		At 50%: 15px repeat(auto, 30px) 35px
+		To:     20px repeat(auto, 40px) 40px
+		</pre>
+	</div>
 
-<pre class="example">
-/* Auto-Repeater → Non-Repeater (Discrete interpolation, segment lengths don't match) */
-from: 10px repeat(auto, 20px) 30px
-to:   20px 40px
-/* At 50%: 20px 40px */
-</pre>
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px repeat(auto, 20px) 30px }
+			to   { column-rule-width: 20px repeat(auto, 40px 50px) 40px }
+		}
+		</pre>
+		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment,
+		applying <a>list interpolation</a> to list of values in the |auto repeat| segment.
+		<pre>
+		From:   10px repeat(auto, 20px 20px) 30px
+		At 50%: 15px repeat(auto, 30px 35px) 35px
+		To:     20px repeat(auto, 40px 50px) 40px
+		</pre>
+	</div>
+
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px repeat(auto, 20px) }
+			to   { column-rule-width: 20px 30px repeat(auto, 40px 50px) }
+		}
+		</pre>
+		Length of the |leading gaps| and |trailing gaps| match, so we can apply the [=repeatable list=] algorithm to each segment,
+		applying <a>list interpolation</a> to list of values in the |auto repeat| segment.
+		<pre>
+		From:   10px 10px repeat(auto, 20px 20px)
+		At 50%: 15px 20px repeat(auto, 30px 35px)
+		To:     20px 30px repeat(auto, 40px 50px)
+		</pre>
+	</div>
+
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px repeat(auto, 20px) 30px }
+			to   { column-rule-width: 20px repeat(auto, 40px) 40px 50px }
+		}
+		</pre>
+		Length of the |trailing gaps| and |leading gaps| in |to| do not match, so we fall back to [=discrete=] interpolation.
+	</div>
+
+	<div class="example">
+		<pre class="lang-css">
+		@keyframes example {
+			from { column-rule-width: 10px repeat(auto, 20px) 30px }
+			to   { column-rule-width: 20px }
+		}
+		</pre>
+		Only |from| contains an <a>auto repeater</a>, so we fall back to [=discrete=] interpolation.
+	</div>
 
 <h3 id="gap-decoration-shorthands">
 Gap decoration shorthands: The 'column-rule' and 'row-rule' properties</h3>
@@ -1134,6 +1224,6 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Added links to WPT suite.
 		<li>Updated 'rule-paint-order' to 'rule-overlap'. (<a href="https://github.com/w3c/csswg-drafts/issues/12540">Issue 12540</a>)
 		<li>Updated the definition for intersections to use 'gutter'. (<a href="https://github.com/w3c/csswg-drafts/issues/12084">Issue 12084</a>)
-    <li>Specified the interpolation behavior for ''repeat()'', 'rule-color', and 'rule-width'.
+    <li>Specified the interpolation behavior for values which may contain repeaters.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/12431">Issue 12431</a>)
 	</ul>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -712,7 +712,7 @@ Gap decoration color: The 'column-rule-color' and 'row-rule-color' properties</h
 		Initial: currentcolor
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>masonry containers</a>
 		Inherited: no
-		Animation type: by computed value type
+		Animation type: repeatable list, (see [[#repeat-interpolation]]).
 	</pre>
 
 	<pre class='prod'>
@@ -807,7 +807,7 @@ Gap decoration width: The 'column-rule-width' and 'row-rule-width' properties</h
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>masonry containers</a>
 		Inherited: no
 		Computed value: list of absolute lengths, <a>snapped as a border width</a>, or ''0'' under conditions described below
-		Animation type: by computed value type
+		Animation type: repeatable list, (see [[#repeat-interpolation]]).
 	</pre>
 
 	<pre class='prod'>
@@ -981,6 +981,36 @@ Lists of values and the ''repeat-line-color/repeat()'' notation</h3>
 		follow the same steps as to <a>assign gap decoration values</a>,
 		except that in step 2, change all instances of "first" to "last".
 	</div>
+
+<h4 id="repeat-interpolation">Interpolation of ''repeat()''</h4>
+When combining ''repeat()'' values for 'rule-color', and 'rule-width',
+
+When interpolating ''repeat()'' values for 'rule-color' or 'rule-width', the interpolation proceeds in two steps:
+
+1. **Expansion**: Expand each ''repeat(n, …)'' into its equivalent list of values.
+2. **List Interpolation**: Apply the [=repeatable list=] interpolation algorithm to the expanded lists, interpolating each item against its counterpart.
+
+<pre class="example">
+/* Repeater → Repeater */
+from: repeat(2, 5px 10px)
+to:   repeat(2, 15px 20px)
+/* At 50%: 10px 15px 10px 15px */
+</pre>
+
+<pre class="example">
+/* Repeater → Non-Repeater */
+from: repeat(2, 10px 20px)
+to:   20px
+/* At 50%: 15px 20px 15px 20px */
+</pre>
+
+<pre class="example">
+/* Repeater → Non-Repeater */
+from: repeat(2, 10px 20px)
+to:   20px 30px
+/* At 50%: 15px 25px 15px 25px */
+</pre>
+
 
 <h3 id="gap-decoration-shorthands">
 Gap decoration shorthands: The 'column-rule' and 'row-rule' properties</h3>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -987,9 +987,10 @@ When combining ''repeat()'' values for 'rule-color', and 'rule-width',
 
 When interpolating ''repeat()'' values for 'rule-color' or 'rule-width', the interpolation proceeds in two steps:
 
-1. **Expansion**: Expand each ''repeat(n, …)'' into its equivalent list of values.
-2. **List Interpolation**: Apply the [=repeatable list=] interpolation algorithm to the expanded lists, interpolating each item against its counterpart.
-
+<ol>
+<li> <dfn>Expansion</dfn>: Expand each ''repeat(n, …)'' into its equivalent list of values. </li>
+<li> <dfn>List Interpolation</dfn>: Apply the [=repeatable list=] interpolation algorithm to the expanded lists, interpolating each item against its counterpart.</li>
+</ol>
 <pre class="example">
 /* Repeater → Repeater */
 from: repeat(2, 5px 10px)
@@ -1011,6 +1012,41 @@ to:   20px 30px
 /* At 50%: 15px 25px 15px 25px */
 </pre>
 
+<h5 id="auto-repeaters">Lists with Auto Repeaters</h5>
+When either of the lists we are interpolating between (let's call them |from| and |to|) include an <a>auto repeater</a> (e.g. ''repeat(auto, …)''), we conceptually split the list into three segments, similar
+to how we [=assign gap decoration values=]:
+- |leading gaps|
+- |auto repeat|
+- |trailing gaps|
+
+Interpolation rules:
+<ol>
+<li>Let |segment lengths| be the length of the |leading gaps| and |trailing gaps| segments (i.e. the number of items in each list, after <a>expansion</a>).</li>
+<li>If either of |leading gaps| or |trailing gaps| is empty and the other has an <a>auto repeater</a>, we do [=discrete=] interpolation.</li>
+<li>If the |segment lengths| match, apply the [=repeatable list=] algorithm separately to the |leading gaps| and |trailing gaps| segments.</li>
+ Otherwise, fall back to [=discrete=] interpolation (the value jumps from |from| to |to| with no intermediates).
+<li>When both |from| and |to| contain auto-repeaters and |segment lengths| match, we apply <a>list interpolation</a>.</li>
+</ol>
+<pre class="example">
+/* Auto-Repeater → Auto-Repeater */
+from: 10px repeat(auto, 20px) 30px
+to:   20px repeat(auto, 40px) 40px
+/* At 50%: 15px repeat(auto, 30px) 35px */
+</pre>
+
+<pre class="example">
+/* Auto-Repeater → Auto-Repeater (Discrete interpolation, segment lengths don't match) */
+from: 10px repeat(auto, 20px) 30px
+to:   20px repeat(auto, 40px) 40px 50px
+/* At 50%: 15px repeat(auto, 30px) 40px 50px */
+</pre>
+
+<pre class="example">
+/* Auto-Repeater → Non-Repeater (Discrete interpolation, segment lengths don't match) */
+from: 10px repeat(auto, 20px) 30px
+to:   20px 40px
+/* At 50%: 20px 40px */
+</pre>
 
 <h3 id="gap-decoration-shorthands">
 Gap decoration shorthands: The 'column-rule' and 'row-rule' properties</h3>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1096,4 +1096,6 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Specified the behavior when gaps are coincident due to track collapsing.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/11814">Issue 11814</a>)
 		<li>Added links to WPT suite.
+		<li>Specified the interpolation behavior for ''repeat()'', 'rule-color', and 'rule-width'.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/12431">Issue 12431</a>)
 	</ul>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1057,13 +1057,12 @@ When interpolating ''repeat()'' values, or lists of values for 'rule-color' or '
 				Let |trailing values| be the values after the <a>auto repeater</a>.
 				Let |auto values| be the values inside the <a>auto repeater</a>.
 				</li>
-				<li>If either of |leading values| or |trailing values| in |from| or |to| is empty and the other has an <a>auto repeater</a>, we fall back to [=discrete=] interpolation.</li>
+				<li>If only one of |from| or |to| contains an auto-repeater, we fall back to [=discrete=] interpolation.</li>
 				<li>Expand any integer repeaters on each segment.</li>
 				<li>
 				If the length of |leading values| in |from| and |leading values| in |to| don't match, we fall back to [=discrete=] interpolation.
 				If the length of |trailing values| in |from| and |trailing values| in |to| don't match, we fall back to [=discrete=] interpolation.
 				</li>
-				<li>If only one of |from| or |to| contains an auto-repeater, we fall back to [=discrete=] interpolation.</li>
 				<li>When both |from| and |to| contain auto-repeaters, and the length of their segments match as described above, we apply <a>list interpolation</a> to each segment.
 				Applying <a>list interpolation</a> to the |auto values| means applying it to the list of values inside the repeater.
 				</li>


### PR DESCRIPTION
This PR aims to define the interpolation behavior for the `rule-width` and `rule-color` properties in CSSGapDecorations, based on the resolution in https://github.com/w3c/csswg-drafts/issues/12431.

Changes can be seen live in https://jav099.github.io/javier-intersections-draft.github.io/
