### PR TITLE
[cssom-1][editorial] Added WPTs

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -23,6 +23,8 @@ Abstract: CSSOM defines APIs (including generic parsing and serialization rules)
 Repository: w3c/csswg-drafts
 Ignored Terms: cssText
 Ignored Vars: m1, m2, camel_cased_attribute, webkit_cased_attribute, dashed_attribute
+WPT Path Prefix: /css/cssom/
+WPT Display: closed
 Include Can I Use Panels: true
 Can I Use URL: https://drafts.csswg.org/cssom/
 Can I Use URL: https://www.w3.org/TR/cssom-1/
@@ -204,6 +206,13 @@ more technical specificity (so as to improve testability and interoperability), 
 features no longer considered to be essential in this context, and (3) to newly specify certain extensions that have been
 or expected to be widely implemented.
 
+<wpt title="Basic CSSOM tests">
+  idlharness.html
+  invalid-pseudo-elements.html
+  historical.html
+  stylesheet-replacedata-dynamic.html
+  xml-stylesheet-pi-in-doctype.xhtml
+</wpt>
 
 Terminology {#terminology}
 ==========================
@@ -491,6 +500,10 @@ To
  </table>
 </div>
 
+<wpt>
+  mediaquery-sort-dedup.html
+</wpt>
+
 ### Serializing Media Feature Values ### {#serializing-media-feature-values}
 
 Issue: This should probably be done in terms of mapping it to
@@ -588,6 +601,15 @@ interface MediaList {
 The object's <a>supported property indices</a> are the numbers in the range zero to one less than the number of media queries
 in the <a>collection of media queries</a> represented by the collection. If there are no such media queries, then there are no
 <a>supported property indices</a>.
+
+<wpt>
+  medialist-dynamic-001.html
+  medialist-interfaces-001.html
+  medialist-interfaces-002.html
+  medialist-interfaces-004.html
+  MediaList.html
+  MediaList2.xhtml
+</wpt>
 
 To <dfn export>create a <code>MediaList</code> object</dfn> with a string <var>text</var>, run the following steps:
 <ol>
@@ -700,6 +722,10 @@ part of the chain of the selector, and finally return
  pseudo-element, to <var>s</var>.
 </ol>
 
+<wpt>
+  selectorSerialize.html
+  serialize-namespaced-type-selectors.html
+</wpt>
 
 To
 <dfn export>serialize a simple selector</dfn>
@@ -851,6 +877,25 @@ represents a style sheet as defined by the CSS specification. In the CSSOM a
   </dd>
 </dl>
 
+<wpt>
+  CSSStyleSheet-constructable-baseURL.html
+  CSSStyleSheet-constructable-concat.html
+  CSSStyleSheet-constructable-cssRules.html
+  CSSStyleSheet-constructable-disabled-regular-sheet-insertion.html
+  CSSStyleSheet-constructable-disallow-import.tentative.html
+  CSSStyleSheet-constructable-duplicate.html
+  CSSStyleSheet-constructable-insertRule-base-uri.html
+  CSSStyleSheet-constructable-invalidation.html
+  CSSStyleSheet-constructable-replace-cssRules.html
+  CSSStyleSheet-constructable-replace-on-regular-sheet.html
+  CSSStyleSheet-constructable.html
+  CSSStyleSheet-modify-after-removal.html
+  CSSStyleSheet-template-adoption.html
+  CSSStyleSheet.html
+  style-sheet-interfaces-001.html
+  style-sheet-interfaces-002.html
+</wpt>
+
 A <a>CSS style sheet</a> has a number of associated state items:
 
 <dl dfn-for="CSSStyleSheet">
@@ -980,6 +1025,9 @@ A <a>CSS style sheet</a> has a number of associated state items:
 
 </dl>
 
+<wpt>
+  base-uri.html
+</wpt>
 
 ### The {{StyleSheet}} Interface ### {#the-stylesheet-interface}
 
@@ -1018,6 +1066,11 @@ is set, or false otherwise. On setting, the {{StyleSheet/disabled}} attribute mu
 <a>disabled flag</a> if the new value is true, or unset the
 <a>disabled flag</a> otherwise.
 
+<wpt>
+  link-element-stylesheet-title.html
+  stylesheet-same-origin.sub.html
+  stylesheet-title.html
+</wpt>
 
 ### The {{CSSStyleSheet}} Interface ### {#the-cssstylesheet-interface}
 
@@ -1075,6 +1128,21 @@ The <dfn method for=CSSStyleSheet>insertRule(<var>rule</var>, <var>index</var>)<
  <li>Return the result of invoking <a>insert a CSS rule</a> <var>rule</var> in the <a for=CSSStyleSheet>CSS rules</a>
  at <var>index</var>.
 </ol>
+
+<wpt>
+  insert-dir-rule-crash.html
+  insert-dir-rule-in-iframe-crash.html
+  insert-invalid-where-rule-crash.html
+  insertRule-across-context.html
+  insertRule-charset-no-index.html
+  insertRule-from-script.html
+  insertRule-import-no-index.html
+  insertRule-import-no-sheet-crash.html
+  insertRule-import-trailing-garbage-crash.html
+  insertRule-namespace-no-index.html
+  insertRule-no-index.html
+  insertRule-syntax-error-01.html
+</wpt>
 
 The <dfn method for=CSSStyleSheet>deleteRule(<var>index</var>)</dfn> method must run the following steps:
 
@@ -1148,6 +1216,10 @@ The <dfn method for=CSSStyleSheet>addRule(<var>selector</var>, <var>block</var>,
   and should instead use and teach the standard {{CSSStyleSheet}} interface defined earlier,
   which is consistent with {{CSSGroupingRule}}.
 </p>
+
+<wpt>
+  removerule-invalidation-crash.html
+</wpt>
 
 CSS Style Sheet Collections {#css-style-sheet-collections}
 ----------------------------------------------------------
@@ -1226,6 +1298,11 @@ steps:
  <li>Set the <a>disabled flag</a>.
 </ol>
 
+<wpt>
+  preferred-stylesheet-order.html
+  preferred-stylesheet-reversed-order.html
+</wpt>
+
 To <dfn export>remove a CSS style sheet</dfn>, run these steps:
 
 <ol>
@@ -1238,6 +1315,10 @@ To <dfn export>remove a CSS style sheet</dfn>, run these steps:
 
  <!-- XXX does anything need to happen wrt alternate style sheets? what if the last style sheet with the preferred style sheet set name is removed? -->
 </ol>
+
+<wpt>
+  delete-namespace-rule-when-child-rule-exists.html
+</wpt>
 
 A <dfn export>persistent CSS style sheet</dfn> is a
 <a>CSS style sheet</a> from the <a>document or shadow root CSS style sheets</a>
@@ -1357,6 +1438,12 @@ sheet</a> in the collection. If there is no <var>index</var>th object in the col
 The <dfn attribute for=StyleSheetList>length</dfn> attribute must return the number of <a>CSS style sheets</a>
 represented by the collection.
 
+<wpt>
+  StyleSheetList-constructable-with-style-recalc.html
+  StyleSheetList-constructable.html
+  StyleSheetList.html
+</wpt>
+
 ### Extensions to the {{DocumentOrShadowRoot}} Interface Mixin ### {#extensions-to-the-document-or-shadow-root-interface}
 
 <pre class=idl>
@@ -1376,6 +1463,14 @@ is the following:
   <li>If <var>value</var>'s <a>constructed flag</a> is not set, or its <a>constructor document</a> is not equal to this
   {{DocumentOrShadowRoot}}'s <a>node document</a>, throw a "{{NotAllowedError}}" {{DOMException}}.</li>
 </ol>
+
+<wpt>
+  adoptedstylesheets-modify-array-and-sheet.html
+  adoptedstylesheets-observablearray.html
+  ttwf-cssom-doc-ext-load-count.html
+  ttwf-cssom-doc-ext-load-tree-order.html
+  ttwf-cssom-document-extension.html
+</wpt>
 
 Style Sheet Association {#style-sheet-association}
 --------------------------------------------------
@@ -1467,6 +1562,19 @@ if there is no <a>associated CSS style sheet</a>.
 Note: Whether or not the node refers to a style sheet is defined
 by the specification that defines the semantics of said node.
 
+<wpt>
+  HTMLLinkElement-disabled-001.html
+  HTMLLinkElement-disabled-002.html
+  HTMLLinkElement-disabled-003.html
+  HTMLLinkElement-disabled-004.html
+  HTMLLinkElement-disabled-005.html
+  HTMLLinkElement-disabled-006.html
+  HTMLLinkElement-disabled-007.html
+  HTMLLinkElement-disabled-alternate.html
+  HTMLLinkElement-load-event-002.html
+  HTMLLinkElement-load-event.html
+  HTMLStyleElement-load-event.html
+</wpt>
 
 ### Requirements on specifications ### {#requirements-on-specifications}
 
@@ -1917,6 +2025,10 @@ follow these steps:
  <li>Return <var>index</var>.
 </ol>
 
+<wpt>
+  serialize-media-rule.html
+</wpt>
+
 To <dfn export>remove a CSS rule</dfn> from a CSS rule list <var>list</var> at index <var>index</var>, follow these steps:
 <ol>
  <li>Set <var>length</var> to the number of items in <var>list</var>.
@@ -1943,6 +2055,10 @@ interface CSSRuleList {
   readonly attribute unsigned long length;
 };
 </pre>
+
+<wpt>
+  CSSRuleList.html
+</wpt>
 
 The object's <a>supported property indices</a> are the numbers in the range zero to one less than the number of
 {{CSSRule}} objects represented by the collection. If there are no such {{CSSRule}} objects, then there are no
@@ -1983,6 +2099,13 @@ interface CSSRule {
 The <dfn attribute for=CSSRule>cssText</dfn> attribute must return a <a lt="serialize a CSS rule">serialization</a> of the
 <a for=/>CSS rule</a>.
 On setting the {{CSSRule/cssText}} attribute must do nothing.
+
+<wpt>
+  css-style-reparse.html
+  cssom-cssText-serialize.html
+  cssom-ruleTypeAndOrder.html
+  declaration-block-all-crash.html
+</wpt>
 
 The <dfn attribute for=CSSRule>parentRule</dfn> attribute must return the <a for=CSSRule>parent CSS
 rule</a>.
@@ -2041,6 +2164,32 @@ This enumeration is thus frozen in its current state,
 and no new new values will be added to reflect additional at-rules;
 all at-rules beyond the ones listed above will return 0.
 
+<wpt hidden title="Tested in other specs">
+  <!-- Part of CSSOM View 1 -->
+  caretPositionFromPoint.html
+  caretPositionFromPoint-audioVideo.html
+  caretPositionFromPoint-with-transformation.html
+
+  <!-- Part of CSS Conditional 3 -->
+  CSSConditionRule-conditionText.html
+
+  <!-- Part of CSS Counter Styles 3 -->
+  CSSCounterStyleRule.html
+
+  <!-- Part of CSS Fonts 3 -->
+  CSSFontFaceRule.html
+  CSSFontFeatureValuesRule.html
+  cssom-fontfacerule-constructors.html
+  cssom-fontfacerule.html
+
+  <!-- Part of CSS Animations 1 -->
+  CSSKeyframeRule.html
+  CSSKeyframesRule.html
+
+  <!-- Part of CSS Custom Properties 1 -->
+  serialize-variable-reference.html
+  variable-names.html
+</wpt>
 
 ### The {{CSSStyleRule}} Interface ### {#the-cssstylerule-interface}
 
@@ -2062,6 +2211,15 @@ On setting the {{CSSStyleRule/selectorText}} attribute these steps must be run:
  <li>If the algorithm returns a non-null value replace the associated [=selector list=] with the returned value.
  <li>Otherwise, if the algorithm returns a null value, do nothing.
 </ol>
+
+<wpt>
+  CSSStyleRule.html
+  CSSStyleRule-set-selectorText.html
+  CSSStyleRule-set-selectorText-namespace.html
+  selectorText-modification-restyle-001.html
+  selectorText-modification-restyle-002.html
+  set-selector-text-attachment.html
+</wpt>
 
 The <dfn attribute for=CSSStyleRule>style</dfn> attribute must return a <code>CSSStyleProperties</code> object for the style rule, with the
 following properties:
@@ -2118,6 +2276,11 @@ or null if the at-rule does not declare a supports condition.
 
 Note: An <code>@import</code> at-rule might not have an associated <a>CSS style sheet</a> (e.g., if it has a non-matching <code>supports()</code> condition).
 
+<wpt>
+  cssimportrule.html
+  cssimportrule-parent.html
+  cssimportrule-sheet-identity.html
+</wpt>
 
 ### The {{CSSGroupingRule}} Interface ### {#the-cssgroupingrule-interface}
 
@@ -2142,6 +2305,10 @@ invoking <a>insert a CSS rule</a> <var>rule</var> into the <a for=CSSRule>child 
 The <dfn method for=CSSGroupingRule>deleteRule(<var>index</var>)</dfn> method must <a>remove a CSS rule</a> from the
 <a for=CSSRule>child CSS rules</a> at <var>index</var>.
 
+<wpt>
+  CSSGroupingRule-cssRules.html
+  CSSGroupingRule-insertRule.html
+</wpt>
 
 ### The {{CSSMediaRule}} Interface ### {#the-cssmediarule-interface}
 
@@ -2207,6 +2374,9 @@ The <dfn attribute for=CSSPageRule>style</dfn> attribute must return a <code>CSS
  <dd>Null.
 </dl>
 
+<wpt>
+  cssom-pagerule.html
+</wpt>
 
 ### The {{CSSMarginRule}} Interface ### {#the-cssmarginrule-interface}
 
@@ -2258,6 +2428,10 @@ The <dfn attribute for=CSSNamespaceRule>namespaceURI</dfn> attribute must return
 The <dfn attribute for=CSSNamespaceRule>prefix</dfn> attribute must return the prefix of the <code>@namespace</code> at-rule or the
 empty string if there is no prefix.
 
+<wpt>
+  at-namespace.html
+  CSSNamespaceRule.html
+</wpt>
 
 CSS Declarations {#css-declarations}
 ------------------------------------
@@ -2338,6 +2512,10 @@ these steps:
  <li>Return <var>s</var>.
 </ol>
 
+<wpt>
+  serialization-CSSDeclaration-with-important.html
+</wpt>
+
 To <dfn export>serialize a CSS declaration block</dfn> <var>declaration block</var> means to run the steps below:
 
 <ol>
@@ -2389,6 +2567,16 @@ Note: The serialization of an empty CSS declaration block is the empty string.
 
 Note: The serialization of a non-empty CSS declaration block does not include any surrounding whitespace, i.e., no whitespace appears
 before the first property name and no whitespace appears after the final semicolon delimiter that follows the last property value.
+
+<wpt>
+  border-shorthand-serialization.html
+  css-style-attr-decl-block.html
+  font-family-serialization-001.html
+  font-shorthand-serialization.html
+  font-variant-shorthand-serialization.html
+  shorthand-serialization.html
+  shorthand-values.html
+</wpt>
 
 A <a>CSS declaration block</a> has these <a>attribute change steps</a> for its <a for="CSSStyleDeclaration">owner node</a>
 with <var>localName</var>, <var>value</var>, and <var>namespace</var>:
@@ -2459,6 +2647,34 @@ interface CSSStyleProperties : CSSStyleDeclaration {
 };
 </pre>
 
+<wpt>
+  css-style-declaration-modifications.html
+  cssom-cssstyledeclaration-set.html
+  cssstyledeclaration-all-shorthand.html
+  cssstyledeclaration-cssfontrule.tentative.html
+  cssstyledeclaration-csstext-all-shorthand.html
+  cssstyledeclaration-csstext-final-delimiter.html
+  cssstyledeclaration-csstext-important.html
+  cssstyledeclaration-csstext-setter.window.html
+  cssstyledeclaration-csstext.html
+  cssstyledeclaration-custom-properties.html
+  cssstyledeclaration-mutability.html
+  cssstyledeclaration-mutationrecord-001.html
+  cssstyledeclaration-mutationrecord-002.html
+  cssstyledeclaration-mutationrecord-003.html
+  cssstyledeclaration-mutationrecord-004.html
+  cssstyledeclaration-mutationrecord-005.html
+  cssstyledeclaration-properties.html
+  cssstyledeclaration-registered-custom-properties.html
+  cssstyledeclaration-removeProperty-all.html
+  cssstyledeclaration-setter-attr.html
+  cssstyledeclaration-setter-declarations.html
+  cssstyledeclaration-setter-form-controls.html
+  cssstyledeclaration-setter-logical.html
+  page-descriptors.html
+  property-accessors.html
+</wpt>
+
 The object's <a>supported property indices</a> are the numbers in the range zero to one less than the number of
 <a>CSS declarations</a> in the <a for="CSSStyleDeclaration">declarations</a>. If there are no such
 <a>CSS declarations</a>, then there are no <a>supported property indices</a>.
@@ -2511,6 +2727,11 @@ The <dfn method for=CSSStyleDeclaration>getPropertyValue(<var>property</var>)</d
  <a>serialize a CSS value</a> of that declaration.
  <li>Return the empty string.
 </ol>
+
+<wpt>
+  cssom-getPropertyValue-common-checks.html
+  serialize-all-longhands.html
+</wpt>
 
 The <dfn method for=CSSStyleDeclaration>getPropertyPriority(<var>property</var>)</dfn> method must run these steps:
 <ol>
@@ -2569,6 +2790,13 @@ The <dfn method for=CSSStyleDeclaration>setProperty(<var>property</var>, <var>va
  <a for="CSSStyleDeclaration">declarations</a>.
  <li>If <var>updated</var> is true, <a>update style attribute for</a> the <a>CSS declaration block</a>.
 </ol>
+
+<wpt>
+  cssom-setProperty-shorthand.html
+  MutationObserver-style.html
+  rule-restrictions.html
+  setproperty-null-undefined.html
+</wpt>
 
 To <dfn export>set a CSS declaration</dfn> <var>property</var> with a value <var>component value list</var> and optionally with an <i>important</i> flag set, in
 a list of declarations <var>declarations</var>, the user agent must ensure the following constraints hold after its steps:
@@ -2686,6 +2914,11 @@ For each CSS property <var>property</var> that is a <a>supported CSS property</a
 the following partial interface applies where <dfn attribute for=CSSStyleProperties>camel-cased attribute</dfn>
 is obtained by running the <a>CSS property to IDL attribute</a> algorithm for
 <var>property</var>.
+
+<wpt>
+  change-rule-with-layers-crash.html
+  style-attr-update-across-documents.html
+</wpt>
 
 <pre class="idl extract">
 partial interface CSSStyleProperties {
@@ -2870,6 +3103,11 @@ follow these rules:
     unless the second item is a "," (U+002C COMMA)
     Return the result.
 
+<wpt>
+  flex-serialization.html
+  overflow-serialization.html
+  serialize-values.html
+</wpt>
 
 To
 <dfn export>serialize a CSS component value</dfn>
@@ -3012,6 +3250,9 @@ Issue: One idea is that we can remove this section somewhere in
 the CSS3/CSS4 timeline by moving the above definitions to the drafts that
 define the CSS components.
 
+<wpt>
+  serialize-custom-props.html
+</wpt>
 
 #### Examples #### {#serializing-css-values-examples}
 
@@ -3078,6 +3319,11 @@ If the user agent supports MathML, the following IDL applies: [[MathML-Core]]
 MathMLElement includes ElementCSSInlineStyle;
 </pre>
 
+<wpt>
+  css-style-attribute-modifications.html
+  inline-style-001.html
+</wpt>
+
 Extensions to the {{Window}} Interface {#extensions-to-the-window-interface}
 ----------------------------------------------------------------------------
 
@@ -3142,6 +3388,45 @@ steps:
 <p class=warning>The {{Window/getComputedStyle()}} method exposes information from <a lt="CSS style sheet">CSS style
 sheets</a> with the <a>origin-clean flag</a> unset.
 
+<wpt>
+getComputedStyle-animations-replaced-into-ib-split.html
+getComputedStyle-detached-subtree.html
+getComputedStyle-display-none-001.html
+getComputedStyle-display-none-002.html
+getComputedStyle-display-none-003.html
+getComputedStyle-dynamic-subdoc.html
+getComputedStyle-getter-v-properties.tentative.html
+getComputedStyle-insets-absolute-crash.html
+getComputedStyle-insets-absolute-logical-crash.html
+getComputedStyle-insets-absolute-roundtrip.html
+getComputedStyle-insets-absolute.html
+getComputedStyle-insets-fixed.html
+getComputedStyle-insets-grid.html
+getComputedStyle-insets-multicol-absolute-crash.html
+getComputedStyle-insets-nobox.html
+getComputedStyle-insets-relative.html
+getComputedStyle-insets-relpos-inline.html
+getComputedStyle-insets-static.html
+getComputedStyle-insets-sticky-container-for-abspos.html
+getComputedStyle-insets-sticky.html
+getComputedStyle-layout-dependent-removed-ib-sibling.html
+getComputedStyle-layout-dependent-replaced-into-ib-split.html
+getComputedStyle-line-height.html
+getComputedStyle-logical-enumeration.html
+getComputedStyle-margins-roundtrip.html
+getComputedStyle-property-order.html
+getComputedStyle-pseudo-checkmark.html
+getComputedStyle-pseudo-picker-icon.html
+getComputedStyle-pseudo-with-argument.html
+getComputedStyle-pseudo.html
+getComputedStyle-resolved-colors.html
+getComputedStyle-resolved-min-max-clamping.html
+getComputedStyle-resolved-min-size-auto.html
+getComputedStyle-special-chars-crash.html
+getComputedStyle-sticky-pos-percent.html
+getComputedStyle-width-scroll.tentative.html
+</wpt>
+
 Issue: Should getComputedStyle() provide a useful serialization?
 See <a href="https://github.com/w3c/csswg-drafts/issues/1033">#1033</a>
 
@@ -3159,6 +3444,10 @@ namespace CSS {
   CSSOMString escape(CSSOMString ident);
 };
 </pre>
+
+<wpt>
+  CSS-namespace-object-class-string.html
+</wpt>
 
 Issue: This was previously specified as an IDL interface
 that only held static methods.
@@ -3186,6 +3475,9 @@ store some state should store the state on the <a spec=html>current global
 object</a>'s <a spec=html>associated <code>Document</code></a>.
 <!-- https://github.com/w3c/csswg-drafts/issues/180 -->
 
+<wpt>
+  escape.html
+</wpt>
 
 Resolved Values {#resolved-values}
 ==================================
@@ -3268,6 +3560,14 @@ as follows:
  <dd>The <a>resolved value</a> is the <a>computed value</a>.
 </dl>
 
+<wpt>
+  computed-style-001.html
+  computed-style-002.html
+  computed-style-003.html
+  computed-style-004.html
+  computed-style-005.html
+  resolved-border-width.html
+</wpt>
 
 IANA Considerations {#iana-considerations}
 ==========================================
@@ -3445,5 +3745,13 @@ Additional thanks to Ian Hickson for writing the
 initial version of the alternative style sheets API and canonicalization
 (now serialization) rules for CSS values.
 
- </body>
-</html>
+<wpt hidden title="Deprecated tests">
+  computed-style-set-property.html
+</wpt>
+
+<wpt ignore>
+  cssstyledeclaration-csstext-setter.window.js
+
+  <!-- Mutation Events are obsolete -->
+  stylesheet-dom-mutation-event-crash.html
+</wpt>


### PR DESCRIPTION
I added all the Web Platform Tests that currently cover the features in CSSOM 1.

Note that I am not totally sure about the tests that intersect with other specs (see "Tested in other specs"). They actually cover features defined in other specs, though they are currently placed in css/cssom/. So they _could_ be added to CSSOM as well.
@emilio You are the author of some of those tests. What do you think?

Sebastian