### PR TITLE
[css-view-transitions-1] Use `position: absolute` instead of `position: fixed` on `::view-transition`

### DIFF
--- a/css-view-transitions-1/Overview.bs
+++ b/css-view-transitions-1/Overview.bs
@@ -857,7 +857,7 @@ urlPrefix: https://wicg.github.io/navigation-api/; type: interface;
 	}
 
 	:root::view-transition {
-		position: fixed;
+		position: absolute;
 		inset: 0;
 	}
 
@@ -1999,7 +1999,11 @@ This appendix is <em>informative</em>.
 
 <h3 id="changes-since-2024-03-28">
 Changes from <a href="https://www.w3.org/TR/2024/CRD-css-view-transitions-1-20240328/">2024-03-28 Candidate Recommendation Draft</a>
+* Always flush the queue of update callbacks before capturing the old state. See <a href="https://github.com/w3c/csswg-drafts/issues/11292">issue 11922</a>.
+* Disallow <css>match-element</css> as a custom-ident. See <a href="https://github.com/w3c/csswg-drafts/issues/10995">Issue 10995</a>.
 * Add a non-normative note to explain that ''::view-transition-image-pair()'' would typically not need custom styling. See <a href="https://github.com/w3c/csswg-drafts/issues/11926#issuecomment-2916977161">issue 11926</a>
+* Inherit more animation properties into pseudo-element tree. See <a href="https://github.com/w3c/csswg-drafts/issues/11546">Issue 11546</a>.
+* Use `position: absolute` instead of `position: fixed` on ''::view-transition''. See <a href="https://github.com/w3c/csswg-drafts/issues/12116">Issue 12116</a>.
 
 <h3 id="changes-since-2023-05-30">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230530/">2023-05-30 Working Draft</a>
@@ -2029,8 +2033,6 @@ Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230
 * Fix scoping to match name instead of element. See <a href="https://github.com/w3c/csswg-drafts/issues/10145">issue 10145</a>.
 * Add a rendering characteristics note about out-of-viewport elements. See <a href="https://github.com/w3c/csswg-drafts/issues/8282">issue 8282</a>.
 * Swap the order of invoking the update callback and setting the phase. See <a href="https://github.com/w3c/csswg-drafts/issues/10822">issue 10822</a>.
-* Always flush the queue of update callbacks before capturing the old state. See <a href="https://github.com/w3c/csswg-drafts/issues/11292">issue 11922</a>.
-* Disallow <css>match-element</css> as a custom-ident. See <a href="https://github.com/w3c/csswg-drafts/issues/10995">Issue 10995</a>.
 
 <h3 id="changes-since-2023-05-25">
 Changes from <a href="https://www.w3.org/TR/2023/WD-css-view-transitions-1-20230525/">2023-05-25 Working Draft</a>


### PR DESCRIPTION
Fixes #12116
