### PR TITLE
[css-counter-styles-3] Add negative sign processing to CJK custom algorithms #12714

### DIFF
--- a/css-counter-styles-3/Overview.bs
+++ b/css-counter-styles-3/Overview.bs
@@ -2200,6 +2200,9 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		the representation is the character for 0 specified for the given counter style.
 		Skip the rest of this algorithm.
 
+		<li>If the counter value is negative,
+		instead use the absolute value of the counter value for the remaining steps of this algorithm.
+
 		<li>Initially represent the counter value as a decimal number.
 		For each digit that is not 0,
 		append the appropriate digit marker to the digit.
@@ -2214,7 +2217,12 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 
 		<li>Replace the digits 0-9 with the appropriate character
 		for the given counter style.
-		Return the resultant string as the representation of the counter value.
+
+		<li>If the counter value was negative,
+		prepend the appropriate negative sign character for the given counter style
+		as specified in the table of characters for each style.
+
+		<li>Return the resultant string as the representation of the counter value.
 	</ol>
 
 	For all of these counter styles,
@@ -2401,6 +2409,9 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 		the representation is the character for 0 specified for the given counter style.
 		Skip the rest of this algorithm.
 
+		<li>If the counter value is negative,
+		instead use the absolute value of the counter value for the remaining steps of this algorithm.
+
 		<li>Initially represent the counter value as a decimal number.
 		Starting from the right (ones place),
 		split the decimal number into groups of four digits.
@@ -2447,7 +2458,12 @@ Chinese: ''simp-chinese-informal'', ''simp-chinese-formal'', ''trad-chinese-info
 
 		<li>Replace the digits 0-9 with the appropriate character
 		for the given counter style.
-		Return the resultant string as the representation of the counter value.
+
+		<li>If the counter value was negative,
+		prepend the appropriate negative sign character for the given counter style
+		as specified in the table of characters for each style.
+
+		<li>Return the resultant string as the representation of the counter value.
 	</ol>
 
 	For all of these counter styles, the descriptors are the same as for the [[#limited-range-required|limited range variants]],


### PR DESCRIPTION
Fixed missing negative sign processing in CJK custom algorithms.
The Limited Chinese and Extended CJK algorithms defined negative signs but lacked explicit steps to handle negative values.

Closes #12714 

## Change

Added negative value processing steps to both custom algorithms(Limited Chinese& Extended CJK Algorithms).
- Added step to use absolute value when counter is negative
- Added step to prepend negative sign at the end

## WPT

No WPT changes should be required. 
The existing WPT already implement this behavior, as the negative sign characters were defined in the specification tables. This change clarifies the algorithmic steps that were implicitly expected but not explicitly documented.

ref: https://github.com/web-platform-tests/wpt/pull/53312 & https://github.com/web-platform-tests/wpt/pull/54469


/cc @nt1m @fantasai @tabatkins 