### PR TITLE
[css-gaps-1] Update gap intersection definition. Issue #12084

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2681,6 +2681,7 @@ Changes</h2>
 			(<a href="https://github.com/w3c/csswg-drafts/issues/1318">Issue 1318</a>)
 		<li>Clamped baselines of scrollable boxes to the border edge, rather than margin edge.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/766">Issue 766</a>)
+		<li>Updated the flex container gap definition to use 'gutter'. (<a href="https://github.com/w3c/csswg-drafts/issues/12084">Issue 12084</a>)
 	</ul>
 
 <h2 id="privacy">

--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -2087,14 +2087,14 @@ Row and Column Gutters: the 'row-gap' and 'column-gap' properties</h3>
 		<dd>
 			When applied to the <a>main axis</a>
 			(e.g. 'column-gap' in a ''flex-flow/row'' <a>flex container</a>),
-			indicates minimum spacing between items
+			indicates the [=gutter=] between items
 			(as if an additional fixed-size margin were inserted
 			between adjacent <a>flex items</a>
 			in a single line).
 
 			When applied to the <a>cross axis</a>
 			(e.g. 'row-gap' in a ''flex-flow/row'' <a>flex container</a>),
-			indicates minimum spacing between adjacent <a>flex lines</a>.
+			indicates the [=gutter=] between adjacent <a>flex lines</a>.
 
 		<dt id="gap-grid"><a>grid containers</a>
 		<dd>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -112,7 +112,7 @@ Layout and painting</h3>
 
 	A <dfn>gap intersection point</dfn> is defined to exist in each of the following locations:
 	<ul>
-		<li>The center of an intersection between a gap and the content edge of the container.</li>
+		<li>The center of an intersection between a gap and the end edge of a [=gutter=].</li>
 		<li>The center of an intersection between gaps in different directions.</li>
 	</ul>
 

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1066,4 +1066,5 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Specified the behavior when gaps are coincident due to track collapsing.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/11814">Issue 11814</a>)
 		<li>Added links to WPT suite.
+		<li>Updated the definition for intersections to use 'gutter'. (<a href="https://github.com/w3c/csswg-drafts/issues/12084">Issue 12084</a>)
 	</ul>


### PR DESCRIPTION
This PR aims to update the definition of a gap intersection point to solve the concerns raised in issue https://github.com/w3c/csswg-drafts/issues/12084. This required a minor update to css-align-3 in how we define the gap for flex containers, which now will use language that multi column and grid use.