### PR TITLE
[css-tables-3][editorial] Added WPTs

### DIFF
--- a/css-tables-3/Overview.bs
+++ b/css-tables-3/Overview.bs
@@ -19,9 +19,11 @@ Former editor: Markus Mielke, Microsoft
 Former editor: Saloni Mira Rai, Microsoft
 Abstract: This CSS module defines a two-dimensional grid-based layout system, optimized for tabular data rendering. In the table layout model, each display node is assigned to an intersection between a set of consecutive rows and a set of consecutive columns, themselves generated from the table structure and sized according to their content.
 Ignored Terms: block-level box
+WPT Path Prefix: css/css-tables/
+WPT Display: open
 </pre>
 
-<!-- NOTE TO SELF: 
+<!-- NOTE TO SELF:
 BEFORE PUBLISHING A NEW WORKING DRAFT:
 - switch Status to WD
 - search the w3c list archives for the wg resolution allowing to republish
@@ -95,6 +97,73 @@ spec:filter-effects-1; type:property; text:filter
 		of the editors of this specification.
 	Authors wishing to use more complex layouts
 		are encouraged to rely on more modern CSS modules such as CSS Grid.
+
+	<wpt title="
+		The following tests are crash tests
+		that relate to general usage
+		of the features described in this specification
+		but are not tied to any particular normative statement.">
+		colspan-zero-crash.html
+		crashtests/caption-repaint-crash.html
+		crashtests/caption-with-multicol-table-cell.html
+		crashtests/cell-contents-with-negative-outer-size.html
+		crashtests/col_span_dynamic_crash.html
+		crashtests/dialog-table-crash.html
+		crashtests/dynamic-recompute-baseline.html
+		crashtests/dynamic_col_width_crash.html
+		crashtests/dynamic_table_layout_crash.html
+		crashtests/empty-tbody-after-tall-section-crash.html
+		crashtests/empty_cells_crash.html
+		crashtests/empty_table_with_cols.html
+		crashtests/expression_width_crash.html
+		crashtests/inline-splitting-crash.html
+		crashtests/large-border-crash.html
+		crashtests/large-col-widths.html
+		crashtests/legacy_ng_mix_crash.html
+		crashtests/move-oof-inside-section-row-with-borders.html
+		crashtests/negative-section-distribution.html
+		crashtests/negative_caption_margin.html
+		crashtests/orthogonal-cell-borders.html
+		crashtests/orthogonal-cell-crash.html
+		crashtests/table-column-display-change-chrome-crash.html
+		crashtests/textarea-intrinsic-size-crash.html
+		crashtests/transition-table-row-group-crash.html
+		crashtests/uninitialized_read_crash.html
+		crashtests/vertical_percentage_crash.html
+		tfoot-crash-print.html
+		th-text-align.html
+		toggle-row-display-property-001.html
+		table-collapsed-row-or-column-crash.html
+	</wpt>
+
+	<wpt title="Tests generally related to table layout">
+		absolute-tables-001.html
+		absolute-tables-006.html
+		anonymous-table-cell-margin-collapsing.html
+		chrome-rowspan-bug.html
+		col_removal.html
+		colspan-001.html
+		colspan-002.html
+		colspan-003.html
+		colspan-004.html
+		dynamic-rowspan-change.html
+		html-display-table.html
+		inheritance.html
+		multicol-table-collapsed-border-crash.html
+		multicol-table-crash.html
+		remove-caption-from-anon-table.html
+		remove-colgroup-from-anon-table.html
+		row-group-order.html
+		table-position-sticky-computed.html
+		table-cell-child-overflow-measure.html
+		table-cell-inline-size-box-sizing-quirks.html
+		table-cell-scroll-height.html
+		table-cell-writing-mode-computed.html
+		zero-rowspan-001.html
+		zero-rowspan-002.html
+		subpixel-table-cell-height-001.html
+		subpixel-table-width-001.html
+	</wpt>
 
 <h3 id="values">Value Definitions</h3>
 
@@ -218,6 +287,12 @@ spec:filter-effects-1; type:property; text:filter
 		<dt><dfn>table-caption</dfn> (equivalent to HTML: &lt;caption&gt;)
 		<dd>Specifies a caption for the table.
 			Table captions are positioned between the table margins and its borders.
+
+			<wpt>
+				caption-cyclic-percentage.html
+				caption-writing-mode-001.html
+				caption-writing-mode-002.html
+			</wpt>
 	</dl>
 
 	Note: [=Replaced elements=] with a 'display' value of
