### PR TITLE
[selectors-4][editorial] Added WPTs

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -29,6 +29,8 @@ At Risk: the '':blank'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
 Ignored Vars: identifier, i
 Ignore MDN Failure: #the-target-within-pseudo
+WPT Path Prefix: css/selectors/
+WPT Display: closed
 </pre>
 <pre class=link-defaults>
 spec:css-values-4; type:dfn; text:identifier
@@ -57,6 +59,8 @@ spec:html; type:element;
 Introduction</h2>
 
 	<em>This section is not normative.</em>
+
+	<wpt title="This section is not normative, it does not need tests."></wpt>
 
 	A <a>selector</a> is a boolean predicate
 	that takes an element in a tree structure
@@ -88,6 +92,8 @@ Introduction</h2>
 
 <h3 id="placement">Module Interactions</h3>
 
+	<wpt title="Tests not needed for this section."></wpt>
+
 	This module replaces the definitions of
 	and extends the set of selectors defined for CSS in [[SELECT]] and [[CSS21]].
 
@@ -103,6 +109,8 @@ Selectors Overview</h2>
 
 	<em>This section is non-normative, as it merely summarizes the
 	following sections.</em>
+
+	<wpt title="This section is not normative, it does not need tests."></wpt>
 
 	A selector represents a structure. This structure can be used as a
 	condition (e.g. in a CSS rule) that determines which elements a
@@ -490,6 +498,306 @@ Selectors Overview</h2>
 
 	Note: Some Level 4 selectors (noted above as "3-UI") were introduced in [[CSS3UI]].
 
+	<wpt>
+		old-tests/css3-modsel-1.xml
+		old-tests/css3-modsel-10.xml
+		old-tests/css3-modsel-100.xml
+		old-tests/css3-modsel-100b.xml
+		old-tests/css3-modsel-101.xml
+		old-tests/css3-modsel-101b.xml
+		old-tests/css3-modsel-102.xml
+		old-tests/css3-modsel-102b.xml
+		old-tests/css3-modsel-103.xml
+		old-tests/css3-modsel-103b.xml
+		old-tests/css3-modsel-104.xml
+		old-tests/css3-modsel-104b.xml
+		old-tests/css3-modsel-105.xml
+		old-tests/css3-modsel-105b.xml
+		old-tests/css3-modsel-106.xml
+		old-tests/css3-modsel-106b.xml
+		old-tests/css3-modsel-107.xml
+		old-tests/css3-modsel-107b.xml
+		old-tests/css3-modsel-108.xml
+		old-tests/css3-modsel-108b.xml
+		old-tests/css3-modsel-109.xml
+		old-tests/css3-modsel-109b.xml
+		old-tests/css3-modsel-11.xml
+		old-tests/css3-modsel-110.xml
+		old-tests/css3-modsel-110b.xml
+		old-tests/css3-modsel-111.xml
+		old-tests/css3-modsel-111b.xml
+		old-tests/css3-modsel-112.xml
+		old-tests/css3-modsel-112b.xml
+		old-tests/css3-modsel-113.xml
+		old-tests/css3-modsel-113b.xml
+		old-tests/css3-modsel-114.xml
+		old-tests/css3-modsel-114b.xml
+		old-tests/css3-modsel-115.xml
+		old-tests/css3-modsel-115b.xml
+		old-tests/css3-modsel-116.xml
+		old-tests/css3-modsel-116b.xml
+		old-tests/css3-modsel-117.xml
+		old-tests/css3-modsel-117b.xml
+		old-tests/css3-modsel-118.xml
+		old-tests/css3-modsel-119.xml
+		old-tests/css3-modsel-120.xml
+		old-tests/css3-modsel-121.xml
+		old-tests/css3-modsel-122.xml
+		old-tests/css3-modsel-123.xml
+		old-tests/css3-modsel-123b.xml
+		old-tests/css3-modsel-124.xml
+		old-tests/css3-modsel-124b.xml
+		old-tests/css3-modsel-125.xml
+		old-tests/css3-modsel-125b.xml
+		old-tests/css3-modsel-126.xml
+		old-tests/css3-modsel-126b.xml
+		old-tests/css3-modsel-127.xml
+		old-tests/css3-modsel-127b.xml
+		old-tests/css3-modsel-128.xml
+		old-tests/css3-modsel-128b.xml
+		old-tests/css3-modsel-129.xml
+		old-tests/css3-modsel-129b.xml
+		old-tests/css3-modsel-13.xml
+		old-tests/css3-modsel-130.xml
+		old-tests/css3-modsel-130b.xml
+		old-tests/css3-modsel-131.xml
+		old-tests/css3-modsel-131b.xml
+		old-tests/css3-modsel-132.xml
+		old-tests/css3-modsel-132b.xml
+		old-tests/css3-modsel-133.xml
+		old-tests/css3-modsel-133b.xml
+		old-tests/css3-modsel-134.xml
+		old-tests/css3-modsel-134b.xml
+		old-tests/css3-modsel-135.xml
+		old-tests/css3-modsel-135b.xml
+		old-tests/css3-modsel-136.xml
+		old-tests/css3-modsel-136b.xml
+		old-tests/css3-modsel-137.xml
+		old-tests/css3-modsel-137b.xml
+		old-tests/css3-modsel-138.xml
+		old-tests/css3-modsel-138b.xml
+		old-tests/css3-modsel-139.xml
+		old-tests/css3-modsel-139b.xml
+		old-tests/css3-modsel-14.xml
+		old-tests/css3-modsel-140.xml
+		old-tests/css3-modsel-140b.xml
+		old-tests/css3-modsel-141.xml
+		old-tests/css3-modsel-141b.xml
+		old-tests/css3-modsel-142.xml
+		old-tests/css3-modsel-142b.xml
+		old-tests/css3-modsel-143.xml
+		old-tests/css3-modsel-143b.xml
+		old-tests/css3-modsel-144.xml
+		old-tests/css3-modsel-145a.xml
+		old-tests/css3-modsel-145b.xml
+		old-tests/css3-modsel-146a.xml
+		old-tests/css3-modsel-146b.xml
+		old-tests/css3-modsel-147a.xml
+		old-tests/css3-modsel-147b.xml
+		old-tests/css3-modsel-148.xml
+		old-tests/css3-modsel-149.xml
+		old-tests/css3-modsel-149b.xml
+		old-tests/css3-modsel-14b.xml
+		old-tests/css3-modsel-14c.xml
+		old-tests/css3-modsel-14d.xml
+		old-tests/css3-modsel-14e.xml
+		old-tests/css3-modsel-15.xml
+		old-tests/css3-modsel-150.xml
+		old-tests/css3-modsel-151.xml
+		old-tests/css3-modsel-152.xml
+		old-tests/css3-modsel-153.xml
+		old-tests/css3-modsel-154.xml
+		old-tests/css3-modsel-155.xml
+		old-tests/css3-modsel-155a.xml
+		old-tests/css3-modsel-155b.xml
+		old-tests/css3-modsel-155c.xml
+		old-tests/css3-modsel-155d.xml
+		old-tests/css3-modsel-156.xml
+		old-tests/css3-modsel-156b.xml
+		old-tests/css3-modsel-156c.xml
+		old-tests/css3-modsel-157.xml
+		old-tests/css3-modsel-158.xml
+		old-tests/css3-modsel-159.xml
+		old-tests/css3-modsel-15b.xml
+		old-tests/css3-modsel-16.xml
+		old-tests/css3-modsel-160.xml
+		old-tests/css3-modsel-161.xml
+		old-tests/css3-modsel-166.xml
+		old-tests/css3-modsel-166a.xml
+		old-tests/css3-modsel-167.xml
+		old-tests/css3-modsel-167a.xml
+		old-tests/css3-modsel-168.xml
+		old-tests/css3-modsel-168a.xml
+		old-tests/css3-modsel-169.xml
+		old-tests/css3-modsel-169a.xml
+		old-tests/css3-modsel-17.xml
+		old-tests/css3-modsel-170.xml
+		old-tests/css3-modsel-170a.xml
+		old-tests/css3-modsel-170b.xml
+		old-tests/css3-modsel-170c.xml
+		old-tests/css3-modsel-170d.xml
+		old-tests/css3-modsel-171.xml
+		old-tests/css3-modsel-172a.xml
+		old-tests/css3-modsel-172b.xml
+		old-tests/css3-modsel-173a.xml
+		old-tests/css3-modsel-173b.xml
+		old-tests/css3-modsel-174a.xml
+		old-tests/css3-modsel-174b.xml
+		old-tests/css3-modsel-175a.xml
+		old-tests/css3-modsel-175b.xml
+		old-tests/css3-modsel-175c.xml
+		old-tests/css3-modsel-176.xml
+		old-tests/css3-modsel-177a.xml
+		old-tests/css3-modsel-177b.xml
+		old-tests/css3-modsel-178.xml
+		old-tests/css3-modsel-179.xml
+		old-tests/css3-modsel-179a.xml
+		old-tests/css3-modsel-18.xml
+		old-tests/css3-modsel-180a.xml
+		old-tests/css3-modsel-181.xml
+		old-tests/css3-modsel-182.xml
+		old-tests/css3-modsel-183.xml
+		old-tests/css3-modsel-184a.xml
+		old-tests/css3-modsel-184b.xml
+		old-tests/css3-modsel-184c.xml
+		old-tests/css3-modsel-184d.xml
+		old-tests/css3-modsel-184e.xml
+		old-tests/css3-modsel-184f.xml
+		old-tests/css3-modsel-18a.xml
+		old-tests/css3-modsel-18b.xml
+		old-tests/css3-modsel-18c.xml
+		old-tests/css3-modsel-19.xml
+		old-tests/css3-modsel-19b.xml
+		old-tests/css3-modsel-2.xml
+		old-tests/css3-modsel-20.xml
+		old-tests/css3-modsel-21.xml
+		old-tests/css3-modsel-21b.xml
+		old-tests/css3-modsel-21c.xml
+		old-tests/css3-modsel-22.xml
+		old-tests/css3-modsel-25.xml
+		old-tests/css3-modsel-27.xml
+		old-tests/css3-modsel-27a.xml
+		old-tests/css3-modsel-27b.xml
+		old-tests/css3-modsel-28.xml
+		old-tests/css3-modsel-28b.xml
+		old-tests/css3-modsel-29.xml
+		old-tests/css3-modsel-29b.xml
+		old-tests/css3-modsel-3.xml
+		old-tests/css3-modsel-30.xml
+		old-tests/css3-modsel-31.xml
+		old-tests/css3-modsel-32.xml
+		old-tests/css3-modsel-33.xml
+		old-tests/css3-modsel-34.xml
+		old-tests/css3-modsel-35.xml
+		old-tests/css3-modsel-36.xml
+		old-tests/css3-modsel-37.xml
+		old-tests/css3-modsel-38.xml
+		old-tests/css3-modsel-39.xml
+		old-tests/css3-modsel-39a.xml
+		old-tests/css3-modsel-39b.xml
+		old-tests/css3-modsel-39c.xml
+		old-tests/css3-modsel-3a.xml
+		old-tests/css3-modsel-4.xml
+		old-tests/css3-modsel-41.xml
+		old-tests/css3-modsel-41a.xml
+		old-tests/css3-modsel-42.xml
+		old-tests/css3-modsel-42a.xml
+		old-tests/css3-modsel-43.xml
+		old-tests/css3-modsel-43b.xml
+		old-tests/css3-modsel-44.xml
+		old-tests/css3-modsel-44b.xml
+		old-tests/css3-modsel-44c.xml
+		old-tests/css3-modsel-44d.xml
+		old-tests/css3-modsel-45.xml
+		old-tests/css3-modsel-45b.xml
+		old-tests/css3-modsel-45c.xml
+		old-tests/css3-modsel-46.xml
+		old-tests/css3-modsel-46b.xml
+		old-tests/css3-modsel-47.xml
+		old-tests/css3-modsel-48.xml
+		old-tests/css3-modsel-49.xml
+		old-tests/css3-modsel-5.xml
+		old-tests/css3-modsel-50.xml
+		old-tests/css3-modsel-51.xml
+		old-tests/css3-modsel-52.xml
+		old-tests/css3-modsel-53.xml
+		old-tests/css3-modsel-54.xml
+		old-tests/css3-modsel-55.xml
+		old-tests/css3-modsel-56.xml
+		old-tests/css3-modsel-57.xml
+		old-tests/css3-modsel-57b.xml
+		old-tests/css3-modsel-59.xml
+		old-tests/css3-modsel-6.xml
+		old-tests/css3-modsel-60.xml
+		old-tests/css3-modsel-61.xml
+		old-tests/css3-modsel-62.xml
+		old-tests/css3-modsel-63.xml
+		old-tests/css3-modsel-64.xml
+		old-tests/css3-modsel-65.xml
+		old-tests/css3-modsel-66.xml
+		old-tests/css3-modsel-66b.xml
+		old-tests/css3-modsel-67.xml
+		old-tests/css3-modsel-7.xml
+		old-tests/css3-modsel-70.xml
+		old-tests/css3-modsel-72.xml
+		old-tests/css3-modsel-72b.xml
+		old-tests/css3-modsel-73.xml
+		old-tests/css3-modsel-73b.xml
+		old-tests/css3-modsel-74.xml
+		old-tests/css3-modsel-74b.xml
+		old-tests/css3-modsel-75.xml
+		old-tests/css3-modsel-75b.xml
+		old-tests/css3-modsel-76.xml
+		old-tests/css3-modsel-76b.xml
+		old-tests/css3-modsel-77.xml
+		old-tests/css3-modsel-77b.xml
+		old-tests/css3-modsel-78.xml
+		old-tests/css3-modsel-78b.xml
+		old-tests/css3-modsel-79.xml
+		old-tests/css3-modsel-7b.xml
+		old-tests/css3-modsel-8.xml
+		old-tests/css3-modsel-80.xml
+		old-tests/css3-modsel-81.xml
+		old-tests/css3-modsel-81b.xml
+		old-tests/css3-modsel-82.xml
+		old-tests/css3-modsel-82b.xml
+		old-tests/css3-modsel-83.xml
+		old-tests/css3-modsel-86.xml
+		old-tests/css3-modsel-87.xml
+		old-tests/css3-modsel-87b.xml
+		old-tests/css3-modsel-88.xml
+		old-tests/css3-modsel-88b.xml
+		old-tests/css3-modsel-89.xml
+		old-tests/css3-modsel-9.xml
+		old-tests/css3-modsel-90.xml
+		old-tests/css3-modsel-90b.xml
+		old-tests/css3-modsel-91.xml
+		old-tests/css3-modsel-92.xml
+		old-tests/css3-modsel-93.xml
+		old-tests/css3-modsel-94.xml
+		old-tests/css3-modsel-94b.xml
+		old-tests/css3-modsel-95.xml
+		old-tests/css3-modsel-96.xml
+		old-tests/css3-modsel-96b.xml
+		old-tests/css3-modsel-97.xml
+		old-tests/css3-modsel-97b.xml
+		old-tests/css3-modsel-98.xml
+		old-tests/css3-modsel-98b.xml
+		old-tests/css3-modsel-99.xml
+		old-tests/css3-modsel-99b.xml
+		old-tests/css3-modsel-d1.xml
+		old-tests/css3-modsel-d1b.xml
+		old-tests/css3-modsel-d2.xml
+		old-tests/css3-modsel-d3.xml
+		old-tests/css3-modsel-d4.xml
+	</wpt>
+
+	<wpt title="Tests that do not relate to any section">
+		eof-right-after-selector-crash.html
+		eof-some-after-selector-crash.html
+		hash-collision.html
+		parsing/invalid-pseudos.html
+	</wpt>
 
 <h2 id="syntax">
 Selector Syntax and Structure</h2>
