### PR TITLE
[fill-stroke] fix SVG paths

### DIFF
--- a/fill-stroke/Overview.bs
+++ b/fill-stroke/Overview.bs
@@ -825,24 +825,24 @@ Stroke Geometry {#stroke-geometry}
 	</figure>
 
 	<figure>
-		<svg style=" width: 600px; height: 180px;">
+		<svg style="width: 600px; height: 180px;">
 			<g transform="translate(0, 0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, l 44.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 l 44.72 72.36 z" />
 			</g>
 			<g transform="translate(200,0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, a 50 50 0 0 1 44.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 a 50 50 0 0 1 44.72 72.36 z" />
 			</g>
 			<g transform="translate(400, 0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, h 80, L 154.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 h 80 L 154.72 72.36 z" />
 			</g>
 		</svg>
 		<figcaption>


### PR DESCRIPTION
The embedded SVG in Figure 8 uses invalid path syntax which separates each segment by a comma. This removes those commas.

#13221