### PR TITLE
[css-text-decor-3] Disallow negative text-shadow blur

### DIFF
--- a/css-text-decor-3/Overview.bs
+++ b/css-text-decor-3/Overview.bs
@@ -861,7 +861,7 @@ Text Shadows: the 'text-shadow' property</h2>
 
 	<pre class="propdef">
 	Name: text-shadow
-	Value: none | [ <<color>>? && <<length>>{2,3} ]#
+	Value: none | [ <<color>>? && [ <<length>>{2} <<length [0,&infin;]>>? ] ]#
 	Initial: none
 	Applies to: text
 	Inherited: yes


### PR DESCRIPTION
The first two length values for `text-shadow` (x and y offsets) are allowed to be negative but the third value (blur) is not.

This behaviour is respected in all major browsers and is tested in WPT, see the second test [here](http://wpt.live/css/css-text-decor/text-shadow/parsing/text-shadow-invalid.html)