### PR TITLE
[css-fonts-4] Create proper types for `<absolute-size>` and `<relative-size>`

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -1384,8 +1384,8 @@ Font size: the 'font-size' property</h3>
 
 	Values have the following meanings:
 
-	<dl dfn-for=font-size dfn-type=value>
-		<dt><dfn><<absolute-size>></dfn>
+	<dl>
+		<dt><dfn type><<absolute-size>></dfn>
 		<dd>
 			An <<absolute-size>> keyword refers to an entry in a table of font sizes
 			computed and kept by the user agent.
@@ -1395,7 +1395,7 @@ Font size: the 'font-size' property</h3>
 
 			<pre class=prod>[ xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large ]</pre>
 
-		<dt><dfn><<relative-size>></dfn>
+		<dt><dfn type><<relative-size>></dfn>
 		<dd>
 			A <<relative-size>> keyword is interpreted
 			relative to the computed 'font-size' of the parent element
@@ -1422,7 +1422,7 @@ Font size: the 'font-size' property</h3>
 			In addition, a user agent may choose to use different ratios
 			when it detects paragraph text as opposed to title text.
 
-		<dt><dfn><<length-percentage [0,∞]>></dfn>
+		<dt><dfn value for=font-size><<length-percentage [0,∞]>></dfn>
 		<dd>
 			A length value specifies an absolute font size
 			(independent of the user agent's font table).
@@ -1435,7 +1435,7 @@ Font size: the 'font-size' property</h3>
 			Note: Use of percentage values or <a>font-relative lengths</a>
 			such as ''em''s and ''rem''s
 			leads to more robust and cascadable style sheets.
-		<dt><dfn>math</dfn></dt>
+		<dt><dfn value for=font-size>math</dfn></dt>
 		<dd>
 			Special <a href="https://w3c.github.io/mathml-core/#the-math-script-level-property">
 			mathematical scaling rules</a> must be applied


### PR DESCRIPTION
Both `<absolute-size>` and `<relative-size>` were defined as values for `font-size`, but that made Bikeshed link the terms to the underlying type definitions in CSS2.

That's confusing for readers following links because the definition of `<absolute-size>` in CSS2 does not have `xxx-large`. That also confuses other spec processing tools, see https://github.com/w3c/webref/issues/1794

This update turns the value definitions into proper type definitions, which will override those defined in CSS2, and make links to `<absolute-size>` and `<relative-size>` target the local definitions.
