### PR TITLE
[css-inline-3][editorial] <text-edge> requires both values

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -1098,9 +1098,6 @@ Text Edge Metrics: the 'line-fit-edge' property</h3>
 
 	The first value specifies the text [=over=] edge;
 	the second value specifies the text [=under=] edge.
-	If only one value is specified,
-	both edges are assigned that same keyword if possible;
-	else ''<<text-edge>>/text'' is assumed as the missing value.
 
 	ISSUE(5236): Do we need [=longhands=] or is this shorthand enough?
 


### PR DESCRIPTION
Fixes an oversight in 764a39b: both keywords are mandatory since this commit.

  > `<text-edge> = [ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]`