### PR TITLE
[css-conditional-5] Made last @supports-condition win #12973

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -1778,7 +1778,8 @@ improving maintainability and readability.
 
 	Once defined, the named supports condition can be used in subsequent ''@supports'' or ''@when'' conditions.
 
-	Multiple ''@supports-condition'' rules with the same name in a style sheet are invalid and must be ignored.
+	If multiple ''@supports-condition'' rules are defined with the same name,
+	the last one in document order wins, and all preceding ones are ignored.
 
 	<div class="example">
 		For example, we can define a supports query checking multiple properties at once:


### PR DESCRIPTION
@cdoublev [pointed out](https://github.com/w3c/csswg-drafts/issues/12973) that naming at-rules are generally defined so that the last one wins when several definitions share the same name.

Therefore, it seems fine to align with that rule instead of ignoring them.

This change closes #12973.

Sebastian