### PR TITLE
[css-multicol-1] Remove redundant set of parentheses

### DIFF
--- a/css-multicol-1/Overview.bs
+++ b/css-multicol-1/Overview.bs
@@ -937,7 +937,7 @@ Two assumptions are being made by the pseudo-algorithm:
 	And:
 
 	<pre>
-	(11)  W := max(0, ((U + column-gap)/N - column-gap))
+	(11)  W := max(0, (U + column-gap)/N - column-gap)
 	</pre>
 
 	For the purpose of finding the number of auto-repeated columns,


### PR DESCRIPTION
They aren't necessary here and just add clutter.

I believe this is non-substantive.