### PR TITLE
[css-inline-3][editorial] Typo

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -1385,7 +1385,7 @@ Shorthand for Text Box Trimming: the 'text-box' property</h3>
 	If the single keyword <dfn for=text-box value>normal</dfn> is specified,
 	it sets 'text-box-trim' to ''text-box-trim/none''
 	and 'text-box-edge' to ''text-box-edge/auto''.
-	Otherwise, omitting the 'text-box-trim' value sets it to ''text-box-trim/both'' (not the initial value),
+	Otherwise, omitting the 'text-box-trim' value sets it to ''text-box-trim/trim-both'' (not the initial value),
 	while omitting the 'text-box-edge' value sets it to ''text-box-edge/auto'' (the initial value).
 
 	ISSUE: Add examples.


### PR DESCRIPTION
The syntax of `text-box-trim` does not accept `both` but `trim-both`.