### PR TITLE
[css-cascade][css-syntax] Add links to the definition of "media type"

### DIFF
--- a/css-cascade-3/Overview.bs
+++ b/css-cascade-3/Overview.bs
@@ -331,7 +331,7 @@ Value Processing</h2>
 	it must assign,
 	to every element in the tree,
 	and correspondingly to every box in the formatting structure,
-	a value to every property that applies to the target media type.
+	a value to every property that applies to the target [=media type=].
 
 	The final value of a CSS property for a given element or box
 	is the result of a multi-step calculation:

--- a/css-cascade-4/Overview.bs
+++ b/css-cascade-4/Overview.bs
@@ -513,7 +513,7 @@ Value Processing</h2>
 	it must assign,
 	to every element in the [=flat tree=],
 	and correspondingly to every box in the formatting structure,
-	a value to every property that applies to the target media type.
+	a value to every property that applies to the target [=media type=].
 
 	The final value of a CSS property for a given element or box
 	is the result of a multi-step calculation:

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -477,7 +477,7 @@ Value Processing</h2>
 	it must assign,
 	to every element in the [=flat tree=],
 	and correspondingly to every box in the formatting structure,
-	a value to every property that applies to the target media type.
+	a value to every property that applies to the target [=media type=].
 
 	The final value of a CSS property for a given element or box
 	is the result of a multi-step calculation:

--- a/css-syntax-3/Overview.bs
+++ b/css-syntax-3/Overview.bs
@@ -133,7 +133,7 @@ Description of CSS's Syntax</h2>
 			}
 		</pre>
 
-		The ''@media'' <a>at-rule</a> begins with a media type
+		The ''@media'' <a>at-rule</a> begins with a [=media type=]
 		and a list of optional media queries.
 		Its block contains entire rules,
 		which are only applied when the ''@media''s conditions are fulfilled.


### PR DESCRIPTION
This hyperlinks the term "media type" for clarity.