### PR TITLE
[css-extensions-1][editorial] Minor syntax fixes

### DIFF
--- a/css-extensions-1/Overview.bs
+++ b/css-extensions-1/Overview.bs
@@ -50,8 +50,8 @@ Extension Names</h2>
 
 	<pre class='prod'>
 	<dfn>@custom-selector</dfn> = @custom-selector <<custom-selector>> <<selector-list>> ;
-	<dfn>&lt;custom-selector></dfn> = <<custom-arg>>? : <<extension-name>> [ ( <<custom-arg>>+#? ) ]? ;
-	<dfn>&lt;custom-arg></dfn> = $ <<ident-token>> ;
+	<dfn>&lt;custom-selector></dfn> = <<custom-arg>>? : <<extension-name>> [ ( <<custom-arg>>+#? ) ]?
+	<dfn>&lt;custom-arg></dfn> = '$' <<ident-token>>
 	</pre>
 
 	Where there must be no whitespace


### PR DESCRIPTION
Removed `;` in `<custom-selector>` since it is already included in `@custom-selector`. Perhaps it was used as the end of the production rule (and as such, it was expected to be ignored), but then this should be specified in the value definition syntax.

Wrapped `$` between single quotes.

   > Delimiters, which represent their corresponding tokens. Slashes (/), commas (,), colons (:), semicolons (;), parentheses (( and )), and braces ({ and }) are written literally. Other delimiters must be written enclosed in single quotes (such as '+').

https://drafts.csswg.org/css-values-4/#component-types

Partially fixes #9290.