### PR TITLE
[css-ui] Fix accidental syntax regression

### DIFF
--- a/css-ui-3/Overview.bs
+++ b/css-ui-3/Overview.bs
@@ -921,7 +921,7 @@ While the content is being scrolled, implementations may adjust their rendering 
 
 <pre class="propdef">
 Name: cursor
-Value: <<cursor-image>>#? <<cursor-predefined>>
+Value: [<<cursor-image>>,]* <<cursor-predefined>>
 Initial: auto
 Applies to: all elements
 Inherited: yes

--- a/css-ui-4/Overview.bs
+++ b/css-ui-4/Overview.bs
@@ -720,7 +720,7 @@ Styling the Cursor: the 'cursor' property</h4>
 
 	<pre class="propdef">
 	Name: cursor
-	Value: <<cursor-image>>#? <<cursor-predefined>>
+	Value: [<<cursor-image>>,]* <<cursor-predefined>>
 	Initial: auto
 	Applies to: all elements
 	Inherited: yes


### PR DESCRIPTION
`[foo,]*` and `foo#?` are not equivalent, as the former has a trailing comma.

See https://github.com/w3c/csswg-drafts/issues/13001
