### PR TITLE
[css-gaps-1] Fix missing syntax for #inset #12848

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1575,4 +1575,5 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 			<a href="https://github.com/w3c/csswg-drafts/issues/12848">Issue 12848</a>,
 			<a href="https://github.com/w3c/csswg-drafts/issues/8402">Issue 8402</a>)
 		<li>Added a paragraph clarifying that gap decorations are not drawn where gaps are suppressed due to fragment breaks.
+		<li>Corrected syntax errors for the inset shorthands.</li>
 	</ul>


### PR DESCRIPTION
This PR makes some changes to the specified syntax for the `*-rule-inset` shorthands since they were actually incorrect in the spec and didn't specify the agreed upon syntax (which sets the four properties).
