### PR TITLE
[css-values-5] Allow 'revert-rule' in the 'all' shorthand

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -431,7 +431,7 @@ Resetting All Properties: the 'all' property</h3>
 
 	<pre class="propdef shorthand">
 	Name: all
-	Value: initial | inherit | unset | revert | revert-layer
+	Value: initial | inherit | unset | revert | revert-layer | revert-rule
 	</pre>
 
 	The 'all' property is a <a>shorthand</a>


### PR DESCRIPTION
This was simply overlooked in #12992.
