### PR TITLE
[scroll-animations-1] Clarify "Computed value" of scroll/view-timeline-name

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -527,7 +527,7 @@ spec:selectors-4; type:dfn; text:selector
 	Initial: none
 	Applies to: all elements
 	Inherited: no
-	Computed value: the keyword ''scroll-timeline-name/none'' or a list of [=CSS identifiers=]
+	Computed value: list, each item either a [=CSS identifier=] or the keyword ''scroll-timeline-name/none''
 	Animation type: not animatable
 	</pre>
 
@@ -964,7 +964,7 @@ spec:selectors-4; type:dfn; text:selector
 	Initial: none
 	Applies to: all elements
 	Inherited: no
-	Computed value: the keyword ''view-timeline-name/none'' or a list of [=CSS identifiers=]
+	Computed value: list, each item either a [=CSS identifier=] or the keyword ''view-timeline-name/none''
 	Animation type: not animatable
 	</pre>
 


### PR DESCRIPTION
The current text would suggest a grammar of `none | <dashed-ident>#`, but the grammar is actually `[none | <dashed-ident>]#`. We probably just forgot to update the text in the edit for #8843.

Resolves #13139.
