### PR TITLE
[css-text-decor-4] Renamed text-decoration-trim to text-decoration-inset

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -860,7 +860,7 @@ Text Decoration Line Uniformity</h3>
 
 
 <h4 id="text-decoration-inset-property">
-Adjusting Text Decoration Line Lengths: the 'text-decoration-inset' property</h4>
+Trimming, Expanding, and Shifting Text Decoration Lines: the 'text-decoration-inset' property</h4>
 
 	<pre class="propdef">
 	Name: text-decoration-inset
@@ -873,9 +873,10 @@ Adjusting Text Decoration Line Lengths: the 'text-decoration-inset' property</h4
 	Animation type: by computed value
 	</pre>
 
-	This property adjusts the start and end points of line decorations,
-	allowing the author to shorten, lengthen, or shift the decoration
-	with respect to the text.
+	This property adjusts the start and end endpoints of line decorations.
+	Positive values move an endpoint inward, trimming the decoration;
+	negative values move it outward, extending the decoration.
+
 	It controls all text decoration lines drawn by this [=decorating box=],
 	but not any text decoration lines drawn by its ancestors.
 	If two component values are given,
@@ -885,8 +886,9 @@ Adjusting Text Decoration Line Lengths: the 'text-decoration-inset' property</h4
 	<dl dfn-type=value dfn-for=text-decoration-inset>
 		<dt><dfn><<length>></dfn></dt>
 		<dd>
-			Inset (positive) or outset (negative)
-			the start/end of the affected line decorations.
+			Adjusts the start or end endpoint of the affected line decorations.
+			Positive values move the endpoint inward (trimming),
+			negative values move it outward (extending).
 
 			<div class="example">
 				<p>The following example offsets an extra thick underline
@@ -917,15 +919,15 @@ Adjusting Text Decoration Line Lengths: the 'text-decoration-inset' property</h4
 			</div>
 	</dl>
 
-	The adjustment of the text decoration's length is subject to 'box-decoration-break':
+	The adjustment of the text decoration's endpoints is subject to 'box-decoration-break':
 	* for ''box-decoration-break/slice'' (the default)
-		length adjustment is only applied to the [=start=] edge of the first fragment
+		endpoint adjustment is only applied to the [=start=] edge of the first fragment
 		and the [=end=] edge of the last fragment,
 		and may accumulate to other fragments if the amount of the inset
 		is more than the length of the fragment.
 		<!-- Percentages are relative to the total length of the [=decorating box=]. -->
 	* for ''box-decoration-break/clone''
-		length adjustment is applied to each fragment independently.
+		endpoint adjustment is applied to each fragment independently.
 		<!-- and percentages are relative to the length of that fragment individually -->
 
 <h3 id="text-decoration-skipping">


### PR DESCRIPTION
According to the resolution from https://github.com/w3c/csswg-drafts/issues/8402#issuecomment-3462630143.

See also #13024 for the part of the `{row|column}-rule-*` properties.

Sebastian