### PR TITLE
[css-position-4] Remove the overlay property

### DIFF
--- a/css-position-4/Overview.bs
+++ b/css-position-4/Overview.bs
@@ -170,10 +170,6 @@ This ensures that "nested" invocations of top-layer-using APIs,
 like a popup within a popup,
 will display correctly.
 
-Note: The [=Document/top layer=] interacts with the 'overlay' property
-in a somewhat unusual way.
-See 'overlay' for details.
-
 {{Document}}s also have a <dfn export>pending top layer removals</dfn> [=ordered set=],
 containing elements that are pending removal.
 (See the algorithms, below, for details on how this is used.)
@@ -274,15 +270,14 @@ Top Layer Manipulation {#top-manip}
 	rather than [=rendered in the top layer=],
 	when they are manipulating the top layer itself.
 	Using this concept avoids the behavior being different
-	based on whether there's an 'overlay' transition,
+	based on whether there's a 'display' transition,
 	or whether two operations happened <em>between</em> rendering updates
 	or <em>across</em> them.
 </div>
 
 <div algorithm>
 	An element |el| is <dfn export lt="render in the top layer">rendered in the top layer</dfn>
-	if |el| is [=list/contained=] in its [=Node/node document's=] [=Document/top layer=],
-	and |el| has ''overlay: auto''.
+	if |el| is [=list/contained=] in its [=Node/node document's=] [=Document/top layer=].
 
 	Note: Specs should use this concept,
 	rather than [=in the top layer=],
@@ -307,10 +302,6 @@ Top Layer Manipulation {#top-manip}
 			and [=pending top layer removals=].
 
 	3. [=set/Append=] |el| to |doc|'s [=Document/top layer=].
-
-	4. At the UA !important [=cascade origin=],
-		add a rule targeting |el|
-		containing an ''overlay: auto'' declaration.
 </div>
 
 <div algorithm>
@@ -324,9 +315,7 @@ Top Layer Manipulation {#top-manip}
 		in |doc|'s [=pending top layer removals=],
 		return.
 
-	3. Remove the UA !important ''overlay: auto'' rule targeting |el|.
-
-	4. [=set/Append=] |el| to |doc|'s [=pending top layer removals=].
+	3. [=set/Append=] |el| to |doc|'s [=pending top layer removals=].
 </div>
 
 <div algorithm>
@@ -337,12 +326,8 @@ Top Layer Manipulation {#top-manip}
 
 	2. [=set/Remove=] |el| from |doc|'s [=Document/top layer=] and [=pending top layer removals=].
 
-	3. Remove the UA !important ''overlay: auto'' rule targeting |el|,
-		if it exists.
-
 	Note: This algorithm is only intended to be used in special cases
 	where removing something from the top layer immediately
-	(bypassing things like an 'overlay' transition)
 	is necessary,
 	such as a modal dialog that is removed from the document.
 	Most of the time, [=requesting removal from the top layer=] is more appropriate.
@@ -353,111 +338,19 @@ Top Layer Manipulation {#top-manip}
 	given a {{Document}} |doc|:
 
 	1. For each element |el| in |doc|'s [=pending top layer removals=]:
-		if |el|&apos;s computed value of 'overlay' is ''none'',
-		or |el| is [=not rendered=],
+		if |el|&apos;s computed value of 'display' is ''none'',
+		or |el| is [=element-not-rendered|not rendered=],
 		[=remove from the top layer immediately=] |el|.
 
 	Note: This is intended to be called during the "Update the Rendering" step
 	of HTML's rendering algorithm.
 	It is not intended to be called by other algorithms.
 
-	Note: The 'overlay' check can be delayed arbitrarily long
-	by author-level transitions;
-	see [[#overlay]] for details.
+	Note: Elements will stay in the top layer until until they are ''display: none''
+	in order to allow animations which transition the element to ''display: none''.
+	If the author's style rules never set ''display: none'', then the element will be
+	stuck in the top layer forever.
 </div>
-
-
-<!-- Big Text: overlay
-
- ███▌  █▌   █▌ █████▌ ████▌  █▌     ███▌  █   ▐▌
-█▌  █▌ █▌   █▌ █▌     █▌  █▌ █▌    ▐█ ▐█  ▐▌  █ 
-█▌  █▌ █▌   █▌ █▌     █▌  █▌ █▌    █▌  █▌  █ ▐▌ 
-█▌  █▌ ▐▌   █  ████   ████▌  █▌    █▌  █▌  ▐▌█  
-█▌  █▌  █  ▐▌  █▌     █▌▐█   █▌    █████▌   █▌  
-█▌  █▌  ▐▌ █   █▌     █▌ ▐█  █▌    █▌  █▌   █▌  
- ███▌    ▐█    █████▌ █▌  █▌ █████ █▌  █▌   █▌  
--->
-
-Controlling the Top Layer: the 'overlay' property {#overlay}
--------------------------------------------------
-
-<pre class=propdef>
-Name: overlay
-Value: none | auto
-Initial: none
-Inherited: no
-Animation Type: see prose
-</pre>
-
-When an element is [=in the top layer=],
-the 'overlay' property determines
-whether it is actually [=rendered in the top layer=] or not.
-
-<dl dfn-type=value dfn-for=overlay>
-	: <dfn>none</dfn>
-	:: The element isn't [=rendered in the top layer=].
-
-	: <dfn>auto</dfn>
-	:: The element is [=rendered in the top layer=]
-		if it is [=in the top layer=].
-
-		Rather than generating boxes as part of its normal position in the document,
-		it generates boxes as a sibling of the root element,
-		rendered "above" it.
-</dl>
-
-<div class=note id=overlay-guidance>
-	Note: 'overlay' is a somewhat unusual property,
-	as it is <em>only</em> set by the user agent,
-	and can't be set by authors <em>at all</em>.
-
-	However, authors <em>do</em> have the ability to affect
-	<em>when</em> 'overlay' changes its value,
-	by setting a 'transition' on the property.
-	This allows an author to align an animation
-	with the transition,
-	with the element moving in or out of the top layer
-	only at the desired point in the animation.
-	This allows, for example,
-	an animation that causes an element to fade out of its normal position on the page,
-	then fade in at its new top-layer position,
-	or vice versa.
-</div>
-
-For animation,
-''overlay/auto'' is [=interpolated=] as a discrete step
-where values of p such that <code>0 < p < 1</code>
-map to ''overlay/auto''
-and other values of p map to the closer endpoint;
-if neither value is ''overlay/auto'' then discrete animation is used.
-
-Note: This is similar to how 'visibility' animates.
-With most [=easing functions=],
-this will keep the element [=rendered in the top layer=]
-for the entire duration of the transition,
-whether it's entering or leaving the top layer.
-''step-start''/''step-end''/''linear()''
-can be used to control when the value flips more precisely.
-
-User agents must have the following rule in their UA stylesheet:
-
-<pre highlight=css>
-* { overlay: none !important; }
-</pre>
-
-Note: This means that the 'overlay' property <em>cannot be set by authors or users</em>--
-it is entirely controlled by the user agent
-(which sets elements to ''overlay: auto'',
-via another UA-!important rule,
-when they're in the [=Document/top layer=]).
-
-User agents <em>may</em>, at their discretion,
-remove a running [=transition=] on 'overlay'.
-The conditions for this are intentionally undefined.
-<span class=note>(This is to prevent potential abuse scenarios
-where a ''transition: overlay 1e9s;'' or similar
-attempts to keep an element in the [=Document/top layer=] permanently.)</span>
-
 
 
 


### PR DESCRIPTION
This enables top layer exit animations without the need for the authors to specify the overlay property by removing elements from the top layer when they are display:none.

Fixes https://github.com/w3c/csswg-drafts/issues/13200