### PR TITLE
[mediaqueries-5][editorial] Fixed a bunch of Bikeshed issues

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -36,7 +36,11 @@ spec:css-values-4;
 		text:<resolution>
 	type:dfn; text:relative length
 spec:dom; type:dfn; text:origin
-
+spec:html;
+	type:dfn; for:/; text:browsing context
+	type:dfn; for:/; text:joint session history
+spec:infra; type:dfn; text:user agent
+spec:selectors-4; type:selector; text::fullscreen
 </pre>
 
 <pre class=biblio>
@@ -348,7 +352,7 @@ Media Types</h3>
 	but the definition of <a>media types</a> as mutually exclusive
 	makes it difficult to use them in a reasonable manner;
 	instead, their exclusive aspects are better expressed as <a>media features</a>
-	such as '@media/grid' or 'scan'.
+	such as '@media/grid' or '@media/scan'.
 
 	As such, the following <a>media types</a> are defined for use in <a>media queries</a>:
 
@@ -447,9 +451,9 @@ Media Features</h3>
 	the <a>media feature</a> must always evaluate to false.
 
 	<div class="example">
-		The media feature ''device-aspect-ratio'' only applies to
+		The media feature '@media/device-aspect-ratio' only applies to
 		visual devices. On an ''speech'' device, expressions involving
-		''device-aspect-ratio'' will therefore always be false:
+		'@media/device-aspect-ratio' will therefore always be false:
 
 		<pre>
 			&lt;link media="speech and (device-aspect-ratio: 16/9)"
@@ -463,7 +467,7 @@ Media Feature Types: “range” and “discrete”</h4>
 	Every media feature defines its “type” as either “range” or “discrete” in its definition table.
 
 	“Discrete” media features,
-	like 'pointer'
+	like '@media/pointer'
 	take their values from a set.
 	The values may be keywords
 	or boolean numbers (0 and 1),
@@ -519,7 +523,7 @@ Evaluating Media Features in a Boolean Context</h4>
 	<div class='example'>
 		Some <a>media features</a> are designed to be written like this.
 
-		For example, 'update' is typically written as ''(update)'' to test if any kind of updating is available,
+		For example, '@media/update' is typically written as ''(update)'' to test if any kind of updating is available,
 		or ''not (update)'' to check for the opposite.
 
 		It can still be given an explicit value as well,
@@ -540,7 +544,7 @@ Evaluating Media Features in a Boolean Context</h4>
 		Only some of the <a>media features</a> that accept keywords are meaningful in a <a>boolean context</a>.
 
 		For example, ''(pointer)'' is useful,
-		as 'pointer' has a ''pointer/none'' value to indicate there's no pointing device at all on the device.
+		as '@media/pointer' has a ''@media/pointer/none'' value to indicate there's no pointing device at all on the device.
 		On the other hand, ''(scan)'' is just always true or always false
 		(depending on whether it applies at all to the device),
 		as there's no value that means “false”.
@@ -1025,7 +1029,7 @@ Error Handling</h3>
 	<div class="example">
 		<pre>@media (min-orientation:portrait) { … }</pre>
 
-		The 'orientation' feature does not accept prefixes,
+		The '@media/orientation' feature does not accept prefixes,
 		so this is considered an unknown <a>media feature</a>,
 		and turned into ''not all''.
 	</div>
@@ -1140,7 +1144,7 @@ Aspect-Ratio: the <a descriptor>aspect-ratio</a> feature</h3>
 
 
 <h3 id='orientation'>
-Orientation: the 'orientation' feature</h3>
+Orientation: the '@media/orientation' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: orientation
@@ -1151,11 +1155,11 @@ Orientation: the 'orientation' feature</h3>
 
 	<dl dfn-type=value dfn-for="@media/orientation">
 		<dt><dfn>portrait</dfn>
-		<dd>The 'orientation' media feature is ''portrait''
+		<dd>The '@media/orientation' media feature is ''portrait''
 		when the value of the '@media/height' media feature is greater than or equal to
 		the value of the '@media/width' media feature.
 		<dt><dfn>landscape</dfn>
-		<dd>Otherwise 'orientation' is ''landscape''.
+		<dd>Otherwise '@media/orientation' is ''landscape''.
 	</dl>
 
 	<div class="example">
@@ -1254,13 +1258,13 @@ Horizontal Viewport Segments: the '@media/horizontal-viewport-segments' feature<
 	</pre>
 
 	The '@media/horizontal-viewport-segments' media feature describes the number of logical segments of
-    the viewport in the horizontal direction.
+	the viewport in the horizontal direction.
 
-    The '@media/horizontal-viewport-segments' media feature is <a>false in the negative range</a>.
+	The '@media/horizontal-viewport-segments' media feature is <a>false in the negative range</a>.
 
-    When the viewport is split by one or more hardware features (such as a fold or a hinge between
-    separate displays) that act as a logical divider, segments are the regions of the viewport that
-    can be treated as logically distinct by the page.
+	When the viewport is split by one or more hardware features (such as a fold or a hinge between
+	separate displays) that act as a logical divider, segments are the regions of the viewport that
+	can be treated as logically distinct by the page.
 
 <h3 id='mf-vertical-viewport-segments'>
 Vertical Viewport Segments: the '@media/vertical-viewport-segments' feature</h3>
@@ -1273,9 +1277,9 @@ Vertical Viewport Segments: the '@media/vertical-viewport-segments' feature</h3>
 	</pre>
 
 	The '@media/vertical-viewport-segments' media feature describes the number of logical segments of
-    the viewport in the vertical direction.
+	the viewport in the vertical direction.
 
-    The '@media/vertical-viewport-segments' media feature is <a>false in the negative range</a>.
+	The '@media/vertical-viewport-segments' media feature is <a>false in the negative range</a>.
 
 	<div class='example'>
 		This media query detects a viewport that has exactly two segments that are side-by-side.
@@ -1284,7 +1288,7 @@ Vertical Viewport Segments: the '@media/vertical-viewport-segments' feature</h3>
 	</div>
 
 <h3 id=display-modes>
-Display Modes: the ''display-mode'' media feature </h3>
+Display Modes: the '@media/display-mode' media feature</h3>
 
 	<pre class='descdef mq'>
 	Name: display-mode
@@ -1367,7 +1371,7 @@ Display Modes: the ''display-mode'' media feature </h3>
 		<summary>The [=display mode/fullscreen=] [=display mode=] is distinct from the
 		[[FULLSCREEN|Fullscreen API]].</summary>
 
-		The ''fullscreen'' value for [=display-mode=] is not directly related
+		The ''fullscreen'' value for '@media/display-mode' is not directly related
 		to the CSS '':fullscreen'' pseudo-class.
 		The '':fullscreen'' pseudo-class matches an element
 		exclusively when that element is put into the fullscreen element stack.
@@ -1414,7 +1418,7 @@ Display Modes: the ''display-mode'' media feature </h3>
 Display Quality Media Features</h2>
 
 <h3 id="resolution" caniuse="css-media-resolution">
-Display Resolution: the 'resolution' feature</h3>
+Display Resolution: the '@media/resolution' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: resolution
@@ -1423,13 +1427,13 @@ Display Resolution: the 'resolution' feature</h3>
 	Type: range
 	</pre>
 
-	The 'resolution' media feature describes the resolution of the output
+	The '@media/resolution' media feature describes the resolution of the output
 	device, i.e. the density of the pixels, taking into account the <a spec=cssom-view>page zoom</a>
 	but assuming a <a spec=cssom-view>pinch zoom</a> of 1.0.
 
-	The 'resolution' media feature is <a>false in the negative range</a>
+	The '@media/resolution' media feature is <a>false in the negative range</a>
 
-	When querying media with non-square pixels, 'resolution' queries the density in the vertical dimension.
+	When querying media with non-square pixels, '@media/resolution' queries the density in the vertical dimension.
 
 	For printers, this corresponds to the screening resolution
 	(the resolution for printing dots of arbitrary color).
