### PR TITLE
[css-backgrounds-3][editorial] Negative values are invalid for 3rd `<shadow>` length

### DIFF
--- a/css-backgrounds-3/Overview.bs
+++ b/css-backgrounds-3/Overview.bs
@@ -3342,7 +3342,7 @@ Border Image Shorthand: the 'border-image' property</h3>
 	represented by 2-4 length values, an optional color, and an optional ''box-shadow/inset'' keyword.
 	Omitted lengths are 0; omitted colors default to ''currentColor''.
 	<pre class=prod>
-	<dfn><<shadow>></dfn> = <<color>>? &amp;&amp; [<<length>>{2} <<length [0,&infin;]>>? <<length>>?] &amp;&amp; inset?</pre>
+	<dfn><<shadow>></dfn> = <<color>>? &amp;&amp; [ <<length>>{2} [ <<length [0,&infin;]>> <<length>>? ]? ] &amp;&amp; inset?</pre>
 
 	The components of each <<shadow>> are interpreted as follows:
 


### PR DESCRIPTION
... as currently [specified](https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow) in prose:

  > **3rd `<length [0,∞]>`**
  >
  > Specifies the blur radius. Negative values are invalid.

... but the current syntax allows `1px 1px -1px` to match:

  > `<shadow> = <color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?`

... while this is invalid in mainstream browsers.