### PR TITLE
Revert "[css-animation-1] Handle <string> values in keyframes-name as identitiers"

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -229,10 +229,6 @@ Declaring Keyframes</h2>
 	the names are fully <a>case-sensitive</a>;
 	two names are equal only if they are codepoint-by-codepoint equal.
 	The <<custom-ident>> additionally excludes the ''animation-name/none'' keyword.
-	The <<string>> should be treated as <<custom-ident>>, hence parsed as invalid if
-	is one of the <a>CSS-wide keywords</a> or "default"; empty string is not allowed
-	either. It's serialized as identifier when possible and as <<string>> otherwise.
-
 
 	<div class=example>
 		For example, the following two ''@keyframes'' rules have the same name,
@@ -258,8 +254,8 @@ Declaring Keyframes</h2>
 		@keyframes None { /* ... */ }
 		</pre>
 
-		They are also <em>invalid</em> if those names are specified with a <<string>>
-		because they can not be serialized as valid <<custom-ident>>:
+		However, those names <em>can</em> be specified with a <<string>>,
+		so the following are both <em>valid</em>:
 
 		<pre class=lang-css>
 		@keyframes "initial" { /* ... */ }


### PR DESCRIPTION
Reverts w3c/csswg-drafts#12985

One implemented suggested to revert, based on a disagreement of the CSSWG resolution.