### PR TITLE
[css-gaps-1] Update gap decoration behavior when gaps are coincident due to track collapsing #11814

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -308,7 +308,7 @@ Layout and painting</h3>
 		grid/subgrid/fragmentation/subgrid-gap-decorations-fragmentation-018.html
 	</wpt>
 
-	gap decorations are [=assigned gap decoration values|assigned=] after collapsing has been applied.
+	Gap decorations are [=assigned gap decoration values|assigned=] after [=gutter collapsing|collapsed gutter=] has been applied.
 	A given set of [=collapsed gutters=] consume exactly one [=gap decoration=]; the next [=gap decoration=]
 	is applied to the next gutter (or set of [=collapsed gutters=]). Therefore, [=collapsed gutters=] are treated as a
 	single gutter for decoration purposes.


### PR DESCRIPTION
This PR updates the logic of assigning gap decorations to gaps that are coincident due to track collapsing. Previously, border-collapsing rules were used to resolve conflicts. Now, following the new resolution taken in #11814, gap decorations are applied after collapsing, treating all coincident gaps as a single visible gap for decoration purposes.