### PR TITLE
[css-text-4][editorial] 2 more "out-of-flow" glosses

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -874,7 +874,7 @@ Mapping Rules</h4>
 	For ''capitalize'', what constitutes a “word“ is UA-dependent;
 	[[!UAX29]] is suggested (but not required)
 	for determining such word boundaries.
-	Out-of-flow elements and inline element boundaries
+	[=Out-of-flow=] elements and inline element boundaries
 	must not introduce a 'text-transform' word boundary
 	and must be ignored when determining such word boundaries.
 
@@ -5882,7 +5882,7 @@ Line Breaking Details</h3>
 			and is forbidden under ''line-break: anywhere''.
 
 		<li>
-			Out-of-flow elements
+			[=Out-of-flow=] elements
 			and inline element boundaries
 			do not introduce a [=forced line break=]
 			or [=soft wrap opportunity=] in the flow.


### PR DESCRIPTION
Regrettably, these were missed in #13030 due to not using a case-insensitive regex at the time. That has been rectified going forward.

This PR hyperlinks the 2 remaining instances of the term "out-of-flow" to its formal definition for clarity.