### PR TITLE
[css-2025][editorial] Removed CSS Color Adjust 1 and CSS Conditional 4 from Rough Interop

### DIFF
--- a/css-2025/Overview.bs
+++ b/css-2025/Overview.bs
@@ -405,15 +405,12 @@ The following specifications are considered to be in a reliable state, meaning t
 	<dt><a href="https://www.w3.org/TR/css-color-adjust-1/">CSS Color Adjustment Module Level 1</a>
 	[[CSS-COLOR-ADJUST-1]]
 	<dd>
-		This module introduces a model and controls over automatic color adjustment by the user agent to handle user preferences,
-		such as "Dark Mode", contrast adjustment, or specific desired color schemes.
+		This module introduces a model and controls over automatic color adjustment by the user agent to handle user preferences and device output optimizations.
 
 	<dt><a href="https://www.w3.org/TR/css-conditional-4/">CSS Conditional Rules Module Level 4</a>
 	[[CSS-CONDITIONAL-4]]
 	<dd>
-		Extends [[CSS-CONDITIONAL-3]],
-		adding the ability to query support for particular selectors
-		through the new ''selector()'' notation for [=supports queries=].
+		Extends [[CSS-CONDITIONAL-3]] to allow testing for supported selectors.
 </dl>
 
 <h3 id=fairly-stable>
@@ -588,16 +585,6 @@ Modules with Rough Interoperability</h3>
 			Extends and supersedes CSS Fonts 3
 			and provides more control over font choice and feature selection,
 			including support for OpenType variations.
-
-		<dt><a href="https://www.w3.org/TR/css-color-adjust-1/">CSS Color Adjustment Module Level 1</a>
-		[[CSS-COLOR-ADJUST-1]]
-		<dd>
-			This module introduces a model and controls over automatic color adjustment by the user agent to handle user preferences and device output optimizations.
-
-		<dt><a href="https://www.w3.org/TR/css-conditional-4/">CSS Conditional Rules Module Level 4</a>
-		[[CSS-CONDITIONAL-4]]
-		<dd>
-			Extends CSS Conditional 3 to allow testing for supported selectors.</dd>
 
 		<dt><a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Level 5</a>
 		[[CSS-CASCADE-5]]


### PR DESCRIPTION
Those two specs were moved to Reliable CRs instead.