### PR TITLE
[css-conditional-5] container-names are not tree-scoped #12090

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -589,6 +589,7 @@ Naming Query Containers: the 'container-name' property</h3>
 	specifies a list of <dfn export lt="query container name">query container names</dfn>.
 	These names can be used by ''@container'' rules
 	to filter which [=query containers=] are targeted.
+	Container names are not [=tree-scoped names=].
 
 	<dl dfn-for=container-name dfn-type=value>
 	<dt><dfn>none</dfn>


### PR DESCRIPTION
Per resolution in:

https://github.com/w3c/csswg-drafts/issues/12090#issuecomment-3204775586