@@ -1479,7 +1483,7 @@ Display Resolution: the 'resolution' feature</h3>
 
 
 <h3 id="scan">
-Display Type: the 'scan' feature</h3>
+Display Type: the '@media/scan' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: scan
@@ -1488,7 +1492,7 @@ Display Type: the 'scan' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'scan' media feature describes the scanning process of some output devices.
+	The '@media/scan' media feature describes the scanning process of some output devices.
 
 	<dl dfn-type=value dfn-for="@media/scan">
 		<dt><dfn>interlace</dfn>
@@ -1558,7 +1562,7 @@ Detecting Console Displays: the '@media/grid' feature</h3>
 	Note: At the time of writing, all known implementations match <code>grid: 0</code> rather than <code>grid: 1</code>.
 
 <h3 id="update">
-Display Update Frequency: the 'update' feature</h3>
+Display Update Frequency: the '@media/update' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: update
@@ -1567,7 +1571,7 @@ Display Update Frequency: the 'update' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'update' media feature is used to query the ability of the output device
+	The '@media/update' media feature is used to query the ability of the output device
 	to modify the appearance of content once it has been rendered.
 	It accepts the following values:
 
@@ -1606,56 +1610,56 @@ Display Update Frequency: the 'update' feature</h3>
 	</div>
 
 <h3 id="environment-blending" oldids="mf-environment">
-Detecting the display technology: the 'environment-blending' feature</h3>
+Detecting the display technology: the '@media/environment-blending' feature</h3>
 
-    <pre class='descdef mq'>
-    Name: environment-blending
-    Value: opaque | additive | subtractive
-    For: @media
-    Type: discrete
-    </pre>
+	<pre class='descdef mq'>
+	Name: environment-blending
+	Value: opaque | additive | subtractive
+	For: @media
+	Type: discrete
+	</pre>
 
-    The 'environment-blending' media feature is used to query the characteristics of the user's display
-    so the author can adjust the style of the document.
-    An author might choose to adjust the visuals and/or layout of the page depending on the display
-    technology to increase the appeal or improve legibility.
+	The '@media/environment-blending' media feature is used to query the characteristics of the user's display
+	so the author can adjust the style of the document.
+	An author might choose to adjust the visuals and/or layout of the page depending on the display
+	technology to increase the appeal or improve legibility.
 
-    The following values are valid:
+	The following values are valid:
 
-    <dl dfn-type=value dfn-for="@media/environment-blending">
-        <dt><dfn>opaque</dfn>
-        <dd>
-            The document is rendered on an opaque medium, such as a traditional monitor or paper.
-            Black is dark and white is 100% light.
+	<dl dfn-type=value dfn-for="@media/environment-blending">
+		<dt><dfn>opaque</dfn>
+		<dd>
+			The document is rendered on an opaque medium, such as a traditional monitor or paper.
+			Black is dark and white is 100% light.
 
-        <dt><dfn>additive</dfn>
-        <dd>
-            The display blends the colors of the canvas with the real world using additive mixing.
-            Black is fully transparent and white is 100% light.
+		<dt><dfn>additive</dfn>
+		<dd>
+			The display blends the colors of the canvas with the real world using additive mixing.
+			Black is fully transparent and white is 100% light.
 
-            For example: a head-up display in a car.
+			For example: a head-up display in a car.
 
-        <dt><dfn>subtractive</dfn>
-        <dd>
-            The display blends the colors of the canvas with the real world using subtractive mixing.
-            White is fully transparent and dark colors have the most contrast.
+		<dt><dfn>subtractive</dfn>
+		<dd>
+			The display blends the colors of the canvas with the real world using subtractive mixing.
+			White is fully transparent and dark colors have the most contrast.
 
-            For example: an LCD display embedded in a bathroom mirror.
-    </dl>
+			For example: an LCD display embedded in a bathroom mirror.
+	</dl>
 
-    Issue: Is there a need for the ''subtractive'' value?
+	Issue: Is there a need for the ''subtractive'' value?
 
-    <div class="example">
-        <pre>
-        body { background-color: white; }
-        p { color: black; }
+	<div class="example">
+		<pre>
+		body { background-color: white; }
+		p { color: black; }
 
-        @media(environment-blending: additive) {
-            body { background-color: black; }
-            p { color: white; font-size: 16px; font-weight: 1000; }
-        }
-        </pre>
-    </div>
+		@media(environment-blending: additive) {
+			body { background-color: black; }
+			p { color: white; font-size: 16px; font-weight: 1000; }
+		}
+		</pre>
+	</div>
 
 <!--
  ██████   ███████  ██        ███████  ████████
@@ -1719,7 +1723,7 @@ Color Depth: the '@media/color' feature</h3>
 	RFC2879 [[RFC2879]] provides more specific media features which may be supported at a later stage.
 
 <h3 id="color-index">
-Paletted Color Screens: the 'color-index' feature</h3>
+Paletted Color Screens: the '@media/color-index' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: color-index
@@ -1728,7 +1732,7 @@ Paletted Color Screens: the 'color-index' feature</h3>
 	Type: range
 	</pre>
 
-	The 'color-index' media feature describes the number of entries in the color lookup table of the output device.
+	The '@media/color-index' media feature describes the number of entries in the color lookup table of the output device.
 	If the device does not use a color lookup table, the value is zero.
 
 	'@media/color-index' is <a>false in the negative range</a>.
@@ -1753,7 +1757,7 @@ Paletted Color Screens: the 'color-index' feature</h3>
 	</div>
 
 <h3 id="monochrome">
-Monochrome Screens: the 'monochrome' feature</h3>
+Monochrome Screens: the '@media/monochrome' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: monochrome
@@ -1762,7 +1766,7 @@ Monochrome Screens: the 'monochrome' feature</h3>
 	Type: range
 	</pre>
 
-	The 'monochrome' media feature describes the number of bits per pixel in a monochrome frame buffer.
+	The '@media/monochrome' media feature describes the number of bits per pixel in a monochrome frame buffer.
 	If the device is not a monochrome device,
 	the output device value will be 0.
 
@@ -1791,7 +1795,7 @@ Monochrome Screens: the 'monochrome' feature</h3>
 	</div>
 
 <h3 id="color-gamut">
-Color Display Quality: the 'color-gamut' feature</h3>
+Color Display Quality: the '@media/color-gamut' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: color-gamut
@@ -1800,7 +1804,7 @@ Color Display Quality: the 'color-gamut' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'color-gamut' media feature describes the approximate range of colors
+	The '@media/color-gamut' media feature describes the approximate range of colors
 	that are supported by the UA and output device.
 	That is, if the UA receives content with colors in the specified space
 	it can cause the output device to render the appropriate color,
@@ -1888,7 +1892,7 @@ Color Display Quality: the 'color-gamut' feature</h3>
 	''not (color-gamut)''.
 
 <h3 id="dynamic-range">
-Dynamic Range: the 'dynamic-range' feature</h3>
+Dynamic Range: the '@media/dynamic-range' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: dynamic-range
@@ -1958,7 +1962,7 @@ color depth, and contrast ratio that are supported by the user agent and output 
 	but is expected to have broadly dependable semantics.
 
 <h3 id="inverted">
-Detecting inverted colors on the display: the 'inverted-colors' feature</h3>
+Detecting inverted colors on the display: the '@media/inverted-colors' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: inverted-colors
@@ -1967,7 +1971,7 @@ Detecting inverted colors on the display: the 'inverted-colors' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'inverted-colors' media feature indicates whether the content is displayed normally,
+	The '@media/inverted-colors' media feature indicates whether the content is displayed normally,
 	or whether colors have been inverted.
 
 	Note: This is an indication that the user agent or underlying
@@ -2041,7 +2045,7 @@ Interaction Media Features</h2>
 	The “interaction” media features reflect various aspects of how the user interacts with the page.
 
 	<div class='note'>
