### PR TITLE
[css-text-decor-4] Remove mention of percentages in text-decoration-trim

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -902,7 +902,7 @@ Text Decoration Line Trimming and Extension: the 'text-decoration-trim' property
 		and the [=end=] edge of the last fragment,
 		and may accumulate to other fragments if the amount of the trim
 		is more than the length of the fragment.
-		Percentages are relative to the total length of the [=decorating box=].
+		<!-- Percentages are relative to the total length of the [=decorating box=]. -->
 	* for ''box-decoration-break/clone''
 		trimming is applied to each fragment independently.
 		<!-- and percentages are relative to the length of that fragment individually -->


### PR DESCRIPTION
The grammar for text-decoration-trim does not accept percentages, so remove (at least for now) any mention of how percentages are resolved for this property.
