### PR TITLE
[css-gaps-1] Update trailing gap decoration assignment to use values in forward order. Issue #12527 

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -963,8 +963,8 @@ Lists of values and the ''repeat-line-color/repeat()'' notation</h3>
 			
 			<li>
 				If |trailing gaps| is non-empty,
-				<a>assign gap decoration values in reverse</a> to |trailing gaps|
-				using the last |trailing count| items in |values|.
+				<a>assign gap decoration values</a> to |trailing gaps|
+				using the first |trailing count| items in |values|.
 			</li>
 			
 			<li>
@@ -973,13 +973,6 @@ Lists of values and the ''repeat-line-color/repeat()'' notation</h3>
 				using the list of values in the second argument of the <a>auto repeater</a>.
 			</li>
 		</ol>
-	</div>
-
-	<div algorithm>
-		To <dfn>assign gap decoration values in reverse</dfn>
-		to a list of <var ignore=''>gaps</var> using a list of <var ignore=''>values</var>,
-		follow the same steps as to <a>assign gap decoration values</a>,
-		except that in step 2, change all instances of "first" to "last".
 	</div>
 
 <h3 id="gap-decoration-shorthands">
@@ -1068,4 +1061,5 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 		<li>Added links to WPT suite.
 		<li>Updated 'rule-paint-order' to 'rule-overlap'. (<a href="https://github.com/w3c/csswg-drafts/issues/12540">Issue 12540</a>)
 		<li>Updated the definition for intersections to use 'gutter'. (<a href="https://github.com/w3c/csswg-drafts/issues/12084">Issue 12084</a>)
+		<li>Updated trailing gap decoration assignment to use values in forward order. (<a href="https://github.com/w3c/csswg-drafts/issues/12527">Issue 12527</a>)
 	</ul>


### PR DESCRIPTION
This PR updates the trailing gap decoration logic so that values are now assigned in forward order(i.e. from first to last). This ensures all decoration values apply left-to-right based on the resolution in #12527.
