### PR TITLE
[css-ui-4][editorial] Let `outline-color` refer to `border-top-color` values

### DIFF
--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -476,7 +476,7 @@ Outline Colors: the 'outline-color' property</h3>
 
 	<pre class="propdef">
 	Name: outline-color
-	Value: auto | <<color>> | <<image-1D>>
+	Value: auto | <<'border-top-color'>>
 	Initial: auto
 	Applies to: all elements
 	Inherited: no
@@ -486,7 +486,7 @@ Outline Colors: the 'outline-color' property</h3>
 	</pre>
 
 	The 'outline-color' property
-	accepts all values of <'border-color'>,
+	accepts all values of <<'border-top-color'>>,
 	as well as the following keywords:
 
 	<dl dfn-type=value dfn-for=outline-color>
@@ -2856,7 +2856,8 @@ Changes from the <a href="https://www.w3.org/TR/2021/WD-css-ui-4-20210316/">16 M
 			(Support for the broader <<image>> type remains allowed but optional.)
 
 		<li>
-			Added <<image-1D>> as value for the 'outline-color' property.
+			Replaced the <<color>> value of the 'outline-color' property by <<'border-top-color'>>,
+			so that new values like <<image-1D>> also apply to it.
 
 		<li>
 			Retired the <code>invert</code> value of 'outline-color'.


### PR DESCRIPTION
The description of `outline-color` refers to `<'border-color'>` while its syntax definition explicitly contains `<color> | <image-1D>`.

This has two issues:

1. The description deviates from the syntax definition.
2. `border-color` is a shorthand that takes one to four values, which is not what was intended for `outline-color`

So this PR changes them to both refer to `<'border-top-color'>`, which only takes _one_ value and is also referenced in other related places.

Sebastian