### PR TITLE
[css-navigation-1] Factor out current from/to URL definitions.

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -68,12 +68,12 @@ The ''@route'' rule can be defined in one of two ways:
 : with the <code>pattern</code> descriptor
 :: in this case the URL pattern represented is
 	the one represented by the <<url-pattern()>> function
-        given as the descriptor's value.
+	given as the descriptor's value.
 : with the other descriptors named by <<init-descriptor-name>>
 :: In this case the URL pattern represented is the result of invoking
-        [=URL pattern/create|create a URL pattern=] given
+	[=URL pattern/create|create a URL pattern=] given
 	<var>input</var> as {{URLPatternInit}}
-        constructed from the descriptors and their values;
+	constructed from the descriptors and their values;
 	if a <code>baseURL</code> descriptor is not given then one is created from
 	the [=style resource base URL=] of the rule.
 
@@ -185,14 +185,14 @@ The syntax of the ''@navigation'' rule is:
 with <<navigation-condition>> defined as:
 
 <pre class="prod def" dfn-type="type" nohighlight>
-	<dfn><<navigation-condition>></dfn> = not <<navigation-in-parens>>
-	                     | <<navigation-in-parens>> [ and <<navigation-in-parens>> ]*
-	                     | <<navigation-in-parens>> [ or <<navigation-in-parens>> ]*
-	<dfn><<navigation-in-parens>></dfn> = ( <<navigation-condition>> ) | ( <<navigation-test>> ) | <<general-enclosed>>
-	<dfn><<navigation-test>></dfn> = <<navigation-location>> | <<navigation-keyword>> : <<navigation-location>>
-	<dfn><<navigation-keyword>></dfn> = at | from | to
-	<dfn><<navigation-location>></dfn> = <<route-name>> | <<url-pattern()>>
-	<dfn><<route-name>></dfn> = <<dashed-ident>>
+<dfn><<navigation-condition>></dfn> = not <<navigation-in-parens>>
+                     | <<navigation-in-parens>> [ and <<navigation-in-parens>> ]*
+                     | <<navigation-in-parens>> [ or <<navigation-in-parens>> ]*
+<dfn><<navigation-in-parens>></dfn> = ( <<navigation-condition>> ) | ( <<navigation-test>> ) | <<general-enclosed>>
+<dfn><<navigation-test>></dfn> = <<navigation-location>> | <<navigation-keyword>> : <<navigation-location>>
+<dfn><<navigation-keyword>></dfn> = at | from | to
+<dfn><<navigation-location>></dfn> = <<route-name>> | <<url-pattern()>>
+<dfn><<route-name>></dfn> = <<dashed-ident>>
 </pre>
 
 The above grammar is purposely very loose for forwards-compatibility reasons,
@@ -231,106 +231,24 @@ as follows:
 	:: The result is whether the result of
 		[=URL pattern/match|match a URL pattern=] is non-null
 		given <var>urlPattern</var> as
-		the [=navigation location URL pattern=] of <<navigation-location>>,
-		<var>input</var> as the document's [=Document/URL=].
+		the [=navigation location URL pattern=] of <<navigation-location>>
+		and <var>input</var> as the document's [=Document/URL=].
 
 	: from: <<navigation-location>>
 	:: The result is true if
