### PR TITLE
[css-backgrounds-4] Clarified that decorations and emphasis marks are included in `background-clip: text` and text color has no influence on clipping

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -1035,7 +1035,8 @@ Painting Area: the 'background-clip' property</h3>
 		<dd>
 			The background is painted within (clipped to)
 			the intersection of the border box
-			and the geometry of the text in the element and its [=in-flow=] and floated descendants.
+			and the geometry of the text including any decorations and <a href="https://www.w3.org/TR/css-text-decor-4/#emphasis-marks">emphasis marks</a> in the element and its [=in-flow=] and floated descendants.
+			The text color has no effect on the painting of the background.
 
 		<dt><dfn>border-area</dfn></dt>
 		<dd>


### PR DESCRIPTION
See the resolution in https://github.com/w3c/csswg-drafts/issues/900#issuecomment-342251900.

Closes #900, closes #10805

Sebastian