### PR TITLE
[css-anchor-position-1] Loose matching for target anchor name

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -421,7 +421,7 @@ in anchor positioning.
 
 		* |el| is an [=anchor element=] with an [=anchor name=] of |anchor spec|.
 
-		* |el|'s [=anchor name=] and |anchor spec| are both associated with the same [=tree=] [=tree/root=].
+		* |el|'s [=anchor name=] [=tree-scoped name/loosely matched|loosely matches=] |anchor spec|.
 
 			Note: The [=anchor name=] is a [=tree-scoped name=],
 			while |anchor spec| is a [=tree-scoped reference=].


### PR DESCRIPTION
97eef7bb375a5f603f487f8649a36428c21dbcf0 intended to allow cross-shadow anchoring, but didn't adjust the same-tree-root requirement in "determine target anchor element".

#9408