### PR TITLE
[css-values-4] Export "style resource base URL" definition.

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -1147,7 +1147,7 @@ URL Modifiers</h4>
 URL Processing Model</h4>
 
 	<div algorithm="style resource base URL">
-		To compute the <dfn>style resource base URL</dfn> for a [=CSS rule=] or a [=CSS declaration block=] |cssRuleOrDeclaration|:
+		To compute the <dfn export>style resource base URL</dfn> for a [=CSS rule=] or a [=CSS declaration block=] |cssRuleOrDeclaration|:
 			1. Let |sheet| be null.
 
 			1. If |cssRuleOrDeclaration| is a [=CSS declaration block=] whose [=parent CSS rule=] is not null,


### PR DESCRIPTION
This exports the "style resource base URL" definition so that it can be used in the definition of a urlpattern() function.