### PR TITLE
[css-borders-4][editorial] Fix syntax rewrite mistake

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -699,7 +699,7 @@ The 'corner-top-left', 'corner-top-right',
 	<pre class=propdef>
 		Name: corner-top-left, corner-top-right, corner-bottom-left, corner-bottom-right,
 			corner-start-start, corner-start-end, corner-end-start, corner-end-end
-		Value: <<'border-top-left-radius'>>{1,2} || <<'corner-top-left-shape'>>
+		Value: <<'border-top-left-radius'>> || <<'corner-top-left-shape'>>
 		Initial: 0
 		Applies to: all elements (but see prose)
 		Inherited: no


### PR DESCRIPTION
The syntax of `corner-top-left` and other "single corner" shorthands is:

  > Value: 	`<'border-top-left-radius'>{1,2} || <'corner-top-left-shape'>`

`{1,2}` is an oversight, because the syntax of `border-top-left-radius` is:

  > Value: `<length-percentage [0,∞]>{1,2}`

Before 5b61925, he syntax of `corner-top-left` and other "single corner" shorthands was:

  > Value: `<length-percentage [0,&infin;]>{1,2} || <corner-shape-value>`

My apologies.