### PR TITLE
[css-borders-4] Added slash syntax for 'border-*-*-radius' longhands #12861

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -854,8 +854,8 @@ Corner Sizing: the 'border-*-*-radius' properties</h3>
 	The radius is specified as a <<border-radius>> value, where
 
 	<pre class="prod">
-	<dfn><<border-radius>></dfn> = <<modern-border-radius-syntax>> | <<legacy-border-radius-syntax>>
-	<dfn><<modern-border-radius-syntax>></dfn> = <<length-percentage [0,&infin;]>> [ / <<length-percentage [0,&infin;]>> ]?
+	<dfn><<border-radius>></dfn> = <<slash-separated-border-radius-syntax>> | <<legacy-border-radius-syntax>>
+	<dfn><<slash-separated-border-radius-syntax>></dfn> = <<length-percentage [0,&infin;]>> [ / <<length-percentage [0,&infin;]>> ]?
 	<dfn><<legacy-border-radius-syntax>></dfn> = <<length-percentage [0,&infin;]>>{1,2}
 	</pre>
 
@@ -871,7 +871,7 @@ Corner Sizing: the 'border-*-*-radius' properties</h3>
 	whereas percentages for the vertical radius refer to the height of the [=border box=].
 	Negative values are invalid.
 
-	Note: Authors <em>should</em> use the ''/'' syntax, which is preferred for new content,
+	Note: Authors <em>should</em> use the slash syntax, which is preferred for new content,
 	but the legacy syntax (two values separated by whitespace)
 	is supported for backwards compatibility.
 


### PR DESCRIPTION
This adds a new syntax using a slash to separate the horizontal and vertical values in the 'border-*-*-radius' longhands.

Closes #12861

Sebastian