### PR TITLE
Grammer patch: Missing noun in css-view-transitions-1/Overview.bs

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -272,7 +272,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 
 	If the ''::view-transition-group()'' has a corresponding element in the "new" states,
 	the browser keeps the properties copied over to the ''::view-transition-group()'' in sync with the DOM element in the "new" state.
-	If the ''::view-transition-group()'' has a corresponding both in the "old" and "new" state,
+	If the ''::view-transition-group()'' has corresponding elements both in the "old" and "new" state,
 	and the property being copied is interpolatable,
 	the browser also sets up a default animation to animate the property smoothly.
 


### PR DESCRIPTION
The previous version of this sentence was missing a noun.

The sentence at the start of the paragraph makes it clear what's missing.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
