### PR TITLE
[css-2025] Delete CSS-CASCADE-5 reference in 2.4 section

### DIFF
--- a/css-2025/Overview.bs
+++ b/css-2025/Overview.bs
@@ -587,11 +587,6 @@ Modules with Rough Interoperability</h3>
 			and provides more control over font choice and feature selection,
 			including support for OpenType variations.
 
-		<dt><a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Level 5</a>
-		[[CSS-CASCADE-5]]
-		<dd>
-			Extends CSS Cascade 4 to add cascade layers.</dd>
-
 		<dt><a href="https://www.w3.org/TR/motion-1/">Motion Path Module Level 1</a>
 		[[MOTION-1]]
 		<dd>


### PR DESCRIPTION
CSS-CASCADE-5 specification is included in "2.2. Reliable Candidate Recommendations" section as "CSS Cascading and Inheritance Module Level 5", but also remains in "2.4. Modules with Rough Interoperability" section as "CSS Cascading and Inheritance Level 5" . Both references link to the same URL https://www.w3.org/TR/css-cascade-5/

I suppose this specification has been promoted from 2.4 section to 2.2 section, so it should be deleted from the 2.4 section.
