### PR TITLE
[css-view-transitions-2] ViewTransition.types should be [SameObject]

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -1719,7 +1719,7 @@ Issue: Is this updated by a <code>rootEl.startViewTransition()</code> call, too?
 			readonly attribute Promise<undefined> ready;
 			readonly attribute Promise<undefined> finished;
 			undefined skipTransition();
-			attribute ViewTransitionTypeSet types;
+			[SameObject] attribute ViewTransitionTypeSet types;
 			readonly attribute Element transitionRoot;
 			undefined waitUntil(Promise<any> promise);
 		};


### PR DESCRIPTION
As it is expected to return the same object all the time.

This matches implementations (and common sense too).