### PR TITLE
[css-borders-4] Clarify how `border-shape` renders `box-shadow`.

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -3079,7 +3079,8 @@ When an element's [=computed value=] of 'border-shape' is not <css>none</css>,
 its 'border-radius' is ignored, as if it was set to 0.
 'corner-shape' is implicitly ignored, as it can only work in tandem with 'border-radius'.
 
-A 'box-shadow' follows both the outer border path.
+An [=outer box-shadow=] follows the outside of the outer path, and an [=inner box-shadow=] follows the inside inner path.
+Both are rendered as a stroke, with a stroke width of <code>spread * 2</code>, clipped by the border shape.
 
 'border-shape' does not affect geometry or layout,
 which is still computed using the existing 'border-width' properties.


### PR DESCRIPTION
This doesn't require a new resolution, as there is no previous resolution on how border-shape shadow rendering works.
Stroking the inner/outer path by the width of the shadow spread matches how box-shadow works elsewhere.