-		Typical examples of devices matching combinations of 'pointer' and 'hover':
+		Typical examples of devices matching combinations of '@media/pointer' and '@media/hover':
 
 		<table class=data>
 			<thead>
@@ -2070,8 +2074,8 @@ Interaction Media Features</h2>
 		</style>
 	</div>
 
-	The 'pointer' and 'hover' features relate to the characteristics of the “primary” pointing device,
-	while 'any-pointer' and 'any-hover' can be used to query the properties of all potentially available pointing devices.
+	The '@media/pointer' and '@media/hover' features relate to the characteristics of the “primary” pointing device,
+	while '@media/any-pointer' and '@media/any-hover' can be used to query the properties of all potentially available pointing devices.
 
 	Note: While this specification does not define how user agents should decide what the “primary” pointing device is,
 	the expectation is that user agents should make this determination
@@ -2085,21 +2089,21 @@ Interaction Media Features</h2>
 	in response to changes in the user environment
 	or in the way the user is interacting with the UA.
 
-	Note: The 'pointer', 'hover', 'any-pointer' and 'any-hover' features only relate to the characteristics,
+	Note: The '@media/pointer', '@media/hover', '@media/any-pointer' and '@media/any-hover' features only relate to the characteristics,
 	or the complete absence, of pointing devices,
 	and can not be used to detect the presence of non-pointing device input mechanisms such as keyboards.
 	Authors should take into account the potential presence of non-pointing device inputs,
 	regardless of which values are matched when querying these features.
 
 	<div class="note">
-		While 'pointer' and 'hover' can be used to design the main style and interaction
+		While '@media/pointer' and '@media/hover' can be used to design the main style and interaction
 		mode of the page to suit the primary input mechanism (based on the characteristics, or complete absence,
-		of the primary pointing device), authors should strongly consider using 'any-pointer' and 'any-hover'
+		of the primary pointing device), authors should strongly consider using '@media/any-pointer' and '@media/any-hover'
 		to take into account all possible types of pointing devices	that have been detected.
 	</div>
 
 <h3 id="pointer">
-Pointing Device Quality: the 'pointer' feature</h3>
+Pointing Device Quality: the '@media/pointer' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: pointer
@@ -2108,12 +2112,12 @@ Pointing Device Quality: the 'pointer' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'pointer' media feature is used to query the presence and accuracy of a pointing device such as a mouse.
+	The '@media/pointer' media feature is used to query the presence and accuracy of a pointing device such as a mouse.
 	If multiple pointing devices are present,
-	the 'pointer' media feature must reflect the characteristics of the “primary” pointing device,
+	the '@media/pointer' media feature must reflect the characteristics of the “primary” pointing device,
 	as determined by the user agent.
 	(To query the capabilities of <em>any</em> available pointing devices,
-		see the 'any-pointer' media feature.)
+		see the '@media/any-pointer' media feature.)
 
 	<dl dfn-type=value dfn-for="@media/pointer">
 		<dt><dfn>none</dfn>
@@ -2149,7 +2153,7 @@ Pointing Device Quality: the 'pointer' feature</h3>
 	to indicate that the user has difficulties manipulating the pointing device accurately or at all.
 	In addition, even if the primary pointing device has ''fine'' pointing accuracy,
 	there may be additional ''coarse'' pointing devices available to the user. Authors may
-	wish to query the 'any-pointer' media feature to take these other ''coarse'' potential
+	wish to query the '@media/any-pointer' media feature to take these other ''coarse'' potential
 	pointing devices into account.
 
 	<div class="example">
@@ -2166,7 +2170,7 @@ Pointing Device Quality: the 'pointer' feature</h3>
 	</div>
 
 <h3 id="hover">
-Hover Capability: the 'hover' feature</h3>
+Hover Capability: the '@media/hover' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: hover
@@ -2175,13 +2179,13 @@ Hover Capability: the 'hover' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'hover' media feature is used to query the user's ability to hover over elements on the page
+	The '@media/hover' media feature is used to query the user's ability to hover over elements on the page
 	with the primary pointing device.
 	If a device has multiple pointing devices,
-	the 'hover' media feature must reflect the characteristics of the “primary” pointing device,
+	the '@media/hover' media feature must reflect the characteristics of the “primary” pointing device,
 	as determined by the user agent.
 	(To query the capabilities of <em>any</em> available pointing devices,
-		see the 'any-hover' media feature.)
+		see the '@media/any-hover' media feature.)
 
 	<dl dfn-type=value dfn-for="@media/hover">
 		<dt><dfn>none</dfn>
@@ -2204,7 +2208,7 @@ Hover Capability: the 'hover' feature</h3>
 
 	<div class='example'>
 		For example, on a touch screen device that can also be controlled by an optional mouse,
-		the 'hover' <a>media feature</a> should match ''hover: none'',
+		the '@media/hover' <a>media feature</a> should match ''hover: none'',
 		as the primary pointing device (the touch screen) does not allow the user to hover.
 
 		However, despite this, the optional mouse does allow users to hover.
@@ -2232,7 +2236,7 @@ Hover Capability: the 'hover' feature</h3>
 	</div>
 
 <h3 id='any-input'>
-All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' features</h3>
+All Available Interaction Capabilities: the '@media/any-pointer' and '@media/any-hover' features</h3>
 
 	<pre class='descdef mq'>
 	Name: any-pointer
@@ -2248,16 +2252,16 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	Type: discrete
 	</pre>
 
-	The 'any-pointer' and 'any-hover' media features are identical to the 'pointer' and 'hover' media features,
+	The '@media/any-pointer' and '@media/any-hover' media features are identical to the '@media/pointer' and '@media/hover' media features,
 	but they correspond to the union of capabilities of all the pointing devices available to the user.
-	In the case of 'any-pointer', more than one of the values can match,
+	In the case of '@media/any-pointer', more than one of the values can match,
 	if different pointing devices have different characteristics.
 
-	'any-pointer' and 'any-hover' must only match ''any-pointer/none'' if <em>all</em> of the pointing devices would match ''pointer/none'' for the corresponding query,
+	'@media/any-pointer' and '@media/any-hover' must only match ''@media/any-pointer/none'' if <em>all</em> of the pointing devices would match ''@media/pointer/none'' for the corresponding query,
 	or there are no pointing devices at all.
 
 	<div class="note">
-	'any-pointer' is used to query the presence and accuracy of pointing devices.
+	'@media/any-pointer' is used to query the presence and accuracy of pointing devices.
 	It does not take into account any additional non-pointing device inputs,
 	and can not be used to test for the presence of other input mechanisms,
 	such as d-pads or keyboard-only controls,
@@ -2276,7 +2280,7 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	or if all the pointing devices present lack hover capabilities.
 	As such, it should be understood as a query to test if any hover-capable pointing devices are present,
 	rather than whether or not any of the pointing devices is hover-incapable.
-	The latter scenario can currently not be determined using 'any-hover' or any other interaction media feature.
+	The latter scenario can currently not be determined using '@media/any-hover' or any other interaction media feature.
 	Additionally, it does not take into account any non-pointing device inputs,
 	such as d-pads or keyboard-only controls,
 	which by their very nature are also not hover-capable.
@@ -2291,7 +2295,7 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 
 	<div class="note">
 	Designing a page that relies on hovering or accurate pointing
-	only because 'any-hover' or 'any-pointer' indicate that at least one of the available
+	only because '@media/any-hover' or '@media/any-pointer' indicate that at least one of the available
 	input mechanisms has these capabilities	is likely to result in a poor experience.
 	However, authors may use this information to inform their decision about the style and
 	functionality they wish to provide based on any additional pointing devices that
@@ -2302,13 +2306,13 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 		A number of smart TVs come with a way to control an on-screen cursor,
 		but it is often fairly basic controller which is difficult to operate accurately.
 
-		A browser in such a smart TV would have ''coarse'' as the value of both 'pointer' and 'any-pointer',
+		A browser in such a smart TV would have ''coarse'' as the value of both '@media/pointer' and '@media/any-pointer',
 		allowing authors to provide a layout with large and easy to reach click targets.
 
 		The user may also have paired a Bluetooth mouse with the TV,
 		and occasionally use it for extra convenience,
 		but this mouse is not the main way the TV is operated.
