### PR TITLE
README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ Specification issues are discussed as issues in this repository.
 Minutes of CSSWG discussion can be found on the public
 [www-style mailing list](https://lists.w3.org/Archives/Public/www-style/).
 
-To read the specifications in this repository, see them at the
+To read the specifications in this repository, see them at the 
 [index of all specifications](https://drafts.csswg.org/).
 
 


### PR DESCRIPTION
[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
