### PR TITLE
[css-color-4] Updated `AccentColor` to take its value from `accent-color`, unless Forced Colors Mode is enabled

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -41,6 +41,8 @@ spec: css-backgrounds-3; type: property; text: border-top-color
 spec: css-backgrounds-3; type: property; text: border-left-color
 spec: css-backgrounds-3; type: property; text: border-bottom-color
 spec: css-backgrounds-3; type: property; text: border-right-color
+spec: css-ui-4;	type: dfn; text: accent color
+spec: css-ui-4; type: property; text: accent-color
 </pre>
 
 
@@ -2012,6 +2014,13 @@ System Colors</h3>
 	Additionally, ''GrayText'' is expected to be readable,
 	though possibly at a lower contrast rating,
 	over any of the backgrounds.
+
+	To maintain consistency with widget [=accent color=] styling,
+	''AccentColor'' takes its value from 'accent-color',
+	unless [=Forced Colors Mode=] is enabled.
+	''AccentColorText'' takes its value from
+	the contrasting foreground color to ''AccentColor''
+	as is described for widget [=accent color=] styling.
 
 	<div class="example" id="ex-SystemCombo">
 		For example, the system color combinations in the browser you are currently using:
@@ -7285,8 +7294,8 @@ Changes</h2>
 <h3 id="changes-from-20250424">Changes since the 
 	<a href="https://www.w3.org/TR/2025/CRD-css-color-4-20250424/">Candidate Recommendation Draft of 24 April 2025</a></h3>
 <ul>
-	<!-- to 23 Apr 2025 -->
-	<li><em>none</em></li>
+	<!-- to 4 Sep 2025 -->
+	<li>Updated ''AccentColor'' to take its value from 'accent-color', unless in [=Forced Colors Mode=]</li>
 </ul>
 
 <h3 id="changes-from-20240213">Changes since the <a href="https://www.w3.org/TR/2024/CRD-css-color-4-20240213/">Candidate Recommendation Draft of 13 Feb 2024</a></h3>


### PR DESCRIPTION
These updates were resolved in both https://github.com/w3c/csswg-drafts/issues/5900 and https://github.com/w3c/csswg-drafts/issues/11332#issuecomment-3200774167

The change to system color text can be found hosted at https://alisonmaher.github.io/alisonmaher/css-color-4/Overview.html#css-system-colors (at the end of the section just before example 15).

For some reason, the second mention of "accent color" does not show as linked, even though it uses the same syntax as the first reference (perhaps a bikeshed issue?)
