### PR TITLE
[cssom-view-1] Add emulation for "Web-exposed screen information" with WebDriver BiDi.

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -55,7 +55,9 @@ spec:css-borders-4; type:property; text:border-top-width
 spec:css-borders-4; type:property; text:border-left-width
 spec:cssom-view-1; type:dictionary; text:MouseEventInit
 spec:cssom-view-1; type:dfn; for:MediaQueryList; text:media
-spec:webdriver-bidi; type:dfn; text:WebDriver BiDi emulated screen area
+spec:webdriver-bidi; type:dfn;
+    text:WebDriver BiDi emulated available screen area
+    text:WebDriver BiDi emulated total screen area
 </pre>
 
 <style>
@@ -417,7 +419,7 @@ corner, and the x- and y-coordinates increase rightwards and downwards, respecti
 The <dfn export>Web-exposed screen area</dfn> must return the result of the following algorithm:
 
 1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
-1. Let |emulated screen area| be the <a>WebDriver BiDi emulated screen area</a> of <var>target</var>.
+1. Let |emulated screen area| be the <a>WebDriver BiDi emulated total screen area</a> of <var>target</var>.
 1. If |emulated screen area| is not null, return |emulated screen area|.
 1. Otherwise, return one of the following:
     * The area of the output device, in <a lt=px value>CSS pixels</a>.
@@ -426,7 +428,7 @@ The <dfn export>Web-exposed screen area</dfn> must return the result of the foll
 The <dfn export>Web-exposed available screen area</dfn> must return the result of the following algorithm:
 
 1. Let <var>target</var> be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
-1. Let |emulated screen area| be the <a>WebDriver BiDi emulated screen area</a> for <var>target</var>.
+1. Let |emulated screen area| be the <a>WebDriver BiDi emulated available screen area</a> for <var>target</var>.
 1. If |emulated screen area| is not null, return |emulated screen area|.
 1. Otherwise, return one of the following:
     * The available area of the rendering surface of the output device, in <a lt=px value>CSS pixels</a>.


### PR DESCRIPTION
The draft PR of the changes which might be required to specify WebDriver BiDi to emulate screen area, see https://github.com/w3c/webdriver-bidi/issues/981.
The PR for the command is https://github.com/w3c/webdriver-bidi/pull/1030
