### PR TITLE
[css-conditional-5] Properly attach values to `@container/scrolled`

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1604,7 +1604,7 @@ Scrolled: the '@container/scrolled' feature</h4>
 	The logical values map to physical based on the direction and writing-mode of the [=query container=].
 	None of the values match if the container is not a [=scroll container=].
 
-	<dl dfn-type=value dfn-for="@container/direction">
+	<dl dfn-type=value dfn-for="@container/scrolled">
 		<dt><dfn>none</dfn>
 		<dd>
 			The [=query container=] has not had a [=relative scroll=] yet.


### PR DESCRIPTION
The `direction` feature was renamed to `scrolled` in #12881, but feature values were still referencing `direction`.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
