### PR TITLE
[css-fonts-5] Define behavior for <meta text-scale> from #12380

### DIFF
--- a/css-fonts-5/Overview.bs
+++ b/css-fonts-5/Overview.bs
@@ -78,20 +78,15 @@ For readability they have not been repeated explicitly.
 <h2 id="text-scale-meta">
 Text-Scale <{meta}> element</h2>
 
-The <dfn>text scale factor</dfn> is a multiplier
-used to calculate the computed value of the ''font-size/medium'' font size.
-The computed value of ''font-size/medium''
-is 16px
-multiplied by the [=text scale factor=].
-This factor also
-affects the computed size of the other <<absolute-size>> keywords,
-but not necessarily by the same factor as ''font-size/medium''.
-The UA should non-uniformly adjust
-keywords other than ''font-size/medium'' for improved readability.
+User agents must calculate the computed value of ''font-size/medium'' by multiplying 16px by
+the <dfn>text scale factor</dfn>.
+User agents must also apply this factor when determining the computed sizes of the other <<absolute-size>> keywords.
+However, user agents should scale these other keywords non-linearly
+to preserve readability.
 
-Note: Scaling all font sizes uniformly would lead to large fonts being too large.
-See <a href="https://github.com/w3c/wcag3/issues/261#issuecomment-2598860630">
-WCAG discussion about minimum and maximum critical font sizes</a>.
+Note: Applying a linear scale to all keywords would render large fonts excessively large. See the
+<a href="https://github.com/w3c/wcag3/issues/261#issuecomment-2598860630">
+WCAG discussion on minimum and maximum critical font sizes</a>.
 
 A document with a <{meta}> tag
 whose <{meta/name}> attribute


### PR DESCRIPTION
Initial definition of `<meta name="text-scale" content="...">` resolved on in https://github.com/w3c/csswg-drafts/issues/12380