@@ -664,6 +972,14 @@ Data Model</h3>
 <h4 id=featureless-elements>
 Featureless Elements</h4>
 
+	<wpt>
+		featureless-001.html
+		featureless-002.html
+		featureless-003.html
+		featureless-004.html
+		featureless-005.html
+	</wpt>
+
 	While individual elements may lack any of the above features,
 	some elements are <dfn export>featureless</dfn>.
 	A <a>featureless</a> element does not match <em>any selector at all</em>,
@@ -770,7 +1086,6 @@ Relative Selectors</h3>
 	and lists of them by <<relative-selector-list>>.
 
 
-
 <h3 id="pseudo-classes">
 Pseudo-classes</h3>
 
@@ -813,7 +1128,12 @@ Pseudo-classes</h3>
 	(such that a <a>compound selector</a> containing them, while valid, will never match anything),
 	while others can apply simultaneously to the same element.
 
+
 <h3 id="pseudo-elements">Pseudo-elements</h3>
+
+	<wpt>
+		x-pseudo-element.html
+	</wpt>
 
 	Similar to how certain <a>pseudo-classes</a> represent additional state information
 	not directly present in the document tree,
@@ -1007,6 +1327,12 @@ Internal Structure</h4>
 <h3 id="case-sensitive">
 Characters and case sensitivity</h3>
 
+	<wpt>
+		case-insensitive-parent.html
+		invalidation/quirks-mode-stylesheet-dynamic-add-001.html
+		selectors-case-sensitive-001.html
+	</wpt>
+
 	All Selectors syntax is [=ASCII case-insensitive=]
 	(i.e. [a-z]  and \[A-Z] are equivalent),
 	except for the parts
@@ -1054,6 +1380,12 @@ Declaring Namespace Prefixes</h3>
 <h3 id="invalid">
 Invalid Selectors and Error Handling</h3>
 
+	<wpt>
+		invalidation/selectorText-dynamic-001.html
+		invalidation/sheet-going-away-001.html
+		invalidation/sheet-going-away-002.html
+	</wpt>
+
 	User agents must observe the rules for handling
 	<dfn export lt="invalid selector" local-lt="invalid">invalid selectors</dfn>:
 
