### PR TITLE
[css-color-adjust-1] Add self as editor

### DIFF
--- a/css-color-adjust-1/Overview.bs
+++ b/css-color-adjust-1/Overview.bs
@@ -9,6 +9,7 @@ TR: https://www.w3.org/TR/css-color-adjust-1/
 ED: https://drafts.csswg.org/css-color-adjust-1/
 Previous Version: https://www.w3.org/TR/2022/CRD-css-color-adjust-1-20220614/
 Implementation Report: https://wpt.fyi/results/css/css-color-adjust?label=experimental&label=master&aligned
+Editor: Alison Maher, Microsoft, almaher@microsoft.com, w3cid 123530
 Editor: Elika J. Etemad / fantasai, Apple, http://fantasai.inkedblade.net/contact, w3cid 35400
 Editor: Rossen Atanassov, Microsoft, ratan@microsoft.com, w3cid 49885
 Editor: Rune Lillesveen, Google, futhark@google.com, w3cid 45291
@@ -1200,7 +1201,6 @@ Acknowledgements {#acknowledgements}
 	at Apple, Google, and Microsoft
 	as well as discussions about print adjustments on www-style.
 	In particular, the CSS Working Group would like to thank:
-	Alison Maher,
 	François Remy,
 	イアンフェッティ
 


### PR DESCRIPTION
Per https://github.com/w3c/csswg-drafts/issues/12815#issuecomment-3524490514, it was resolved to add myself as editor. In addition to this addition, this change removes my name from additional acknowledgements section since that is now redundant.
