### PR TITLE
[css-navigation-1] Add a bunch of examples.

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -404,7 +404,7 @@ A simple example of a ''::link-to()'' selector is this one,
 which matches any links that link to the site's homepage:
 
 <pre highlight=css>
-:link-to(/) {
+:link-to(url-pattern("/")) {
   font-weight: bold;
 }
 </pre>


### PR DESCRIPTION
This adds a bunch of examples and hopefully makes the spec a bit more readable.  (I should probably add more in the future, but this is a start.)

(Also fix an edit I missed adding support for named routes declared by @route to :link-to().)