### PR TITLE
[css-env] fix typo of unit name in draft

### DIFF
--- a/css-env-1/Overview.bs
+++ b/css-env-1/Overview.bs
@@ -256,7 +256,7 @@ would cause text sizes to double,
 then ''env(preferred-text-scale)'' would resolve to ''2''.
 
 Note: The ''pem'' unit represents this same information;
-''1em'' is exactly equivalent to ''calc(1em * env(preferred-text-scale))''.
+''1pem'' is exactly equivalent to ''calc(1em * env(preferred-text-scale))''.
 When directly sizing things, ''bsem'' is just a more convenient length to use.
 
 <div class=example>


### PR DESCRIPTION
1em didn't make sense with the associated formula. 

The context of the line above makes me think it was meant to be pem.

The definition of pem here fits the line

https://github.com/w3c/csswg-drafts/issues/10674

Although it also suggests it's going away, so maybe the whole section needs removing.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
