### PR TITLE
[css-overflow] For the purposes of block-ellipsis "immediately preceding", abspos and end of element are ignored

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -715,7 +715,7 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	This property only affects a line box
 	if it immediately precedes either a [=region break=]
 	or a [=clamp point=] in the [=block formatting context=].
-	For this purposes, any end edges of boxes,
+	For this purpose, any end edges of boxes,
 	as well as any [=absolutely positioned=] boxes,
 	between the line box and the region break or clamp point,
 	are ignored.


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/10868#issuecomment-3206198816.
