### PR TITLE
[css-backgrounds-4] Allowed combining `border-area` and `text` in `background-clip`

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -326,7 +326,7 @@ Painting Area: the 'background-clip' property</h3>
 	The syntax of the property is given with
 
 	<pre class=prod>
-	<dfn>&lt;bg-clip></dfn> = <<visual-box>> | border-area| text
+	<dfn>&lt;bg-clip></dfn> = <<visual-box>> | [ border-area || text ]
 	</pre>
 
 	Issue: Or should this be defining the <css>-webkit-background-clip</css> property,


### PR DESCRIPTION
This adjusts the syntax of `background-clip` to accept a combination of `border-area` and `text`, as it was resolved on in https://github.com/w3c/csswg-drafts/issues/10696#issuecomment-2461103750.

Closes #10696

Sebastian