### PR TITLE
[css-nesting-1] Fix warning about multiple elements with the same ID

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -1108,7 +1108,7 @@ Nesting Selector: the ''&'' selector {#nest-selector}
 █▌   ▐▌ █████▌  ███▌    █▌   █████▌ ████▌      ████▌  █████▌  ███▌  █████
 -->
 
-<h2 id=nested-declarations-rule>
+<h2 id=nested-declarations>
 The Nested Declarations Rule</h2>
 
 	For somewhat-technical reasons,


### PR DESCRIPTION
`WARNING: Multiple elements have the same id 'nested-declarations-rule'`