### PR TITLE
[css-mixins-1] Correct @function grammar #13046 

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -194,7 +194,7 @@ optionally a <dfn>parameter type</dfn>, described by a [=syntax definition=];
 and optionally a <dfn>default value</dfn>.
 
 <pre class="prod def" nohighlight>
-&lt;@function> = @function <<function-token>> <<function-parameter>>#? )
+&lt;@function> = @function <<function-token>> ( <<function-parameter>>#? )
 	[ returns <<css-type>> ]?
 {
 	<<declaration-rule-list>>


### PR DESCRIPTION
Add the missing literal open-paren (`(`) to the definition.

Fixes #13046
