### PR TITLE
[filter-effects-1] rename `kernalMatrix` to `kernelMatrix`

### DIFF
--- a/filter-effects-1/mathml/feConvolveMatrix00.mml
+++ b/filter-effects-1/mathml/feConvolveMatrix00.mml
@@ -79,7 +79,7 @@
         </mrow>
         <mo stretchy="false">⋅</mo>
         <msub>
-         <mi>kernalMatrix</mi>
+         <mi>kernelMatrix</mi>
          <mrow>
           <mrow>
            <mrow>
@@ -123,7 +123,7 @@
     </mrow>
    </mrow>
   </mrow>
-  <annotation encoding="StarMath 5.0">func color_{X , Y} = { sum from{i=0} to{func orderY -1} sum from{j=0} to{func orderX -1} func source_{x - func targetX + j , y - targetY + i} cdot func kernalMatrix_{func orderX - j - 1, func orderY - i - 1 }} over  {func divisor} + func bias cdot func alpha_{x,y}
+  <annotation encoding="StarMath 5.0">func color_{X , Y} = { sum from{i=0} to{func orderY -1} sum from{j=0} to{func orderX -1} func source_{x - func targetX + j , y - targetY + i} cdot func kernelMatrix_{func orderX - j - 1, func orderY - i - 1 }} over  {func divisor} + func bias cdot func alpha_{x,y}
 </annotation>
  </semantics>
 </math>


### PR DESCRIPTION
Fix the `kernalMatrix` typo present in the `feConvolveMatrix` section: https://www.w3.org/TR/filter-effects-1/?utm_source=chatgpt.com#feConvolveMatrixElement