### PR TITLE
[css-nesting-1] Fix character reference errors

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -327,10 +327,10 @@ Syntax {#syntax}
 		as nesting is not a syntax transformation,
 		but rather matches on the actual elements the parent selector matches.
 
-		It is also true that the selector ''&Bar'' is invalid in CSS in the first place,
+		It is also true that the selector ''&amp;Bar'' is invalid in CSS in the first place,
 		as the ''Bar'' part is a type selector,
 		which must come first in the compound selector.
-		(That is, it must be written as ''Bar&''.)
+		(That is, it must be written as ''Bar&amp;''.)
 		So, luckily, there is no overlap between CSS Nesting
 		and the preprocessor syntax.
 	</div>
@@ -1091,10 +1091,10 @@ Nesting Selector: the ''&'' selector {#nest-selector}
 
 	While the position of a [=nesting selector=] in a [=compound selector=]
 	does not make a difference in its behavior
-	(that is, ''&.foo'' and ''.foo&'' match the same elements),
+	(that is, ''&amp;.foo'' and ''.foo&amp;'' match the same elements),
 	the existing rule that a [=type selector=], if present, must be first in the [=compound selector=]
 	continues to apply
-	(that is, ''&div'' is illegal, and must be written ''div&'' instead).
+	(that is, ''&amp;div'' is illegal, and must be written ''div&amp;'' instead).
 
 
 <!-- Big Text: Nested Decl
@@ -1350,7 +1350,7 @@ Significant changes since the
 
 * Clarified that the [=nesting selector=] is allowed to match featureless elements.
 
-* Switched ''&div'' back to being invalid;
+* Switched ''&amp;div'' back to being invalid;
 	now that Syntax does "infinite lookahead",
 	we no longer need to allow it.
 	Plus, doing so avoids a clash with preprocessors.


### PR DESCRIPTION
For example:
`LINE 330:39: Character reference '&Bar' didn't end in ;`.

Replaced various instances of `&` with `&amp;`.