### PR TITLE
[css-gaps-1] Change `rule-paint-order` to `rule-overlap`. Issue #12431

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -644,10 +644,10 @@ Adjusting gap decoration endpoints: The 'column-rule-outset', 'row-rule-outset',
 	</wpt>
 
 <h3 id="paint-order">
-Gap decoration paint order: The 'rule-paint-order' property</h3>
+Gap decoration overlap: The 'rule-overlap' property</h3>
 
 	<pre class='propdef'>
-		Name: rule-paint-order
+		Name: rule-overlap
 		Value: row-over-column | column-over-row
 		Initial: row-over-column
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, and <a>masonry containers</a>
@@ -657,12 +657,12 @@ Gap decoration paint order: The 'rule-paint-order' property</h3>
 
 	Sets the paint order for <a>gap decorations</a> in two-dimensional containers.
 
-	The following examples illustrate adjustment of gap decoration paint order using the 'rule-paint-order' property.
+	The following examples illustrate adjustment of gap decoration paint order using the 'rule-overlap' property.
 
 	<div class="example">
 		<pre>
 			.row-over-coulumn {
-				rule-paint-order: row-over-column;
+				rule-overlap: row-over-column;
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 			}
@@ -677,7 +677,7 @@ Gap decoration paint order: The 'rule-paint-order' property</h3>
 
 	<div class="example">
 		<pre>
-			rule-paint-order: column-over-row;
+			rule-overlap: column-over-row;
 			row-rule: 6px solid red;
 			column-rule: 6px solid blue;
 		</pre>
@@ -1066,4 +1066,5 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Specified the behavior when gaps are coincident due to track collapsing.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/11814">Issue 11814</a>)
 		<li>Added links to WPT suite.
+		<li>Updated 'rule-paint-order' to 'rule-overlap'. (<a href="https://github.com/w3c/csswg-drafts/issues/12540">Issue 12540</a>)
 	</ul>

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -643,7 +643,7 @@ Adjusting gap decoration endpoints: The 'column-rule-outset', 'row-rule-outset',
 		parsing/rule-outset-valid.html
 	</wpt>
 
-<h3 id="paint-order">
+<h3 id="overlap">
 Gap decoration overlap: The 'rule-overlap' property</h3>
 
 	<pre class='propdef'>
@@ -655,9 +655,9 @@ Gap decoration overlap: The 'rule-overlap' property</h3>
 		Animation type: discrete
 	</pre>
 
-	Sets the paint order for <a>gap decorations</a> in two-dimensional containers.
+	Sets the overlap for <a>gap decorations</a> in two-dimensional containers.
 
-	The following examples illustrate adjustment of gap decoration paint order using the 'rule-overlap' property.
+	The following examples illustrate adjustment of gap decoration overlap using the 'rule-overlap' property.
 
 	<div class="example">
 		<pre>
@@ -670,7 +670,7 @@ Gap decoration overlap: The 'rule-overlap' property</h3>
 		<figure>
 			<img alt="" src="images/example-row-over-column.png">
 			<figcaption>
-				Row-over-column gap decoration paint order.
+				Row-over-column gap decoration overlap.
 			</figcaption>
 		</figure>
 	</div>
@@ -684,7 +684,7 @@ Gap decoration overlap: The 'rule-overlap' property</h3>
 		<figure>
 			<img alt="" src="images/example-column-over-row.png">
 			<figcaption>
-				Column-over-row gap decoration paint order.
+				Column-over-row gap decoration overlap.
 			</figcaption>
 		</figure>
 	</div>


### PR DESCRIPTION
This PR changes `rule-paint-order` to `rule-overlap`, as per the resolution in https://github.com/w3c/csswg-drafts/issues/12540