@@ -1077,6 +1409,7 @@ Invalid Selectors and Error Handling</h3>
 
 	An <a>invalid selector</a> represents, and therefore matches, nothing.
 
+
 <h3 id="legacy-aliasing">
 	Legacy Aliases</h3>
 
@@ -1084,8 +1417,14 @@ Invalid Selectors and Error Handling</h3>
 	This is a name which, at parse time, is converted to the standard name
 	(and thus does not appear anywhere in any object model representing the selector).
 
+
 <h2 id="logical-combination">
 Logical Combinations</h2>
+
+	<wpt>
+		invalidation/is-where-pseudo-containing-hard-pseudo-and-never-matching.html
+		invalidation/is-where-pseudo-containing-hard-pseudo.html
+	</wpt>
 
 	Selector logic can be manipulated by
 	[=compound selector|compounding=] (logical AND),
@@ -1102,6 +1441,7 @@ Logical Combinations</h2>
 	invalid arguments are dropped without invaliding the [=pseudo-class=] itself,
 	selector arguments that are invalidated by contextual restrictions
 	likewise do not invalidate the '':is()'' pseudo-class itself.
+
 
 <h3 id="grouping">
 Selector Lists</h3>
@@ -1153,8 +1493,31 @@ Selector Lists</h3>
 		is dropped.)
 	</div>
 
+
 <h3 id="matches">
 The Matches-Any Pseudo-class: '':is()''</h3>
+
+	<wpt>
+		invalidation/is.html
+		is-default-ns-001.html
+		is-default-ns-002.html
+		is-default-ns-003.html
+		is-default-ns-002.html
+		is-default-ns-003.html
+		is-nested.html
+		is-specificity-shadow.html
+		is-specificity.html
+		is-where-basic.html
+		is-where-error-recovery.html
+		is-where-not.html
+		is-where-pseudo-classes.html
+		is-where-pseudo-elements.html
+		is-where-shadow.html
+		is-where-visited.html
+		parsing/parse-is-where.html
+		parsing/parse-is.html
+		query/query-is.html
+	</wpt>
 
 	The matches-any pseudo-class, <dfn id='matches-pseudo'>:is()</dfn>,
 	is a functional pseudo-class taking a <<forgiving-selector-list>> as its sole argument.
@@ -1207,8 +1570,22 @@ The Matches-Any Pseudo-class: '':is()''</h3>
 	as a [=legacy selector alias=] for '':is()''
 	if needed for backwards-compatibility.
 
+
 <h3 id="negation">
 The Negation (Matches-None) Pseudo-class: '':not()''</h3>
+
+	<wpt>
+		invalidation/not-001.html
+		invalidation/not-002.html
+		not-complex.html
+		not-default-ns-001.html
+		not-default-ns-002.html
+		not-default-ns-003.html
+		not-links.html
+		not-specificity.html
+		parsing/parse-not.html
+		query/query-where.html
+	</wpt>
 
 	The negation pseudo-class, <dfn id='negation-pseudo'>:not()</dfn>,
 	is a functional pseudo-class taking a <<complex-real-selector-list>> as an argument.
@@ -1257,6 +1634,12 @@ The Negation (Matches-None) Pseudo-class: '':not()''</h3>
 <h3 id="zero-matches">
 The Specificity-adjustment Pseudo-class: '':where()''</h3>
 
+	<wpt>
+		invalidation/where.html
+		parsing/parse-where.html
+		pseudo-where-crash.html
+	</wpt>
+
 	The Specificity-adjustment pseudo-class, <dfn id="where-pseudo">:where()</dfn>,
 	is a functional pseudo-class
 	with the same syntax and functionality as '':is()''.
@@ -1302,6 +1685,94 @@ The Specificity-adjustment Pseudo-class: '':where()''</h3>
 
 <h3 id='relational'>
 The Relational Pseudo-class: '':has()''</h3>
+
+	<wpt>
+		has-argument-with-explicit-scope.html
+		has-basic.html
+		has-display-none-checked.html
+		has-focus-display-change.html
+		has-matches-to-uninserted-elements.html
+		has-nth-of-crash.html
+		has-relative-argument.html
+		has-sibling-chrome-crash.html
+		has-specificity.html
+		has-style-sharing-001.html
+		has-style-sharing-002.html
+		has-style-sharing-003.html
+		has-style-sharing-004.html
+		has-style-sharing-005.html
+		has-style-sharing-006.html
+		has-style-sharing-007.html
+		has-style-sharing-pseudo-001.html
+		has-style-sharing-pseudo-002.html
+		has-style-sharing-pseudo-003.html
+		has-style-sharing-pseudo-004.html
+		has-style-sharing-pseudo-005.html
+		has-style-sharing-pseudo-006.html
+		has-style-sharing-pseudo-007.html
+		has-style-sharing-pseudo-008.html
+		has-visited.html
+		invalidation/attribute-or-elemental-selectors-in-has.html
+		invalidation/child-indexed-pseudo-classes-in-has.html
+		invalidation/crashtests/has-pseudoclass-only-crash.html
+		invalidation/defined-in-has.html
+		invalidation/dir-pseudo-class-in-has.html
+		invalidation/empty-pseudo-in-has.html
+		invalidation/fullscreen-pseudo-class-in-has.html
+		invalidation/has-append-first-node.html
+		invalidation/has-complexity.html
+		invalidation/has-css-nesting-shared.html
+		invalidation/has-in-adjacent-position.html
+		invalidation/has-in-ancestor-position.html
+		invalidation/has-in-parent-position.html
+		invalidation/has-in-sibling-position.html
+		invalidation/has-invalidation-after-removing-non-first-element.html
+		invalidation/has-invalidation-first-in-sibling-chain.html
+		invalidation/has-invalidation-for-wiping-an-element.html
+		invalidation/has-nested-pseudo-001-crash.html
+		invalidation/has-nested-pseudo-002-crash.html
+		invalidation/has-nested-pseudo-003-crash.html
+		invalidation/has-pseudo-element.html
+		invalidation/has-pseudoclass-only.html
+		invalidation/has-sibling-insertion-removal.html
+		invalidation/has-sibling.html
+		invalidation/has-side-effect.html
+		invalidation/has-unstyled.html
+		invalidation/has-with-nesting-parent-containing-complex.html
+		invalidation/has-with-nesting-parent-containing-hover.html
+		invalidation/has-with-not.html
+		invalidation/has-with-nth-child-sibling-remove.html
+		invalidation/has-with-nth-child.html
+		invalidation/has-with-pseudo-class.html
+		invalidation/host-context-pseudo-class-in-has.html
+		invalidation/host-has-shadow-tree-element-at-nonsubject-position.html
+		invalidation/host-has-shadow-tree-element-at-subject-position.html
+		invalidation/host-pseudo-class-in-has.html
+		invalidation/input-pseudo-classes-in-has.html
+		invalidation/is-pseudo-containing-complex-in-has.html
+		invalidation/is-pseudo-containing-sibling-relationship-in-has.html
+		invalidation/lang-pseudo-class-in-has-document-element.html
+		invalidation/lang-pseudo-class-in-has-multiple-document-elements.html
+		invalidation/lang-pseudo-class-in-has-xhtml.xhtml
+		invalidation/lang-pseudo-class-in-has.html
+		invalidation/link-pseudo-class-in-has.html
+		invalidation/link-pseudo-in-has.html
+		invalidation/location-pseudo-classes-in-has.html
+		invalidation/media-loading-pseudo-classes-in-has.html
+		invalidation/media-pseudo-classes-in-has.html
+		invalidation/modal-pseudo-class-in-has.html
+		invalidation/negated-has-in-nonsubject-position.html
+		invalidation/not-pseudo-containing-complex-in-has.html
+		invalidation/not-pseudo-containing-sibling-relationship-in-has.html
+		invalidation/state-in-has.html
+		invalidation/subject-has-invalidation-with-display-none-anchor-element.html
+		invalidation/target-pseudo-in-has.html
+		invalidation/typed-child-indexed-pseudo-classes-in-has.html
+		invalidation/user-action-pseudo-classes-in-has.html
+		parsing/parse-has-disallow-nesting-has-inside-has.html
+		parsing/parse-has-forgiving-selector.html
+		parsing/parse-has.html
+	</wpt>
 
 	The relational pseudo-class, <dfn id='has-pseudo'>:has()</dfn>,
 	is a functional pseudo-class taking a <<relative-selector-list>> as an argument.
