### PR TITLE
[css-borders-4] Allowed single <length> value in 'box-shadow-offset'

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -2727,7 +2727,7 @@ Offsetting shadows: the 'box-shadow-offset' property</h3>
 
 	<pre class="propdef">
 		Name: box-shadow-offset
-		Value: [ none | <<length>>{2} ]#
+		Value: [ none | <<length>>{1,2} ]#
 		Initial: none
 		Applies to: all elements
 		Inherited: no
@@ -2742,8 +2742,11 @@ Offsetting shadows: the 'box-shadow-offset' property</h3>
 	<p>The 'box-shadow-offset' property defines one or more drop shadow offsets.
 	The property accepts a comma-separated list.
 	Each item in that list can either be the ''box-shadow-offset/none'' value,
-	which indicates no shadow, or a pair of horizontal and vertical offsets,
-	where both values are described as <<length>> values.
+	which indicates no shadow,
+	a pair of <<length>> values,
+	which define the horizontal and vertical offsets,
+	or a single <<length>> value,
+	which sets both offsets to the same value.
 
 	<dl dfn-type=value dfn-for=box-shadow-offset>
 	<dt><dfn id="shadow-offset-none">none</dfn>
@@ -2756,6 +2759,9 @@ Offsetting shadows: the 'box-shadow-offset' property</h3>
 		Specifies the <dfn>horizontal offset</dfn> of the shadow.
 		A positive value draws a shadow that is offset to the right of the box,
 		a negative length to the left.
+
+		If only one <<length>> value is specified,
+		it sets both the horizontal and vertical offsets to that value.
 
 	<dt><dfn id="shadow-offset-y">2nd <<length>></dfn>
 	<dd>
@@ -2902,14 +2908,18 @@ Drop Shadows Shorthand: the 'box-shadow' property</h3>
 	ordered front to back.
 
 	<p>Each shadow is given as a <<spread-shadow>>,
-	outlining the 'box-shadow-offset', and optional values for the 'box-shadow-blur',
+	outlining the 'box-shadow-offset' defined by two <<length>> values, and optional values for the 'box-shadow-blur',
 	'box-shadow-spread', 'box-shadow-color', and 'box-shadow-position'.
 	Omitted lengths are ''0'';
 	omitted colors default to ''transparent'' when the specified offset is ''box-shadow-offset/none''
 	and to ''currentcolor'' otherwise.
 
+	Note: To avoid ambiguities in parsing the different <<length>> values,
+	the offset has to be specified as two <<length>> values, in opposite to the 'box-shadow-offset' property,
+	where a single <<length>> value can be used to specify both offsets.
+
 	<pre class=prod>
-	<dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ <<'box-shadow-offset'>> [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
+	<dfn><<spread-shadow>></dfn> = <<'box-shadow-color'>>? &amp;&amp; [ [ none | <<length>>{2} ] [ <<'box-shadow-blur'>> <<'box-shadow-spread'>>? ]? ] &amp;&amp; <<'box-shadow-position'>>?</pre>
 
 	<div class="example">
 		The example below demonstrates the effects of spread and blur on the shadow:
@@ -3221,24 +3231,25 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-borders-4-20250722/
 First Public Working Draft</a> of 22 July 2025
 </h3>
 
-	* added 'corner-*' shorthands
-	* renamed <code>corners</code> to 'corner'
+	* Added 'corner-*' shorthands
+	* Renamed <code>corners</code> to 'corner'
 	* Added Web Platform Tests coverage
-	* incorporated full text of [[CSS3BG]] related to borders and shadows
+	* Incorporated full text of [[CSS3BG]] related to borders and shadows
 	* Renamed 'border-clip-*' properties to 'border-*-clip' and added logical longhands and shorthands
 	* Renamed <css>normal</css> value of 'border-*-clip' properties to ''border-top-clip/none''
 	* Added new syntax for 'border-*-*-radius' longhands using a slash to separate horizontal and vertical radii
+	* Allowed a single <<length>> value for 'box-shadow-offset' to set both offsets to the same value
 
 <h3 class=no-num id="level-changes">
 Additions since [[CSS3BG]]</h3>
 
 	* <<image-1D>> as value for 'border-color' and its longhands
-	* added physical and logical 'border-*-radius' shorthands
-	* added 'corner-shape' and 'corner-*-shape' shorthands, plus related 'corner' and 'corner-*' shorthands
-	* added 'border-shape'
-	* added <a href="#partial-borders">partial borders</a> via 'border-limit' and 'border-*-clip' properties
-	* added 'box-shadow-*' longhands and turned 'box-shadow' into a shorthand
-	* moved logical border properties from [[CSS-LOGICAL-1]] to this spec.
+	* Added physical and logical 'border-*-radius' shorthands
+	* Added 'corner-shape' and 'corner-*-shape' shorthands, plus related 'corner' and 'corner-*' shorthands
+	* Added 'border-shape'
+	* Added <a href="#partial-borders">partial borders</a> via 'border-limit' and 'border-*-clip' properties
+	* Added 'box-shadow-*' longhands and turned 'box-shadow' into a shorthand
+	* Moved logical border properties from [[CSS-LOGICAL-1]] to this spec.
 
 <h2 class=no-num id="acknowledgments">
 Acknowledgments</h2>


### PR DESCRIPTION
Changed the syntax of `box-shadow-offset` to allow a single `<length>` value to set both the horizontal and vertical offset to the same value.

To avoid ambiguities, the `box-shadow` shorthand still only takes _two_ values.

Closes #8568