### PR TITLE
[selectors-4] Fix typo: "if first" → "is first"

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -3256,7 +3256,7 @@ Child-indexed Pseudo-classes</h3>
 '':first-child'' pseudo-class</h4>
 
 	The <dfn id='first-child-pseudo'>:first-child</dfn> pseudo-class
-	represents an element that if first among its <a>inclusive siblings</a>.
+	represents an element that is first among its <a>inclusive siblings</a>.
 	Same as '':nth-child(1)''.
 
 	<div class="example">


### PR DESCRIPTION
This is just a simple fix of a typographical error. Per the [Contributor Guidelines](https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md) (“Non-substantive contributions”), I’m submitting this as a pull request.