### PR TITLE
[fill-stroke-3][editorial] Fixed display of figure 8

### DIFF
--- a/fill-stroke/Overview.bs
+++ b/fill-stroke/Overview.bs
@@ -825,24 +825,30 @@ Stroke Geometry {#stroke-geometry}
 	</figure>
 
 	<figure>
-		<svg style=" width: 600px; height: 180px;">
+		<svg style=" width: 600px; height: 180px; color-scheme: light dark;">
+			<style>
+				@media (prefers-color-scheme: dark) {
+					path[stroke="black"] { stroke: white; }
+					path[stroke="white"] { stroke: black; }
+				}
+			</style>
 			<g transform="translate(0, 0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, l 44.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 l 44.72 72.36 z" />
 			</g>
 			<g transform="translate(200,0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, a 50 50 0 0 1 44.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 a 50 50 0 0 1 44.72 72.36 z" />
 			</g>
 			<g transform="translate(400, 0)">
-				<path fill=none stroke=black stroke-width=100 d="M 10 50, h 100" />
-				<path fill=none stroke=black stroke-width=100 d="M 110 50, l -50 100" />
-				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50, h 100, l -100 200" />
-				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50, v -50, h 80, L 154.72 72.36, z" />
+				<path fill=none stroke=black stroke-width=100 d="M 10 50 h 100" />
+				<path fill=none stroke=black stroke-width=100 d="M 110 50 l -50 100" />
+				<path fill=none stroke=white stroke-dasharray="5 3" stroke-width=1 d="M 10 50 h 100 l -100 200" />
+				<path fill="hsla(0, 50%, 70%, 1)" d="M 110 50 v -50 h 80 L 154.72 72.36 z" />
 			</g>
 		</svg>
 		<figcaption>


### PR DESCRIPTION
The paths incorrectly split the data points with commas instead of the x and y coordinates _within_ the data points.

And the change also fixes the display for dark themes.

Fixes #13221.

Sebastian