### PR TITLE
[css-backgrounds-4] Defined interaction of `border-area` and `text` values for `background-clip`

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -351,6 +351,9 @@ Painting Area: the 'background-clip' property</h3>
 		</dd>
 	</dl>
 
+	If both ''background-clip/border-area'' and ''background-clip/text'' are specified,
+	the background is painted within (clipped to) the union of these two areas.
+
 <h3 id='background-layers'>
 Background Image Layers: the 'background-tbd' shorthand property</h3>
 


### PR DESCRIPTION
In #12738 I missed to define what happens when both `border-area` and `text` are defined for `background-clip`, as @Loirooriol immediately [pointed out](https://github.com/w3c/csswg-drafts/pull/12738#discussion_r2324929980).

The [minutes of the call](https://github.com/w3c/csswg-drafts/issues/10696#issuecomment-2461103750) suggest the consensus was to do a union. So I added this note.

Sebastian