### PR TITLE
[css-cascade-6] <scope-start> and <scope-end> produce <complex-real-selector-list>

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -443,13 +443,15 @@ Syntax of ''@scope''</h4>
 	@scope [(<<scope-start>>)]? [to (<<scope-end>>)]? {
 	  <<block-contents>>
 	}
+    <scope-start> = <<complex-real-selector-list>>
+    <scope-end> = <<complex-real-selector-list>>
 	</pre>
 
 	where:
 
-	* <dfn><<scope-start>></dfn> is a <<selector-list>> [=selector=]
+	* <dfn><<scope-start>></dfn> is a <<complex-real-selector-list>>
 		used to identify the [=scoping root=](s).
-	* <dfn><<scope-end>></dfn> is a <<selector-list>> [=selector=]
+	* <dfn><<scope-end>></dfn> is a <<complex-real-selector-list>>
 		used to identify any [=scoping limits=].
 	* the [=qualified rules=] within <<block-contents>>,
 		as well as any [=nested declarations rules=]


### PR DESCRIPTION
This PR allows `w3c/webref` to extract syntax rules for both, encoding the exclusion of pseudo-elements. It also clarifies the type they produce.