### PR TITLE
[css-box-3][editorial] block-layout.bs: Gloss "in-flow" jargon

### DIFF
--- a/css-box-3/block-layout.bs
+++ b/css-box-3/block-layout.bs
@@ -1774,7 +1774,7 @@ between the second and the last.
 
   <!--
   <li>Margins of an ''inline-block'' box do not collapse (not even
-  with its in-flow children). <span class=issue>Assuming the first
+  with its <a>in-flow</a> children). <span class=issue>Assuming the first
   rule above (“only block-level”) is correct, this rule seems
   redundant, because an inline block is not block-level.</span>
   -->
@@ -1794,19 +1794,19 @@ between the second and the last.
   <!-- The CSS 2.1 rule for all-horizontal text -->
   <li>If the top margin of a box with non-zero computed
   'min-height' and 'auto' computed 'height' collapses with the
-  bottom margin of its last in-flow child, then the child's bottom
+  bottom margin of its last <a>in-flow</a> child, then the child's bottom
   margin does not collapse with the parent's bottom margin.
 
   <!-- The following can happen in vertical-rl text -->
   <li>If the right margin of a box with non-zero computed
   'min-width' and 'auto' computed 'width' collapses with the
-  left margin of its last in-flow child, then the child's left
+  left margin of its last <a>in-flow</a> child, then the child's left
   margin does not collapse with the parent's left margin.
 
   <!-- The following can happen in vertical-lr text -->
   <li>If the left margin of a box with non-zero computed
   'min-width' and 'auto' computed 'width' collapses with the
-  right margin of its last in-flow child, then the child's right
+  right margin of its last <a>in-flow</a> child, then the child's right
   margin does not collapse with the parent's right margin.
 </ul>
 
@@ -2949,7 +2949,7 @@ stacking contexts, except that any elements that actually create new
 stacking contexts take part in the float's parent's stacking context. 
 A float can overlap other boxes in the normal flow (e.g., when a
 normal flow box next to a float has negative margins). When this
-happens, floats are rendered in front of non-positioned in-flow
+happens, floats are rendered in front of non-positioned <a>in-flow</a>
 blocks, but behind in-flow inlines.
 
 <div class=example>
@@ -3773,7 +3773,7 @@ z-index:  canvas  -1	0    1	  2
 	negative first) then tree order.
 
       <li>
-	<p>For all its in-flow, non-positioned, <a>block-level</a>
+	<p>For all its <a>in-flow</a>, non-positioned, <a>block-level</a>
 	descendants in tree order: If the element is a block,
 	list-item, or other block equivalent:
 	<ol>
@@ -3814,7 +3814,7 @@ z-index:  canvas  -1	0    1	  2
 	</ol>
 
       <li>
-	<p>Otherwise: first for the element, then for all its in-flow,
+	<p>Otherwise: first for the element, then for all its <a>in-flow</a>,
 	non-positioned, <a>block-level</a> descendants in tree order:
 	<ol>
 	  <li>
@@ -3838,7 +3838,7 @@ z-index:  canvas  -1	0    1	  2
 		    <p>For inline elements:
 		    <ol>
 		      <li>
-			<p>For all the element's in-flow,
+			<p>For all the element's <a>in-flow</a>,
 			non-positioned, inline-level children that are
 			in this line box, and all runs of text inside
 			the element that is on this line box, in tree


### PR DESCRIPTION
This hyperlinks the term "in-flow" to its formal definition for clarity. Instances in a multi-paragraph example were excluded, as that example doesn't currently link any terms, and out of an abundance of caution to avoid overkill linkage.
No instances of the term "out-of-flow" were found in this file.