### PR TITLE
[css-borders-4][editorial] Oversights

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -903,11 +903,6 @@ To interpolate a [=superellipse parameter=] |s| to an interpolation value betwee
 	</dl>
 </div>
 
-<h3 id=corners-shorthand>
-Corner Shaping Shorthand: the 'corners' property</h3>
-
-Issue(11623): Decide on the exact name and syntax of this property.
-
 <h2 id="partial-borders">
 Partial borders</h2>
 
@@ -1536,14 +1531,15 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-borders-4-20250722/
 First Public Working Draft</a> of 22 July 2025
 </h3>
 
-	* (none)
+    * added 'corner-*' shorthands
+	* renamed 'corners' to 'corner'
 
 <h3 class=no-num id="level-changes">
 Additions since [[CSS3BG]]</h3>
 
 	* <<image-1D>> as value for 'border-color' and its longhands
 	* added physical and logical 'border-*-radius' shorthands
-	* added 'corner-shape' and 'corner-*-shape' shorthands, plus related 'corners' shorthand
+	* added 'corner-shape' and 'corner-*-shape' shorthands, plus related 'corner' and 'corner-*' shorthands
 	* added 'border-shape'
 	* added <a href="#partial-borders">partial borders</a> via 'border-limit' and 'border-*-clip' properties
 	* added 'box-shadow-*' longhands and turned 'box-shadow' into a shorthand


### PR DESCRIPTION
Fix oversights in f3d0da1. 

`corners` is basically renamed to `corner`:

> > Thanks. So I guess [`corners`](https://drafts.csswg.org/css-borders-4/#corners-shorthand) is now [`corner`](https://drafts.csswg.org/css-borders-4/#corner-shorthand). So is there any reason to keep _3.4. Corner Shaping Shorthand: the `corners` property_?
> 
> Oh I thought I removed the leftover. No there isn't.

https://github.com/w3c/csswg-drafts/issues/11623#issuecomment-3232601870