### PR TITLE
[css-images-4][css-shapes-2][editorial] Fetching an image/shape requires a declaration block

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -147,7 +147,7 @@ Fetching External Images {#fetching-images}
 -------------------------------------------
 
 	To <dfn export>fetch an external image for a stylesheet</dfn>,
-	given a <<url>> |url| and a [=CSS style declaration=] |declaration|,
+	given a <<url>> |url| and a [=CSS declaration block=] |declaration|,
 	[=fetch a style resource=] given |url|,
 	with ruleOrDeclaration being |declaration|,
 	destination "image",

--- a/css-shapes-2/Overview.bs
+++ b/css-shapes-2/Overview.bs
@@ -189,7 +189,7 @@ Shapes from Image</h3>
 Fetching external shapes</h2>
 
 	To <dfn>fetch an external resource for a shape</dfn>, either an SVG or an image, given a
-		[=CSS style declaration=] |declaration|,
+		[=CSS declaration block=] |declaration|,
 		[=fetch a style resource=] given a <<url>> value,
 		with ruleOrDeclaration being |declaration|,
 		destination "image",


### PR DESCRIPTION
This is an obvious bugfix, I think.

The `declaration` passed from the updated algorithms ultimately arrives in [resolve](https://drafts.csswg.org/css-values-4/#resolve-a-style-resource-url) and [compute a style resource URL](https://drafts.csswg.org/css-values-4/#style-resource-base-url), which are specified as receiving a CSS rule or declaration **block**, to access some internal properties (base URL, or location) of the associated `CSSStyleSheet`.

A [declaration](https://drafts.csswg.org/cssom-1/#css-declarations) is not specified with any property that allows access to the needed internal properties of the associated style sheet.

A CSS declaration block has access to a parent rule, which has access to a parent style sheet.