### PR TITLE
[css-transitions-1][editorial] Added WPTs

### DIFF
--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -21,6 +21,8 @@ Abstract: CSS Transitions allows property changes in CSS values to occur smoothl
 Status Text: <strong>This document</strong> is expected to be relatively close to last call.  While some issues raised have yet to be addressed, new features are extremely unlikely to be considered for this level.
 Ignored Vars: x1, x2, y1, y2
 Link Defaults: css-transforms (property) transform
+WPT Path Prefix: css/css-transitions/
+WPT Display: open
 </pre>
 <style type="text/css">
   div.prod { margin: 1em 2em; }
@@ -122,6 +124,13 @@ Introduction {#introduction}
       <p>
         This document introduces new CSS features to enable <em>implicit transitions</em>, which describe how CSS properties can be made to change smoothly from one value to another over a given duration.
       </p>
+
+      <wpt title="crashes">
+        crashtests/delete-image-set.html
+        crashtests/size-container-transition-crash.html
+        crashtests/transition-during-style-attr-mutation.html
+        crashtests/transition-large-word-spacing-001.html
+      </wpt>
 
 Value Definitions {#values}
 -----------------
@@ -231,6 +240,29 @@ Transitions</h2>
         ([[WCAG20]]).
       </p>
 
+      <wpt>
+        animations/animate-with-color-mix.html
+        animations/color-transition-premultiplied.html
+        animations/text-shadow-composition.html
+        animations/text-shadow-interpolation.html
+        animations/vertical-align-composition.html
+        animations/vertical-align-interpolation.html
+        animations/z-index-interpolation.html
+        idlharness.html
+        inherit-background-color-transition.html
+        inheritance.html
+        properties-value-001.html
+        properties-value-002.html
+        properties-value-003.html
+        properties-value-implicit-001.html
+        retargetted-transition-with-box-sizing.html
+        shadow-root-insertion.html
+        transition-base-response-001.html
+        transition-base-response-002.html
+        transition-base-response-003.html
+        transition-in-iframe-001.html
+      </wpt>
+
 <span id="the-transition-property-property-">The 'transition-property' Property</span> {#transition-property-property}
 ----------------------------------------------------------------------------------------------------------------------
 
@@ -247,6 +279,65 @@ Transitions</h2>
         Computed value: the keyword ''transition-property/none'' else a list of identifiers
         Animation type: not animatable
       </pre>
+
+      <wpt>
+        animations/move-after-transition.html
+        animations/transition-end-event-shorthands.html
+        parsing/transition-property-computed.html
+        parsing/transition-property-invalid.html
+        parsing/transition-property-valid.html
+        pseudo-element-transform.html
+        pseudo-elements-001.html
+        pseudo-elements-002.html
+        transition-background-position-with-edge-offset.html
+        transition-property-001.html
+        transition-property-002.html
+        transition-property-003-manual.html
+        transition-property-004-manual.html
+        transition-property-005-manual.html
+        transition-property-006-manual.html
+        transition-property-007-manual.html
+        transition-property-008-manual.html
+        transition-property-009-manual.html
+        transition-property-010-manual.html
+        transition-property-011-manual.html
+        transition-property-012-manual.html
+        transition-property-013-manual.html
+        transition-property-014-manual.html
+        transition-property-015-manual.html
+        transition-property-016-manual.html
+        transition-property-017-manual.html
+        transition-property-018-manual.html
+        transition-property-019-manual.html
+        transition-property-020-manual.html
+        transition-property-021-manual.html
+        transition-property-022-manual.html
+        transition-property-023-manual.html
+        transition-property-024-manual.html
+        transition-property-025-manual.html
+        transition-property-026-manual.html
+        transition-property-027-manual.html
+        transition-property-028-manual.html
+        transition-property-029-manual.html
+        transition-property-030-manual.html
+        transition-property-031-manual.html
+        transition-property-032-manual.html
+        transition-property-033-manual.html
+        transition-property-034-manual.html
+        transition-property-035-manual.html
+        transition-property-036-manual.html
+        transition-property-037-manual.html
+        transition-property-038-manual.html
+        transition-property-039-manual.html
+        transition-property-040-manual.html
+        transition-property-041-manual.html
+        transition-property-042-manual.html
+        transition-property-043-manual.html
+        transition-property-044-manual.html
+        transition-property-045-manual.html
+        transition-test.html
+        transition-zero-duration-with-delay.html
+      </wpt>
 
       <div class="prod">
         <dfn type id="single-transition-property">&lt;single-transition-property&gt;</dfn> = ''transition-property/all'' | <<custom-ident>>
@@ -322,6 +413,19 @@ Transitions</h2>
         Computed value: list, each item a duration
         Animation type: not animatable
       </pre>
+
+      <wpt>
+        infinite-duration-crash.html
+        parsing/transition-duration-computed.html
+        parsing/transition-duration-invalid.html
+        parsing/transition-duration-valid.html
+        transition-duration-001.html
+        transition-duration-002-manual.html
+        transition-duration-003-manual.html
+        transition-duration-004-manual.html
+        transition-duration-shorthand.html
+      </wpt>
+
       <p>
         This property specifies how long the transition from the old value to the new value should take. By default the value is ''0s'', meaning that the transition is immediate (i.e. there will be no animation). A negative value for 'transition-duration' renders the declaration invalid.
       </p>
@@ -354,6 +458,18 @@ Transitions</h2>
         Animation type: not animatable
       </pre>
 
+      <wpt>
+        animations/transition-timing-function.html
+        parsing/transition-timing-function-computed.html
+        parsing/transition-timing-function-invalid.html
+        parsing/transition-timing-function-valid.html
+        transition-timing-function-002-manual.html
+        transition-timing-function-003-manual.html
+        transition-timing-function-004-manual.html
+        transition-timing-function-005-manual.html
+        transition-timing-function-006-manual.html
+        transition-timing-function-010-manual.html
+      </wpt>
 
 <span id="the-transition-delay-property-">The 'transition-delay' Property</span> {#transition-delay-property}
 -------------------------------------------------------------------------------------------------------------
@@ -375,6 +491,16 @@ Transitions</h2>
         Animation type: not animatable
       </pre>
 
+      <wpt>
+        parsing/transition-delay-computed.html
+        parsing/transition-delay-invalid.html
+        parsing/transition-delay-valid.html
+        transition-delay-000-manual.html
+        transition-delay-001.html
+        transition-delay-002-manual.html
+        transition-delay-003-manual.html
+      </wpt>
+
 <span id="the-transition-shorthand-property-">The 'transition' Shorthand Property</span> {#transition-shorthand-property}
 -------------------------------------------------------------------------------------------------------------------------
 
@@ -389,6 +515,14 @@ Transitions</h2>
         Percentages: N/A
         Animation type: not animatable
       </pre>
+
+      <wpt>
+        parsing/transition-computed.html
+        parsing/transition-invalid.html
+        parsing/transition-valid.html
+        parsing/transition-shorthand.html
+        transition-001.html
+      </wpt>
 
       <div class="prod">
         <dfn type id="single-transition">&lt;single-transition&gt;</dfn> = [ ''transition-property/none'' | <<single-transition-property>> ] || <<time>> || <<easing-function>> || <<time>>
@@ -429,6 +563,10 @@ Starting of transitions {#starting}
           and <a>reversing shortening factor</a>, see [[#reversing]].
         </span>
       </p>
+
+      <wpt>
+        transitioncancel-003.html
+      </wpt>
 
       <p>
         Implementations must also maintain a set of
@@ -517,6 +655,10 @@ Starting of transitions {#starting}
         for a script API that depends on it.)
       </p>
 
+      <wpt>
+        render-blocking/no-transition-from-ua-to-blocking-stylesheet.html
+      </wpt>
+
       <p>
         Since this specification does not define
         when a <a>style change event</a> occurs,
@@ -559,6 +701,12 @@ Starting of transitions {#starting}
         the <a>before-change style</a> due to newly created or canceled CSS
         Animations.
       </p>
+
+      <wpt>
+        after-change-style-inherited-try-fallback.html
+        after-change-style-inherited.html
+        animations/change-duration-during-transition.html
+      </wpt>
 
       <div class="note">
         <p>
@@ -928,6 +1076,32 @@ Starting of transitions {#starting}
         style for declarative animations.
       </p>
 
+      <wpt>
+        before-load-001.html
+        changing-while-transition-001.html
+        changing-while-transition-002.html
+        changing-while-transition-003.html
+        changing-while-transition-004.html
+        currentcolor-animation-001.html
+        disconnected-element-001.html
+        dynamic-root-element.html
+        historical.html
+        inherit-height-transition.html
+        non-rendered-element-001.html
+        non-rendered-element-002.html
+        properties-value-inherit-001.html
+        properties-value-inherit-002.html
+        properties-value-inherit-003.html
+        starting-of-transitions-001.html
+        root-color-transition.html
+        transition-after-animation-001.html
+        transition-remove-and-change-immediate.html
+        transition-reparented.html
+        transitions-retarget.html
+        zero-duration-multiple-transition.html
+      </wpt>
+
+
 Faster reversing of interrupted transitions {#reversing}
 --------------------------------------------------------
 
@@ -991,6 +1165,10 @@ Application of transitions {#application}
         to the CSS cascade
         at the level defined for CSS Transitions in [[!CSS3CASCADE]].
       </p>
+
+      <wpt>
+        transition-important.html
+      </wpt>
 
       <p class="note">
         Note that this means that computed values
@@ -1088,6 +1266,10 @@ with changes to transitions.
 Each event provides the name of the property the transition is
 associated with as well as the duration of the transition.
 
+<wpt>
+  transition-events-with-document-change.html
+</wpt>
+
 ## Interface {{TransitionEvent}} ## {#interface-transitionevent}
 
 The {{TransitionEvent}} interface provides specific contextual information
@@ -1110,6 +1292,10 @@ associated with transitions.
     CSSOMString pseudoElement = "";
   };
 </pre>
+
+<wpt>
+  transitionevent-interface.html
+</wpt>
 
 ### Attributes ### {#interface-transitionevent-attributes}
 
@@ -1183,6 +1369,16 @@ The different types of transition events that can occur are:
         <li>Cancelable: No</li>
         <li>Context Info: propertyName, elapsedTime, pseudoElement</li>
       </ul>
+
+      <wpt>
+        events-001.html
+        events-002.html
+        events-003.html
+        events-004.html
+        events-005.html
+        events-006.html
+        events-007.html
+      </wpt>
     </dd>
 
     <dt><dfn id=transitioncancel>transitioncancel</dfn></dt>
@@ -1203,6 +1399,11 @@ The different types of transition events that can occur are:
         <li>Cancelable: No</li>
         <li>Context Info: propertyName, elapsedTime, pseudoElement</li>
       </ul>
+
+      <wpt>
+        transitioncancel-001.html
+        transitioncancel-002.html
+      </wpt>
     </dd>
   </dl>
 
@@ -1365,6 +1566,7 @@ dated 11 October 2018</a>:
 * Removed trailing semicolon from <<single-transition-property>> syntax.
 * Associated event definitions with their {{GlobalEventHandlers}} container.
 * Added range definition notations to property values.
+* Added Web Platform Tests coverage.
 * Minor editorial fixes and improvements.
 
 For more details on these changes, see the version control
@@ -1408,3 +1610,23 @@ Jasper St. Pierre,
 Estelle Weyl,
 and all the rest of the
 <a href="http://lists.w3.org/Archives/Public/www-style/">www-style</a> community.</p>
+
+<wpt title="Tests related to later levels of this specification">
+  allow-discrete-auto-inset.html
+  custom-property-and-allow-discrete.html
+  display-none-no-animations.html
+  idlharness-2.html
+  inert-while-transitioning-to-display-none.html
+  parsing/starting-style-parsing.html
+  parsing/transition-behavior.html
+  starting-style-adjustment.html
+  starting-style-cascade.html
+  starting-style-first-letter-crash.html
+  starting-style-name-defining-rules.html
+  starting-style-rule-basic.html
+  starting-style-rule-none.html
+  starting-style-rule-pseudo-elements.html
+  starting-style-size-container.html
+  transition-behavior.html
+  transition-behavior-events.html
+</wpt>


### PR DESCRIPTION
I added all the Web Platform Tests that currently cover the features in CSS Transitions 1.

Note that this PR does _not_ include hints about missing WPT coverage or notes about tests not being necessary for specific sections. Those should be added separately.

Notes:
- Some tests explicitly refer to level 2 of the spec, though to me it seems they target things already covered by level 1.
- Some tests don't have a reference to the level of the spec.
- Some tests check things that are not yet part of the spec.

I tried to match them as good as possible. If I couldn't find a proper section, I added them to the general "Transitions" section at the beginning of the spec.

Sebastian