### PR TITLE
[css-navigation-1] Renamed 'baseURL' descriptor to 'base-url'

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -56,7 +56,7 @@ based on the following definitions:
 <dfn><<init-descriptors>></dfn> = ;* <<init-descriptor>> [ ;+ <<init-descriptor>> ]* ;*
 <dfn><<init-descriptor>></dfn> = <<init-descriptor-name>> : <<string>>
 <dfn><<init-descriptor-name>></dfn> = protocol | username | password | hostname | port
-                         pathname | search | hash | baseURL
+                         pathname | search | hash | base-url
 </pre>
 
 This associates an author-defined keyword with a URL pattern,
@@ -74,7 +74,7 @@ The ''@route'' rule can be defined in one of two ways:
 	[=URL pattern/create|create a URL pattern=] given
 	<var>input</var> as {{URLPatternInit}}
 	constructed from the descriptors and their values;
-	if a <code>baseURL</code> descriptor is not given then one is created from
+	if a <code>base-url</code> descriptor is not given then one is created from
 	the [=style resource base URL=] of the rule.
 
 ISSUE: Should this use <<dashed-ident>>, <<custom-ident>>, or <<ident>>


### PR DESCRIPTION
Renamed the `baseURL` descriptor to `base-url` to make it consistent with the rest of CSS keywords.

Closes #13171

Sebastian