### PR TITLE
Put back removed defs for animation trigger state values

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -2365,8 +2365,17 @@ these possible values:
 
 <dl dfn-for="animation trigger state">
   <dt><dfn>idle</dfn>
-  <dt><dfn>primary</dfn>
-  <dt><dfn>inverse</dfn>
+    <dd>
+      The [=animation effect=] associated |animation| remains in
+      its [=animation effect/before phase=] and stays at zero [=animation/current time=].
+
+    <dt><dfn>primary</dfn>
+    <dd>
+      When switched to this value the [=animation trigger state/primary=] behavior type defined by |type| is applied to |animation|.
+
+    <dt><dfn>inverse</dfn>
+    <dd>
+      When switched to this value the [=animation trigger state/inverse=] behavior type defined by |type| is applied to |animation|.
 </dl>
 
 The values of [=animation trigger state|state=] and [=did trigger=] are


### PR DESCRIPTION
Last push these defs were deleted and it's breaking publication.
Putting those back for now so that we can publish a WD, and they can later be revised.
