### PR TITLE
[css-align-3][editorial] Fixed incorrect "Applies to" lines for place-* shorthands

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -1157,7 +1157,7 @@ Content-Distribution Shorthand: the 'place-content' property</h3>
 	Name: place-content
 	Value: <<'align-content'>> <<'justify-content'>>?
 	Initial: normal
-	Applies to: block containers, flex containers, and grid containers
+	Applies to: see individual properties
 	Inherited: no
 	Percentages: n/a
 	Computed value: see individual properties
@@ -1764,7 +1764,7 @@ Self-Alignment Shorthand: the 'place-self' property</h3>
 	Name: place-self
 	Value: <<'align-self'>> <<'justify-self'>>?
 	Initial: auto
-	Applies to: block-level boxes, absolutely-positioned boxes, and grid items
+	Applies to: see individual properties
 	Inherited: no
 	Percentages: n/a
 	Computed value: see individual properties


### PR DESCRIPTION
This is a follow-up fix on the old issue #764 for the incorrect/outdated "Applies to" lines related to `place-content` and `place-self`.

Sebastian