### PR TITLE
[css-forms-1] Use border-radius: 50% instead of 100%

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -880,7 +880,7 @@ input:is([type=checkbox]:not([switch]), [type=radio]) {
 }
 
 input[type=radio] {
-    border-radius: 100%;
+    border-radius: 50%;
 }
 
 input[type=checkbox]:not([switch]):checked::checkmark {


### PR DESCRIPTION
100% relies on the fixup rules to scale down to 50%, so maybe we should just say 50% directly since that's what we mean?