### PR TITLE
[selectors-4][selectors-5] Deferred several features from Level 4 to 5

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -25,9 +25,12 @@ Abstract: <a>Selectors</a> are patterns that match against elements in a tree, a
 Abstract: Selectors Level 4 describes the selectors that already exist in [[!SELECT]], and further introduces new selectors for CSS and other languages that may need them.
 At Risk: the column combinator
 At Risk: [=user action pseudo-classes=] applying to non-[=tree-abiding pseudo-elements=]
-At Risk: the '':blank'' pseudo-class
 Ignored Terms: function token, Document, DocumentFragment, math, h1, shadow tree, querySelector(), quirks mode, button, a, span, object, p, div, q, area, link, label, input, html, em, li, ol, pre, CSS Value Definition Syntax
 Ignored Vars: identifier, i
+Ignore MDN Failure: #blank-pseudo
+Ignore MDN Failure: #the-column-combinator
+Ignore MDN Failure: #the-future-pseudo
+Ignore MDN Failure: #the-past-pseudo
 Ignore MDN Failure: #the-target-within-pseudo
 WPT Path Prefix: css/selectors/
 WPT Display: closed
@@ -47,6 +50,7 @@ spec:html; type:element-attr; for:a; text:href
 spec:html; type:element;
 	text:meta
 	text:audio
+spec:selectors-5; type:selector; text::blank
 </pre>
 
 <style>