-		the [=document's navigation API=] of the document
-		is non-null, and either:
-
-		* its [=transition=] is non-null,
-			its [=from entry=]'s {{NavigationHistoryEntry/url}}
-			is non-null and
-			[=URL pattern/match|match a URL pattern=] is non-null when
-			given <var>urlPattern</var> as
-			the [=navigation location URL pattern=] of <<navigation-location>>,
-			<var>input</var> as that
-			[=from entry=]'s {{NavigationHistoryEntry/url}}.
-
-			NOTE: This part handles <code>from:</code> when it matches in the old page.
-
-		* its [=activation=] is non-null,
-			the document's [=has been revealed=] is false or
-			was false at the start of the current [=task=],
-			and the activation's {{NavigationActivation/from}}'s
-			{{NavigationHistoryEntry/url}}
-			is non-null and
-			[=URL pattern/match|match a URL pattern=] is non-null when
-			given <var>urlPattern</var> as
-			the [=navigation location URL pattern=] of <<navigation-location>>,
-			<var>input</var> as that
-			activation's {{NavigationActivation/from}}'s
-			{{NavigationHistoryEntry/url}}.
-
-			NOTE: This part handles <code>from:</code> when it matches in the new page.
+		the [=current from URL=] <var>from</var> of the document is non-null and
+		[=URL pattern/match|match a URL pattern=] is non-null when
+		given <var>urlPattern</var> as
+		the [=navigation location URL pattern=] of <<navigation-location>>
+		and <var>input</var> as <var>from</var>.
 
 	: to: <<navigation-location>>
 	:: The result is true if
-		the [=document's navigation API=] of the document
-		is non-null, and either:
-
-		* its [=ongoing navigate event=] is non-null,
-			[=URL pattern/match|match a URL pattern=] is non-null
-			given <var>urlPattern</var> as
-			the [=navigation location URL pattern=] of <<navigation-location>>,
-			<var>input</var> as the [=current to url=],
-			where the <dfn>current to url</dfn> is defined as:
-
-			* if the {{pageswap}} event has fired since that navigation began,
-				and its {{PageSwapEvent/activation}} was non-null,
-				and that {{PageSwapEvent/activation}}'s
-				{{NavigationActivation/entry}}'s
-				{{NavigationHistoryEntry/url}} is non-null,
-				then that
-				{{NavigationHistoryEntry/url}}.
-
-				NOTE: This part <em>does</em> expose the result of redirects.
-
-				ISSUE: Is the final "non-null" check needed?
-
-			* otherwise, the [=ongoing navigate event=]'s
-				{{NavigateEvent/destination}}'s
-				{{NavigationDestination/url}}
-
-				NOTE: This part does <em>not</em> expose the result of redirects.
-
-			ISSUE: This assumes that the [=ongoing navigate event=]
-			and the [=transition=] have the same lifetime,
-			but this isn't really
-			true if the event is intercepted.
-			After
-			<a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
-			<a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
-			we could probably define this more like "from" above.
-			But which lifetime is the one we want?
-
-			NOTE: This part handles <code>to:</code> when it matches in the old page.
-
-		* its [=activation=] is non-null,
-			the document's [=has been revealed=] is false or
-			was false at the start of the current [=task=],
-			and the activation's {{NavigationActivation/entry}}'s
-			{{NavigationHistoryEntry/url}}
-			is non-null and
-			[=URL pattern/match|match a URL pattern=] is non-null
-			given <var>urlPattern</var> as
-			the [=navigation location URL pattern=] of <<navigation-location>>,
-			<var>input</var> as that
-			activation's {{NavigationActivation/entry}}'s
-			{{NavigationHistoryEntry/url}}.
-
-			NOTE: This part handles <code>to:</code> when it matches in the new page.
-
-	ISSUE: The above definitions of from and to apparently don't work right
-	if you start a same-document navigation (e.g., with {{History/pushState}})
-	in the middle of a cross-document navigation.
-
-	ISSUE: Generally improve integration with the HTML spec for these definitions,
-	instead of monkeypatching.
-	This includes the interaction with [=has been revealed=]
-	and the interaction with the {{pageswap}} event,
-	and other things where this section links to non-exported definitions.
+		the [=current to URL=] <var>to</var> of the document is non-null and
+		[=URL pattern/match|match a URL pattern=] is non-null when
+		given <var>urlPattern</var> as
+		the [=navigation location URL pattern=] of <<navigation-location>>
+		and <var>input</var> as <var>to</var>.
 
 : <<general-enclosed>>
 ::
@@ -539,11 +457,8 @@ if the following steps return true:
 		1. If <<navigation-param>> is a <<navigation-param-function>>,
 			and <var>entry</var>'s [=map/key=] is the function's <<ident>>,
 			then for each <var>navigationUrl</var> of the
-			current to URL
-			and current from URL
-			<span class="issue">extract "current to URL" and
-			"current from URL" from ''@navigation''
-			definitions above and link to them</span>:
+			[=current to URL=]
+			and [=current from URL=]:
 			1. Let <var>navigationMatchResult</var> be the result of
 				[=URL pattern/match|match a URL pattern=]
 				given <var>urlPattern</var> and <var>navigationUrl</var>.
@@ -554,20 +469,111 @@ if the following steps return true:
 				whose [=map/key=] is the same as <var>entry</var>'s key
 				and whose [=map/value=] is the same as <var>entry</var>'s value.
 
-                                NOTE: This step makes the ''navigation-param()'' function
-                                perform what is essentially a three-way match,
-                                between the target of the link,
-                                the provided URL pattern,
-                                and the from or to URL of the current navigation.
+				NOTE: This step makes the ''navigation-param()'' function
+				perform what is essentially a three-way match,
+				between the target of the link,
+				the provided URL pattern,
+				and the from or to URL of the current navigation.
 
 ISSUE: A <<link-condition>> should also be able to be a named route
 once those are added back to the spec.
+
+<h2 id="current-nav-urls">Current navigation URLs</h2>
+
+Both the ''@navigation'' rule and the '':link-to()'' pseudo-class
+rely on the following definitions of
+the [=current from URL=] and [=current to URL=].
+
+The <dfn>current from URL</dfn> of a [=/document=] is a URL or null.
+It is defined as follows:
+
+1. If the [=document's navigation API=] of the document is non-null and
+	its [=transition=] is non-null,
+	its [=from entry=]'s {{NavigationHistoryEntry/url}}.
+
+	NOTE: This part is for when the old document in the navigation
+	is still the current document.
+
+1. If the [=document's navigation API=] of the document is non-null and
+	its [=activation=] is non-null,
+	the document's [=has been revealed=] is false or
+	was false at the start of the current [=task=],
+	the activation's {{NavigationActivation/from}}'s
+	{{NavigationHistoryEntry/url}}.
+
+	NOTE: This part is for when the new document in the navigation
+	has become the current document.
+
+1. Otherwise, null.
+
+	NOTE: The previous two branches can also produce null results.
+
+The <dfn>current to URL</dfn> of a [=/document=] is a URL or null.
+It is defined as follows:
+
+1. If the [=document's navigation API=] of the document is non-null and
+	its [=ongoing navigate event=] is non-null:
+
+	1. if the {{pageswap}} event has fired since that navigation began,
+		and its {{PageSwapEvent/activation}} was non-null,
+		and that {{PageSwapEvent/activation}}'s
+		{{NavigationActivation/entry}}'s
+		{{NavigationHistoryEntry/url}} is non-null,
+		then that
+		{{NavigationHistoryEntry/url}}.
+
+		NOTE: This part <em>does</em> expose the result of redirects.
+
+		ISSUE: Is the final "non-null" check needed?
+
+	1. otherwise, the [=ongoing navigate event=]'s
+		{{NavigateEvent/destination}}'s
+		{{NavigationDestination/url}}
+
+		NOTE: This part does <em>not</em> expose the result of redirects.
+
+	ISSUE: This assumes that the [=ongoing navigate event=]
+	and the [=transition=] have the same lifetime,
+	but this isn't really
+	true if the event is intercepted.
+	After
+	<a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
+	<a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
+	we could probably define this more like "from" above.
+	But which lifetime is the one we want?
+
+	NOTE: This part is for when the old document in the navigation
+	is still the current document.
+
+1. If the [=document's navigation API=] of the document is non-null and
+	its [=activation=] is non-null,
+	the document's [=has been revealed=] is false or
+	was false at the start of the current [=task=],
+	and the activation's {{NavigationActivation/entry}}'s
+	{{NavigationHistoryEntry/url}}.
+
+	NOTE: This part is for when the new document in the navigation
+	has become the current document.
+
+1. Otherwise, null.
+
+	NOTE: The previous two branches can also produce null results.
+
+ISSUE: The above definitions of from and to apparently don't work right
+if you start a same-document navigation (e.g., with {{History/pushState}})
+in the middle of a cross-document navigation.
+
+ISSUE: Generally improve integration with the HTML spec for these definitions,
+instead of monkeypatching.
+This includes the interaction with [=has been revealed=]
+and the interaction with the {{pageswap}} event,
+and other things where this section links to non-exported definitions.
 
 <h2 id="url-pattern-function">The ''url-pattern()'' function</h2>
 
 <!--
 
-NOTE:  We may eventually want to move this to css-values.
+NOTE: We may eventually want to move this to css-values.
 
 If we do, the definition of "style resource base URL" probably doesn't need to be
 exported any more, since it was exported for this definition.
@@ -612,7 +618,7 @@ using the steps of the <dfn>create a URL pattern for url-pattern()</dfn> algorit
 1. Return the result of [=URL pattern/create|create a URL pattern=] given
 	<var>arg</var>, <var>baseURL</var>, and an empty [=map=].
 
-NOTE:  This function requires that its argument is quoted.
+NOTE: This function requires that its argument is quoted.
 This differs from the ''url()'' function,
 which allows its argument to be quoted or unquoted.
 


### PR DESCRIPTION
This extracts the defintions of current from URL and current to URL from the definition of the `@navigation` rule, which both allows them to be used more formally in the definition of the ::link-to() pseudo-class and also makes the definitions a bit more readable.

This also cleans up some whitespace in the spec.