### PR TITLE
[css-cascade-5] Add the revert-rule keyword

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -31,6 +31,7 @@ Informative Classes: ex
 spec:dom; type:dfn; text:shadow tree
 spec:css-color-4; type:property; text:color
 spec:css-values-3; type: value; text:ex
+spec:css-values-5; type: function; text:if()
 spec:css-conditional-3; type:at-rule; text:@media
 spec:mediaqueries-4; type:type; for:@media; text:all
 spec:mediaqueries-4; type:type; text:<media-query>
@@ -1817,7 +1818,7 @@ Explicit Defaulting</h3>
 	As specified in <a href="https://www.w3.org/TR/css-values/#common-keywords">CSS Values and Units</a> [[!css-values-3]],
 	all CSS properties can accept these values.
 
-	The keywords ''revert'' and ''revert-layer''
+	The keywords ''revert'', ''revert-layer'', and ''revert-rule''
 	are <dfn export lt="cascade-dependent keyword">cascade-dependent keywords</dfn>;
 	some contexts may restrict their use
 	while allowing the other [=CSS-wide keywords=].
@@ -1954,6 +1955,42 @@ Rolling Back Cascade Layers: the ''revert-layer'' keyword</h4>
 	as it is for ''revert'',
 	and thus effectively forms its own [=cascade layer=].
 
+<h4 id="revert-rule-keyword">
+Rolling Back Rules: the ''revert-rule'' keyword</h4>
+
+	The <dfn value for=all>revert-rule</dfn> [=CSS-wide keyword=]
+	rolls back the cascade similar to ''revert'' and ''revert-layer'',
+	except it works by [=style rule=]
+	rather than [=cascade origin=] or [=cascade layer=].
+
+	If the <a>cascaded value</a> of a property is the ''revert-rule'' keyword,
+	the <a>cascaded value</a> is rolled back
+	such that the <a>specified value</a> is calculated
+	as if the current [=style rule=] had not been present at all.
+
+	<div class="example">
+		The ''revert-rule'' keyword can be combined with ''if()''
+		to conditionally ignore a declaration:
+
+		<pre class='lang-css'>
+		div {
+		  border-radius: 5px;
+		}
+		.apply-sharp {
+		  border-radius: if(style(--mode:sharp): 0px; else: revert-rule);
+		}
+		</pre>
+
+		Given an element <code>&lt;div class=apply-sharp></code>,
+		the above style sets ''border-radius'' to <code>0px</code>
+		only when the [=computed value=] of <code>--mode</code>
+		is <code>sharp</code>.
+		</pre>
+	</div>
+
+	The ''revert-rule'' keyword behaves like ''revert-layer''
+	in the [=author origin=].
+
 <h2 id="layer-apis">Layer APIs</h2>
 
 <h3 id="the-csslayerblockrule-interface">
@@ -2025,6 +2062,8 @@ Changes since the 13 Jan 2022 Candidate Recommendation Snapshot</h3>
 Non-trivial changes since the <a href="CSS Cascading and Inheritance Level 5">13 January 2022 Candidate Recommendation Snapshot</a>:
 
 <!-- to 13 Jan 2022 -->
+	* Added the ''revert-rule'' keyword.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/10443">Issue 10443</a>)
 	* Clarify that all “aliases” of a property are reverted by ''revert''/''revert-layer''.
 	* Clarify that style sheets are ordered in [[final CSS style sheets]] order.
 	* Clarify that only ''@layer'' statement rules are ignored when checking validity of ''@import'', not empty ''@layer'' block rules.


### PR DESCRIPTION
A link-defaults entry is needed for 'if()' to avoid links to css-conditional-values-1.

#10443