### PR TITLE
[css-animation-1] Handle <string> values in keyframes-name as identitiers

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -229,6 +229,10 @@ Declaring Keyframes</h2>
 	the names are fully <a>case-sensitive</a>;
 	two names are equal only if they are codepoint-by-codepoint equal.
 	The <<custom-ident>> additionally excludes the ''animation-name/none'' keyword.
+	The <<string>> should be treated as <<custom-ident>>, hence parsed as invalid if
+	is one of the <a>CSS-wide keywords</a> or "default"; empty string is not allowed
+	either. It's serialized as identifier when possible and as <<string>> otherwise.
+
 
 	<div class=example>
 		For example, the following two ''@keyframes'' rules have the same name,
@@ -254,8 +258,8 @@ Declaring Keyframes</h2>
 		@keyframes None { /* ... */ }
 		</pre>
 
-		However, those names <em>can</em> be specified with a <<string>>,
-		so the following are both <em>valid</em>:
+		They are also <em>invalid</em> if those names are specified with a <<string>>
+		because they can not be serialized as valid <<custom-ident>>:
 
 		<pre class=lang-css>
 		@keyframes "initial" { /* ... */ }


### PR DESCRIPTION
Per resolution:

https://github.com/w3c/csswg-drafts/issues/2435#issuecomment-428646888 

> 1. Accept `<string>` or `<custom-ident>` as we currently do.
> 2. If `<string>` is one of the CSS-wide keywords or "default" then it is invalid (at parse / variable-resolution time) as per the rules for custom-idents: https://www.w3.org/TR/css-values-3/#custom-idents
> 3. When serializing, if the value doesn't have [whitespace](https://www.w3.org/TR/css-syntax-3/#whitespace)(??) serialize without quotes (i.e. as <custom-ident>), otherwise serialize as `<string>`.

Fixes issues #2435 and #7762