### PR TITLE
[pointer-animations-1] Link `source` and `target` back to right type

### DIFF
--- a/pointer-animations-1/Overview.bs
+++ b/pointer-animations-1/Overview.bs
@@ -437,7 +437,7 @@ spec:selectors-4; type:dfn; text:selector
 	which indicates a [=CSS identifier=] representing
 	one of the following:
 
-	<dl dfn-type=value dfn-for="timeline-range-center-subject">
+	<dl dfn-type=value dfn-for="<timeline-range-center-subject>">
 		<dt><dfn>source</dfn>
 		<dd>
 			The element whose [=pointer offset=]


### PR DESCRIPTION
The values are for the `<timeline-range-center-subject>` type but the wrapping `<>` were missing.
