### PR TITLE
[css-color-5][editorial] Tweak syntax

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -218,7 +218,7 @@ Mixing Colors: the ''color-mix()'' Function {#color-mix}
 
 
 <pre class='prod'>
-	<dfn>color-mix()</dfn> = color-mix( [ <<color-interpolation-method>> ,]? [ <<color>> && <<percentage [0,100]>>? ]#)
+	<dfn>color-mix()</dfn> = color-mix( <<color-interpolation-method>>? , [ <<color>> && <<percentage [0,100]>>? ]#)
 </pre>
 
 <wpt>


### PR DESCRIPTION
Replaces `[<color-interpolation-method> , ]? ...` with `<color-interpolation-method>? , ...`.

  > **Commas specified in the grammar are implicitly omissible** in some circumstances, when used to separate optional terms in the grammar. Within a top-level list in a property or other CSS value, or **a function’s argument list**, a comma specified in the grammar must be omitted if:
  >
  > - all items preceding the comma have been omitted

https://drafts.csswg.org/css-values-4/#comb-comma