### PR TITLE
Fix markup

### DIFF
--- a/css-ruby-1/Overview.bs
+++ b/css-ruby-1/Overview.bs
@@ -204,12 +204,12 @@ Ruby-specific 'display' Values</h3>
 	authors must map document language elements to ruby elements;
 	this is done with the 'display' property.
 
-	<div class="informative">
-		<pre class=propdef partial>
-		Name: display
-		New values: ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container
-		</pre>
-	</div>
+	
+	<pre class="propdef partial">
+	Name: display
+	New values: ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container
+	</pre>
+	
 
 	The following new 'display' values assign ruby layout roles to an arbitrary element:
 


### PR DESCRIPTION
[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