@@ -270,12 +274,6 @@ Selectors Overview</h2>
 				<td>[[#link]]
 				<td>1
 			<tr>
-				<td><code>E:local-link</code>
-				<td>an E element being the source anchor of a hyperlink
-					targeting the current URL
-				<td>[[#the-local-link-pseudo]]
-				<td>4
-			<tr>
 				<td><code>E:target</code>
 				<td>an E element being the target of the current URL
 				<td>[[#the-target-pseudo]]
@@ -284,28 +282,6 @@ Selectors Overview</h2>
 				<td><code>E:scope</code>
 				<td>an E element being a [=scoping root=]
 				<td>[[#the-scope-pseudo]]
-				<td>4
-		<tbody>
-			<tr>
-				<td><code>E:current</code>
-				<td>an E element that is currently presented in a time-dimensional canvas
-				<td>[[#the-current-pseudo]]
-				<td>4
-			<tr>
-				<td><code>E:current(<var>s</var>)</code>
-				<td>an E element that is the deepest '':current'' element that
-						matches selector <var>s</var>
-				<td>[[#the-current-pseudo]]
-				<td>4
-			<tr>
-				<td><code>E:past</code>
-				<td>an E element that is in the past in a time-dimensional canvas
-				<td>[[#the-past-pseudo]]
-				<td>4
-			<tr>
-				<td><code>E:future</code>
-				<td>an E element that is in the future in a time-dimensional canvas
-				<td>[[#the-future-pseudo]]
 				<td>4
 		<tbody>
 			<tr>
@@ -381,11 +357,6 @@ Selectors Overview</h2>
 				<td>a user-input element E that requires/does not require input
 				<td>[[#opt-pseudos]]
 				<td>3-UI/4
-			<tr>
-				<td><code>E:blank</code>
-				<td>a user-input element E whose value is blank (empty/missing)
-				<td>[[#blank]]
-				<td>4
 			<tr>
 				<td><code>E:user-invalid</code>
 				<td>a user-altered user-input element E with incorrect input (invalid, out-of-range, omitted-but-required)
@@ -475,25 +446,6 @@ Selectors Overview</h2>
 				<td>an F element preceded by an E element
 				<td>[[#general-sibling-combinators]]
 				<td>3
-		<tbody>
-			<tr>
-				<td><code>F || E</code>
-				<td>an E element that represents a cell in a grid/table
-						belonging to a column represented by an element F
-				<td>[[#the-column-combinator]]
-				<td>4
-			<tr>
-				<td><code>E:nth-col(<var>n</var>)</code>
-				<td>an E element that represents a cell belonging to the
-						<var>n</var>th column in a grid/table
-				<td>[[#the-nth-col-pseudo]]
-				<td>4
-			<tr>
-				<td><code>E:nth-last-col(<var>n</var>)</code>
-				<td>an E element that represents a cell belonging to the
-						<var>n</var>th column in a grid/table, counting from the last one
-				<td>[[#the-nth-last-col-pseudo]]
-				<td>4
 	</table>
 
 	Note: Some Level 4 selectors (noted above as "3-UI") were introduced in [[CSS3UI]].
@@ -2831,40 +2783,6 @@ The Link History Pseudo-classes: '':link'' and '':visited''</h3>
 		they might not need to click the footnote again.
 	</div>
 
-
-<h3 id="the-local-link-pseudo">
-The Local Link Pseudo-class: '':local-link''</h3>
-
-	The <dfn id='local-link-pseudo'>:local-link</dfn> pseudo-class
-	allows authors to style <a href="#the-any-link-pseudo">hyperlinks</a>
-	based on the users current location within a site.
-	It represents an element that is
-	the source anchor of a hyperlink whose target's absolute URL
-	matches the element's own document URL.
-	If the hyperlink's target includes a fragment URL,
-	then the fragment URL of the current URL must also match;
-	if it does not, then the fragment URL portion of the current URL
-	is not taken into account in the comparison.
-
-	<div class="example">
-		For example, the following rule prevents links targeting the
-		current page from being underlined when they are part of the
-		navigation list:
-
-		<pre>nav :local-link { text-decoration: none; } </pre>
-	</div>
-
-	Note: The current URL of a page can change as a result of user actions
-	such as activating a link targeting a different fragment within the same page;
-	or by use of the <code>pushState</code> API;
-	as well as by the more obvious actions of navigating to a different page
-	or following a redirect (which could be initiated by protocols such as HTTP,
-	markup instructions such as <code>&lt;meta http-equiv="..."></code>,
-	or scripting instructions <!-- such as ? -->).
-	UAs must ensure that '':local-link'',
-	as well as the '':target'' pseudo-class below,
-	respond correctly to all such changes in state.
-
 <h3 id="the-target-pseudo">
 The Target Pseudo-class: '':target''</h3>
 
@@ -3244,114 +3162,6 @@ The Focus Container Pseudo-class: '':focus-within''</h3>
 	matches the conditions for matching '':focus''.
 
 
-<h3 id="interest-pseudos">
-The Interest Pseudo-classes: '':interest-source'' and '':interest-target''</h3>
-
-	A common UI feature is the ability for the user to "show interest" in certain elements
-	(an <dfn export>interest source</dfn>),
-	and the UI to respond to that interest
-	by showing additional information in another element
-	(the <dfn export>interest target</dfn>),
-	typically a popup.
-	For example, hovering a username on a page
-	might bring up an information card for that user;
-	or long-pressing a link
-	might bring up a preview of the link's destination.
-	Whenever this happens, the first element
-
-	Note: Exactly what elements are capable of being [=interest sources=],
-	how they're linked to [=interest targets=],
-	and how "interest" is shown
-	are all [=host language=]-defined.
-	In HTML, for example,
-	this is done with the <{html-global/interestfor}> attribute
-	to indicate an element capable of "showing interest" 
-	(being an [=interest source=],
-	and that attribute points to another element
-	intended to show the additional information
-	(the associated [=interest target=])
-	(usually a <{html-global/popover}> element).
-
-	The <dfn>:interest-source</dfn> pseudo-class
-	applies to an [=interest source=] element that the user is currently "showing interest" in,
-	and the <dfn>:interest-target</dfn> pseudo-class
-	applies to the associated [=interest target=]
-	of an element matching '':interest-source''.
-
-	Note: '':interest-source'' only matches an [=interest source=]
-	the user is <em>currently</em> interested in,
-	not any element that can <em>potentially</em> have interest shown in it.
-	In HTML, for example,
-	just having the <{html-global/interestfor}> attribute
-	does not make an element match this pseudo-class;
-	the user has to actually indicate interest in it too.
-	Similarly, '':interest-target'' only matches an [=interest target=]
-	that is linked to an element the user is <em>currently</em> interested in,
-	not any element pointed to by an <{html-global/interestfor}> attribute.
-
-
-<h2 id="time-pseudos">
-Time-dimensional Pseudo-classes</h2>
-
-	These pseudo-classes classify elements with respect to the
-	currently-displayed or active position in some timeline, such as
-	during speech rendering of a document, or during the display of
-	a video using WebVTT to render subtitles.
-
-	CSS does not define this timeline;
-	the host language must do so.
-	If there is no timeline defined for an element,
-	these pseudo-classes must not match the element.
-
-	Note: Ancestors of a '':current'' element are also '':current'',
-	but ancestors of a '':past'' or '':future'' element are not necessarily '':past'' or '':future'' as well.
-	A given element matches at most one of '':current'', '':past'', or '':future''.
-
-<h3 id="the-current-pseudo">
-The Current-element Pseudo-class: '':current''</h3>
-
-	The <dfn id='current-pseudo'>:current</dfn> pseudo-class represents the
-	element, or an ancestor of the element, that is currently being displayed.
-
-	Its alternate form <dfn>:current()</dfn> 
-	takes a list of <a>compound selectors</a> as its argument: 
-	it represents the '':current'' element that matches the argument 
-	or, if that does not match, 
-	the innermost ancestor of the '':current'' element that does. 
-	(If neither the '':current'' element nor its ancestors match the argument, then the selector does not represent anything.)
-
-	<div class="example">
-		For example, the following rule will highlight whichever paragraph
-		or list item is being read aloud in a speech rendering of the document:
-
-		<pre>
-		:current(p, li, dt, dd) {
-		  background: yellow;
-		}
-		</pre>
-	</div>
-
-<h3 id="the-past-pseudo">
-The Past-element Pseudo-class: '':past''</h3>
-
-	The <dfn id='past-pseudo'>:past</dfn> pseudo-class represents any element that is
-	defined to occur entirely prior to a '':current'' element.
-	For example, the WebVTT spec defines the '':past'' pseudo-class <a href="http://dev.w3.org/html5/webvtt/#the-past-and-future-pseudo-classes">relative to the current playback position of a media element</a>.
-	If a time-based order of elements is not defined by the document language,
-	then this represents any element that is a (possibly indirect) previous
-	sibling of a '':current'' element.
-
-<h3 id="the-future-pseudo">
-The Future-element Pseudo-class: '':future''</h3>
-
-	The <dfn id='future-pseudo'>:future</dfn> pseudo-class represents any element that is
-	defined to occur entirely after a '':current'' element.
-	For example, the WebVTT spec defines the '':future'' pseudo-class <a href="http://dev.w3.org/html5/webvtt/#the-past-and-future-pseudo-classes">relative to the current playback position of a media element</a>.
-	If a time-based order of elements is not defined by the document language,
-	then this represents any element that is a (possibly indirect) next
-	sibling of a '':current'' element.
-
-
 <h2 id='resource-pseudos'>
 Resource State Pseudo-classes</h2>
 
@@ -3699,36 +3509,6 @@ The Selected-option Pseudo-classes: '':checked'', '':unchecked'', and '':indeter
 
 <h3 id='ui-validity'>
 Input Value-checking</h3>
-
-<h4 id="blank">
-The Empty-Value Pseudo-class: '':blank''</h4>
-
-	The <dfn id="blank-pseudo">:blank</dfn> pseudo-class
-	applies to user-input elements whose input value is empty
-	(consists of the empty string or otherwise null input).
-
-	<div class="note">
-		Roughly speaking, if a human looked at a printout of the form
-		and would say it’s blank,
-		it matches '':blank''.
-
-		A rule of thumb for interpreting '':blank'' on form controls is:
-
-		* If the control always submits,
-			and would do so with an empty string, it matches '':blank''.
-			(Such as HTML’s <code>&lt;input type=text></code> when its value is empty.)
-		* If it sometimes submits, and is set to not submit, it matches '':blank''.
-			(Such as HTML’s <code>&lt;input type=checkbox></code> when not checked.)
-		* If it's an “action button”
-			(rather than a “toggle button” that represents a state)
-			such as <code>&lt;button></code>, <code>&lt;input type=submit></code>, etc.,
-			it never matches '':blank''.
-
-		Host languages can specify more precise rules
-		for when form controls match '':blank''.
-	</div>
-
-	Note: This selector is at-risk.
 
 <h4 id="validity-pseudos">
 The Validity Pseudo-classes: '':valid'' and '':invalid''</h4>
@@ -4525,89 +4305,6 @@ Subsequent-sibling combinator (<code>~</code>)</h3>
 	</div>
 
 
-<h2 id="table-pseudos">
-Grid-Structural Selectors</h2>
-
-	The double-association of a cell in a 2D grid (to its row and column)
-	cannot be represented by parentage in a hierarchical markup language.
-	Only one of those associations can be represented hierarchically: the
-	other must be explicitly or implicitly defined in the document language
-	semantics. In both HTML and DocBook, two of the most common hierarchical
-	markup languages, the markup is row-primary (that is, the row associations
-	are represented hierarchically); the columns must be implied.
-	To be able to represent such implied column-based relationships, the
-	<a>column combinator</a> and the
-	'':nth-col()'' and '':nth-last-col()'' pseudo-classes
-	are defined.
-	In a column-primary format, these pseudo-classes match against row associations instead.
-
-
-<h3 id="the-column-combinator">
-Column combinator (<code>||</code>)</h3>
-
-	The <dfn export>column combinator</dfn>, which consists of two pipes (<dfn selector id="selectordef-column">||</dfn>)
-	represents the relationship of a column element
-	to a cell element belonging to the column it represents.
-	Column membership is determined based on the semantics of the document language only:
-	whether and how the elements are presented is not considered.
-	If a cell element belongs to more than one column,
-	it is represented by a selector indicating membership in any of those columns.
-
-	<div class="example">
-		The following example makes cells C, E, and G gray.
-
-		<pre>
-		col.selected || td {
-			background: gray;
-			color: white;
-			font-weight: bold;
-		}
-		</pre>
-
-		<pre>
-		&lt;table>
-			&lt;col span="2">
-			&lt;col class="selected">
-			&lt;tr>&lt;td>A &lt;td>B &lt;td>C
-			&lt;tr>&lt;td colspan="2">D &lt;td>E
-			&lt;tr>&lt;td>F &lt;td colspan="2">G
-		&lt;/table>
-		</pre>
-	</div>
-
-
-<h3 id="the-nth-col-pseudo">
-'':nth-col()'' pseudo-class</h3>
-
-	The <dfn id='nth-col-pseudo' lt=":nth-col()">:nth-col(<var>An+B</var>)</dfn>
-	pseudo-class notation represents a cell element belonging to a column
-	that has <var>An+B</var>-1 columns
-	<strong>before</strong> it, for any positive
-	integer or zero value of <code>n</code>. Column membership is determined
-	based on the semantics of the document language only: whether and how the
-	elements are presented is not considered. If a cell element belongs to
-	more than one column, it is represented by a selector indicating any of
-	those columns.
-
-	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
-
-
-<h3 id="the-nth-last-col-pseudo">
-'':nth-last-col()'' pseudo-class</h3>
-
-	The <dfn id='nth-last-col-pseudo' lt=":nth-last-col()">:nth-last-col(<var>An+B</var>)</dfn>
-	pseudo-class notation represents a cell element belonging to a column
-	that has <var>An+B</var>-1 columns
-	<strong>after</strong> it, for any positive
-	integer or zero value of <code>n</code>. Column membership is determined
-	based on the semantics of the document language only: whether and how the
-	elements are presented is not considered. If a cell element belongs to
-	more than one column, it is represented by a selector indicating any of
-	those columns.
-
-	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
-
-
 <h2 id="specificity-rules">
 Calculating a selector's specificity</h2>
 
@@ -5392,7 +5089,7 @@ Changes since the 11 November 2022 Working Draft</h3>
 
 	Significant changes since the <a href="https://www.w3.org/TR/2022/WD-selectors-4-20221111/">11 November 2022 Working Draft</a>:
 
-	* Marked '':blank'' as at-risk and removed the at-risk status from '':read-write'' and '':has()''
+	* Removed the at-risk status from '':read-write'' and '':has()''
 	* Added '':popover-open'' pseudo-class.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/8637">Issue 8637</a>)
 	* Made '':has()'' and the selector argument of '':nth-child()''/'':nth-last-child()''
@@ -5400,6 +5097,16 @@ Changes since the 11 November 2022 Working Draft</h3>
 		(<a href="https://github.com/w3c/csswg-drafts/issues/7676">Issue 7676</a>)
 	* Moved the legacy single-colon pseudo-element syntax into the grammar itself.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/8122">Issue 8122</a>)
+	* Deferred the '':local-link'' pseudo-class to Level 5.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/12799">Issue 12799</a>)
+	* Deferred the '':interest-source'' and '':interest-target'' pseudo-classes to Level 5.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/12799">Issue 12799</a>)
+	* Deferred the '':blank'' pseudo-class to Level 5.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/12799">Issue 12799</a>)
+	* Deferred the <a href="selectors-5#grid-structural-selectors">grid-structural (column) selectors</a> to Level 5.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/12799">Issue 12799</a>)
+	* Deferred the <a href="selectors-5#time-pseudos">time-dimensional pseudo-classes</a> to Level 5.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/12799">Issue 12799</a>)
 
 <h3 id="changes-2022-05">
 Changes since the 7 May 2022 Working Draft</h3>
@@ -5585,15 +5292,13 @@ Changes Since Level 3</h3>
 		<li>Extended '':not()'' to accept a selector list.
 		<li>Added '':is()'' and '':where()'' and '':has()''.
 		<li>Added '':scope''.
-		<li>Added '':any-link'' and '':local-link''.
-		<li>Added <a href="#time-pseudos">time-dimensional pseudo-classes</a>.
+		<li>Added '':any-link''.
 		<li>Added '':target-within'', '':focus-within'', and '':focus-visible''.
 		<li>Added '':dir()''.
 		<li>Expanded '':lang()'' to accept wildcard matching and lists of language codes.
 		<li>Expanded <css>:nth-child()</css> to accept a selector list.
 		<li>Merged in input selectors from <a href="https://www.w3.org/TR/css-ui-3/">CSS Basic User Interface Module Level 3</a> and added back '':indeterminate''.
-		<li>Added '':blank'' and '':user-invalid''.
-		<li>Added <a href="#table-pseudos">grid-structural (column) selectors</a>.
+		<li>Added '':user-invalid''.
 		<li>Added case-insensitive / case-sensitive attribute-value matching flags.
 	</ul>
 

--- a/selectors-5/Overview.bs
+++ b/selectors-5/Overview.bs
@@ -38,7 +38,7 @@ Module Interactions</h3>
 Location Pseudo-classes</h2>
 
 <h3 id="local-pseudo">
-The local link pseudo-class '':local-link''</h3>
+The Local Link Pseudo-class '':local-link''</h3>
 
 	The <dfn id='local-link-pseudo'>:local-link</dfn> pseudo-class allows authors to style
 	[[selectors-4#the-any-link-pseudo|hyperlinks]]
@@ -136,6 +136,149 @@ The local link pseudo-class '':local-link''</h3>
 		and the link is same-page?
 		Should "null segments" count as matching, or not?
 
+<h2 id="useraction-pseudos">
+User Action Pseudo-classes</h2>
+
+<h3 id="interest-pseudos">
+The Interest Pseudo-classes: '':interest-source'' and '':interest-target''</h3>
+
+	A common UI feature is the ability for the user to "show interest" in certain elements
+	(an <dfn export>interest source</dfn>),
+	and the UI to respond to that interest
+	by showing additional information in another element
+	(the <dfn export>interest target</dfn>),
+	typically a popup.
+	For example, hovering a username on a page
+	might bring up an information card for that user;
+	or long-pressing a link
+	might bring up a preview of the link's destination.
+	Whenever this happens, the first element
+
+	Note: Exactly what elements are capable of being [=interest sources=],
+	how they're linked to [=interest targets=],
+	and how "interest" is shown
+	are all [=host language=]-defined.
+	In HTML, for example,
+	this is done with the <{html-global/interestfor}> attribute
+	to indicate an element capable of "showing interest"
+	(being an [=interest source=],
+	and that attribute points to another element
+	intended to show the additional information
+	(the associated [=interest target=])
+	(usually a <{html-global/popover}> element).
+
+	The <dfn>:interest-source</dfn> pseudo-class
+	applies to an [=interest source=] element that the user is currently "showing interest" in,
+	and the <dfn>:interest-target</dfn> pseudo-class
+	applies to the associated [=interest target=]
+	of an element matching '':interest-source''.
+
+	Note: '':interest-source'' only matches an [=interest source=]
+	the user is <em>currently</em> interested in,
+	not any element that can <em>potentially</em> have interest shown in it.
+	In HTML, for example,
+	just having the <{html-global/interestfor}> attribute
+	does not make an element match this pseudo-class;
+	the user has to actually indicate interest in it too.
+	Similarly, '':interest-target'' only matches an [=interest target=]
+	that is linked to an element the user is <em>currently</em> interested in,
+	not any element pointed to by an <{html-global/interestfor}> attribute.
+
+<h2 id="input-pseudos">
+The Input Pseudo-classes</h2>
+
+<h3 id="ui-validity">
+Input Value-checking</h3>
+
+<h4 id="blank">
+The Empty-Value Pseudo-class: '':blank''</h4>
+
+	The <dfn id="blank-pseudo">:blank</dfn> pseudo-class
+	applies to user-input elements whose input value is empty
+	(consists of the empty string or otherwise null input).
+
+	<div class="note">
+		Roughly speaking, if a human looked at a printout of the form
+		and would say it’s blank,
+		it matches '':blank''.
+
+		A rule of thumb for interpreting '':blank'' on form controls is:
+
+		* If the control always submits,
+			and would do so with an empty string, it matches '':blank''.
+			(Such as HTML’s <code>&lt;input type=text></code> when its value is empty.)
+		* If it sometimes submits, and is set to not submit, it matches '':blank''.
+			(Such as HTML’s <code>&lt;input type=checkbox></code> when not checked.)
+		* If it's an “action button”
+			(rather than a “toggle button” that represents a state)
+			such as <code>&lt;button></code>, <code>&lt;input type=submit></code>, etc.,
+			it never matches '':blank''.
+
+		Host languages can specify more precise rules
+		for when form controls match '':blank''.
+	</div>
+
+<h2 id="time-pseudos">
+Time-dimensional Pseudo-classes</h2>
+
+	These pseudo-classes classify elements with respect to the
+	currently-displayed or active position in some timeline, such as
+	during speech rendering of a document, or during the display of
+	a video using WebVTT to render subtitles.
+
+	CSS does not define this timeline;
+	the host language must do so.
+	If there is no timeline defined for an element,
+	these pseudo-classes must not match the element.
+
+	Note: Ancestors of a '':current'' element are also '':current'',
+	but ancestors of a '':past'' or '':future'' element are not necessarily '':past'' or '':future'' as well.
+	A given element matches at most one of '':current'', '':past'', or '':future''.
+
+<h3 id="the-current-pseudo">
+The Current-element Pseudo-class: '':current''</h3>
+
+	The <dfn id='current-pseudo'>:current</dfn> pseudo-class represents the
+	element, or an ancestor of the element, that is currently being displayed.
+
+	Its alternate form <dfn>:current()</dfn>
+	takes a list of <a>compound selectors</a> as its argument:
+	it represents the '':current'' element that matches the argument
+	or, if that does not match,
+	the innermost ancestor of the '':current'' element that does.
+	(If neither the '':current'' element nor its ancestors match the argument, then the selector does not represent anything.)
+
+	<div class="example">
+		For example, the following rule will highlight whichever paragraph
+		or list item is being read aloud in a speech rendering of the document:
+
+		<pre>
+		:current(p, li, dt, dd) {
+		  background: yellow;
+		}
+		</pre>
+	</div>
+
+<h3 id="the-past-pseudo">
+The Past-element Pseudo-class: '':past''</h3>
+
+	The <dfn id='past-pseudo'>:past</dfn> pseudo-class represents any element that is
+	defined to occur entirely prior to a '':current'' element.
+	For example, the WebVTT spec defines the '':past'' pseudo-class <a href="http://dev.w3.org/html5/webvtt/#the-past-and-future-pseudo-classes">relative to the current playback position of a media element</a>.
+	If a time-based order of elements is not defined by the document language,
+	then this represents any element that is a (possibly indirect) previous
+	sibling of a '':current'' element.
+
+<h3 id="the-future-pseudo">
+The Future-element Pseudo-class: '':future''</h3>
+
+	The <dfn id='future-pseudo'>:future</dfn> pseudo-class represents any element that is
+	defined to occur entirely after a '':current'' element.
+	For example, the WebVTT spec defines the '':future'' pseudo-class <a href="http://dev.w3.org/html5/webvtt/#the-past-and-future-pseudo-classes">relative to the current playback position of a media element</a>.
+	If a time-based order of elements is not defined by the document language,
+	then this represents any element that is a (possibly indirect) next
+	sibling of a '':current'' element.
+
 <h2 id="custom-state">
 Exposing custom state: the '':state()'' pseudo-class</h2>
 
@@ -213,6 +356,85 @@ Heading Structures: the heading pseudo-classes '':heading'', and '':heading()''<
 		parsing/parse-heading.html
 	</wpt>
 
+<h2 id="grid-structural-selectors" oldids="table-pseudos">
+Grid-Structural Selectors</h2>
+
+	The double-association of a cell in a 2D grid (to its row and column)
+	cannot be represented by parentage in a hierarchical markup language.
+	Only one of those associations can be represented hierarchically: the
+	other must be explicitly or implicitly defined in the document language
+	semantics. In both HTML and DocBook, two of the most common hierarchical
+	markup languages, the markup is row-primary (that is, the row associations
+	are represented hierarchically); the columns must be implied.
+	To be able to represent such implied column-based relationships, the
+	<a>column combinator</a> and the
+	'':nth-col()'' and '':nth-last-col()'' pseudo-classes
+	are defined.
+	In a column-primary format, these pseudo-classes match against row associations instead.
+
+<h3 id="the-column-combinator">
+Column combinator (<code>||</code>)</h3>
+
+	The <dfn export>column combinator</dfn>, which consists of two pipes (<dfn selector id="selectordef-column">||</dfn>)
+	represents the relationship of a column element
+	to a cell element belonging to the column it represents.
+	Column membership is determined based on the semantics of the document language only:
+	whether and how the elements are presented is not considered.
+	If a cell element belongs to more than one column,
+	it is represented by a selector indicating membership in any of those columns.
+
+	<div class="example">
+		The following example makes cells C, E, and G gray.
+
+		<pre>
+		col.selected || td {
+			background: gray;
+			color: white;
+			font-weight: bold;
+		}
+		</pre>
+
+		<pre>
+		&lt;table>
+			&lt;col span="2">
+			&lt;col class="selected">
+			&lt;tr>&lt;td>A &lt;td>B &lt;td>C
+			&lt;tr>&lt;td colspan="2">D &lt;td>E
+			&lt;tr>&lt;td>F &lt;td colspan="2">G
+		&lt;/table>
+		</pre>
+	</div>
+
+<h3 id="the-nth-col-pseudo">
+'':nth-col()'' pseudo-class</h3>
+
+	The <dfn id='nth-col-pseudo' lt=":nth-col()">:nth-col(<var>An+B</var>)</dfn>
+	pseudo-class notation represents a cell element belonging to a column
+	that has <var>An+B</var>-1 columns
+	<strong>before</strong> it, for any positive
+	integer or zero value of <code>n</code>. Column membership is determined
+	based on the semantics of the document language only: whether and how the
+	elements are presented is not considered. If a cell element belongs to
+	more than one column, it is represented by a selector indicating any of
+	those columns.
+
+	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
+
+<h3 id="the-nth-last-col-pseudo">
+'':nth-last-col()'' pseudo-class</h3>
+
+	The <dfn id='nth-last-col-pseudo' lt=":nth-last-col()">:nth-last-col(<var>An+B</var>)</dfn>
+	pseudo-class notation represents a cell element belonging to a column
+	that has <var>An+B</var>-1 columns
+	<strong>after</strong> it, for any positive
+	integer or zero value of <code>n</code>. Column membership is determined
+	based on the semantics of the document language only: whether and how the
+	elements are presented is not considered. If a cell element belongs to
+	more than one column, it is represented by a selector indicating any of
+	those columns.
+
+	The CSS Syntax Module [[!CSS3SYN]] defines the <a href="https://drafts.csswg.org/css-syntax/#anb"><var>An+B</var> notation</a>.
+
 <h2 id="combinators">
 Combinators</h2>
 
@@ -256,12 +478,21 @@ Changes Since Level 4</h3>
 	Additions since <a href="https://www.w3.org/TR/selectors-4/">Level 4</a>:
 
 	<ul>
-	        <li>Reference combinators
-	        (deferred from an <a href="https://www.w3.org/TR/2013/WD-selectors4-20130502/">earlier draft</a> of Selectors 4)</li>
-	        <li>The functional form of the '':local-link'' pseudo-class
-	        (deferred from an <a href="https://www.w3.org/TR/2013/WD-selectors4-20130502/">earlier draft</a> of Selectors 4)</li>
-	        <li>The '':state()'' pseudo-class</li>
-	        <li>The '':heading'' and '':heading()'' pseudo-classes</li>
+		<li>Reference combinators
+		(deferred from an <a href="https://www.w3.org/TR/2013/WD-selectors4-20130502/">earlier draft</a> of Selectors 4)</li>
+		<li>The functional form of the '':local-link'' pseudo-class
+		(deferred from an <a href="https://www.w3.org/TR/2013/WD-selectors4-20130502/">earlier draft</a> of Selectors 4)</li>
+		<li>The '':state()'' pseudo-class</li>
+		<li>The '':heading'' and '':heading()'' pseudo-classes</li>
+		<li>The '':local-link'' pseudo-class
+		(deferred from an <a href="https://www.w3.org/TR/2022/WD-selectors-4-20221111/">earlier draft</a> of Selectors 4)</li>
+		<li>The '':interest-source'' and '':interest-target'' pseudo-classes</li>
+		<li>The '':blank'' pseudo-class
+		(deferred from an <a href="https://www.w3.org/TR/2022/WD-selectors-4-20221111/">earlier draft</a> of Selectors 4)</li>
+		<li>The <a href="#grid-structural-selectors">grid-structural (column) selectors</a>
+		(deferred from an <a href="https://www.w3.org/TR/2022/WD-selectors-4-20221111/">earlier draft</a> of Selectors 4)</li>
+		<li>The <a href="#time-pseudos">time-dimensional pseudo-classes</a>
+		(deferred from an <a href="https://www.w3.org/TR/2022/WD-selectors-4-20221111/">earlier draft</a> of Selectors 4)</li>
 	</ul>
 
 <h2 id="acknowledgements">


### PR DESCRIPTION
To be able to move Level 4 to CR, several features were moved to Level 5 of the spec. Those features include the `:local-link` pseudo-class, the `:interest-source` and `:interest-target` pseudo-classes, the `:blank` pseudo-class, the grid-structural selectors, and the time-dimensional pseudo-classes.

Resolution: https://github.com/w3c/csswg-drafts/issues/12799#issuecomment-3628969842

Sebastian