### PR TITLE
[cssom-view-1] Fix indentation of "run the scroll" steps

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2354,28 +2354,28 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>target</var> is a {{Document}}, and <var>type</var> is <code>"scroll"</code> or <code>"scrollend"</code>,
         <a>fire an event</a> named <var>type</var> that bubbles at <var>target</var>.
     1. Otherwise, if <var>type</var> is <code>"scrollsnapchange"</code>, then:
-      1. Let |blockTarget| and |inlineTarget| be null initially.
-      1. If the <a>scrollsnapchangeTargetBlock</a> associated with <var>target</var> is a pseudo-element,
-        set |blockTarget| to the owning element of that <a>scrollsnapchangeTargetBlock</a>.
-      1. Otherwise, set |blockTarget| to that <a>scrollsnapchangeTargetBlock</a>.
-      1. If the <a>scrollsnapchangeTargetInline</a> associated with <var>target</var> is a pseudo-element,
-        set |inlineTarget| to the owning element of that <a>scrollsnapchangeTargetInline</a>.
-      1. Otherwise, Set |inlineTarget| to that <a>scrollsnapchangeTargetInline</a>.
-      1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
-        and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget| respectively.
-    1. Otherwise, if <var>type</var> is <code>"scrollsnapchanging"</code>, then:
-      1. Let |blockTarget| and |inlineTarget| be null initially.
-      1. If the <a>scrollsnapchanging block-axis target</a> associated with <var>target</var> is a pseudo-element,
-        set |blockTarget| to the owning element of that <a>scrollsnapchanging block-axis target</a>.
-      1. Otherwise, set |blockTarget| to that <a>scrollsnapchanging block-axis target</a>.
-      1. If the <a>scrollsnapchanging inline-axis target</a> associated with <var>target</var> is a pseudo-element,
-        set |inlineTarget| to the owning element of that <a>scrollsnapchanging inline-axis target</a>.
-      1. Otherwise, set |inlineTarget| to that <a>scrollsnapchanging inline-axis target</a>.
-      1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
-        and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
-    1. Otherwise, <a>fire an event</a> named <var>type</var> at <var>target</var>.
+        1. Let |blockTarget| and |inlineTarget| be null initially.
+        1. If the <a>scrollsnapchangeTargetBlock</a> associated with <var>target</var> is a pseudo-element,
+            set |blockTarget| to the owning element of that <a>scrollsnapchangeTargetBlock</a>.
+        1. Otherwise, set |blockTarget| to that <a>scrollsnapchangeTargetBlock</a>.
+        1. If the <a>scrollsnapchangeTargetInline</a> associated with <var>target</var> is a pseudo-element,
+            set |inlineTarget| to the owning element of that <a>scrollsnapchangeTargetInline</a>.
+        1. Otherwise, Set |inlineTarget| to that <a>scrollsnapchangeTargetInline</a>.
+        1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
+            and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+            {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget| respectively.
+      1. Otherwise, if <var>type</var> is <code>"scrollsnapchanging"</code>, then:
+          1. Let |blockTarget| and |inlineTarget| be null initially.
+          1. If the <a>scrollsnapchanging block-axis target</a> associated with <var>target</var> is a pseudo-element,
+            set |blockTarget| to the owning element of that <a>scrollsnapchanging block-axis target</a>.
+          1. Otherwise, set |blockTarget| to that <a>scrollsnapchanging block-axis target</a>.
+          1. If the <a>scrollsnapchanging inline-axis target</a> associated with <var>target</var> is a pseudo-element,
+            set |inlineTarget| to the owning element of that <a>scrollsnapchanging inline-axis target</a>.
+          1. Otherwise, set |inlineTarget| to that <a>scrollsnapchanging inline-axis target</a>.
+          1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
+            and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+            {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
+      1. Otherwise, <a>fire an event</a> named <var>type</var> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll events</a>.
 
 Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent must run these steps:


### PR DESCRIPTION
The markdown assumed that a 2-space indent was enough to create substeps, but four spaces are needed and the structure of the algorithm was wrong in the generated document as a result.
