### PR TITLE
[css-inline-3][editorial] Hyperlink instance of "in-flow" jargon

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -2837,7 +2837,7 @@ Interaction with Fragmentation (Pagination)</h4>
 	for the purpose of block-axis <a>fragmentation</a>
 	(breaking across pages, columns, regions, etc.).
 	Additionally,
-	breaks between the in-flow lines alongside an <a>initial letter box</a>
+	breaks between the <a>in-flow</a> lines alongside an <a>initial letter box</a>
 	are avoided,
 	much as breaks between line boxes affected be 'widows' and 'orphans'
 	are avoided.


### PR DESCRIPTION
This hyperlinks another instance of the term "in-flow" to its formal definition for clarity.

I note that this spec is already inconsistent in whether it uses the `<a>term</a>` vs. `[=term=]` Bikeshed linking syntax, including for `in-flow` specifically. Here, I've opted for the anchor syntax, for consistency with the surrounding paragraph.