-		'pointer' still matches ''coarse'', while 'any-pointer' now both matches ''coarse'' and ''fine''.
+		'@media/pointer' still matches ''coarse'', while '@media/any-pointer' now both matches ''coarse'' and ''fine''.
 
 		Switching to small click targets based on the fact that ''(any-pointer: fine)'' is now true
 		would not be appropriate.
@@ -2327,7 +2331,7 @@ All Available Interaction Capabilities: the 'any-pointer' and 'any-hover' featur
 	</div>
 
 <h3 id=nav-controls>
-Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
+Detecting UA-supplied navigation controls: the '@media/nav-controls' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: nav-controls
@@ -2336,7 +2340,7 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'nav-controls' media features allows authors to know
+	The '@media/nav-controls' media features allows authors to know
 	whether the user agent is providing [=obviously discoverable=] navigation controls
 	as part of its user interface.
 
@@ -2363,20 +2367,20 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 	as convenient as these can be,
 	these are not obviously discoverable by just looking at (in the case of a visual UI) the user agent.
 
-    The following values are valid:
+	The following values are valid:
 
 	<dl dfn-type=value dfn-for="@media/nav-controls">
 		<dt><dfn>none</dfn>
 		<dd>
 			The user agent does not have any [=obviously discoverable=] navigation controls,
 			and in particular none that cause the user agent
-			to move back one page in the <a spec=html>joint session history</a>.
+			to move back one page in the [=joint session history=].
 
 		<dt><dfn>back</dfn>
 		<dd>
 			The user agent provides navigation controls,
 			including at least an [=obviously discoverable=] control
-			causing the user agent to move back one page in the <a spec=html>joint session history</a>
+			causing the user agent to move back one page in the [=joint session history=]
 			(typically, a “back” button).
 	</dl>
 
@@ -2406,7 +2410,7 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 		as there could be new values in a future extension of this media feature
 		other than ''back''
 		that could match when ''back'' doesn't.
-		In that case, using the 'nav-controls' feature in a boolean context could be misleading.
+		In that case, using the '@media/nav-controls' feature in a boolean context could be misleading.
 		However, given that navigation back is arguably the most fundamental navigation operation,
 		the CSS Working Group does not anticipate
 		user interfaces with explicit navigation controls but no back button,
@@ -2416,7 +2420,7 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 	Whether [=obviously discoverable=] controls are active does not impact the evaluation of this media feature.
 
 	<div class=example>
-		If there is no previous page in the <a spec=html>joint session history</a>,
+		If there is no previous page in the [=joint session history=],
 		a user agent with a “back” button could toggle it to a disabled state
 		that cannot be interacted with until there actually is history
 		that can be navigated back to.
@@ -2452,7 +2456,7 @@ Detecting UA-supplied navigation controls: the 'nav-controls' feature</h3>
 	video-prefixed features and their non-prefixed counterparts.
 
 <h3 id="video-color-gamut">
-Video Color Display Quality: the 'video-color-gamut' feature</h3>
+Video Color Display Quality: the '@media/video-color-gamut' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: video-color-gamut
@@ -2467,10 +2471,10 @@ The '@media/video-color-gamut' media feature describes the approximate range of 
 	it can cause the output device to render the appropriate color,
 	or something appropriately close enough.
 
-Value and color space definitions are the same as 'color-gamut'
+Value and color space definitions are the same as '@media/color-gamut'.
 
 <h3 id="video-dynamic-range">
-Video Dynamic Range: the 'video-dynamic-range' feature</h3>
+Video Dynamic Range: the '@media/video-dynamic-range' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: video-dynamic-range
@@ -2499,7 +2503,7 @@ Supported values are the same as <a href="#dynamic-range">dynamic-range</a>.
 Scripting Media Features</h2>
 
 <h3 id="scripting">
-Scripting Support: the 'scripting' feature</h3>
+Scripting Support: the '@media/scripting' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: scripting
@@ -2508,7 +2512,7 @@ Scripting Support: the 'scripting' feature</h3>
 	Type: discrete
 	</pre>
 
-	The 'scripting' media feature is used to query whether scripting languages,
+	The '@media/scripting' media feature is used to query whether scripting languages,
 	such as JavaScript,
 	are supported on the current document.
 
@@ -2565,8 +2569,8 @@ Scripting Support: the 'scripting' feature</h3>
 
 	Some user agents have the ability to turn off scripting support on a per script basis or per domain basis,
 	allowing some, but not all, scripts to run in a particular document.
-	The 'scripting' media feature does not allow fine grained detection of which script is allowed to run.
-	In this scenario, the value of the 'scripting' media feature should be ''scripting/enabled'' or ''scripting/initial-only''
+	The '@media/scripting' media feature does not allow fine grained detection of which script is allowed to run.
+	In this scenario, the value of the '@media/scripting' media feature should be ''scripting/enabled'' or ''scripting/initial-only''
 	if scripts originating on the same domain as the document are allowed to run,
 	and ''scripting/none'' otherwise.
 
@@ -2717,8 +2721,8 @@ typedef (MediaList or boolean) CustomMediaQuery;
 
 [Exposed=Window]
 interface CSSCustomMediaRule : CSSRule {
-    readonly attribute CSSOMString name;
-    readonly attribute CustomMediaQuery query;
+	readonly attribute CSSOMString name;
+	readonly attribute CustomMediaQuery query;
 };
 </pre>
 
