### PR TITLE
[css-animations-1] Make `@keyframes` name disallow empty `<string>`

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -227,9 +227,12 @@ Declaring Keyframes</h2>
 	As normal for <<custom-ident>>s and <<string>>s,
 	the names are fully <a>case-sensitive</a>;
 	two names are equal only if they are codepoint-by-codepoint equal.
-	The <<custom-ident>> additionally excludes the ''animation-name/none'' keyword.
-	The empty <<string>> should be parsed as invalid, any other should be serialized as <<ident>>
-	when possible, or as <<string>> otherwise (eg, <a>CSS Wide Keywords<a>).
+The <<custom-ident>> additionally excludes the ''animation-name/none'' keyword.
+The <<string>> additionally excludes the empty string 
+(but allows the string "none" and other excluded keywords).
+When serialized, the value is serialized as an <<ident>>
+unless it's a disallowed keyword,
+in which case it's serialized as a <<string>>.
 
 	<div class=example>
 		For example, the following two ''@keyframes'' rules have the same name,


### PR DESCRIPTION
As discussed in the issue #7762 an empty ```<string>``` should not be allowed to be used in ```@keyframes-name``` style rule, or in the ```animation-name``` CSS property to refer a specific rule. 

Fixes #7762