### PR TITLE
[css-color-4] Fix reference URL in comment

### DIFF
--- a/css-color-4/conversions.js
+++ b/css-color-4/conversions.js
@@ -338,7 +338,7 @@ function XYZ_to_Lab(XYZ) {
 
 function Lab_to_XYZ(Lab) {
 	// Convert Lab to D50-adapted XYZ
-	// http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+	// http://www.brucelindbloom.com/index.html?Eqn_Lab_to_XYZ.html
 	var κ = 24389/27;   // 29^3/3^3
 	var ε = 216/24389;  // 6^3/29^3
 	var f = [];


### PR DESCRIPTION
While working on color conversions on my side, I noticed the URL in the documentation of one of the sample code function was incorrect. This should be the correct one for that function.