### PR TITLE
[css-break-3] Add the concept of grouping boxes

### DIFF
--- a/css-break-3/Overview.bs
+++ b/css-break-3/Overview.bs
@@ -1003,6 +1003,30 @@ Splitting Boxes</h3>
     </p>
   </div>
 
+<h4 id="grouping-boxes">
+Grouping Boxes</h4>
+
+  <p>
+    Certain formatting contexts may establish what is known as a <dfn>grouping box</dfn>.
+    Other boxes can then be <dfn>assigned to</dfn> one or more of those [=grouping boxes=], which will encompass the entirety of the assigned box.
+    If a box is assigned to any [=grouping boxes=] and gets broken,
+    then for the purpose of filling any [=remaining fragmentainer extent=] as described above,
+    the [=remaining fragmentainer extent=] should be treated as if the [=fragmentainer=] it belongs to did not extend past the [=block-end=] of the [=grouping box=] that the break falls within.
+
+  <p>
+    Furthermore, if a box is assigned to any [=grouping boxes=] and the ancestors of those [=grouping boxes=] are broken between any two of the [=grouping boxes=], user agents should try to avoid creating box fragments for the [=assigned to|assigned box=], which span across that break.
+
+  <p class="note">
+    One way of accomplishing this is to make sure that within any [=assigned to|assigned box=] there is at least one break, preceding each point where there is a break between the [=grouping boxes=] that it is [=assigned to=].
+    Care should be taken to ensure that there is enough space below said break in the [=grouping box=] to fit any <a href="#valdef-box-decoration-break-clone">cloned margins/border/padding</a> so that they do not cause the [=assigned to|assigned box=] to extend beyond the [=grouping box=].
+
+  <p>
+    Grouping boxes are established in the following situations:
+  <ul>
+    <li>All table rows establish a grouping box. Any boxes for cells with a rowspan greater than 1 are [=assigned to=] the [=grouping boxes=] for all rows that they span.
+    <li>All grid rows in a [=grid container=] establish a [=grouping box=]. In this case, all [=grid items=] have their box [=assigned to=] the [=grouping boxes=] for all grid rows that their [=grid area=] covers.
+  </ul>
+
 <h3 id="break-decoration">
 Fragmented Borders and Backgrounds: the 'box-decoration-break' property</h3>
 


### PR DESCRIPTION
This improves layout in tables and grid containers which contain cells that span across multiple rows which may be broken into separate fragmentainers.

Here is an example of what behavior this aims to improve:
<img width="1310" height="653" alt="489477628-789bbcb1-69ab-4781-872d-0378335b3d6f" src="https://github.com/user-attachments/assets/2e68a4da-cdef-4335-8a5f-dc3f41d91875" />

This is not meant to be a requirement for UAs, but rather just a suggestion. I hope the use of "should" instead of "must" has that power. (if not, that can be changed)

More context: https://github.com/w3c/csswg-drafts/issues/12801

I'd be happy to sign the IPR thingy, but I can't seem to do that on my own on the website. (I'm not a member of the working group, nor do I work for a member organization)