### PR TITLE
Correct CSS Cascading and Inheritance Level 5 specification name in 2…

### DIFF
--- a/css-2025/Overview.bs
+++ b/css-2025/Overview.bs
@@ -397,7 +397,7 @@ The following specifications are considered to be in a reliable state, meaning t
 		Extends and supersedes [[CSS-GRID-1]],
 		introducing “subgrids” for managing nested markup in a shared grid framework.
 
-	<dt><a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Module Level 5</a>
+	<dt><a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Level 5</a>
 	[[CSS-CASCADE-5]]
 	<dd>
 		Extends and supersedes [[CSS-CASCADE-4]],


### PR DESCRIPTION
….2 section

The actual name of the specification is "CSS Cascading and Inheritance Level 5", not "CSS Cascading and Inheritance Module Level 5".

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
