### PR TITLE
[css-color-adjust-1] Expand on how forced colors mode handles emojis

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -890,7 +890,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	* 'accent-color' computes to ''accent-color/auto''
 	* If 'font-variant-emoji' computes to ''font-variant-emoji/normal'' or ''font-variant-emoji/unicode'',
 		UAs should force any emoji on the page to its monochrome variant, if available,
-		by forcing the [=used value=] of 'font-variant-emoji' to ''font-variant-emoji/text''.
+		by forcing the [=computed value=] of 'font-variant-emoji' to ''font-variant-emoji/text''.
 
 	UAs may further tweak these <a>forced colors mode</a> heuristics
 	to provide better user experience.

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -889,7 +889,8 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	* 'scrollbar-color' computes to ''scrollbar-color/auto''
 	* 'accent-color' computes to ''accent-color/auto''
 	* If 'font-variant-emoji' computes to ''font-variant-emoji/normal'' or ''font-variant-emoji/unicode'',
-		UAs should force any emoji on the page to its monochrome variant, if available.
+		UAs should force any emoji on the page to its monochrome variant, if available,
+		by forcing 'font-variant-emoji' to ''font-variant-emoji/text''.
 
 	UAs may further tweak these <a>forced colors mode</a> heuristics
 	to provide better user experience.

--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -890,7 +890,7 @@ Properties Affected by Forced Colors Mode {#forced-colors-properties}
 	* 'accent-color' computes to ''accent-color/auto''
 	* If 'font-variant-emoji' computes to ''font-variant-emoji/normal'' or ''font-variant-emoji/unicode'',
 		UAs should force any emoji on the page to its monochrome variant, if available,
-		by forcing 'font-variant-emoji' to ''font-variant-emoji/text''.
+		by forcing the [=used value=] of 'font-variant-emoji' to ''font-variant-emoji/text''.
 
 	UAs may further tweak these <a>forced colors mode</a> heuristics
 	to provide better user experience.


### PR DESCRIPTION
The team in Chromium making the updates to forced colors mode emoji handling noted that it would be helpful to specify that `font-variant-emoji` gets overridden to `text` to ensure that the monochrome variant is chosen if available. This change adds more text to specify the exact details.

I wasn't sure if a new resolution was needed for this given the resolution in https://github.com/w3c/csswg-drafts/issues/8064#issuecomment-2163389692 but more than happy to file a new issue as needed.
