### PR TITLE
[web-animations-2] Replace incorrect references to `iteration duration` with `specified iteration duration`

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -204,7 +204,7 @@ Add:
 > maximum value a timeline may generate for its current time. This value is
 > used to calculate the [=intrinsic iteration duration=] for the target effect
 > of an animation that is associated with the timeline when the effect's
-> [=iteration duration=] is "auto". The value is computed such that the effect
+> [=specified iteration duration=] is "auto". The value is computed such that the effect
 > fills the available time. For a monotonic timeline, there is no upper bound
 > on current time, and [=timeline duration=] is unresolved. For a non-monotonic
 > (e.g. scroll) timeline, the duration has a fixed upper bound. In this
@@ -227,7 +227,7 @@ Append:
 > a <dfn lt="time-based animation to a proportional animation"></dfn> is as
 > follows:
 >
-> 1.  If the [=iteration duration=] is auto, then perform the following steps.
+> 1.  If the [=specified iteration duration=] is auto, then perform the following steps.
 >     *   Set [=start delay=] and [=end delay=] to 0, as it is not
 >         possible to mix time and proportions.
 >
@@ -255,7 +255,7 @@ Append:
 > Otherwise:
 >     1.   Set [=start delay=] = |specified start delay|
 >     1.   Set [=end delay=] = |specified end delay|
->     1.   If [=iteration duration=] is auto:
+>     1.   If [=specified iteration duration=] is auto:
 >              *   Set [=iteration duration=] = [=intrinsic iteration duration=]
 >          Otherwise:
 >              *   Set [=iteration duration=] = |specified iteration duration|


### PR DESCRIPTION
These references were to when `iteration duration` was equal to `auto`, but that is applicable to `specified iteration duration` rather than `iteration duration` as of level 2.