@@ -2742,20 +2746,20 @@ interface CSSCustomMediaRule : CSSRule {
 </dl>
 
 <!--
-  ██     ██  ██████  ████████ ████████  ████████  ████████  ████████ ████████  ██████
-  ██     ██ ██    ██ ██       ██     ██ ██     ██ ██     ██ ██       ██       ██    ██
-  ██     ██ ██       ██       ██     ██ ██     ██ ██     ██ ██       ██       ██
-  ██     ██  ██████  ██████   ████████  ████████  ████████  ██████   ██████    ██████
-  ██     ██       ██ ██       ██   ██   ██        ██   ██   ██       ██             ██
-  ██     ██ ██    ██ ██       ██    ██  ██        ██    ██  ██       ██       ██    ██
-   ███████   ██████  ████████ ██     ██ ██        ██     ██ ████████ ██        ██████
+██     ██  ██████  ████████ ████████  ████████  ████████  ████████ ████████  ██████
+██     ██ ██    ██ ██       ██     ██ ██     ██ ██     ██ ██       ██       ██    ██
+██     ██ ██       ██       ██     ██ ██     ██ ██     ██ ██       ██       ██
+██     ██  ██████  ██████   ████████  ████████  ████████  ██████   ██████    ██████
+██     ██       ██ ██       ██   ██   ██        ██   ██   ██       ██             ██
+██     ██ ██    ██ ██       ██    ██  ██        ██    ██  ██       ██       ██    ██
+ ███████   ██████  ████████ ██     ██ ██        ██     ██ ████████ ██        ██████
 -->
 
 <h2 id='mf-user-preferences'>
 User Preference Media Features</h2>
 
 <h3 id="prefers-reduced-motion">
-Detecting the desire for less motion on the page: the 'prefers-reduced-motion' feature</h3>
+Detecting the desire for less motion on the page: the '@media/prefers-reduced-motion' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: prefers-reduced-motion
@@ -2764,7 +2768,7 @@ Detecting the desire for less motion on the page: the 'prefers-reduced-motion' f
 	Type: discrete
 	</pre>
 
-	The 'prefers-reduced-motion' media feature is used to detect if the user
+	The '@media/prefers-reduced-motion' media feature is used to detect if the user
 	has requested the system minimize the amount of non-essential motion
 	it uses.
 
@@ -2785,7 +2789,7 @@ Detecting the desire for less motion on the page: the 'prefers-reduced-motion' f
 	</dl>
 
 <h3 id="prefers-reduced-transparency">
-Detecting the desire for reduced transparency on the page: the 'prefers-reduced-transparency' feature</h3>
+Detecting the desire for reduced transparency on the page: the '@media/prefers-reduced-transparency' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: prefers-reduced-transparency
@@ -2794,7 +2798,7 @@ Detecting the desire for reduced transparency on the page: the 'prefers-reduced-
 	Type: discrete
 	</pre>
 
-	The 'prefers-reduced-transparency' media feature is used to detect if the user
+	The '@media/prefers-reduced-transparency' media feature is used to detect if the user
 	has requested the system minimize the amount of transparent or translucent
 	layer effects it uses.
 
@@ -2816,7 +2820,7 @@ Detecting the desire for reduced transparency on the page: the 'prefers-reduced-
 	They're not about transparency, but they also interfere with shape recognition.
 
 <h3 id="prefers-contrast">
-Detecting the desire for increased or decreased color contrast from elements on the page: the 'prefers-contrast' feature</h3>
+Detecting the desire for increased or decreased color contrast from elements on the page: the '@media/prefers-contrast' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: prefers-contrast
@@ -2825,7 +2829,7 @@ Detecting the desire for increased or decreased color contrast from elements on 
 	Type: discrete
 	</pre>
 
-	The 'prefers-contrast' media feature is used to detect
+	The '@media/prefers-contrast' media feature is used to detect
 	if the user has requested more or less contrast in the page.
 	This could be responded to, for example,
 	by adjusting the contrast ratio between adjacent colors,
@@ -2930,7 +2934,7 @@ Detecting the desire for increased or decreased color contrast from elements on 
 	</div>
 
 <h3 id="forced-colors">
-Detecting Forced Colors Mode: the 'forced-colors' feature</h3>
+Detecting Forced Colors Mode: the '@media/forced-colors' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: forced-colors
@@ -2968,7 +2972,7 @@ Detecting Forced Colors Mode: the 'forced-colors' feature</h3>
 
 			Similarly,
 			if the forced color palette chosen by the user
-			fits within one of the color schemes described by 'prefers-color-scheme',
+			fits within one of the color schemes described by '@media/prefers-color-scheme',
 			the corresponding value must also match.
 
 		<dt><dfn>none</dfn>
@@ -2985,7 +2989,7 @@ Detecting Forced Colors Mode: the 'forced-colors' feature</h3>
 	</div>
 
 <h3 id="prefers-color-scheme">
-Detecting the desire for light or dark color schemes: the 'prefers-color-scheme' feature</h3>
+Detecting the desire for light or dark color schemes: the '@media/prefers-color-scheme' feature</h3>
 
 	<pre class='descdef mq'>
 	Name: prefers-color-scheme
@@ -2994,7 +2998,7 @@ Detecting the desire for light or dark color schemes: the 'prefers-color-scheme'
 	Type: discrete
 	</pre>
 
-	The 'prefers-color-scheme' media feature reflects the user's
+	The '@media/prefers-color-scheme' media feature reflects the user's
 	desire that the page use a light or dark color theme.
 
 	<dl dfn-type=value dfn-for="@media/prefers-color-scheme">
@@ -3029,7 +3033,7 @@ Detecting the desire for light or dark color schemes: the 'prefers-color-scheme'
 	and/or because inked text on blank paper prints better
 	than blank letterforms knocked out of an inked background).
 	UAs are expected to take such variances into consideration
-	so that 'prefers-color-scheme' reflects preferences appropriate to the medium
+	so that '@media/prefers-color-scheme' reflects preferences appropriate to the medium
 	rather than preferences taken out of context.
 
 	If evaluated in an embedded SVG document
@@ -3074,7 +3078,7 @@ Detecting the desire for light or dark color schemes: the 'prefers-color-scheme'
 	</div>
 
 <h3 id="prefers-reduced-data">
-Detecting the desire for reduced data usage when loading a page: the 'prefers-reduced-data' feature</h3>
+Detecting the desire for reduced data usage when loading a page: the '@media/prefers-reduced-data' feature</h3>
 
 	Issue(10076): This feature may be an undesired source of fingerprinting,
 	with a bias towards low income with limited data.
@@ -3086,7 +3090,7 @@ Detecting the desire for reduced data usage when loading a page: the 'prefers-re
 	Type: discrete
 	</pre>
 
-	The 'prefers-reduced-data' media feature is used to detect if the user
+	The '@media/prefers-reduced-data' media feature is used to detect if the user
 	has a preference for being served alternate content that uses less
 	data for the page to be rendered.
 
@@ -3105,9 +3109,9 @@ Detecting the desire for reduced data usage when loading a page: the 'prefers-re
 
 	The method by which the user expresses their preference can vary.
 	It might be a system-wide setting exposed by the Operating System,
-	or a setting controlled by the user agent. User agents may consider 
-	setting this based on the same user or system preference as they use to 
-	set the <a href="https://wicg.github.io/savedata/">Save-Data</a> 
+	or a setting controlled by the user agent. User agents may consider
+	setting this based on the same user or system preference as they use to
+	set the <a href="https://wicg.github.io/savedata/">Save-Data</a>
 	HTTP request header.
 
 	Note: User agents are encouraged to use their own user centered discretion
@@ -3168,7 +3172,7 @@ Automatic handling of User Preferences</h3>
 		For instance, liquid crystal displays can be washed out and very hard to read
 		in brightly lit environments.
 		A device with such a screen and with an ambient light sensor
-		could automatically switch 'prefers-contrast' to ''prefers-contrast/more''
+		could automatically switch '@media/prefers-contrast' to ''prefers-contrast/more''
 		when it detects conditions that would make the screen difficult to read.
 		A user agent on a device with an e-ink display
 		would not make the same adjustment,
@@ -3177,8 +3181,8 @@ Automatic handling of User Preferences</h3>
 		In the opposite situation,
 		user agents running of device with a light-emitting screen (LCD, OLED, etc.)
 		and an ambient light sensor
-		could automatically switch 'prefers-contrast' to ''prefers-contrast/less''
-		and 'prefers-color-scheme' to ''prefers-color-scheme/dark''
+		could automatically switch '@media/prefers-contrast' to ''prefers-contrast/less''
+		and '@media/prefers-color-scheme' to ''prefers-color-scheme/dark''
 		when used in a dim environment
 		where excessive contrast and brightness would be distracting or uncomfortable to the reader.
 	</div>
@@ -3189,8 +3193,8 @@ Automatic handling of User Preferences</h3>
 		allows for unlimited data or is on a metered plan.
 	</div>
 
-<h2 id=auto-pref>
-Script Control of User Preferences</h3>
+<h2 id=script-control-user-prefs>
+Script Control of User Preferences</h2>
 
 It is common for website authors to want to respect the user's system preferences while also allowing
 those preferences to be overridden. To help with this, this specification defines a way for authors to
