### PR TITLE
[css-view-transitions-2] Resolve finished promise at own task when animations are done

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -1788,6 +1788,7 @@ Issue: Is this updated by a <code>rootEl.startViewTransition()</code> call, too?
 			1. "`pending-capture`".
 			1. "`update-callback-called`".
 			1. "`animating`".
+			1. "`pending-done`".
 			1. "`done`".
 
 			Note: For the most part, a developer using this API does not need to worry about the different phases, since they progress automatically.


### PR DESCRIPTION
Closes #12442
