### PR TITLE
[css-cascade-5] The revert-rule keyword behaves like revert-layer ...

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1989,7 +1989,7 @@ Rolling Back Rules: the ''revert-rule'' keyword</h4>
 	</div>
 
 	The ''revert-rule'' keyword behaves like ''revert-layer''
-	in the [=author origin=].
+	in the [=animation origin=].
 
 <h2 id="layer-apis">Layer APIs</h2>
 


### PR DESCRIPTION
... in the *animation origin*, not the author origin.

This fixes an obvious mistake from #12992.
