### PR TITLE
[cssom-1][editorial] Fix links to CSSStyleProperties

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -2221,7 +2221,7 @@ On setting the {{CSSStyleRule/selectorText}} attribute these steps must be run:
   set-selector-text-attachment.html
 </wpt>
 
-The <dfn attribute for=CSSStyleRule>style</dfn> attribute must return a <code>CSSStyleProperties</code> object for the style rule, with the
+The <dfn attribute for=CSSStyleRule>style</dfn> attribute must return a {{CSSStyleProperties}} object for the style rule, with the
 following properties:
 <dl>
  <dt><a for="CSSStyleDeclaration">computed flag</a>
@@ -3297,7 +3297,7 @@ interface mixin ElementCSSInlineStyle {
 };
 </pre>
 
-The <dfn attribute for=ElementCSSInlineStyle>style</dfn> attribute must return a <a>CSSStyleProperties</a> object whose
+The <dfn attribute for=ElementCSSInlineStyle>style</dfn> attribute must return a {{CSSStyleProperties}} object whose
 <a for="CSSStyleDeclaration">readonly flag</a> is unset, whose <a for="CSSStyleDeclaration">parent CSS rule</a> is null, and
 whose <a for="CSSStyleDeclaration">owner node</a> is [=this=].
 


### PR DESCRIPTION
One has its `title` defined with `LINK ERROR: No 'dfn' refs found for 'cssstyleproperties'.`. The other is wrapped in `<code>`.