### PR TITLE
[css-overflow-4] Refactor the text about block-ellipsis insertion

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -835,23 +835,32 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 		that would still allow the entire <a>block overflow ellipsis</a> to fit on the line,
 		applying [[css-text-4#white-space-rules]] including [[css-text-4#white-space-phase-2]]
 		before insertion.
-		For this purpose, <a>soft wrap opportunities</a> added by 'overflow-wrap' are ignored,
-		as are those inhibited by ''text-wrap-mode: nowrap''.
-		If this results in the entire contents of the line box being displaced,
-		the line box is considered to contain a [=strut=], as defined in [[CSS2/visudet#leading]].
 
 		<wpt>
 			block-ellipsis-001.html
+			block-ellipsis-028.html
+			webkit-line-clamp-025.html
+		</wpt>
+
+		For this purpose, <a>soft wrap opportunities</a> added by 'overflow-wrap' are ignored,
+		as are those inhibited by ''text-wrap-mode: nowrap''.
+
+		<wpt>
 			block-ellipsis-013.html
 			block-ellipsis-014.html
 			block-ellipsis-015.tentative.html
 			block-ellipsis-016.html
 			block-ellipsis-017.html
+			block-ellipsis-027.html
+		</wpt>
+
+		If this results in the entire contents of the line box being displaced,
+		the line box is considered to contain a [=strut=], as defined in [[CSS2/visudet#leading]].
+
+		<wpt>
+			block-ellipsis-016.html
 			block-ellipsis-018.html
 			block-ellipsis-025.html
-			block-ellipsis-027.html
-			block-ellipsis-028.html
-			webkit-line-clamp-025.html
 		</wpt>
 
 	* The anonymous inline of [=block overflow ellipsis=] is placed


### PR DESCRIPTION
The text had accreted various rules and constraints, but no longer had clear structure.

This attempt to reorganize the whole thing in a more understandable manner.

No new behavior is (intended to be) introduced by this reformulated text, though some previously implicit consequences are made explicit, for clarity.

The PR is split into two commits, for better readability: [one](802f5cb185632c9006318406a97263eb19d9de03) reorganizing the text, and [one](f3cdfcb354f9e31624f8d7a5238c8c7d3b843787) re-attributing the relevant test annotations to the relevant part (but making no change to the text).

cc: @andreubotella @fantasai 