### PR TITLE
[css-borders-4] Define logical property group of border-*-radius longhands

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -309,6 +309,7 @@ The 'border-top-radius', 'border-right-radius',
 		Initial: 0
 		Applies to: all elements (but see prose)
 		Inherited: no
+		Logical property group: border-radius
 		Percentages: Refer to corresponding dimension of the <a>border box</a>.
 		Computed value: see individual properties
 		Animation type: see individual properties


### PR DESCRIPTION
This PR adds a Logical property group field to physical/logical `border-*-radius` longhands, as required by [this resolution](https://github.com/w3c/csswg-drafts/issues/2822#issuecomment-722050788).