### PR TITLE
[cssom-view] Correct indentation for "run the scroll steps"

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2391,27 +2391,27 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. If <var>target</var> is a {{Document}}, and <var>type</var> is <code>"scroll"</code> or <code>"scrollend"</code>,
         <a>fire an event</a> named <var>type</var> that bubbles at <var>target</var>.
     1. Otherwise, if <var>type</var> is <code>"scrollsnapchange"</code>, then:
-      1. Let |blockTarget| and |inlineTarget| be null initially.
-      1. If the <a>scrollsnapchangeTargetBlock</a> associated with <var>target</var> is a pseudo-element,
-        set |blockTarget| to the owning element of that <a>scrollsnapchangeTargetBlock</a>.
-      1. Otherwise, set |blockTarget| to that <a>scrollsnapchangeTargetBlock</a>.
-      1. If the <a>scrollsnapchangeTargetInline</a> associated with <var>target</var> is a pseudo-element,
-        set |inlineTarget| to the owning element of that <a>scrollsnapchangeTargetInline</a>.
-      1. Otherwise, Set |inlineTarget| to that <a>scrollsnapchangeTargetInline</a>.
-      1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
-        and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget| respectively.
+        1. Let |blockTarget| and |inlineTarget| be null initially.
+        1. If the <a>scrollsnapchangeTargetBlock</a> associated with <var>target</var> is a pseudo-element,
+          set |blockTarget| to the owning element of that <a>scrollsnapchangeTargetBlock</a>.
+        1. Otherwise, set |blockTarget| to that <a>scrollsnapchangeTargetBlock</a>.
+        1. If the <a>scrollsnapchangeTargetInline</a> associated with <var>target</var> is a pseudo-element,
+          set |inlineTarget| to the owning element of that <a>scrollsnapchangeTargetInline</a>.
+        1. Otherwise, Set |inlineTarget| to that <a>scrollsnapchangeTargetInline</a>.
+        1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchange}} at <var>target</var>
+          and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+          {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget| respectively.
     1. Otherwise, if <var>type</var> is <code>"scrollsnapchanging"</code>, then:
-      1. Let |blockTarget| and |inlineTarget| be null initially.
-      1. If the <a>scrollsnapchanging block-axis target</a> associated with <var>target</var> is a pseudo-element,
-        set |blockTarget| to the owning element of that <a>scrollsnapchanging block-axis target</a>.
-      1. Otherwise, set |blockTarget| to that <a>scrollsnapchanging block-axis target</a>.
-      1. If the <a>scrollsnapchanging inline-axis target</a> associated with <var>target</var> is a pseudo-element,
-        set |inlineTarget| to the owning element of that <a>scrollsnapchanging inline-axis target</a>.
-      1. Otherwise, set |inlineTarget| to that <a>scrollsnapchanging inline-axis target</a>.
-      1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
-        and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
-        {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
+        1. Let |blockTarget| and |inlineTarget| be null initially.
+        1. If the <a>scrollsnapchanging block-axis target</a> associated with <var>target</var> is a pseudo-element,
+          set |blockTarget| to the owning element of that <a>scrollsnapchanging block-axis target</a>.
+        1. Otherwise, set |blockTarget| to that <a>scrollsnapchanging block-axis target</a>.
+        1. If the <a>scrollsnapchanging inline-axis target</a> associated with <var>target</var> is a pseudo-element,
+          set |inlineTarget| to the owning element of that <a>scrollsnapchanging inline-axis target</a>.
+        1. Otherwise, set |inlineTarget| to that <a>scrollsnapchanging inline-axis target</a>.
+        1. Fire a {{SnapEvent}}, |snapevent|, named {{scrollsnapchanging}} at <var>target</var>
+          and let |snapevent|'s {{SnapEvent/snapTargetBlock}} and
+          {{SnapEvent/snapTargetInline}} attributes be |blockTarget| and |inlineTarget|, respectively.
     1. Otherwise, <a>fire an event</a> named <var>type</var> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll events</a>.
 


### PR DESCRIPTION
These substeps were indented by 2 spaces, which Bikeshed didn't interpret as being nested, but was placing them at the same level. Indenting the steps by 4 spaces instead corrects the HTML output.

This is an editorial change, purely whitespace.

To illustrate, before:
<img width="750" height="832" alt="image" src="https://github.com/user-attachments/assets/fe388fdb-3fbd-465a-ae62-930289caa838" />

And after:
<img width="742" height="894" alt="image" src="https://github.com/user-attachments/assets/d0ccb0b6-b43d-480a-9b98-ad09b0f6248b" />
