### PR TITLE
[css-borders-4] Adjusted border-clip longhands

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -2402,7 +2402,8 @@ Partial Borders: the 'border-limit' property</h3>
 The 'border-clip' properties</h3>
 
 	<pre class="propdef">
-		Name: border-clip, border-clip-top, border-clip-right, border-clip-bottom, border-clip-left
+		Name: border-clip, border-top-clip, border-right-clip, border-bottom-clip, border-left-clip,
+			border-block-start-clip, border-block-end-clip, border-inline-start-clip, border-inline-end-clip
 		Value: normal | [ <<length-percentage [0,&infin;]>> | <<flex>> ]+
 		Initial: normal
 		Inherited: no


### PR DESCRIPTION
Renamed the `border-clip-*` longhand properties to `border-*-clip` to make them consistent with the other `border-*` properties and added logical `border-*-clip` longhands.

Closes #9637, closes #9252

Sebastian