### PR TITLE
[css-cascade-4][css-cascade-5][css-cascade-6][editorial] Added "Module" to spec title

### DIFF
--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: CSS Cascading and Inheritance Level 4
+Title: CSS Cascading and Inheritance Module Level 4
 Shortname: css-cascade
 Level: 4
 Status: ED
@@ -222,7 +222,7 @@ Conditional ''@import'' Rules</h3>
 
 	<div class="example">
 		The following rule illustrates how an author can provide rules
-		for modern user agents that support newer web features 
+		for modern user agents that support newer web features
 		without impacting network performance on older user agents.
 		In this example, a CSS file which loads COLRv1 fonts
 		is only fetched when COLRv1 is supported:

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: CSS Cascading and Inheritance Level 5
+Title: CSS Cascading and Inheritance Module Level 5
 Shortname: css-cascade
 Level: 5
 Status: ED

--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -1,5 +1,5 @@
 <pre class='metadata'>
-Title: CSS Cascading and Inheritance Level 6
+Title: CSS Cascading and Inheritance Module Level 6
 Shortname: css-cascade
 Level: 6
 Status: ED


### PR DESCRIPTION
I believe, the titles of the different specs should be consistent regarding their naming. And https://github.com/w3c/csswg-drafts/pull/12865 gave me the incentive to start with the CSS Cascade specs.

CSS Cascade 3 is already a recommendation, so I thought I won't touch that one, even when it's also missing the word "Module" in its title.

Also, I'm not sure whether changing the title of a spec is actually only editorial. Please let me know whether that requires a formal resolution!

Sebastian