### PR TITLE
[css-borders-4] Specify the corner-* shorthands

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -672,7 +672,7 @@ The 'corner' shorthand</h4>
 		Animation type: see individual properties
 	</pre>
 
-	The 'corner' longhand sets the 'corner-shape' and 'border-radius' longhands all together.
+	The 'corner' shorthand sets the 'corner-shape' and 'border-radius' longhands all together.
 
 
 <h4 id=corner-shape-rendering>


### PR DESCRIPTION
This specifies 17 shorthands for corner-shape/border-radius
- corner-* -* (4 physical, 4 logical) for each corner
- corner-* (4 physical, 4 logical) for each side
- corner (for specifying all the corners/border-radius in one go)

Resolution: https://github.com/w3c/csswg-drafts/issues/11623#issuecomment-3209549632

Closes #11623