@@ -1371,8 +1842,13 @@ Type (tag name) selector</h3>
 	[[!CSS3NAMESPACE]]
 	(See [[#type-nmsp]].)
 
+
 <h3 id="the-universal-selector">
 Universal selector </h3>
+
+	<wpt>
+		parsing/parse-universal.html
+	</wpt>
 
 	The <dfn export>universal selector</dfn> is a special <a>type selector</a>,
 	that represents an element of any element type.
@@ -1406,6 +1882,7 @@ Universal selector </h3>
 	even though it has no effect on the matching behavior.
 	For example, ''div :first-child'' and ''div:first-child'' are somewhat difficult to tell apart at a quick glance,
 	but writing the former as ''div *:first-child'' makes the difference obvious.
+
 
 <h3 id='type-nmsp'>
 Namespaces in Elemental Selectors</h3>
@@ -1489,8 +1966,13 @@ Namespaces in Elemental Selectors</h3>
 	that has not been previously <a href="#nsdecl">declared</a>
 	is an <a>invalid selector</a>.
 
+
 <h3 id="the-defined-pseudo">
 The Defined Pseudo-class: '':defined''</h3>
+
+	<wpt>
+		invalidation/defined.html
+	</wpt>
 
 	In some host languages,
 	elements can have a distinction between being “defined”/“constructed” or not.
@@ -1518,8 +2000,18 @@ The Defined Pseudo-class: '':defined''</h3>
 		<pre>custom-element:defined { visibility: visible }</pre>
 	</div>
 
+
 <h2 id="attribute-selectors">
 Attribute selectors</h2>
+
+	<wpt>
+		attribute-selectors/style-attribute-selector.html
+		invalidation/attribute.html
+		invalidation/class-id-attr.html
+		missing-right-token.html
+		parsing/parse-attribute.html
+		selectors-attr-many.html
+	</wpt>
 
 	Selectors allow the representation of an element's attributes. When
 	a selector is used as an expression to match against an element,
@@ -1530,6 +2022,7 @@ Attribute selectors</h2>
 	<p class="issue">Add comma-separated syntax for
 	<a href="http://lists.w3.org/Archives/Public/www-style/2011Mar/0215.html">multiple-value matching</a>?
 	e.g. [rel ~= next, prev, up, first, last]
+
 
 <h3 id="attribute-representation">
 Attribute presence and value selectors</h3>
@@ -1630,6 +2123,7 @@ Attribute presence and value selectors</h3>
 
 	</div>
 
+
 <h3 id="attribute-substrings">
 Substring matching attribute selectors</h3>
 
@@ -1679,8 +2173,15 @@ Substring matching attribute selectors</h3>
 		<pre>p[title*="hello"] </pre>
 	</div>
 
+
 <h3 id="attribute-case">
 Case-sensitivity</h3>
+
+	<wpt>
+		attribute-selectors/attribute-case/cssom.html
+		attribute-selectors/attribute-case/semantics.html
+		attribute-selectors/attribute-case/syntax.html
+	</wpt>
 
 	By default case-sensitivity of attribute names and values in selectors
 	depends on the document language.
@@ -1738,6 +2239,10 @@ Case-sensitivity</h3>
 <h3 id="attrnmsp">
 Attribute selectors and namespaces</h3>
 
+	<wpt>
+		selectors-namespace-001.xml
+	</wpt>
+
 	The attribute name in an attribute selector is given as a
 	[=CSS qualified name=]: a namespace prefix that has been previously [=declared=]
 	may be prepended to the attribute name separated by the namespace
@@ -1776,6 +2281,7 @@ Attribute selectors and namespaces</h3>
 		with the attribute <code>att</code> where the attribute is not
 		in a namespace.
 	</div>
+
 
 <h3 id="def-values">
 Default attribute values in DTDs</h3>
@@ -1836,8 +2342,14 @@ Default attribute values in DTDs</h3>
 		are overridden in the non-default cases' style rules.
 	</div>
 
+
 <h3 id="class-html">
 Class selectors</h3>
+
+	<wpt>
+		parsing/parse-class.html
+		xml-class-selector.xml
+	</wpt>
 
 	The <dfn export>class selector</dfn> is given as a full stop (. U+002E) immediately
 	followed by an identifier. It represents an element belonging to the
@@ -1907,8 +2419,14 @@ Class selectors</h3>
 	class selectors are otherwise case-sensitive,
 	only matching class names they are [=identical to=]. [[INFRA]]
 
+
 <h3 id="id-selectors">
 ID selectors</h3>
+
+	<wpt>
+		historical-xmlid.xht
+		parsing/parse-id.html
+	</wpt>
 
 	Document languages may contain attributes that are declared to be of type ID.
 	What makes attributes of type ID special
@@ -1965,11 +2483,39 @@ ID selectors</h3>
 	ID selectors are otherwise case-sensitive,
 	only matching IDs they are [=identical to=]. [[INFRA]]
 
+
 <h2 id="linguistic-pseudos">
 Linguistic Pseudo-classes</h2>
 
 <h3 id="the-dir-pseudo">
 The Directionality Pseudo-class: '':dir()''</h3>
+
+	<wpt>
+		dir-pseudo-in-has.html
+		dir-pseudo-on-bdi-element.html
+		dir-pseudo-on-input-element.html
+		dir-pseudo-update-document-element.html
+		dir-selector-auto-direction-change-001.html
+		dir-selector-auto.html
+		dir-selector-change-001.html
+		dir-selector-change-002.html
+		dir-selector-change-003.html
+		dir-selector-change-004.html
+		dir-selector-ltr-001.html
+		dir-selector-ltr-002.html
+		dir-selector-ltr-003.html
+		dir-selector-querySelector.html
+		dir-selector-rtl-001.html
+		dir-selector-white-space-001.html
+		dir-style-01a.html
+		dir-style-01b.html
+		dir-style-02a.html
+		dir-style-02b.html
+		dir-style-03a.html
+		dir-style-03b.html
+		dir-style-04.html
+		invalidation/part-dir.html
+	</wpt>
 
 	The <dfn id='dir-pseudo'>:dir()</dfn> pseudo-class allows the author to write
 	selectors that represent an element based on its directionality
@@ -2007,8 +2553,84 @@ The Directionality Pseudo-class: '':dir()''</h3>
 	'':dir(ltr)'' or '':dir(rtl)'' depending on the resolved
 	directionality of the elements as determined by its contents. [[HTML5]]
 
+
 <h3 id="the-lang-pseudo">
 The Language Pseudo-class: '':lang()''</h3>
+
+	<wpt>
+		i18n/css3-selectors-lang-001.html
+		i18n/css3-selectors-lang-002.html
+		i18n/css3-selectors-lang-004.html
+		i18n/css3-selectors-lang-005.html
+		i18n/css3-selectors-lang-006.html
+		i18n/css3-selectors-lang-007.html
+		i18n/css3-selectors-lang-008.html
+		i18n/css3-selectors-lang-009.html
+		i18n/css3-selectors-lang-010.html
+		i18n/css3-selectors-lang-011.html
+		i18n/css3-selectors-lang-012.html
+		i18n/css3-selectors-lang-014.html
+		i18n/css3-selectors-lang-015.html
+		i18n/css3-selectors-lang-016.html
+		i18n/css3-selectors-lang-021.html
+		i18n/css3-selectors-lang-022.html
+		i18n/css3-selectors-lang-024.html
+		i18n/css3-selectors-lang-025.html
+		i18n/css3-selectors-lang-026.html
+		i18n/css3-selectors-lang-027.html
+		i18n/css3-selectors-lang-028.html
+		i18n/css3-selectors-lang-029.html
+		i18n/css3-selectors-lang-030.html
+		i18n/css3-selectors-lang-031.html
+		i18n/css3-selectors-lang-032.html
+		i18n/css3-selectors-lang-034.html
+		i18n/css3-selectors-lang-035.html
+		i18n/css3-selectors-lang-036.html
+		i18n/css3-selectors-lang-041.html
+		i18n/css3-selectors-lang-042.html
+		i18n/css3-selectors-lang-044.html
+		i18n/css3-selectors-lang-045.html
+		i18n/css3-selectors-lang-046.html
+		i18n/css3-selectors-lang-047.html
+		i18n/css3-selectors-lang-048.html
+		i18n/css3-selectors-lang-049.html
+		i18n/css3-selectors-lang-050.html
+		i18n/css3-selectors-lang-051.html
+		i18n/css3-selectors-lang-052.html
+		i18n/css3-selectors-lang-054.html
+		i18n/css3-selectors-lang-055.html
+		i18n/css3-selectors-lang-056.html
+		i18n/lang-pseudo-class-across-shadow-boundaries.html
+		i18n/lang-pseudo-class-disconnected.html
+		i18n/lang-pseudo-class-empty-attribute.xhtml
+		invalidation/part-lang.html
+		selectors-4/lang-000.html
+		selectors-4/lang-001.html
+		selectors-4/lang-002.html
+		selectors-4/lang-003.html
+		selectors-4/lang-004.html
+		selectors-4/lang-005.html
+		selectors-4/lang-006.html
+		selectors-4/lang-007.html
+		selectors-4/lang-008.html
+		selectors-4/lang-009.html
+		selectors-4/lang-010.html
+		selectors-4/lang-011.html
+		selectors-4/lang-012.html
+		selectors-4/lang-013.html
+		selectors-4/lang-014.html
+		selectors-4/lang-015.html
+		selectors-4/lang-016.html
+		selectors-4/lang-017.html
+		selectors-4/lang-018.html
+		selectors-4/lang-019.html
+		selectors-4/lang-020.html
+		selectors-4/lang-021.html
+		selectors-4/lang-022.html
+		selectors-4/lang-023.html
+		selectors-4/lang-024.html
+		selectors-4/lang-025.html
+	</wpt>
 
 	If the document language specifies how
 	the (human) <a>content language</a> of an element is determined,
@@ -2121,6 +2743,11 @@ Location Pseudo-classes</h2>
 <h3 id="the-any-link-pseudo">
 The Hyperlink Pseudo-class: '':any-link''</h3>
 
+	<wpt>
+		invalidation/any-link-attribute-removal.html
+		invalidation/any-link-pseudo.html
+	</wpt>
+
 	The <dfn id='any-link-pseudo'>:any-link</dfn> pseudo-class represents an element
 	that acts as the source anchor of a hyperlink.
 	For example, in [[HTML5]],
@@ -2132,6 +2759,17 @@ The Hyperlink Pseudo-class: '':any-link''</h3>
 
 <h3 id="link">
 The Link History Pseudo-classes: '':link'' and '':visited''</h3>
+
+	<wpt>
+		caret-color-visited-inheritance.html
+		text-emphasis-visited-inheritance.html
+		text-fill-color-visited-inheritance.html
+		text-stroke-color-visited-inheritance.html
+		visited-in-visited-compound.html
+		visited-inheritance.html
+		visited-nested.html
+		visited-part-crash.html
+	</wpt>
 
 	User agents commonly display unvisited [[#the-any-link-pseudo|hyperlinks]]
 	differently from previously visited ones.
@@ -2276,6 +2914,11 @@ The Target Pseudo-class: '':target''</h3>
 <h3 id="the-scope-pseudo">
 The Reference Element Pseudo-class: '':scope''</h3>
 
+	<wpt>
+		scope-selector.html
+		scope-without-scoping.html
+	</wpt>
+
 	In some contexts, selectors are matched
 	with respect to one or more [=scoping roots=],
 	such as when calling the {{Element/querySelector()}} method in [[DOM]].
@@ -2308,6 +2951,7 @@ The Reference Element Pseudo-class: '':scope''</h3>
 		However, <code highlight=js>df.querySelector(":scope")</code> will not match anything,
 		as the document fragment itself can't be the [=subject of the selector=].
 	</div>
+
 
 <h2 id="useraction-pseudos">
 User Action Pseudo-classes</h2>
@@ -2350,6 +2994,12 @@ User Action Pseudo-classes</h2>
 <h3 id="the-hover-pseudo">
 The Pointer Hover Pseudo-class: '':hover''</h3>
 
+	<wpt>
+		hover-001-manual.html
+		hover-002.html
+		remove-hovered-element.html
+	</wpt>
+
 	The <dfn id='hover-pseudo'>:hover</dfn> pseudo-class applies
 	while the user designates an element (or pseudo-element)
 	with a pointing device,
@@ -2374,6 +3024,7 @@ The Pointer Hover Pseudo-class: '':hover''</h3>
 	because its child is designated by a pointing device,
 	it is possible for '':hover'' to apply
 	to an element that is not underneath the pointing device.
+
 
 <h3 id="the-active-pseudo">
 The Activation Pseudo-class: '':active''</h3>
@@ -2403,6 +3054,12 @@ The Activation Pseudo-class: '':active''</h3>
 <h3 id="the-focus-pseudo">
 The Input Focus Pseudo-class: '':focus''</h3>
 
+	<wpt>
+		focus-display-none-001.html
+		focus-in-focus-event-001.html
+		focus-in-focusin-event-001.html
+	</wpt>
+
 	The <dfn id='focus-pseudo'>:focus</dfn> pseudo-class applies
 	while an element (or pseudo-element) has the focus
 	(accepts keyboard or other forms of input).
@@ -2424,8 +3081,57 @@ The Input Focus Pseudo-class: '':focus''</h3>
 	See <a href="https://github.com/w3c/csswg-drafts/issues/397">CSSWG issue (CSS)</a>
 	and <a href="https://github.com/whatwg/html/issues/1632">WHATWG issue (HTML)</a>.
 
+
 <h3 id="the-focus-visible-pseudo" oldids="the-focusring-pseudo,focus-ring-pseudo">
 The Focus-Indicated Pseudo-class: '':focus-visible''</h3>
+
+	<wpt>
+		focus-visible-001.html
+		focus-visible-002.html
+		focus-visible-003.html
+		focus-visible-004.html
+		focus-visible-005.html
+		focus-visible-006.html
+		focus-visible-007.html
+		focus-visible-008.html
+		focus-visible-009.html
+		focus-visible-010.html
+		focus-visible-011.html
+		focus-visible-012.html
+		focus-visible-013.html
+		focus-visible-014.html
+		focus-visible-015.html
+		focus-visible-016.html
+		focus-visible-017-2.html
+		focus-visible-017.html
+		focus-visible-018-2.html
+		focus-visible-018.html
+		focus-visible-019.html
+		focus-visible-020.html
+		focus-visible-021.html
+		focus-visible-023.html
+		focus-visible-024.html
+		focus-visible-025.html
+		focus-visible-026.html
+		focus-visible-027.html
+		focus-visible-028.html
+		focus-visible-script-focus-001.html
+		focus-visible-script-focus-004.html
+		focus-visible-script-focus-005.html
+		focus-visible-script-focus-008-b.html
+		focus-visible-script-focus-008.html
+		focus-visible-script-focus-009.html
+		focus-visible-script-focus-010.html
+		focus-visible-script-focus-011.html
+		focus-visible-script-focus-012.html
+		focus-visible-script-focus-013.html
+		focus-visible-script-focus-014.html
+		focus-visible-script-focus-015.html
+		focus-visible-script-focus-018.html
+		focus-visible-script-focus-019.html
+		focus-visible-script-focus-020.html
+		parsing/parse-focus-visible.html
+	</wpt>
 
 	While the '':focus'' [=pseudo-class=] always matches the currently-focused element,
 	UAs only sometimes visibly <dfn>indicate focus</dfn>
@@ -2502,8 +3208,32 @@ The Focus-Indicated Pseudo-class: '':focus-visible''</h3>
 	so that authors using '':focus-visible'' will not also need to disable
 	the default '':focus'' style.
 
+
 <h3 id="the-focus-within-pseudo">
 The Focus Container Pseudo-class: '':focus-within''</h3>
+
+	<wpt>
+		focus-within-001.html
+		focus-within-002.html
+		focus-within-003.html
+		focus-within-004.html
+		focus-within-005.html
+		focus-within-006.html
+		focus-within-007.html
+		focus-within-008.html
+		focus-within-009.html
+		focus-within-010.html
+		focus-within-011.html
+		focus-within-012.html
+		focus-within-013.html
+		focus-within-display-none-001.html
+		focus-within-shadow-001.html
+		focus-within-shadow-002.html
+		focus-within-shadow-003.html
+		focus-within-shadow-004.html
+		focus-within-shadow-005.html
+		focus-within-shadow-006.html
+	</wpt>
 
 	The <dfn id='focus-within-pseudo'>:focus-within</dfn> pseudo-class
 	applies to any element (or pseudo-element)
@@ -2512,6 +3242,7 @@ The Focus Container Pseudo-class: '':focus-within''</h3>
 	whose descendant in the <a>flat tree</a>
 	(including non-element nodes, such as text nodes)
 	matches the conditions for matching '':focus''.
+
 
 <h3 id="interest-pseudos">
 The Interest Pseudo-classes: '':interest-source'' and '':interest-target''</h3>
@@ -2631,6 +3362,10 @@ Resource State Pseudo-classes</h2>
 <h3 id="video-state">
 Media Playback State: the '':playing'', '':paused'', and '':seeking'' pseudo-classes</h3>
 
+	<wpt>
+		media/media-playback-state.html
+	</wpt>
+
 	The <dfn>:playing</dfn> pseudo-class represents an element
 	that is capable of being “played” or “paused”,
 	when that element is “playing”.
@@ -2653,6 +3388,10 @@ Media Playback State: the '':playing'', '':paused'', and '':seeking'' pseudo-cla
 <h3 id="media-loading-state">
 Media Loading State: the '':buffering'' and '':stalled'' pseudo-classes</h3>
 
+	<wpt>
+		media/media-loading-state.html
+	</wpt>
+
 	The <dfn>:buffering</dfn> pseudo-class represents an element
 	that is capable of being “played” or “paused”,
 	when that element cannot continue playing
@@ -2673,8 +3412,13 @@ Media Loading State: the '':buffering'' and '':stalled'' pseudo-classes</h3>
 	Whenever '':stalled'' matches an element,
 	'':playing'' also matches the element.)
 
+
 <h3 id="sound-state">
 Sound State: the '':muted'' and '':volume-locked'' pseudo-classes</h3>
+
+	<wpt>
+		media/sound-state.html
+	</wpt>
 
 	The <dfn>:muted</dfn> pseudo-class represents
 	an element that is capable of making sound,
@@ -2689,11 +3433,19 @@ Sound State: the '':muted'' and '':volume-locked'' pseudo-classes</h3>
 	(For the <{audio}> and <{video}> elements of HTML,
 	see the algorithm for setting the element's [=HTMLMediaElement/effective media volume=]. [[HTML]])
 
+
 <h2 id="display-state-pseudos">
 Element Display State Pseudo-classes</h2>
 
 <h3 id="open-state">
 Collapse State: the '':open'' pseudo-class</h3>
+
+	<wpt>
+		open-pseudo.html
+		selectors-4/details-open-pseudo-001.html
+		selectors-4/details-open-pseudo-002.html
+		selectors-4/details-open-pseudo-003.html
+	</wpt>
 
 	The <dfn>:open</dfn> pseudo-class represents an element
 	that has both “open” and “closed” states,
@@ -2714,8 +3466,13 @@ Collapse State: the '':open'' pseudo-class</h3>
 	Note: A ":closed" pseudo-class might be added in the future
 	once the full set of things that support '':open'' is known.
 
+
 <h3 id="popover-open-state">
 Popover State: the '':popover-open'' pseudo-class</h3>
+
+	<wpt>
+		popover-open-with-has-sibling-selector.html
+	</wpt>
 
 	The <dfn>:popover-open</dfn> pseudo-class represents an element
 	that has both “popover-showing” and “popover-hidden” states
@@ -2731,8 +3488,13 @@ Popover State: the '':popover-open'' pseudo-class</h3>
 	but is exemplified by the presence of the HTML <{html-global/popover}> attribute
 	and the associated <a>popover visibility state</a>.
 
+
 <h3 id="modal-state">
 Modal (Exclusive Interaction) State: the '':modal'' pseudo-class</h3>
+
+	<wpt>
+		modal-pseudo-class.html
+	</wpt>
 
 	The <dfn>:modal</dfn> pseudo-class represents
 	an element which is in a state that excludes all interaction
@@ -2748,6 +3510,7 @@ Modal (Exclusive Interaction) State: the '':modal'' pseudo-class</h3>
 		since this prevents interaction with the rest of the page.
 	</div>
 
+
 <h3 id="fullscreen-state">
 Fullscreen Presentation State: the '':fullscreen'' pseudo-class</h3>
 
@@ -2755,6 +3518,7 @@ Fullscreen Presentation State: the '':fullscreen'' pseudo-class</h3>
 	an element which is displayed in a mode that
 	takes up most (usually all) of the screen,
 	such as that defined by the Fullscreen API. [[FULLSCREEN]]
+
 
 <h3 id="pip-state">
 Picture-in-Picture Presentation State: the '':picture-in-picture'' pseudo-class</h3>
@@ -2766,17 +3530,24 @@ Picture-in-Picture Presentation State: the '':picture-in-picture'' pseudo-class<
 	while being displayed over other content,
 	for example when using the Picture-in-Picture API. [[picture-in-picture]]
 
+
 <h2 id='input-pseudos'>
 The Input Pseudo-classes</h2>
 
 	The pseudo-classes in this section mostly apply to elements that take user input,
 	such as HTML's <a element>input</a> element.
 
+
 <h3 id="input-states">
 Input Control States</h3>
 
 <h4 id="enableddisabled">
 The '':enabled'' and '':disabled'' Pseudo-classes</h4>
+
+	<wpt>
+		invalidation/enabled-disabled.html
+		pseudo-enabled-disabled.html
+	</wpt>
 
 	The <dfn id='enabled-pseudo'>:enabled</dfn> pseudo-class represents
 	user interface elements that are in an enabled state;
@@ -2801,6 +3572,11 @@ The '':enabled'' and '':disabled'' Pseudo-classes</h4>
 <h4 id="rw-pseudos">
 The Mutability Pseudo-classes: '':read-only'' and '':read-write''</h4>
 
+	<wpt>
+		selector-read-write-type-change-001.html
+		selector-read-write-type-change-002.html
+	</wpt>
+
 	An element matches <dfn id="read-write-pseudo">:read-write</dfn> if it is user-alterable,
 	as defined by the document language.
 	Otherwise, it is <dfn id="read-only-pseudo">:read-only</dfn>.
@@ -2810,6 +3586,15 @@ The Mutability Pseudo-classes: '':read-only'' and '':read-write''</h4>
 
 <h4 id="placeholder">
 The Placeholder-shown Pseudo-class: '':placeholder-shown''</h4>
+
+	<wpt>
+		invalidation/placeholder-shown.html
+		placeholder-shown.html
+		selector-placeholder-shown-emptify-placeholder.html
+		selector-placeholder-shown-type-change-001.html
+		selector-placeholder-shown-type-change-002.html
+		selector-placeholder-shown-type-change-003.html
+	</wpt>
 
 	Input elements can sometimes show placeholder text
 	as a hint to the user on what to type in.
@@ -2848,6 +3633,7 @@ The Default-option Pseudo-class: '':default''</h4>
 	<a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-default">the “default button” in a form,
 	the initially-selected <code>&lt;option></code>(s) in a <code>&lt;select></code>,
 	and a few other elements.</a>
+
 
 <h3 id="input-value-states">
 Input Value States</h3>
@@ -2981,6 +3767,12 @@ The Range Pseudo-classes: '':in-range'' and '':out-of-range''</h4>
 <h4 id="opt-pseudos">
 The Optionality Pseudo-classes: '':required'' and '':optional''</h4>
 
+	<wpt>
+		selector-required-type-change-001.html
+		selector-required-type-change-002.html
+		selector-required.html
+	</wpt>
+
 	A form element is <dfn id="required-pseudo">:required</dfn> or
 	<dfn id="optional-pseudo">:optional</dfn>
 	if a value for it is, respectively, required or optional before the
@@ -2989,6 +3781,14 @@ The Optionality Pseudo-classes: '':required'' and '':optional''</h4>
 
 <h4 id="user-pseudos">
 The User-interaction Pseudo-classes: '':user-valid'' and '':user-invalid''</h4>
+
+	<wpt>
+		invalidation/user-valid-user-invalid.html
+		user-invalid-form-submission-invalidation.html
+		user-invalid.html
+		user-valid.html
+		valid-invalid-form-fieldset.html
+	</wpt>
 
 	The <dfn id="user-invalid-pseudo">:user-invalid</dfn>
 	and the <dfn id="user-valid-pseudo">:user-valid</dfn> pseudo-classes
@@ -3037,8 +3837,13 @@ The User-interaction Pseudo-classes: '':user-valid'' and '':user-invalid''</h4>
 		</pre>
 	</div>
 
+
 <h2 id="structural-pseudos">
 Tree-Structural pseudo-classes</h2>
+
+	<wpt>
+		selector-structural-pseudo-root.html
+	</wpt>
 
 	Selectors introduces the concept of <dfn export id="structural-pseudo-classes">structural pseudo-classes</dfn>
 	to permit selection based on extra information that lies in
@@ -3057,6 +3862,10 @@ Tree-Structural pseudo-classes</h2>
 <h3 id="the-root-pseudo">
 '':root'' pseudo-class</h3>
 
+	<wpt>
+		root-siblings.html
+	</wpt>
+
 	The <dfn id='root-pseudo'>:root</dfn> pseudo-class represents an element that is
 	the root of the document.
 
@@ -3065,8 +3874,13 @@ Tree-Structural pseudo-classes</h2>
 	In HTML, this will be the <{html}> element
 	(unless scripting has been used to modify the document).
 
+
 <h3 id="the-empty-pseudo">
 '':empty'' pseudo-class</h3>
+
+	<wpt>
+		selectors-empty-001.xml
+	</wpt>
 
 	The <dfn id='empty-pseudo'>:empty</dfn> pseudo-class represents
 	an element that has no children
@@ -3112,8 +3926,86 @@ Tree-Structural pseudo-classes</h2>
 	elements which authors perceive of as empty
 	can be selected by this selector, as they expect.
 
+
 <h3 id='child-index'>
 Child-indexed Pseudo-classes</h3>
+
+	<wpt>
+		child-indexed-no-parent.html
+		child-indexed-pseudo-class.html
+		invalidation/negated-nth-child-when-ancestor-changes.html
+		invalidation/negated-nth-last-child-when-ancestor-changes.html
+		invalidation/nth-child-containing-ancestor.html
+		invalidation/nth-child-in-shadow-root.html
+		invalidation/nth-child-of-attr-largedom.html
+		invalidation/nth-child-of-attr.html
+		invalidation/nth-child-of-class-prefix.html
+		invalidation/nth-child-of-class.html
+		invalidation/nth-child-of-has.html
+		invalidation/nth-child-of-id-prefix.html
+		invalidation/nth-child-of-ids.html
+		invalidation/nth-child-of-in-ancestor.html
+		invalidation/nth-child-of-in-is.html
+		invalidation/nth-child-of-in-shadow-root.html
+		invalidation/nth-child-of-is.html
+		invalidation/nth-child-of-pseudo-class.html
+		invalidation/nth-child-of-sibling.html
+		invalidation/nth-child-when-ancestor-changes.html
+		invalidation/nth-child-when-sibling-changes.html
+		invalidation/nth-child-whole-subtree.html
+		invalidation/nth-last-child-containing-ancestor.html
+		invalidation/nth-last-child-in-shadow-root.html
+		invalidation/nth-last-child-of-attr.html
+		invalidation/nth-last-child-of-class-prefix.html
+		invalidation/nth-last-child-of-class.html
+		invalidation/nth-last-child-of-has.html
+		invalidation/nth-last-child-of-id-prefix.html
+		invalidation/nth-last-child-of-ids.html
+		invalidation/nth-last-child-of-in-ancestor.html
+		invalidation/nth-last-child-of-in-is.html
+		invalidation/nth-last-child-of-in-shadow-root.html
+		invalidation/nth-last-child-of-is.html
+		invalidation/nth-last-child-of-pseudo-class.html
+		invalidation/nth-last-child-of-sibling.html
+		invalidation/nth-last-child-when-ancestor-changes.html
+		invalidation/nth-last-child-when-sibling-changes.html
+		nth-child-and-nth-last-child.html
+		nth-child-of-attribute.html
+		nth-child-of-classname-002.html
+		nth-child-of-classname.html
+		nth-child-of-complex-selector-many-children-2.html
+		nth-child-of-complex-selector-many-children.html
+		nth-child-of-complex-selector.html
+		nth-child-of-compound-selector.html
+		nth-child-of-has.html
+		nth-child-of-nesting.html
+		nth-child-of-no-space-after-of.html
+		nth-child-of-not.html
+		nth-child-of-nth-child.html
+		nth-child-of-pseudo.html
+		nth-child-of-tagname.html
+		nth-child-of-universal-selector.html
+		nth-child-specificity-1.html
+		nth-child-specificity-2.html
+		nth-child-specificity-3.html
+		nth-child-specificity-4.html
+		nth-child-spurious-brace-crash.html
+		nth-last-child-invalid.html
+		nth-last-child-of-classname.html
+		nth-last-child-of-complex-selector.html
+		nth-last-child-of-compound-selector.html
+		nth-last-child-of-nesting.html
+		nth-last-child-of-no-space-after-of.html
+		nth-last-child-of-style-sharing-1.html
+		nth-last-child-of-style-sharing-2.html
+		nth-last-child-of-tagname.html
+		nth-last-child-specificity-1.html
+		nth-last-child-specificity-2.html
+		nth-last-child-specificity-3.html
+		nth-last-child-specificity-4.html
+		sharing-in-svg-use.html
+		parsing/parse-anplusb.html
+	</wpt>
 
 	The pseudo-classes defined in this section select elements
 	based on their index amongst their <a>inclusive siblings</a>.
@@ -3126,6 +4018,12 @@ Child-indexed Pseudo-classes</h3>
 
 <h4 id="the-nth-child-pseudo">
 '':nth-child()'' pseudo-class</h4>
+
+	<wpt>
+		nth-of-invalid.html
+		invalidation/crashtests/nth-child-of-attribute-crash.html
+		invalidation/nth-of-namespace-class-invalidation-crash.html
+	</wpt>
 
 	The <dfn id='nth-child-pseudo' lt=":nth-child()">:nth-child(<var>An+B</var> [of <var>S</var>]? )</dfn>
 	pseudo-class notation represents elements that
@@ -3255,6 +4153,11 @@ Child-indexed Pseudo-classes</h3>
 <h4 id="the-first-child-pseudo">
 '':first-child'' pseudo-class</h4>
 
+	<wpt>
+		first-child.html
+		invalidation/first-child-last-child.html
+	</wpt>
+
 	The <dfn id='first-child-pseudo'>:first-child</dfn> pseudo-class
 	represents an element that is first among its <a>inclusive siblings</a>.
 	Same as '':nth-child(1)''.
@@ -3297,6 +4200,10 @@ Child-indexed Pseudo-classes</h3>
 <h4 id="the-last-child-pseudo">
 '':last-child'' pseudo-class</h4>
 
+	<wpt>
+		last-child.html
+	</wpt>
+
 	The <dfn id='last-child-pseudo'>:last-child</dfn> pseudo-class
 	represents an element that is last among its <a>inclusive siblings</a>.
 	Same as '':nth-last-child(1)''.
@@ -3312,6 +4219,10 @@ Child-indexed Pseudo-classes</h3>
 <h4 id="the-only-child-pseudo">
 '':only-child'' pseudo-class</h4>
 
+	<wpt>
+		only-child.html
+	</wpt>
+
 	The <dfn id='only-child-pseudo'>:only-child</dfn> pseudo-class
 	represents an element that has no siblings.
 	Same as '':first-child:last-child''
@@ -3321,6 +4232,10 @@ Child-indexed Pseudo-classes</h3>
 
 <h3 id='typed-child-index'>
 Typed Child-indexed Pseudo-classes</h3>
+
+	<wpt>
+		nth-of-type-namespace.html
+	</wpt>
 
 	The pseudo-classes in this section are similar to the <a href="#child-index">Child Index Pseudo-classes</a>,
 	but they resolve based on an element's index <strong>among elements of the same <a href="#type-selectors">type (tag name)</a></strong> in their sibling list.
@@ -3351,9 +4266,12 @@ Typed Child-indexed Pseudo-classes</h3>
 	That is, ''img:nth-of-type(2)''
 	is equivalent to ''*:nth-child(2 of img)''.
 
-
 <h4 id="the-nth-last-of-type-pseudo">
 '':nth-last-of-type()'' pseudo-class</h4>
+
+	<wpt>
+		last-of-type.html
+	</wpt>
 
 	The <dfn id='nth-last-of-type-pseudo' lt=":nth-last-of-type()">:nth-last-of-type(<var>An+B</var>)</dfn> pseudo-class notation
 	represents the same elements that would be matched by '':nth-last-child(|An+B| of |S|)'',
@@ -3379,6 +4297,17 @@ Typed Child-indexed Pseudo-classes</h3>
 
 <h4 id="the-first-of-type-pseudo">
 '':first-of-type'' pseudo-class</h4>
+
+	<wpt>
+		first-of-type.html
+		invalidation/negated-always-matches-negated-first-of-type-when-ancestor-changes.html
+		invalidation/negated-first-of-type-in-nonsubject-position.html
+		invalidation/negated-is-always-matches-negated-first-of-type-when-ancestor-changes.html
+		invalidation/negated-is-never-matches-negated-first-of-type-when-ancestor-changes.html
+		invalidation/negated-negated-first-of-type-when-ancestor-changes.html
+		invalidation/negated-never-matches-negated-first-of-type-when-ancestor-changes.html
+		of-type-selectors.xhtml
+	</wpt>
 
 	The <dfn id='first-of-type-pseudo'>:first-of-type</dfn> pseudo-class
 	represents the same element as '':nth-of-type(1)''.
@@ -3413,6 +4342,15 @@ Typed Child-indexed Pseudo-classes</h3>
 <h4 id="the-last-of-type-pseudo">
 '':last-of-type'' pseudo-class</h4>
 
+	<wpt>
+		invalidation/negated-always-matches-negated-last-of-type-when-ancestor-changes.html
+		invalidation/negated-is-always-matches-negated-last-of-type-when-ancestor-changes.html
+		invalidation/negated-is-never-matches-negated-last-of-type-when-ancestor-changes.html
+		invalidation/negated-last-of-type-invalidation.html
+		invalidation/negated-negated-last-of-type-when-ancestor-changes.html
+		invalidation/negated-never-matches-negated-last-of-type-when-ancestor-changes.html
+	</wpt>
+
 	The <dfn id='last-of-type-pseudo'>:last-of-type</dfn> pseudo-class
 	represents the same element as '':nth-last-of-type(1)''.
 
@@ -3427,6 +4365,10 @@ Typed Child-indexed Pseudo-classes</h3>
 <h4 id="the-only-of-type-pseudo">
 '':only-of-type'' pseudo-class</h4>
 
+	<wpt>
+		only-of-type.html
+	</wpt>
+
 	The <dfn id='only-of-type-pseudo'>:only-of-type</dfn> pseudo-class
 	represents the same element as '':first-of-type:last-of-type''.
 
@@ -3436,6 +4378,10 @@ Combinators</h2>
 
 <h3 id="descendant-combinators">
 Descendant combinator (<code> </code>)</h3>
+
+	<wpt>
+		parsing/parse-descendant.html
+	</wpt>
 
 	At times, authors may want selectors to describe an element that is
 	the descendant of another element in the document tree (e.g., "an
@@ -3480,8 +4426,13 @@ Descendant combinator (<code> </code>)</h3>
 		<pre>div p *[href]</pre>
 	</div>
 
+
 <h3 id="child-combinators">
 Child combinator (<code>></code>)</h3>
+
+	<wpt>
+		parsing/parse-child.html
+	</wpt>
 
 	A <dfn export>child combinator</dfn> describes a childhood relationship
 	between two elements. A child combinator is made of the
@@ -3511,8 +4462,18 @@ Child combinator (<code>></code>)</h3>
 	For information on selecting the first child of an element,
 	please see the section on the '':first-child'' pseudo-class above.
 
+
 <h3 id="adjacent-sibling-combinators">
 Next-sibling combinator (<code>+</code>)</h3>
+
+	<wpt>
+		invalidation/insert-sibling-001.html
+		invalidation/insert-sibling-002.html
+		invalidation/insert-sibling-003.html
+		invalidation/insert-sibling-004.html
+		invalidation/sibling.html
+		parsing/parse-sibling.html
+	</wpt>
 
 	The <dfn export id="next-sibling-combinator">next-sibling combinator</dfn> is made of the “plus sign”
 	(U+002B, <dfn selector id=selectordef-adjacent>+</dfn>) code point that separates two
@@ -3580,6 +4541,7 @@ Grid-Structural Selectors</h2>
 	are defined.
 	In a column-primary format, these pseudo-classes match against row associations instead.
 
+
 <h3 id="the-column-combinator">
 Column combinator (<code>||</code>)</h3>
 
@@ -3613,6 +4575,7 @@ Column combinator (<code>||</code>)</h3>
 		</pre>
 	</div>
 
+
 <h3 id="the-nth-col-pseudo">
 '':nth-col()'' pseudo-class</h3>
 
@@ -3629,7 +4592,6 @@ Column combinator (<code>||</code>)</h3>
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
 
 
-
 <h3 id="the-nth-last-col-pseudo">
 '':nth-last-col()'' pseudo-class</h3>
 
@@ -3644,6 +4606,7 @@ Column combinator (<code>||</code>)</h3>
 	those columns.
 
 	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
+
 
 <h2 id="specificity-rules">
 Calculating a selector's specificity</h2>
@@ -3747,8 +4710,13 @@ Calculating a selector's specificity</h2>
 	specified in an HTML <code>style</code> attribute
 	<a href="https://www.w3.org/TR/css-style-attr/#interpret">is described in CSS Style Attributes</a>. [[CSSSTYLEATTR]]
 
+
 <h2 id="grammar" oldids="formal-syntax">
 Grammar</h2>
+
+	<wpt>
+		selectors-attr-white-space-001.html
+	</wpt>
 
 	Selectors are [=CSS/parsed=] according to the following grammar:
 
@@ -3863,6 +4831,7 @@ Grammar</h2>
 		be written with only a single ":" character at their front,
 		making them resemble a <<pseudo-class-selector>>.
 
+
 <h3 id='forgiving-selector'>
 <<forgiving-selector-list>> and <<forgiving-relative-selector-list>></h3>
 
@@ -3929,6 +4898,7 @@ API Hooks</h2>
 	and details like the exact order of elements returned from <code>querySelector</code>
 	seem to make more sense being defined in the DOM specification than in Selectors.
 
+
 <h3 id='parse-selector' algorithm>
 Parse A Selector</h3>
 
@@ -3953,6 +4923,7 @@ Parse A Selector</h3>
 			return <var>selector</var>.
 	</ol>
 
+
 <h3 id='parse-relative-selector' algorithm>
 Parse A Relative Selector</h3>
 
@@ -3976,6 +4947,7 @@ Parse A Relative Selector</h3>
 			Otherwise,
 			return <var>selector</var>.
 	</ol>
+
 
 <h3 id='match-against-element' algorithm>
 Match a Selector Against an Element</h3>
@@ -4021,6 +4993,7 @@ Match a Selector Against an Element</h3>
 		Otherwise, return failure.
 	</ul>
 
+
 <h3 id='match-against-pseudo-element' algorithm>
 Match a Selector Against a Pseudo-element</h3>
 
@@ -4051,6 +5024,7 @@ Match a Selector Against a Pseudo-element</h3>
 	Otherwise
 	(that is, if this doesn't happen for any of the complex selectors in <var>selector</var>),
 	return failure.
+
 
 <h3 id='match-against-tree' algorithm>
 Match a Selector Against a Tree</h3>
@@ -4122,6 +5096,7 @@ Match a Selector Against a Tree</h3>
 			</ol>
 
 	</ol>
+
 
 <h2 id='dom-mapping'>
 Appendix A: Guidance on Mapping Source Documents &amp; Data to an Element Tree</h2>
@@ -4230,6 +5205,10 @@ Appendix A: Guidance on Mapping Source Documents &amp; Data to an Element Tree</
 <h2 id="compat">
 Appendix B: Obsolete but Required <code>-webkit-</code> Parsing Quirks for Web Compat</h2>
 
+	<wpt>
+		webkit-pseudo-element.html
+	</wpt>
+
 	<em>This appendix is normative.</em>
 
 	Due to legacy Web-compat constraints,
@@ -4302,6 +5281,7 @@ Appendix B: Obsolete but Required <code>-webkit-</code> Parsing Quirks for Web C
 			will be met with shaming and derision from members of the CSSWG,
 			and all right-thinking web developers.
 		</details>
+
 
 <h2 id="visited-privacy">
 Appendix C: Example Privacy-Preserving '':visited'' Restrictions</h2>
@@ -4404,7 +5384,6 @@ while still preserving as much of the <em>usefulness</em> of '':visited'' as pos
 </div>
 
 
-
 <h2 id="changes">
 Changes</h2>
 
@@ -4440,6 +5419,7 @@ Changes since the 7 May 2022 Working Draft</h3>
 		(<a href="https://github.com/w3c/csswg-drafts/issues/7474">Issue 7474</a>)
 	* Moved the legacy single-colon pseudo-element syntax into the grammar itself.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/8122">Issue 8122</a>)
+
 
 <h3 id="changes-2018-11">
 Changes since the 21 November 2018 Working Draft</h3>
@@ -4477,6 +5457,7 @@ Changes since the 21 November 2018 Working Draft</h3>
 			when a <<combinator>> token is missing.
 	</ul>
 
+
 <h3 id="changes-2018-02">
 Changes since the 2 February 2018 Working Draft</h3>
 
@@ -4504,6 +5485,7 @@ Changes since the 2 February 2018 Working Draft</h3>
 		<li>Rewrote grammar rules about where white space is allowed for clarity.
 		(See [[#grammar]].)
 	</ul>
+
 
 <h3 id="changes-2013">
 Changes since the 2 May 2013 Working Draft</h3>
@@ -4556,6 +5538,7 @@ Changes since the 2 May 2013 Working Draft</h3>
 	Note: The 1 February 2018 draft included an inadvertent commit of unfinished work;
 	2 February 2018 has reverted this commit (and fixed some links because why not).
 
+
 <h3 id="changes-2012">
 Changes since the 23 August 2012 Working Draft</h3>
 
@@ -4572,6 +5555,7 @@ Changes since the 23 August 2012 Working Draft</h3>
 		<li>The '':local-link()'' pseudo-class now ignores trailing slashes.
 	</ul>
 
+
 <h3 id="changes-2011">
 Changes since the 29 September 2011 Working Draft</h3>
 
@@ -4584,6 +5568,7 @@ Changes since the 29 September 2011 Working Draft</h3>
 		<li>Added <css>:valid-drop-target</css>.
 		<li>Changed <a>column combinator</a> from double slash to double pipe.
 	</ul>
+
 
 <h3 id="changes-level-3">
 Changes Since Level 3</h3>
@@ -4606,6 +5591,7 @@ Changes Since Level 3</h3>
 		<li>Added case-insensitive / case-sensitive attribute-value matching flags.
 	</ul>
 
+
 <h2 id="acknowledgements">
 Acknowledgements</h2>
 
@@ -4625,7 +5611,7 @@ Acknowledgements</h2>
 	Lea Verou
 
 
-	<h2 class=no-num id=privacy>Privacy Considerations</h2>
+<h2 class=no-num id=privacy>Privacy Considerations</h2>
 
 	<ul>
 		<li>
@@ -4642,5 +5628,26 @@ Acknowledgements</h2>
 	The <a href="#privacy">Privacy Considerations</a>
 	could also be considered to affect Security.
 
+<wpt hidden title="Features from higher-level specs">
+	heading.html
+	parsing/parse-heading.html
+	parsing/parse-state.html
+</wpt>
 
-
+<wpt hidden title="Features from other specs and unrelated tests">
+	first-letter-flag-001.html
+	first-line-bidi-001.html
+	first-line-bidi-002.html
+	floating-first-letter-05d0.html
+	floating-first-letter-feff.html
+	invalidation/part-pseudo.html
+	link-sharing-crash.html
+	parsing/parse-part.html
+	parsing/parse-slotted.html
+	quirks-mode-import.html
+	selection-image-001-no-selection-noref.html
+	selection-image-001-noref.html
+	selection-image-001.html
+	selection-image-002.html
+	spurious-brace-crash.html
+</wpt>


### PR DESCRIPTION
I added all the Web Platform Tests that currently cover the features in Selectors 4.

For the reviewers: Please especially check whether the tests under `old-tests/` are placed in the correct section and the tests in "Features from other specs and unrelated tests".

Note that this PR does _not_ include hints about missing WPT coverage. This needs to be done separately.

(This is part of the effort to get Selectors 4 into shape for CR, see https://github.com/w3c/csswg-drafts/issues/12799#issuecomment-3291663905.)

Sebastian