### PR TITLE
[css-grid-3][masonry] Clarifications to intrinsic auto-repeats

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -433,20 +433,24 @@ Intrinsic Tracks and repeat()</h4>
 	<div algorithm="determine intrinsic repetitions">
 		To determine the number of repetitions
 		that a ''repeat()'' function resolves to,
-		run layout as defined in [[#track-sizing-performance]],
-		with the following changes:
+		resolve the repeated track sizing functions to definite sizes
+		by initializing the track sizes (per [[css-grid-2#algo-init]])
+		and resolving intrinsic track sizes (per [[css-grid-2#algo-content]])
+		in accordance with [[#track-sizing]]
+		with the following assumptions:
 
 		* Expand ''repeat()/auto-fill''/''repeat()/auto-fit'' repeat functions once.
 		* Ignore explicit item placement.
 			(That is, assume all items have an [=automatic position=].)
+		* Do not [=collapsed grid track|collapse=] any tracks.
 		* If a [=masonry item=] has a span larger than 1,
-			then for each of its intrinsic sizes
-			that it would contribute to the [=virtual masonry item=],
+			then for each of its intrinsic size contributions,
 			first subtract the combined size of the gaps it would span,
 			and divide by its span.
-			Then treat it as being a span-1 item with those sizes.
+			Then treat it as an item that has a span of 1
+			and these modified intrinsic size contributions.
 
-		Any intrinsically-sized tracks are then treated as having the size
+		All tracks are then treated as having the size
 		calculated by this simplified layout
 		(including those in ''repeat()'' arguments,
 		taking from their corresponding single repetition)


### PR DESCRIPTION
* Don't apply collapse tracks. #12485
* Use intrinsic sizing rules for percentage resolution. #12432
* Don't apply free space to stretch tracks. #12423