### PR TITLE
[css-borders-4][editorial] Rewrite syntaxes with property value range productions

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -613,6 +613,10 @@ The 'corner-shape' shorthand</h4>
 
 	The 'corner-shape' property specifies the shape of the box's corners,
 	within the region specified by 'border-radius'.
+	The four values set the top, right, bottom and left shape, respectively.
+	A missing left is the same as right,
+	a missing bottom is the same as top,
+	and a missing right is also the same as top.
 
 <h3 id="corner-shorthands">
 Corner Sizing & Shaping Shorthands: the 'corner' and 'corner-*' shorthand properties</h3>


### PR DESCRIPTION
It might not be obvious why property value range productions should be preferred (imo), so taking `corner-*` shorthands as an example, its current syntax is:

  > `<length-percentage [0,∞]>{1,2} || <corner-shape-value>`.

When replaced with `<'border-top-left-radius'> || <'corner-top-left-shape'>`:

  - readers know *immediately* that the first value is a radius (and the second is a shape)
  - spec authors will not need to update it if the syntax of `corner-*-shape` is later updated to eg. `<corner-shape-value> | none`
  - implementers do not need to look up what the second `<length-percentage>` value should be when omitted
  - implementers may have to write less code to validate a grammar rule applying on the longhand value, to expand the shorthand value, and serialize a value according to the shortest value principle

Applying this change left the extended definition of `<corner-shape-value>` at an inappropriate place, below the definition table of `corner-shape`, while it was no longer used in its syntax.

So I took changes a little further and ended with moving/rewriting corner shaping sections to make all *Corners" sections more consistent, in a separate commit.

I also made an unrelated editorial change. Although experienced CSS authors might intuitevily guess this, I suggest to explicitly defining that `corner-shape` values are expanded clockwise starting from the top corner, and what their default values when omitted. I preferred to suggest this change in a single PR to avoid merge conflicts.