@@ -235,6 +310,10 @@ spec:filter-effects-1; type:property; text:filter
 	behave according to their [=outer display type=],
 	as per [[css-display-3#outer-role]].
 	<strong>This is a breaking change from CSS 2.1 but matches implementations.</strong>
+
+	<wpt>
+		table-model-fixup-2.html
+	</wpt>
 
 	<h4 id="terminology">Terminology</h4>
 
@@ -299,6 +378,10 @@ spec:filter-effects-1; type:property; text:filter
 				A sequence of sibling boxes is consecutive
 					if each box in the sequence is consecutive to the one before it in the sequence.
 
+				<wpt>
+					whitespace-001.html
+				</wpt>
+
 			<dt><dfn id="table-grid">table grid</dfn>
 			<dd>
 				A matrix 
@@ -314,7 +397,7 @@ spec:filter-effects-1; type:property; text:filter
 					by the intersection of a row <code>r</code> and a column <code>c</code> in the <a>table grid</a>.
 				
 				Each slot of the table grid is covered by at least one <a>table-cell</a> (<a href="#missing-cells-fixup">some of them anonymous</a>), and at most two.
-				Each table-cell of a table-root covers at least one slot. 
+				Each table-cell of a table-root covers at least one slot.
 
 				Table-cells which cover more than one slot do so densely, 
 					meaning the set of slots they cover can always be described as a set of four strictly-positive integers <code>(rowStart, colStart, rowSpan, colSpan)</code>
@@ -331,7 +414,7 @@ spec:filter-effects-1; type:property; text:filter
 
 				Such table-cell is said to <dfn>span</dfn> all rows <code>r</code> and columns <code>c</code> matching the above condition. 
 				Also:
-				
+
 				<ul><li>A table-cell is said to span a table-row <i>(resp. table-column)</i> if it spans its corresponding row <i>(resp. column)</i>
 					<li>A table-row <i>(resp. table-column)</i> corresponding to a row <i>(resp. column)</i> is said to span this row <i>(resp. column)</i>
 					<li>A table-row <i>(resp. table-column)</i> is said to span all columns of the grid <i>(resp. row)</i>
@@ -461,6 +544,15 @@ spec:filter-effects-1; type:property; text:filter
 				We have modified the text of this section from CSS 2.2 to make it easier to read.
 				If you find any mistakes due to these changes please file an issue
 			</div>
+
+			<wpt>
+				anonymous-table-ws-001.html
+				fixup-dynamic-anonymous-inline-table-001.html
+				fixup-dynamic-anonymous-inline-table-002.html
+				fixup-dynamic-anonymous-inline-table-003.html
+				fixup-dynamic-anonymous-table-001.html
+				table-model-fixup.html
+			</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="fixup-boxes">Characteristics of fixup boxes</h4>
@@ -644,6 +736,10 @@ spec:filter-effects-1; type:property; text:filter
 			<figcaption>Overview of the table layout algorithm. Not normative.</figcaption>
 		</figure>
 
+		<wpt>
+			html5-table-formatting-1.html
+		</wpt>
+
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="dimensioning-the-row-column-grid">Dimensioning the row/column grid</h3>
 
@@ -738,6 +834,11 @@ spec:filter-effects-1; type:property; text:filter
 
 		</div>
 
+		<wpt>
+			html5-table-formatting-fixed-layout-1.html
+			table_grid_size_col_colspan.html
+		</wpt>
+
 		<h4 id="dimensioning-the-row-column-grid--step2">Track merging</h4>
 		<p class="note">
 			The HTML Table Formatting algorithm sometimes generates more tracks than necessary to layout the table properly.
@@ -761,6 +862,10 @@ spec:filter-effects-1; type:property; text:filter
 		Finally, assign to the <a>table-root</a> grid its correct number of rows and columns (from its mapped element),
 			and to each <a>table-cell</a> its accurate <a href="#slot">rowStart/colStart/rowSpan/colSpan</a> (from its mapped element).
 
+		<wpt>
+			column-track-merging.html
+		</wpt>
+
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="missing-cells-fixup">Missing cells fixup</h3>
 
@@ -772,6 +877,14 @@ spec:filter-effects-1; type:property; text:filter
 		Once the amount of columns in a table is known, any table-row box must be modified such that
 			it owns enough cells to fill all the columns of the table, when taking <a>spans</a> into account.
 		New table-cell <a href="#fixup-boxes">anonymous boxes</a> must be appended to its rows content until this condition is met.
+
+		<wpt>
+			col-definite-max-size-001.html
+			col-definite-min-size-001.html
+			col-definite-size-001.html
+			html5-table-formatting-2.html
+			html5-table-formatting-3.html
+		</wpt>
 
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="layout-modes">Table layout modes</h3>
@@ -792,6 +905,12 @@ spec:filter-effects-1; type:property; text:filter
 				Computed value: specified keyword
 				Animation type: discrete
 			</pre>
+
+			<wpt>
+				parsing/table-layout-computed.html
+				parsing/table-layout-invalid.html
+				parsing/table-layout-valid.html
+			</wpt>
 
 			A table-root is said to be laid out <dfn>in fixed mode</dfn>
 				whenever the computed value of the 'table-layout' property is equal to <code>fixed</code>,
@@ -832,6 +951,17 @@ spec:filter-effects-1; type:property; text:filter
 			A <a>table-root</a> is said to be laid out <dfn>in collapsed-borders mode</dfn> in this case.
 			Otherwise, the <a>table-root</a> is said to be laid out <dfn>in separated-borders mode</dfn>.
 
+			<wpt>
+				background-clip-001.html
+				box-shadow-001.html
+				collapsed-border-color-change-with-compositing.html
+				collapsed-border-remove-row-group.html
+				collapsed-scroll-overflow.html
+				parsing/border-collapse-computed.html
+				parsing/border-collapse-invalid.html
+				parsing/border-collapse-valid.html
+			</wpt>
+
 			<!--——————————————————————————————————————————————————————————————————————————-->
 			<h5 id="border-spacing-property">The Border-Spacing property</h5>
 
@@ -853,6 +983,12 @@ spec:filter-effects-1; type:property; text:filter
 
 			See [[#computing-undistributable-space]] for details on how this affects the table layout.
 
+			<wpt>
+				animations/border-spacing-interpolation.html
+				parsing/border-spacing-computed.html
+				parsing/border-spacing-invalid.html
+				parsing/border-spacing-valid.html
+			</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="caption-side-property">The Caption-Side property</h4>
@@ -866,6 +1002,13 @@ spec:filter-effects-1; type:property; text:filter
 				Computed value: specified keyword
 				Animation type: discrete
 			</pre>
+
+			<wpt>
+				caption-side-1.html
+				parsing/caption-side-computed.html
+				parsing/caption-side-invalid.html
+				parsing/caption-side-valid.html
+			</wpt>
 
 			This property specifies the position of the caption box with respect to the table grid box.
 			Values have the following meanings:
@@ -934,6 +1077,10 @@ spec:filter-effects-1; type:property; text:filter
 					Where the specified values are not applied on the table grid and/or wrapper boxes,
 						the unset values are used instead for that box (inherit or initial, depending on the property).
 
+					<wpt>
+						caption-relative-positioning.html
+					</wpt>
+
 				<li>The 'overflow' property on the <a>table-root</a> and <a>table-wrapper</a> box, when its value is not either <code>visible</code>, <code>clip</code> or <code>hidden</code>,
 					is ignored and treated as if its value was <code>visible</code>.
 
@@ -943,6 +1090,10 @@ spec:filter-effects-1; type:property; text:filter
 				<li>The 'margin', 'padding', 'overflow' and 'z-index' of <a>table-track</a> and <a>table-track-group</a> boxes are ignored.
 
 				<li>The 'margin' of <a>table-cell</a> boxes is ignored (as if it was set to 0px).
+
+					<wpt>
+						no-overflow-with-table-cell-margins.html
+					</wpt>
 
 				<li>The 'background' of <a>table-cell</a> boxes
 					are painted using a special background painting algorithm described in [[#drawing-cell-backgrounds]].
@@ -993,10 +1144,24 @@ spec:filter-effects-1; type:property; text:filter
 
 		</div>
 
+		<wpt>
+			border-collapse-double-border.html
+			border-collapse-dynamic-col-001.html
+			border-collapse-dynamic-oof.html
+			border-collapse-dynamic-section.html
+			border-collapse-empty-cell.html
+			border-collapse-rowspan-cell.html
+			collapsed-border-remove-cell.html
+		</wpt>
+
 		ISSUE(604): border-collapsing breaking change from 2.1
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="conflict-resolution-for-collapsed-borders">Conflict Resolution for Collapsed Borders</h4>
+
+			<wpt>
+				border-conflict-resolution.html
+			</wpt>
 
 			When they are laid out <a>in collapsed-borders mode</a>,
 				<a>table-root</a> and <a>table-cell</a> boxes sharing a border attempt to unify their borders
@@ -1103,6 +1268,14 @@ spec:filter-effects-1; type:property; text:filter
 			<a href="https://jsfiddle.net/bn3d1sm4/15/">https://jsfiddle.net/bn3d1sm4/15/</a><br/>
 		</div>
 
+		<wpt>
+			subpixel-collapsed-borders-001.html
+			subpixel-collapsed-borders-002.html
+			subpixel-collapsed-borders-003.html
+			subpixel-table-cell-width-001.html
+			subpixel-table-cell-width-002.html
+		</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h5 id="border-style-harmonization-algorithm">Harmonization Algorithm for Collapsed Borders</h5>
 		<div class="note">
@@ -1170,6 +1343,12 @@ spec:filter-effects-1; type:property; text:filter
 
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="content-measure">Computing table measures</h3>
+
+		<wpt>
+			calc-percent-plus-0px-auto.html
+			calc-percent-plus-0px-fixed.html
+			height-distribution/percentage-sizing-of-table-cell-children-002.html
+		</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="computing-undistributable-space">Computing Undistributable Space</h4>
@@ -1308,6 +1487,10 @@ spec:filter-effects-1; type:property; text:filter
 							and prefer to rely on 'width' only instead.
 					</div>
 			</dl>
+
+			<wpt>
+				fractional-percent-width.html
+			</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="computing-column-measures">Computing Column Measures</h4>
@@ -1523,6 +1706,16 @@ spec:filter-effects-1; type:property; text:filter
 					for distributing excess width to columns for intrinsic width calculation.
 			</div>
 
+			<wpt>
+				height-distribution/computing-row-measure-0.html
+				height-distribution/computing-row-measure-1.html
+				height-distribution/percentage-sizing-of-table-cell-children.html
+				height-distribution/percentage-sizing-of-table-cell-replaced-children-001.html
+				width-distribution/computing-column-measure-0.html
+				width-distribution/computing-column-measure-1.html
+				width-distribution/computing-column-measure-2.html
+			</wpt>
+
 <!--
 ██      ██ ████ ████████  ████████ ██     ██       ████████  ████  ██████  ████████ ████████  ████ ████████  ██     ██ ████████ ████  ███████  ██    ██
 ██  ██  ██  ██  ██     ██    ██    ██     ██       ██     ██  ██  ██    ██    ██    ██     ██  ██  ██     ██ ██     ██    ██     ██  ██     ██ ███   ██
@@ -1533,6 +1726,17 @@ spec:filter-effects-1; type:property; text:filter
  ███  ███  ████ ████████     ██    ██     ██       ████████  ████  ██████     ██    ██     ██ ████ ████████   ███████     ██    ████  ███████  ██    ██
 -->
 	<h3 id="width-distribution">Available Width Distribution</h3>
+
+		<wpt>
+			width-distribution/distribution-algo-1.html
+			width-distribution/distribution-algo-2.html
+			width-distribution/distribution-algo-min-content-guess.html
+			width-distribution/distribution-algo-min-content-percent-guess.html
+			width-distribution/distribution-algo-min-content-specified-guess.1.html
+			width-distribution/distribution-algo-min-content-specified-guess.html
+			width-distribution/td-with-subpixel-padding-vertical-rl.html
+			width-distribution/td-with-subpixel-padding.html
+		</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="computing-the-table-width">Computing the table width</h4>
@@ -1583,6 +1787,11 @@ spec:filter-effects-1; type:property; text:filter
 							the <a href="#used-min-width-of-table">used min-width of the table</a>.
 			</ul>
 
+			<wpt>
+				absolute-tables-002.html
+				absolute-tables-003.html
+			</wpt>
+
 			The <dfn>assignable table width</dfn> is
 				the used width of the table
 				minus the [=total horizontal border spacing=] (if any).
@@ -1593,6 +1802,25 @@ spec:filter-effects-1; type:property; text:filter
 				and are constrained by the dimensions of the cells they contain.
 				Setting the width of a column might indirectly influence the height of a row, and vice versa.
 			</div>
+
+			<wpt>
+				visibility-collapse-col-001.html
+				visibility-collapse-col-002.html
+				visibility-collapse-col-003.html
+				visibility-collapse-col-004-dynamic.html
+				visibility-collapse-col-005.html
+				visibility-collapse-colspan-001.html
+				visibility-collapse-colspan-002.html
+				visibility-hidden-col-001.html
+				visibility-hidden-nested-001.html
+				visibility-hidden-nested-002.html
+				width-distribution/computing-table-width-0.html
+				width-distribution/computing-table-width-1.html
+				table-intrinsic-size-001.html
+				table-intrinsic-size-002.html
+				table-intrinsic-size-003.html
+				table-intrinsic-size-004.html
+			</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="width-distribution-principles">Core distribution principles</h4>
@@ -1672,6 +1900,10 @@ spec:filter-effects-1; type:property; text:filter
 					display: inline-block;
 				}
 			</style>
+
+			<wpt>
+				percent-width-cell-dynamic.html
+			</wpt>
 
 			<h5 id="width-distribution-principles-rR">Available sizings</h5>
 
@@ -1827,6 +2059,10 @@ spec:filter-effects-1; type:property; text:filter
 					one with the pixel value, the other with the percentage value. This is different from resolving the percentage away,
 					because of how width distribution works for percentage-based columns.
 
+			<wpt>
+				fixed-layout-1.html
+				fixed-layout-2.html
+			</wpt>
 
 		<h5 id="distributing-width-to-columns">Distributing excess width to columns</h5>
 
@@ -1899,6 +2135,12 @@ spec:filter-effects-1; type:property; text:filter
 				<li>otherwise, the excess width is distributed equally to the zero-sized columns</ul>
 		</div>
 
+		<wpt>
+			auto-layout-calc-width-001.html
+			fixed-layout-calc-width-001.html
+			fixed-layout-excess-width-distribution-001.html
+		</wpt>
+
 <!--
 ██     ██ ████████ ████  ██████   ██     ██ ████████       ████████  ████  ██████  ████████ ████████  ████ ████████  ██     ██ ████████ ████  ███████  ██    ██
 ██     ██ ██        ██  ██    ██  ██     ██    ██          ██     ██  ██  ██    ██    ██    ██     ██  ██  ██     ██ ██     ██    ██     ██  ██     ██ ███   ██
@@ -1909,6 +2151,11 @@ spec:filter-effects-1; type:property; text:filter
 ██     ██ ████████ ████  ██████   ██     ██    ██          ████████  ████  ██████     ██    ██     ██ ████ ████████   ███████     ██    ████  ███████  ██    ██
 -->
 	<h3 id="height-distribution">Available Height Distribution</h3>
+
+		<wpt>
+			table-cell-overflow-explicit-height-001.html
+			table-cell-overflow-explicit-height-002.html
+		</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="computing-the-table-height">Computing the table height</h4>
@@ -1942,6 +2189,40 @@ spec:filter-effects-1; type:property; text:filter
 				then <a href="#height-distribution-algorithm">height distribution</a> will happen to adjust their heights to collectively meet the table height,
 				then table-cell descendants might get a <a href="#table-cell-content-relayout">second layout</a> (where their percentage heights are resolved).
 
+			<wpt>
+				absolute-crash.html
+				absolute-tables-004.html
+				absolute-tables-005.html
+				absolute-tables-007.html
+				empty-table-height.html
+				max-height-table.html
+				min-height-table.html
+				min-height-table-2.html
+				min-max-size-table-content-box.html
+				paint/table-border-paint-caption-change.html
+				percentages-grandchildren-quirks-mode-001.html
+				percentages-grandchildren-quirks-mode-002.html
+				table-as-item-cell-percentage-001.html
+				table-as-item-cell-percentage-002.html
+				table-as-item-cell-percentage-003.html
+				table-as-item-cell-percentage-004.html
+				visibility-collapse-non-rowcol-001.html
+				visibility-collapse-row-001.html
+				visibility-collapse-row-002-dynamic.html
+				visibility-collapse-row-003-dynamic.html
+				visibility-collapse-row-004.html
+				visibility-collapse-row-005.html
+				visibility-collapse-row-group-001.html
+				visibility-collapse-row-group-002.html
+				visibility-collapse-rowcol-001.html
+				visibility-collapse-rowcol-002.html
+				visibility-collapse-rowspan-001.html
+				visibility-collapse-rowspan-003-border-separate.html
+				visibility-collapse-rowspan-003.html
+				visibility-hidden-row-001.html
+				visibility-hidden-row-002.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="row-layout">Row layout (first pass)</h4>
 
@@ -1955,7 +2236,7 @@ spec:filter-effects-1; type:property; text:filter
 				but their other properties are conserved.
 
 			For the purpose of calculating this height,
-				descendants of table cells whose height depends on percentages of their parent cell' height 
+				descendants of table cells whose height depends on percentages of their parent cell' height
 				<a href="#appropriateness-of-child-percentage-resolution">(see section below)</a>
 				are considered to have an auto height
 					if they have 'overflow' set to ''overflow/visible'', ''overflow/clip'', or ''overflow/hidden''
@@ -1965,7 +2246,7 @@ spec:filter-effects-1; type:property; text:filter
 			<a href="https://jsfiddle.net/0e12ve9b/3/">!!Testcase</a>
 
 			<div class="note">
-				For table-cell descendants whose percentage height was ignored as a result of the above, 
+				For table-cell descendants whose percentage height was ignored as a result of the above,
 					a second layout pass of the table-cell content will happen once height distribution has concluded
 					to attempt to properly take this sizing into account
 					<a href="#resolving-percentages-heights-in-table-cell-content">(see section below)</a>
@@ -1977,6 +2258,13 @@ spec:filter-effects-1; type:property; text:filter
 				whichever comes first.
 			If there is no such line box or table-row,
 				the baseline is the bottom of content edge of the cell box.
+
+			<wpt>
+				baseline-vertical.html
+				baseline-empty-cell-001.html
+				table-cell-baseline-static-position.html
+				table-cell-overflow-auto.html
+			</wpt>
 
 			<div class="example">
 
@@ -2130,6 +2418,16 @@ spec:filter-effects-1; type:property; text:filter
 				Please note that heights being defined on row groups are being ignored by this algorithm
 			</div>
 
+			<wpt>
+				dynamic-table-cell-height.html
+				percent-height-overflow-auto-in-restricted-block-size-cell.html
+				height-distribution/percentage-sizing-of-table-cell-007.html
+				height-distribution/percentage-sizing-of-table-cell-children-003.html
+				height-distribution/percentage-sizing-of-table-cell-children-004.html
+				height-distribution/percentage-sizing-of-table-cell-children-005.html
+				height-distribution/percentage-sizing-of-table-cell-children-006.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="row-relayout">Row layout (second pass)</h4>
 
@@ -2275,11 +2573,21 @@ spec:filter-effects-1; type:property; text:filter
 
 			</div>
 
+			<wpt>
+				height-distribution/extra-height-given-to-all-row-groups-001.html
+				height-distribution/extra-height-given-to-all-row-groups-002.html
+				height-distribution/extra-height-given-to-all-row-groups-003.html
+				height-distribution/extra-height-given-to-all-row-groups-004.html
+				height-distribution/extra-height-given-to-all-row-groups-005.html
+				height-distribution/td-different-subpixel-padding-in-same-row-vertical-rl.html
+				height-distribution/td-different-subpixel-padding-in-same-row.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="table-cell-content-relayout">Table-cell content layout (second pass)</h4>
 
 			Once table-height distribution has concluded, and the sum of row heights plus spacing/border is equal to the table height,
-				the content of table-cells which contained descendants whose percentage heights were ignored 
+				the content of table-cells which contained descendants whose percentage heights were ignored
 				or treated as 0px by the first-pass row layout rules <a href="#row-layout">(see above)</a>
 				must undergo a second layout pass, as defined below.
 
@@ -2343,7 +2651,7 @@ spec:filter-effects-1; type:property; text:filter
 							<th>result&nbsp;&nbsp;</th>
 						</tr>
 					</thead>
-					
+
 					<tbody>
 						<tr>
 							<td>&lt;length&gt;</td>
@@ -2375,20 +2683,35 @@ spec:filter-effects-1; type:property; text:filter
 
 				Note that neither <code>--other-table-cell-height</code> nor <code>--wrapper-height</code> do influence the algorithm's outcome.
 
-				A previous version of this specification incorrectly stated that <code>--wrapper-height</code> was taken into account when the table had a percentage height, 
+				A previous version of this specification incorrectly stated that <code>--wrapper-height</code> was taken into account when the table had a percentage height,
 				but compat issues appeared when an implementation landed, and the behavior was then special-cased.
 
 			</div>
 
 			<div class="note">
 				It is possible that this second layout pass (where height percentages are being resolved)
-					will make some cell contents overflow their parent cell, 
-					for instance if the sum of all percentages used is superior to 100%. 
+					will make some cell contents overflow their parent cell,
+					for instance if the sum of all percentages used is superior to 100%.
 				This is by design.
 			</div>
 
+			<wpt>
+				percent-height-replaced-in-percent-cell-002.html
+				percent-height-replaced-in-percent-cell-003.html
+				percent-height-replaced-in-percent-cell-004.html
+				percent-height-table-cell-child.html
+			</wpt>
+
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="bounding-box-assignment">Positioning of cells, captions and other internal table boxes</h3>
+
+		<wpt>
+			border-spacing-included-in-sizes-001.html
+			bounding-box-computation-1.html
+			bounding-box-computation-2.html
+			bounding-box-computation-3.html
+			table-cell-overflow-auto-scrolled.html
+		</wpt>
 
 		ISSUE(478): We need a resolution on what visibility:collapse does.
 
@@ -2448,8 +2771,8 @@ spec:filter-effects-1; type:property; text:filter
 		<div class="note">
 			The above formula take in account 'border-spacing', and it might not be directly obvious what the effect of these mean, so here are a couple of properties of those formula:
 			<ul>
-				<li> the border-spacing before the first track or after the last track in a direction is not included in any track's or track-group's breadth. 
-				<li> the border-spacing between tracks is not included in any track's breadth, but is included in the breadth of track-groups spanning both tracks. 
+				<li> the border-spacing before the first track or after the last track in a direction is not included in any track's or track-group's breadth.
+				<li> the border-spacing between tracks is not included in any track's breadth, but is included in the breadth of track-groups spanning both tracks.
 			</ul>
 		</div>
 
@@ -2549,6 +2872,14 @@ With a table-root as containing block</h3>
 
 	</div>
 
+	<wpt>
+		absolute-tables-012.html
+		absolute-tables-013.html
+		absolute-tables-014.html
+		absolute-tables-015.html
+		absolute-tables-016.html
+	</wpt>
+
 <h3 id="abspos-boxes-in-table-internal">
 With a table-internal as containing block</h3>
 
@@ -2573,6 +2904,10 @@ With a table-internal as containing block</h3>
 	<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=417223">[Chrome bug]</a>
 	<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1289682">[Interop risk: Firefox bug]</a>
 
+	<wpt>
+		abspos-container-change-dynamic-001.html
+		internal-containing-block-001.html
+	</wpt>
 
 <h3 id="static-position">
 With a table-internal box as non-containing block parent</h3>
@@ -2582,7 +2917,7 @@ With a table-internal box as non-containing block parent</h3>
 
 	For table-cells, the absolutely-positioned content is positioned follows the rules for block layout as usual.
 
-	Due to <a href="#fixup">table fixup</a>, 
+	Due to <a href="#fixup">table fixup</a>,
 	it is not possible to create an absolutely-positioned box 
 	that is the child of a table-internal box that is not a table-cell 
 	(see note about float and position for more details).
@@ -2597,6 +2932,11 @@ With a table-internal box as non-containing block parent</h3>
 ██     ██ ████████ ██    ██ ████████  ████████ ██     ██ ████ ██    ██  ██████
 -->
 <h2 id="rendering">Rendering</h2>
+
+	<wpt>
+		row-group-margin-border-padding.html
+		row-margin-border-padding.html
+	</wpt>
 
 	<!--——————————————————————————————————————————————————————————————————————————-->
 	<h3 id="paint-order">Paint order of cells</h3>
@@ -2616,6 +2956,12 @@ With a table-internal box as non-containing block parent</h3>
 			Computed value: specified keyword
 			Animation type: discrete
 		</pre>
+
+		<wpt>
+			parsing/empty-cells-computed.html
+			parsing/empty-cells-invalid.html
+			parsing/empty-cells-valid.html
+		</wpt>
 
 		<a>In collapsed-borders mode</a>,
 			this property has no effect.
@@ -2691,6 +3037,10 @@ With a table-internal box as non-containing block parent</h3>
 
 			<a class="hint" href="https://wptest.center/#/6xd2b3">!Testcase</a>
 
+			<wpt>
+				out-of-order-elements-collapsed-border.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h5 id="drawing-collapsed-borders-1">Changes in collapsed-borders mode</h5>
 
@@ -2711,6 +3061,15 @@ With a table-internal box as non-containing block parent</h3>
 			<p class="note">
 				Even if they are not drawn by the table, the table borders still occupy their space in the layout.
 					Cells will <a href="#drawing-cell-borders">render those shared borders</a>.
+
+			<wpt>
+				collapsed-border-paint-phase-001.html
+				collapsed-border-paint-phase-002.html
+				collapsed-border-partial-invalidation-001.html
+				collapsed-border-partial-invalidation-002.html
+				collapsed-border-partial-invalidation-003.html
+				collapsed-border-positioned-tr-td.html
+			</wpt>
 
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="drawing-cell-backgrounds">Drawing cell backgrounds</h4>
@@ -2775,6 +3134,14 @@ With a table-internal box as non-containing block parent</h3>
 				as if <code>visibility: hidden</code> was specified on them,
 				letting the table background show through.
 
+			<wpt>
+				paint/col-change-span-bg-invalidation-001.html
+				paint/col-change-span-bg-invalidation-002.html
+				paint/col-paint-htb-rtl.html
+				paint/col-paint-vrl-rtl.html
+				paint/row-background-paint-remove-last-cell.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="drawing-cell-borders">Drawing cell borders</h4>
 
@@ -2798,6 +3165,10 @@ With a table-internal box as non-containing block parent</h3>
 				which has a greater specificity than the other ones according to this spec.
 				<span class="hint">See [[#paint-order]] and [[#border-conflict-resolution-algorithm]].</span>
 
+			<wpt>
+				border-writing-mode-dynamic-001.html
+			</wpt>
+
 		<!--——————————————————————————————————————————————————————————————————————————-->
 		<h4 id="border-style-overrides">Border styles (collapsed-borders mode)</h4>
 
@@ -2815,7 +3186,13 @@ With a table-internal box as non-containing block parent</h3>
 	<h3 id="visibility-collapse-rendering">Rendering for visibility: collapse</h3>
 
 	When a table part has <a href="http://www.w3.org/TR/CSS22/visufx.html#visibility">visibility: collapse</a> set, the rendering is handled
-	differently depending if it is on a <a>table-cell</a>, spanning <a>table-cell</a>, or a <a>table-track</a>/<a>table-track-group</a>.	
+	differently depending if it is on a <a>table-cell</a>, spanning <a>table-cell</a>, or a <a>table-track</a>/<a>table-track-group</a>.
+
+	<wpt>
+		visibility-collapse-border-spacing-001.html
+		visibility-collapse-border-spacing-002.html
+		visibility-hidden-collapsed-borders.html
+	</wpt>
 
 		<h4 id="visibility-collapse-cell-rendering">Rendering a visibility: collapse table cell</h4>
 		As stated in CSS 2.2, if a <a>table-cell</a> has its visibility set to that of collapse, it is rendered the same as
@@ -2836,10 +3213,19 @@ With a table-internal box as non-containing block parent</h3>
 
 		<h4 id="visibility-collapse-track-rendering">Rendering a visibility: collapse table-track or table-track-group</h4>
 		When a <a>table-track</a> or <a>table-track-group</a> has <a href="http://www.w3.org/TR/CSS22/visufx.html#visibility">visibility: collapse</a>, 
-		all the backgrounds, borders or outlines that are contributed by the cells within the given <a>table-track</a> or 
+		all the backgrounds, borders or outlines that are contributed by the cells within the given <a>table-track</a> or
 		<a>table-track-group</a> will continue to be painted on cells that have not been fully collapsed
 		(because they spanned multiple tracks).
 
+		<wpt>
+			visibility-collapse-colspan-003.html
+			visibility-collapse-colspan-crash.html
+			visibility-collapse-rowspan-002-border-separate.html
+			visibility-collapse-rowspan-002.html
+			visibility-collapse-rowspan-004-dynamic.html
+			visibility-collapse-rowspan-005.html
+			visibility-collapse-rowspan-crash.html
+		</wpt>
 
 <!--
 ████████ ████████     ███     ██████   ██     ██ ████████ ██    ██ ████████    ███    ████████ ████  ███████  ██    ██
@@ -3409,6 +3795,14 @@ Using CSS Tables does not incur any privacy risk to mitigate.
 
 </pre>
 
+	<wpt>
+		html-to-css-mapping-1.html
+		html-to-css-mapping-2.html
+		table-has-box-sizing-border-box-001.html
+		table-has-box-sizing-border-box-002.html
+		rules-groups.html
+	</wpt>
+
 	<div class="note">
 		Some of the content here came from the WHATWG spec on the
 		<a href="https://html.spec.whatwg.org/#tables-2">HTML to CSS mapping of tables</a>.
@@ -3431,6 +3825,7 @@ Significant changes since the <a href="https://www.w3.org/TR/2019/WD-css-tables-
 	<li>Replaced mentions of '':matches()'' pseudo-class with '':is()''.
 	<li>Clarified that outer table elements behave according to their outer display type.
 	<li>Allowed ''overflow/clip'' to apply to [=table-root=] and [=table-wrapper=] boxes.
+	<li>Added Web Platform Test coverage.
 
 </ul>
 
@@ -3454,3 +3849,55 @@ Significant changes since the <a href="https://www.w3.org/TR/2019/WD-css-tables-
 	/* END OF COMMENT */
 
 </style>
+
+<wpt hidden title="Tentative tests">
+	tentative/baseline-table.html
+	tentative/baseline-td.html
+	tentative/border-collapse-spanning-cells-001.html
+	tentative/border-collapse-spanning-cells-002.html
+	tentative/border-collapse-spanning-cells-003.html
+	tentative/border-collapse-spanning-cells-004.html
+	tentative/caption.html
+	tentative/col-collapse-table-size.html
+	tentative/colgroup-col.html
+	tentative/collapsed-borders-painting-order-001.html
+	tentative/collapsed-borders-painting-order-002.html
+	tentative/collapsed-borders-painting-order-003.html
+	tentative/collapsed-borders-painting-order-004.html
+	tentative/collapsed-borders-painting-order-005.html
+	tentative/collapsed-borders-painting-order-006.html
+	tentative/collapsed-borders-painting-order-007.html
+	tentative/collapsed-borders-painting-order-008.html
+	tentative/collapsed-borders-painting-order-009.html
+	tentative/collapsed-borders-painting-order-010.html
+	tentative/collapsed-borders-painting-order-011.html
+	tentative/collapsed-borders-painting-order-012.html
+	tentative/collapsed-borders-painting-order-013.html
+	tentative/colspan-redistribution.html
+	tentative/column-widths.html
+	tentative/element-sizing.html
+	tentative/padding-percentage.html
+	tentative/paint/background-image-column-collapsed.html
+	tentative/paint/background-image-column.html
+	tentative/paint/background-image-row-collapsed.html
+	tentative/paint/background-image-row.html
+	tentative/paint/collapsed-border-large-cell.html
+	tentative/paint/overflow-hidden-table.html
+	tentative/position-sticky-container.html
+	tentative/rowspan-height-redistribution.html
+	tentative/section-no-tbody-fixed-distribution.html
+	tentative/section-no-tbody-percent-distribution.html
+	tentative/table-fixed-minmax.html
+	tentative/table-height-redistribution.html
+	tentative/table-limited-quirks.html
+	tentative/table-minmax.html
+	tentative/table-quirks.html
+	tentative/table-rows-with-zero-columns.html
+	tentative/table-width-redistribution-fixed-padding.html
+	tentative/table-width-redistribution-fixed.html
+	tentative/table-width-redistribution.html
+	tentative/tbody-height-redistribution.html
+	tentative/td-box-sizing-001.html
+	tentative/td-box-sizing-002.html
+	tentative/td-box-sizing-003.html
+</wpt>


### PR DESCRIPTION
I added all the Web Platform Tests that currently cover the features in CSS Tables 3.

I was not sure whether the tests in the tentative/ folder are actually still tentative. For now I've added them as hidden.
Also, a bunch of tests do not refer to a specific section. I've tried to match them as good as possible.

Note that this PR does not include hints about missing WPT coverage or notes about tests not being necessary for specific sections. Those should be added separately.

Sebastian