### PR TITLE
[css-animations-2] Define trigger scope

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -813,7 +813,7 @@ of what can be achieved with the Web Animations API in Javascript,
 allowing simple, common interaction patterns
 to be created and managed purely in CSS.
 
-Currently, two types of <dfn export for=CSS>triggers</dfn> are defined:
+Currently, two types of <dfn export for=CSS lt="trigger">triggers</dfn> are defined:
 
 * [=timeline triggers=], managed by the 'timeline-trigger' properties,
     which allow animations to be triggered by entering or leaving certain timeline ranges.
@@ -826,7 +826,7 @@ Currently, two types of <dfn export for=CSS>triggers</dfn> are defined:
     such as clicking an element or pressing certain keys.
 
 A [=trigger=] is <em>defined</em> on some specific triggering element.
-All triggers have a name,
+All triggers have a <dfn export for=CSS>trigger name</dfn>,
 and the specific type of trigger dictates how and when it's activated.
 A trigger can define multiple "types" of activation.
 (For example, [=timeline triggers=] can do different things on entry and exit.)
@@ -844,20 +844,6 @@ is intentionally somewhat generic,
 intended to support using [=triggers=] for <em>other</em> purposes in the future.
 For now, though, [=triggered animations=] are the only user of this feature.
 
-
-<h3 id="trigger-name-scoping">
-Trigger Name Scoping</h3>
-
-A <dfn export>trigger-instantiating property</dfn> specifies the details for
-instantiating an [=Animation Trigger=] along with a name for the instantiated
-trigger, a <dfn export>trigger name</dfn>.
-
-All [=trigger names=] are document-global by default but may be
-scoped by 'trigger-scope'.
-
-ISSUE: Is "document-global" the right term here given that these "global" names are
-still tree scoped?
-
 If a single element attempts to define multiple [=triggers=] of different types
 with the same [=trigger name=],
 it only exposes one of the [=triggers=],
@@ -867,11 +853,22 @@ Note: This order is completely arbitrary
 (based on alphabetic order of the concept name),
 as this is just an error case.
 
+
+<h3 id="trigger-scope">
+Trigger Name Scoping: the 'trigger-scope' property</h3>
+
+[=Trigger names=] are global by default,
+usable by other elements regardless of their position.
+(Though they are [=tree-scoped names=],
+so have interactions with [=shadow roots=]).
 If multiple elements define [=triggers=] with the same [=trigger name=],
 the [=trigger=] defined by the later element in [=tree order=] is used.
 
-<h4 id="trigger-scope">
-Scoping Trigger Names: the 'trigger-scope' property</h4>
+The 'trigger-scope' property can limit the scope of a name
+to a subtree of the document,
+so elements outside won't see the chosen [=trigger name=],
+and elements inside will only see the version of the [=trigger name=]
+defined inside the scope.
 
 <pre class=propdef>
 Name: trigger-scope
@@ -884,8 +881,7 @@ Computed value: as specified
 </pre>
 
 This property scopes [=trigger names=] to the subtree of the matching element.
-
-The accepted values mean the following:
+Its values are:
 
 <dl dfn-for="trigger-scope" dfn-type=value>
   <dt><dfn>none</dfn>


### PR DESCRIPTION


We [resolved](https://github.com/w3c/csswg-drafts/issues/12581#issuecomment-3206707173) to have a name scoping property for animation triggers and have it behave like anchor-scope. 
