### PR TITLE
[css-color-hdr-1] Added alpha() RCS to color syntax #10689

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -528,6 +528,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 			<<hsl()>> | <<hsla()>> | <<hwb()>> |
 			<<lab()>> | <<lch()>> | <<oklab()>> | <<oklch()>> |
 			<<ictcp()>> | <<jzazbz()>> | <<jzczhz()>> |
+			<<alpha()>> |
 			<<color()>>
 	<dfn>ictcp()</dfn> = ictcp([from <<color>>]?
 		[<<percentage>> | <<number>> | none]


### PR DESCRIPTION
Follow up on 5c4bf40 and 231f593.