### PR TITLE
[css-nesting-1] Fix linking of <<scope-start>>

### DIFF
--- a/css-nesting-1/Overview.bs
+++ b/css-nesting-1/Overview.bs
@@ -1344,7 +1344,7 @@ will collapse into a single rule when serialized and parsed again.
 Significant changes since the
 <a href="https://www.w3.org/TR/2023/WD-css-nesting-1-20230214/">Feb 14, 2023 Working Draft</a>:
 
-* The ''<scope-start>'' selector of a ''@scope'' rule
+* The <<scope-start>> selector of a ''@scope'' rule
 	no longer acts as the parent rule for nesting.
 	(<a href="https://github.com/w3c/csswg-drafts/issues/9740">Issue 9740</a>)
 


### PR DESCRIPTION
`<scope-start>` is a production, and should use the production markup `<<scope-start>>`.

Fixes this error:

  LINE 1347:22: ''...'' shorthand (opened on 1347:7) was closed,
  but there were still open elements inside of it.
