### PR TITLE
[css-borders-4] Refactor contour path algorithm

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1483,18 +1483,18 @@ An [=/element=]'s [=outline=] follows the [=outer contour=] with the [=used valu
 The precise way in which it is rendered is implementation-defined.
 
 An [=/element=]'s [=overflow=] area is shaped by its [=inner contour=].
-An [=/element=]'s [=overflow clip edge=] is shaped by the [=border contour path=] given |element|, and an [=inset from a uniform outset=] given |element|'s [=used value|used=] 'overflow-clip-margin'.
+An [=/element=]'s [=overflow clip edge=] is shaped by the [=border contour path=] given |element|, and an [=uniform inset from an outset=] given |element|'s [=used value|used=] 'overflow-clip-margin'.
 
-Each shadow of [=/element=]'s 'box-shadow' is shaped by the [=border contour path=] given |element|, and an [=inset from a uniform outset=] given the shadow's [=used value|used=] 'box-shadow-spread'.
+Each shadow of [=/element=]'s 'box-shadow' is shaped by the [=border contour path=] given |element|, and an [=uniform inset from an outset=] given the shadow's [=used value|used=] 'box-shadow-spread'.
 
-An <dfn>inset from a uniform outset</dfn> given a number |outset| is an [=edge=] whose value is <code>-|outset|</code> in all directions.
+An <dfn>uniform inset from an outset</dfn> given a number |outset| is an [=edge=] whose value is <code>-|outset|</code> in all directions.
 
 <h5 id=vector-math-helpers>Vector Math Helpers</h5>
 
 A <dfn>two-dimensional vector</dfn> is a pair of numbers (x, y).
 <div algorithm="extend-point">
 A <dfn>point extended by vectors</dfn> given a {{DOMPointReadOnly}} |p| and a [=/list=] of [=two-dimensional vector=]s |vectors|:
-	1. Let |x| be |p|'s {{DOMPointReadOnly/y}}.
+	1. Let |x| be |p|'s {{DOMPointReadOnly/x}}.
 	1. Let |y| be |p|'s {{DOMPointReadOnly/y}}.
 	1. [=list/For each=] |v| in |vectors|:
 		1. Increment |x| by |v|[0];
@@ -1598,7 +1598,7 @@ To get the <dfn>border-aligned corner clip-out path</dfn> given a {{DOMPointRead
 		1. Let |v2| be  [=vector between two points|the vector between=] |curveCenter| and |adjustedCornerStart|, [=two-dimensional vector/scale|scaled by=] |y|.
 		1. Return the {{DOMPointReadOnly}} at <code>(|x|, |y|)</code>, [=point extended by vectors|extended by=] « |v1|, |v2| ».
 
-	1. Let |controlPoint| be the result of calling |mapPointToCorner| given |unitVectorFromStartToControlPoint|'s {{DOMPointReadOnly/y}} and <code>1 - |unitVectorFromStartToControlPoint|'s {{DOMPointReadOnly/x}}</code>.
+	1. Let |controlPoint| be the result of calling |mapPointToCorner| given |vectorFromStartToControlPoint|'s {{DOMPointReadOnly/y}} and <code>1 - |unitVectorFromStartToControlPoint|'s {{DOMPointReadOnly/x}}</code>.
 	1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be <code>adjustedCornerStart</code>.
 	1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be <code>adjustedCornerEnd</code>.
 


### PR DESCRIPTION
Use vector math to better describe how to draw a border-align contour. Also use the miter points (which are the axisAlignedCornerStart/End points) to make sure shadows are rendered in a border-aligned manner.

Closes #13037