@@ -3198,17 +3202,17 @@ override the [[#mf-user-preferences]] using the {{PreferenceManager}} interface.
 
 This override allows the preference to integrate with various platform features that are affected by these preferences.
 
-<h3 id=auto-pref>
+<h3 id=navigator-interface>
 Extensions to the {{Navigator}} interface</h3>
 
 <script type=idl>
 [Exposed=Window, SecureContext]
 partial interface Navigator {
-  [SameObject] readonly attribute PreferenceManager preferences;
+	[SameObject] readonly attribute PreferenceManager preferences;
 };
 </script>
 
-<h4 id=auto-pref>
+<h4 id=preferences-attribute>
 {{preferences}} attribute</h4>
 
 When getting the {{preferences}} attribute always return the same instance of the {{PreferenceManager}} object.
@@ -3218,15 +3222,15 @@ When getting the {{preferences}} attribute always return the same instance of th
 <script type=idl>
 [Exposed=Window, SecureContext]
 interface PreferenceManager {
-  readonly attribute PreferenceObject colorScheme;
-  readonly attribute PreferenceObject contrast;
-  readonly attribute PreferenceObject reducedMotion;
-  readonly attribute PreferenceObject reducedTransparency;
-  readonly attribute PreferenceObject reducedData;
+	readonly attribute PreferenceObject colorScheme;
+	readonly attribute PreferenceObject contrast;
+	readonly attribute PreferenceObject reducedMotion;
+	readonly attribute PreferenceObject reducedTransparency;
+	readonly attribute PreferenceObject reducedData;
 };
 </script>
 
-<h4 id=auto-pref>
+<h4 id=color-scheme-attribute>
 {{colorScheme}} attribute</h4>
 
 The {{colorScheme}} attribute is a {{PreferenceObject}} used to override the user's preference for the color scheme of the site.
@@ -3248,7 +3252,7 @@ If an override is set for this preference:
 - The user agent MUST also use this override when sending [[USER-PREFERENCE-MEDIA-FEATURES-HEADERS#sec-ch-prefers-color-scheme]].
 - The user agent MUST also use this override for any UA features that are normally affected by [[#prefers-color-scheme]].
 
-<h4 id=auto-pref>
+<h4 id=contrast-attribute>
 {{contrast}} attribute</h4>
 
 The {{contrast}} attribute is a {{PreferenceObject}} used to override the user's preference for the contrast of the site.
@@ -3272,7 +3276,7 @@ If an override is set for this preference:
 
 Note: Unlike the media feature this preference is NOT able to be set to ''@media/prefers-contrast/custom'' as this is tightly coupled to the [[#forced-colors]].
 
-<h4 id=auto-pref>
+<h4 id=reduced-motion-attribute>
 {{reducedMotion}} attribute</h4>
 
 The {{reducedMotion}} attribute is a {{PreferenceObject}} used to override the user's preference for reduced motion on the site.
@@ -3295,7 +3299,7 @@ If an override is set for this preference:
 
 Note: An example of a UA feature that is affected by this preference could be disabling smooth scrolling, or pausing marquee elements.
 
-<h4 id=auto-pref>
+<h4 id=reduced-transparency-attribute>
 {{reducedTransparency}} attribute</h4>
 
 The {{reducedTransparency}} attribute is a {{PreferenceObject}} used to override the user's preference for reduced transparency on the site.
@@ -3316,7 +3320,7 @@ If an override is set for this preference:
 - The user agent MUST also use this override when sending [[USER-PREFERENCE-MEDIA-FEATURES-HEADERS#sec-ch-prefers-reduced-transparency]].
 - The user agent MUST also use this override for any UA features that are normally affected by [[#prefers-reduced-transparency]].
 
-<h4 id=auto-pref>
+<h4 id=reduced-data-attribute>
 {{reducedData}} attribute</h4>
 
 The {{reducedData}} attribute is a {{PreferenceObject}} used to override the user's preference for reduced data usage on the site.
@@ -3338,24 +3342,24 @@ If an override is set for this preference:
 - The user agent MUST also use this override when calculating the [[SAVEDATA#savedata-attribute]].
 - The user agent MUST also use this override for any UA features that are normally affected by [[#prefers-reduced-data]].
 
-<h4 id=auto-pref>
+<h4 id=preference-object-interface>
 {{PreferenceObject}} interface</h4>
 
 <script type=idl>
 [Exposed=Window, SecureContext]
 interface PreferenceObject : EventTarget {
-  readonly attribute DOMString? override;
-  readonly attribute DOMString value;
-  readonly attribute FrozenArray<DOMString> validValues;
+	readonly attribute DOMString? override;
+	readonly attribute DOMString value;
+	readonly attribute FrozenArray<DOMString> validValues;
 
-  undefined clearOverride();
-  Promise<undefined> requestOverride(DOMString? value);
+	undefined clearOverride();
+	Promise<undefined> requestOverride(DOMString? value);
 
-  attribute EventHandler onchange;
+	attribute EventHandler onchange;
 };
 </script>
 
-<h5 id=auto-pref>
+<h5 id=override-attribute>
 {{override}} attribute</h5>
 
 <div algorithm='get preference override'>
@@ -3367,7 +3371,7 @@ interface PreferenceObject : EventTarget {
 	1. Return |override|.
 </div>
 
-<h5 id=auto-pref>
+<h5 id=preference-value-attribute>
 {{PreferenceObject/value}} attribute</h5>
 
 <div algorithm='get preference value'>
@@ -3380,7 +3384,7 @@ interface PreferenceObject : EventTarget {
 	1. Return |value|.
 </div>
 
-<h5 id=auto-pref>
+<h5 id=valid-values-attribute>
 {{validValues}} attribute</h5>
 
 <div algorithm>
@@ -3402,9 +3406,10 @@ interface PreferenceObject : EventTarget {
 				 <dt>"{{reducedData}}"</dt>
 				 <dd>Return the result of [=get valid values for reducedData=].</dd>
 			 </dl>
+		</ol>
 </div>
 
-<h5 id=auto-pref>
+<h5 id=onchange-attribute>
 {{onchange}} event handler attribute</h5>
 
 The <dfn attribute for=PreferenceObject>onchange</dfn> attribute is an [=event handler IDL attribute=] for
@@ -3422,7 +3427,7 @@ update steps</dfn>:
 	1. If |document| is null or |document| is not [=Document/fully active=], terminate this algorithm.
 1. <a>Fire an event</a> named <code>change</code> at |preference|.
 
-<h5 id=auto-pref>
+<h5 id=request-override-method>
 {{requestOverride()}} method</h5>
 
 <div algorithm='request preference override'>
@@ -3471,7 +3476,7 @@ Issue: Is TypeError correct here?
 
 Note: The `change` event is fired when the computed value changes, but when a new override is set it is also fired if the value hasn't changed.
 
-<h5 id=auto-pref>
+<h5 id=clear-override-method>
 {{clearOverride()}} method</h5>
 
 <div algorithm='clear preference override'>
@@ -3482,7 +3487,7 @@ Note: The `change` event is fired when the computed value changes, but when a ne
 	1. If an override for |preference| exists, set |override| to the value of that override.
 	1. If |override| is null, then return.
 	1. Clear the override for |preference|.
-	1. Let |newValue| be the preference object's |value|.
+	1. Let |newValue| be the preference object's value.
 	1. If |newValue| is equal to |override|, then:
 	1. <a>Fire an event</a> named <code>change</code> at [=this=].
 </div>
@@ -3565,8 +3570,8 @@ Appendix A: Deprecated Media Features</h2>
 
 	<p class="note">To query for the size of the viewport (or the page box
 	on page media), the '@media/width', '@media/height' and <a descriptor>aspect-ratio</a> <a>media features</a>
-	should be used, rather than 'device-width', 'device-height' and
-	'device-aspect-ratio', which refer to the physical size of the device
+	should be used, rather than '@media/device-width', '@media/device-height' and
+	'@media/device-aspect-ratio', which refer to the physical size of the device
 	regardless of how much space is available for the document being laid out. The
 	device-* <a>media features</a> are also sometimes used as a proxy to detect
 	mobile devices. Instead, authors should use <a>media features</a> that better
@@ -3582,7 +3587,7 @@ device-width</h3>
 	Type: range
 	</pre>
 
-	The 'device-width' media feature describes the width of the rendering surface of the output device.
+	The '@media/device-width' media feature describes the width of the rendering surface of the output device.
 	For [=continuous media=], this is the width of the <a>Web-exposed screen area</a>.
 	For [=paged media=], this is the width of the page sheet size.
 
@@ -3611,7 +3616,7 @@ device-height</h3>
 	Type: range
 	</pre>
 
-	The 'device-height' media feature describes the height of the rendering surface of the output device.
+	The '@media/device-height' media feature describes the height of the rendering surface of the output device.
 	For [=continuous media=], this is the height of the <a>Web-exposed screen area</a>.
 	For [=paged media=], this is the height of the page sheet size.
 
@@ -3636,9 +3641,9 @@ device-aspect-ratio</h3>
 	Type: range
 	</pre>
 
-	The 'device-aspect-ratio media feature is defined as the ratio of
-	the value of the 'device-width' media feature to
-	the value of the 'device-height media feature.
+	The '@media/device-aspect-ratio' media feature is defined as the ratio of
+	the value of the '@media/device-width' media feature to
+	the value of the '@media/device-height' media feature.
 
 	<div class="example">
 		For example, if a screen device with square pixels
@@ -3652,79 +3657,6 @@ device-aspect-ratio</h3>
 		@media (device-aspect-ratio: 1280/720) { … }
 		@media (device-aspect-ratio: 2560/1440) { … }
 		</pre>
-	</div>
-
-<h2 id=privacy class=no-num>
-Appendix B: Privacy Considerations</h2>
-
-	<em>This section is not normative.</em>
-
-<div class="non-normative">
-
-	Issue: this section is <a href="https://github.com/w3c/csswg-drafts/issues?q=is%3Aopen+is%3Aissue+label%3Amediaqueries-5+label%3Aprivacy-tracker">incomplete</a> 
-
-	Many media features enable fingerprinting of users
-	based on the display and interaction characteristics of their device:
-
-	* <a href="#mf-colors">Colors</a>: {{color}}, {{color-index}}, {{monochrome}}, {{color-gamut}} and {{dynamic-range}}
-	* <a href="#mf-viewport-characteristics>Viewport characteristics</a>: {{aspect-ratio}}, {{orientation}},
-	  {{horizontal-viewport-segments}} and
-	  {{vertical-viewport-segments}}
-	* <a href="#mf-display-quality">Display quality</a>: {{resolution}}, {{scan}}, {{grid}}, {{update}} and {{environment-blending}}
-	* <a href="#interaction">Interaction devices</a>: {{pointer}}, {{hover}}, {{any-pointer}} and {{any-hover}}.
-
-	The {{environment-blending}} feature is of particular concern
-	because it suggests <em>where</em> a user may be located,
-	and is likely present in a small set of devices.
-	Uncommon device properties are stronger fingerprinting features
-	because they help segment devices into smaller sets.
-
-	Media features that reflect operating system preferences are a fingerprinting risk
-	because such preferences are correlated with characteristics of the user themselves:
-
-	* The {{prefers-reduced-data}} media feature may be correlated with low income and limited data.
-	* The {{prefers-reduced-motion}}, {{prefers-color-scheme}}, {{prefers-reduced-transparency}},
-	  {{forced-colors}} and {{inverted-colors}} queries reflect affordances for a range of special needs.
-	
-	Properties dependent on one of the above media queries may be accessed by script:
-
-	* Colors and other property values may be directly accessed through computed style,
-	  though user agents may elect to return constants for some colors
-	  (see, for example, <a href="https://drafts.csswg.org/css-color-4/#css-system-colors">CSS Color 4</a>).
-	* Layout affecting properties (such as font size) influence lengths, positions and sizes available to script.
-
-	User agents may disable these media features when users have expressed sensitivity to tracking.
-	Alternatively, user agents may limit the combination of features within a single page
-	to reduce the fingerprinting power of the page.
-
-	The {{PreferenceManager}} object allows querying some user-preference [=media features=]. This
-	is not a privacy leak, as that information is already trivially
-	available by using [=media features=] themselves.
-
-	The {{PreferenceManager}} object also allows overriding these user-preference [=media features=]; this
-	is also neither a privacy nor accessibility regression, as the [=media features=] were already ignorable by simply
-	not querying them.
-
-</div>
-
-<h2 id=security class=no-num>
-	Appendix C: Security Considerations</h2>
-	
-		<em>This section is not normative.</em>
-	
-	<div class="non-normative">
-
-	Issue: this section is <a href="https://github.com/w3c/csswg-drafts/issues?q=is%3Aopen+is%3Aissue+label%3Amediaqueries-5+label%3Asecurity-tracker+">incomplete</a>
-
-	The {{display-mode}} media feature allows an origin
-	access to aspects of a user’s local computing environment and,
-	particularly when used together with an [=application manifest=] [=manifest/display=] member [[APPMANIFEST]],
-	allows an origin some measure of control over a user agent’s native UI.
-	Through a CSS media query, a script can know the display mode of a web application.
-	An attacker could, in such a case,
-	exploit the fact that an application is being displayed in fullscreen
-	to mimic the user interface of another application.
-
 	</div>
 
 <h2 id="changes" class="no-num">
@@ -3741,11 +3673,11 @@ In addition to editorial changes and minor clarifications,
 the following changes and additions were made to this module since the
 <a href="https://www.w3.org/TR/2021/WD-mediaqueries-5-20211218/">2021-12-18 Working Draft</a>:
 
-* Moved 'display mode' definition back to [[APPMANIFEST]] ('display-mode' media feature remains
+* Moved 'display mode' definition back to [[APPMANIFEST]] ('@media/display-mode' media feature remains
 	here). (See <a href="https://github.com/w3c/csswg-drafts/issues/7306">Issue 7306</a>)
 * Establish a normative reference for [[Display-P3]]
 * Disallow use of ''layer'' as a media type, rather than merely treat it as an unknown one, for compatibility with [=cascade layers=].
-* Clarify intent of 'prefers-reduced-motion'
+* Clarify intent of '@media/prefers-reduced-motion'
 * Added further discussion of fingerprinting vectors
 
 <h3 id="changes-since-2020-07-31"
@@ -3764,18 +3696,18 @@ the following changes and additions were made to this module since the
 		<code>video-height</code>,
 		and <code>video-resolution</code>.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/5044">Issue 5044</a>)
-	* Renamed 'prefers-contrast' values <code>high</code> and <code>low</code>
+	* Renamed '@media/prefers-contrast' values <code>high</code> and <code>low</code>
 		to ''prefers-contrast/more'' and ''prefers-contrast'' less.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/2942">Issue 2943</a>)
-	* Rework the interaction between 'prefers-contrast' and 'forced-colors',
+	* Rework the interaction between '@media/prefers-contrast' and '@media/forced-colors',
 		retiring <code>prefers-contrast: forced</code> and introducing ''prefers-contrast/custom''.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/5433">Issue 5433</a>)
 		and <a href="https://github.com/w3c/csswg-drafts/issues/6036">Issue 6036</a>)
-	* Added the 'horizontal-viewport-segments' and 'vertical-viewport-segments' media feature.
+	* Added the '@media/horizontal-viewport-segments' and '@media/vertical-viewport-segments' media feature.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/6234">Issue 6234</a>)
-	* Added the 'nav-controls' media feature.
+	* Added the '@media/nav-controls' media feature.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/6234">Issue 6234</a>)
-	* Make it possible for multiple values of 'dynamic-range' to match at the same time.
+	* Make it possible for multiple values of '@media/dynamic-range' to match at the same time.
 		(See <a href="https://github.com/w3c/csswg-drafts/issues/6793">Issue 6793</a>)
 
 
@@ -3787,7 +3719,7 @@ The following additions were made to this module since the
 
 <ul>
 	<li>
-		Added a UA style sheet rule for 'inverted-colors'.
+		Added a UA style sheet rule for '@media/inverted-colors'.
 
 	<li>
 		Added the ''prefers-contrast: forced'' value.
@@ -3824,7 +3756,7 @@ The following additions were made to this module since the
 
 <ul>
 	<li>
-		Added 'video-*' and 'dynamic-range' media features
+		Added 'video-*' and '@media/dynamic-range' media features
 
 	<li>
 		Removed 'prefers-color-scheme: no-preference'
@@ -3849,18 +3781,16 @@ The following additions were made to create the First Public Working Draft of th
 
 <ul>
 	<li>
-		Reinstate the <code>light-level</code>, 'inverted-colors', and Custom Media Queries sections
+		Reinstate the <code>light-level</code>, '@media/inverted-colors', and Custom Media Queries sections
 		from earlier Media Queries Level 4 drafts.
 
 	<li>
-		Added 'prefers-reduced-motion',
-		'prefers-reduced-transparency',
-		'prefers-contrast',
-		'prefers-color-scheme',
-		and 'forced-colors' media features.
+		Added '@media/prefers-reduced-motion',
+		'@media/prefers-reduced-transparency',
+		'@media/prefers-contrast',
+		'@media/prefers-color-scheme',
+		and '@media/forced-colors' media features.
 </ul>
-
-</div>
 
 <h2 class="no-num" id="acknowledgments">
 Acknowledgments</h2>
@@ -3871,61 +3801,124 @@ This specification is the product of the W3C Working Group on
 Cascading Style Sheets.
 
 Comments from
- Adam Argyle,
- Amelia Bellamy-Royds,
- Andreas Lind,
- Andres Galante,
- Arve Bersvendsen,
- Björn Höhrmann,
- Chen Hui Jing,
- Chris Lilley,
- Chris Rebert,
- Christian Biesinger,
- Christoph Päper,
- Elika J. Etemad (fantasai),
- Emilio Cobos Álvarez,
- François Remy,
- Frédéric Wang,
- Fuqiao Xue,
- Greg Whitworth,
- Ian Pouncey,
- James Craig,
- Jay Harris,
- Jinfeng Ma,
- Kivi Shapiro,
- L. David Baron,
- Masataka Yakura,
- Matt Giuca,
- Melinda Grant,
- Michael Smith,
- Nicholas C. Zakas
- Patrick H. Lauke,
- Philipp Hoschka,
- Rick Byers,
- Rijk van Geijtenbeek,
- Rik Cabanier,
- Roger Gimson,
- Rossen Atanassov,
- Sam Sneddon,
- Sigurd Lerstad,
- Simon Kissane,
- Simon Pieters,
- Stephen Chenney,
- Steven Pemberton,
- Susan Lesch,
- Tantek Çelik,
- Thomas Wisniewski,
- Vi Nguyen,
- Xidorn Quan,
- Yves Lafon,
- akklesed,
- and 張俊芝
+Adam Argyle,
+Amelia Bellamy-Royds,
+Andreas Lind,
+Andres Galante,
+Arve Bersvendsen,
+Björn Höhrmann,
+Chen Hui Jing,
+Chris Lilley,
+Chris Rebert,
+Christian Biesinger,
+Christoph Päper,
+Elika J. Etemad (fantasai),
+Emilio Cobos Álvarez,
+François Remy,
+Frédéric Wang,
+Fuqiao Xue,
+Greg Whitworth,
+Ian Pouncey,
+James Craig,
+Jay Harris,
+Jinfeng Ma,
+Kivi Shapiro,
+L. David Baron,
+Masataka Yakura,
+Matt Giuca,
+Melinda Grant,
+Michael Smith,
+Nicholas C. Zakas
+Patrick H. Lauke,
+Philipp Hoschka,
+Rick Byers,
+Rijk van Geijtenbeek,
+Rik Cabanier,
+Roger Gimson,
+Rossen Atanassov,
+Sam Sneddon,
+Sigurd Lerstad,
+Simon Kissane,
+Simon Pieters,
+Stephen Chenney,
+Steven Pemberton,
+Susan Lesch,
+Tantek Çelik,
+Thomas Wisniewski,
+Vi Nguyen,
+Xidorn Quan,
+Yves Lafon,
+akklesed,
+and 張俊芝
 improved this specification.
 
 <h2 class=no-num id=privacy>Privacy Considerations</h2>
 
-No new privacy considerations have been reported on this specification.
+	<em>This section is not normative.</em>
+
+<div class="non-normative">
+
+	Issue: this section is <a href="https://github.com/w3c/csswg-drafts/issues?q=is%3Aopen+is%3Aissue+label%3Amediaqueries-5+label%3Aprivacy-tracker">incomplete</a>
+
+	Many media features enable fingerprinting of users
+	based on the display and interaction characteristics of their device:
+
+	* <a href="#mf-colors">Colors</a>: '@media/color', '@media/color-index', '@media/monochrome', '@media/color-gamut' and '@media/dynamic-range'
+	* <a href="#mf-viewport-characteristics">Viewport characteristics</a>: '@media/aspect-ratio', '@media/orientation',
+		'@media/horizontal-viewport-segments' and
+		'@media/vertical-viewport-segments'
+	* <a href="#mf-display-quality">Display quality</a>: '@media/resolution', '@media/scan', '@media/grid', '@media/update' and '@media/environment-blending'
+	* <a href="#mf-interaction">Interaction devices</a>: '@media/pointer', '@media/hover', '@media/any-pointer' and '@media/any-hover'.
+
+	The '@media/environment-blending' feature is of particular concern
+	because it suggests <em>where</em> a user may be located,
+	and is likely present in a small set of devices.
+	Uncommon device properties are stronger fingerprinting features
+	because they help segment devices into smaller sets.
+
+	Media features that reflect operating system preferences are a fingerprinting risk
+	because such preferences are correlated with characteristics of the user themselves:
+
+	* The '@media/prefers-reduced-data' media feature may be correlated with low income and limited data.
+	* The '@media/prefers-reduced-motion', '@media/prefers-color-scheme', '@media/prefers-reduced-transparency',
+		'@media/forced-colors' and '@media/inverted-colors' queries reflect affordances for a range of special needs.
+
+	Properties dependent on one of the above media queries may be accessed by script:
+
+	* Colors and other property values may be directly accessed through computed style,
+		though user agents may elect to return constants for some colors
+		(see, for example, <a href="https://drafts.csswg.org/css-color-4/#css-system-colors">CSS Color 4</a>).
+	* Layout affecting properties (such as font size) influence lengths, positions and sizes available to script.
+
+	User agents may disable these media features when users have expressed sensitivity to tracking.
+	Alternatively, user agents may limit the combination of features within a single page
+	to reduce the fingerprinting power of the page.
+
+	The {{PreferenceManager}} object allows querying some user-preference [=media features=]. This
+	is not a privacy leak, as that information is already trivially
+	available by using [=media features=] themselves.
+
+	The {{PreferenceManager}} object also allows overriding these user-preference [=media features=]; this
+	is also neither a privacy nor accessibility regression, as the [=media features=] were already ignorable by simply
+	not querying them.
+
+</div>
 
 <h2 class=no-num id=security>Security Considerations</h2>
 
-No new security considerations have been reported on this specification.
+	<em>This section is not normative.</em>
+
+<div class="non-normative">
+
+	Issue: this section is <a href="https://github.com/w3c/csswg-drafts/issues?q=is%3Aopen+is%3Aissue+label%3Amediaqueries-5+label%3Asecurity-tracker+">incomplete</a>
+
+	The '@media/display-mode' media feature allows an origin
+	access to aspects of a user’s local computing environment and,
+	particularly when used together with an [=application manifest=] [=manifest/display=] member [[APPMANIFEST]],
+	allows an origin some measure of control over a user agent’s native UI.
+	Through a CSS media query, a script can know the display mode of a web application.
+	An attacker could, in such a case,
+	exploit the fact that an application is being displayed in fullscreen
+	to mimic the user interface of another application.
+
+</div>


### PR DESCRIPTION
The spec. had a lot of Bikeshed issues, which I tried to fix with this patch.

What this change fixes:

* Descriptor references (Now _all_ of them are pointing to the definition. Before it was some mix. Let me know if that's ok.)
* Fixed external references
* Indentation (tabs everywhere)
* Section IDs (obviously a copy & paste error)
* Merged redundant Privacy and Security Considerations sections

Notes:
There's still one link error left. "joint session history" refers to the HTML spec., but there is no definition for that. There's only one [occurrence of that expression in an example](https://html.spec.whatwg.org/#example-sync-navigation-steps-queue-jumping-basic). Not sure if that's what is meant.
There are two notes left regarding unexported definitions for the 'change' event and the 'update steps' algorithm. What should be done with them?

Sebastian