### PR TITLE
[css-pseudo] Define .selectorText for CSSPseudoElement IDL

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1760,6 +1760,7 @@ Additions to the CSS Object Model</h2>
         readonly attribute CSSOMString type;
         readonly attribute Element element;
         readonly attribute (Element or CSSPseudoElement) parent;
+        readonly attribute CSSOMString selectorText;
         CSSPseudoElement? pseudo(CSSOMString type);
     };
   </pre>
@@ -1792,6 +1793,15 @@ Additions to the CSS Object Model</h2>
   for [=sub-pseudo-elements=],
   {{CSSPseudoElement/parent}} will return a {{CSSPseudoElement}}
   while {{CSSPseudoElement/element}} returns an {{Element}}.
+
+  The <dfn attribute for=CSSPseudoElement>selectorText</dfn> attribute
+  is a string representing the full, normalized selector text
+  used to select the pseudo-element.
+  This includes the pseudo-element name and any arguments,
+  serialized in a form that can round-trip.
+  For example, <code>"::after"</code> for a ''::after'' pseudo-element,
+  or <code>"::scroll-button(left)"</code> for a ''::scroll-button()'' pseudo-element
+  with a <code>left</code> argument.
 
   The <dfn attribute for=CSSPseudoElement>pseudo(type)</dfn> method
   returns the {{CSSPseudoElement}} interface


### PR DESCRIPTION
As resolved in #12161, add .selectorText property to return a string representing the full, normalized selector text used to select the pseudo-element.