### PR TITLE
[css-animations-2] Use correct property names for timeline-triger-range

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -1000,7 +1000,7 @@ The Exit Range: the 'timeline-trigger-exit-range' property</h4>
 
 <pre class="propdef shorthand">
 Name: timeline-trigger-exit-range
-Value: [ <<'animation-trigger-exit-range-start'>> <<'animation-trigger-exit-range-end'>>? ]#
+Value: [ <<'trigger-exit-range-start'>> <<'trigger-exit-range-end'>>? ]#
 </pre>
 
 The 'timeline-trigger-exit-range' property is a [=shorthand property=]


### PR DESCRIPTION
This seems to have been a change from https://github.com/w3c/csswg-drafts/pull/13009.
