### PR TITLE
[css-borders-4] Renamed 'border-clip' value 'normal' to 'none'

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -2453,12 +2453,12 @@ The 'border-clip' properties</h3>
 	<pre class="propdef">
 		Name: border-top-clip, border-right-clip, border-bottom-clip, border-left-clip,
 			border-block-start-clip, border-block-end-clip, border-inline-start-clip, border-inline-end-clip
-		Value: normal | [ <<length-percentage [0,&infin;]>> | <<flex>> ]+
-		Initial: normal
+		Value: none | [ <<length-percentage [0,&infin;]>> | <<flex>> ]+
+		Initial: none
 		Inherited: no
 		Logical property group: border-clip
 		Percentages: refer to length of border-edge side
-		Computed value: ''border-clip/normal'', or a list consisting of absolute lengths, or percentages as specified
+		Computed value: ''border-top-clip/none'', or a list consisting of absolute lengths, or percentages as specified
 		Animation type: by computed value
 	</pre>
 
@@ -2467,7 +2467,7 @@ The 'border-clip' properties</h3>
 	the third part is visible, etc. Parts can be specified with lengths,
 	percentages, or flexible lengths (expressed by the ''fr'' unit, as per
 	[[CSS3GRID]]).
-	The ''border-clip/normal'' value means
+	The ''border-top-clip/none'' value means
 	that the border is not split, but shown normally.
 
 	The [=flow-relative=] longhands
@@ -3226,6 +3226,7 @@ First Public Working Draft</a> of 22 July 2025
 	* Added Web Platform Tests coverage
 	* incorporated full text of [[CSS3BG]] related to borders and shadows
 	* Renamed 'border-clip-*' properties to 'border-*-clip' and added logical longhands and shorthands
+	* Renamed <css>normal</css> value of 'border-*-clip' properties to ''border-top-clip/none''
 	* Added new syntax for 'border-*-*-radius' longhands using a slash to separate horizontal and vertical radii
 
 <h3 class=no-num id="level-changes">


### PR DESCRIPTION
This renames the initial value of the `border-*-clip` properties to `none`.

Closes #9636

Sebastian