### PR TITLE
[css-spec-shortname-1] Define `set scrollbar type` for enabling emulations  https://github.com/w3c/webdriver-bidi/issues/772

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -62,7 +62,6 @@ spec:html; type:method; text:focus()
 url: https://www.w3.org/TR/2008/CR-css3-marquee-20081205/#the-overflow-style; type: property; text: overflow-style;
 url: https://www.w3.org/TR/CSS22/visuren.html#positioned-element; type: dfn; spec:css2; text:positioned;
 url: https://www.w3.org/TR/CSS22/visudet.html#strut-element; type: dfn; spec:css2; text:strut;
-url: https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-emulated-scrollbar-type; type:dfn; spec:webdriver-bidi; text:WebDriver BiDi emulated scrollbar type;
 </pre>
 <style>
 .awesome-table td { padding: 5px; }
@@ -862,19 +861,22 @@ Reserving space for the scrollbar: the 'scrollbar-gutter' property</h3>
 	are called <dfn export>classic scrollbars</dfn>.
 	Such scrollbars are usually opaque.
 
-	The appearance and size of the scrollbar, and whether scrollbars appear on the start or end edge
-	of the box, is UA defined.
+	Whether <a>classic scrollbars</a> or <a>overlay scrollbars</a> are used,
+	the appearance and size of the scrollbar,
+	and whether scrollbars appear on the start or end edge of the box,
+	is UA defined.
 
-	Whether <a>classic scrollbars</a> or <a>overlay scrollbars</a> is used in the given |document|
-	is defined by the following steps:
-
-	1. Let |emulated scrollbar type| be the result of [=WebDriver BiDi emulated scrollbar type=] for |document|;
-	1. If |emulated scrollbar type| is "<code>classic</code>", use <a>classic scrollbars</a>;
-	1. Otherwise, if |emulated scrollbar type| is "<code>overlay</code>", use <a>overlay scrollbars</a>;
-	1. Otherwise, use the UA defined default.
-
-	Note: The scrollbar type should be updated each time the result of the
-	[=WebDriver BiDi emulated scrollbar type=] is changed.
+	<div algorithm>
+		To <dfn export>set scrollbar type</dfn> of [=/document=] |document| to string or null
+		|scrollbar type|:
+		1. Assert that |scrollbar type| is "<code>classic</code>", "<code>overlay</code>" or null.
+		1. If |scrollbar type| is "<code>classic</code>", run [=implementation-defined=] steps to make
+		    the |document| to use <a>classic scrollbars</a>.
+		1. Otherwise, if |scrollbar type| is "<code>overlay</code>", run [=implementation-defined=]
+		    steps to make the |document| to use <a>overlay scrollbars</a>.
+		1. Otherwise, run [=implementation-defined=] steps to make the |document| to use a UA defined
+		    default scrollbar type.
+	</div>
 
 	Note: Which side a scrollbar appears on may depend on
 	operating system conventions,


### PR DESCRIPTION
[css-spec-shortname-1] Define `set scrollbar type` for enabling emulations  https://github.com/w3c/webdriver-bidi/issues/772

This hook is expected to invoked from the WebDriver BiDi specification.

### Blocked on https://github.com/w3c/webdriver-bidi/pull/1050