### PR TITLE
[css-fonts-4] Clarify range constraints on descriptor values in `<font-feature-value-type>`

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -5850,7 +5850,7 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 		parsing/font-variant-alternates-valid.html
 	</wpt>
 
-	<pre class="prod"><dfn id="font-feature-index-value">&lt;font-feature-index&gt;</dfn> = <<integer [0,∞]>></pre>
+	<pre class="prod"><dfn id="font-feature-index-value">&lt;font-feature-index&gt;</dfn> = <<integer>></pre>
 	<pre class="prod"><dfn id="font-feature-value-name-value">&lt;font-feature-value-name&gt;</dfn> = <<ident>></pre>
 
 	For any given character, fonts can provide a variety of alternate
@@ -6101,11 +6101,21 @@ Defining font specific alternates: the <dfn>@font-feature-values</dfn> rule</h3>
 	and the value must be a list of one or more non-negative <<integer>>s.
 
 	The [=feature value blocks=] accept any declaration name;
-	these names must be identifiers,
+	these names must be <<font-feature-value-name>>,
 	per standard CSS syntax rules,
 	and are [=case-sensitive=]
 	(so <css>foo: 1;</css> and <css>FOO: 2</css> define two different features).
-	Each declaration's value must match the grammar ''<<integer [0,∞]>>+'',
+
+	Each declaration's value in ''@annotation'', ''@ornaments'', ''@stylistic'', ''@swash'',
+	must match the grammar <<font-feature-index>>,
+	or else the declaration is invalid and must be ignored.
+
+	Each declaration’s value in ''@character-variant''
+	must match the grammar <<font-feature-index [0,99]>> <<font-feature-index [0,∞]>>,
+	or else the declaration is invalid and must be ignored.
+
+	Each declaration’s value in ''@styleset''
+	must match the grammar <<font-feature-index [0,20]>>+,
 	or else the declaration is invalid and must be ignored.
 
 	Note: Each feature name is unique only within a single [=feature value block=].

--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -5808,13 +5808,13 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 
 	<pre class="propdef">
 	Name: font-variant-alternates
-	Value: normal | [ stylistic(<<feature-value-name>>) ||
+	Value: normal | [ stylistic(<<font-feature-value-name>>) ||
 		historical-forms ||
-		styleset(<<feature-value-name>>#) ||
-		character-variant(<<feature-value-name>>#) ||
-		swash(<<feature-value-name>>) ||
-		ornaments(<<feature-value-name>>) ||
-		annotation(<<feature-value-name>>) ]
+		styleset(<<font-feature-value-name>>#) ||
+		character-variant(<<font-feature-value-name>>#) ||
+		swash(<<font-feature-value-name>>) ||
+		ornaments(<<font-feature-value-name>>) ||
+		annotation(<<font-feature-value-name>>) ]
 	Initial: normal
 	Applies to: all elements and text
 	Inherited: yes
@@ -5850,8 +5850,8 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 		parsing/font-variant-alternates-valid.html
 	</wpt>
 
-	<pre class="prod"><dfn id="feature-index-value">&lt;feature-index&gt;</dfn> = <<integer [0,∞]>></pre>
-	<pre class="prod"><dfn id="feature-value-name-value">&lt;feature-value-name&gt;</dfn> = <<ident>></pre>
+	<pre class="prod"><dfn id="font-feature-index-value">&lt;font-feature-index&gt;</dfn> = <<integer [0,∞]>></pre>
+	<pre class="prod"><dfn id="font-feature-value-name-value">&lt;font-feature-value-name&gt;</dfn> = <<ident>></pre>
 
 	For any given character, fonts can provide a variety of alternate
 	glyphs in addition to the default glyph for that character. This
@@ -5865,8 +5865,8 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 	of these alternates is font-specific, the
 	''@font-feature-values'' rule is used to define values for a
 	specific font family or set of families that associate a font-specific
-	numeric <<feature-index>> with a custom
-	<<feature-value-name>>, which is then used in this
+	numeric <<font-feature-index>> with a custom
+	<<font-feature-value-name>>, which is then used in this
 	property to select specific alternates:
 
 	<pre class=example  id="ex-noble-script">
@@ -5878,10 +5878,10 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 	}
 	</pre>
 
-	When a particular <<feature-value-name>> has not
+	When a particular <<font-feature-value-name>> has not
 	been defined for a given family or for a particular feature type, the
 	computed value must be the same as if it had been defined.  However,
-	property values that contain these undefined <<feature-value-name>>
+	property values that contain these undefined <<font-feature-value-name>>
 	identifiers must be ignored when choosing glyphs.
 
 	<pre class=example  id="ex-effectively-same">
@@ -5911,16 +5911,16 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 			</div>
 		</dd>
 
-		<dt><dfn id="stylistic" title="stylistic">stylistic(<<feature-value-name>>)</dfn>
-		<dd>Enables display of stylistic alternates ([=font specific=], OpenType feature: <span class="tag">salt <<feature-index>></span>).
+		<dt><dfn id="stylistic" title="stylistic">stylistic(<<font-feature-value-name>>)</dfn>
+		<dd>Enables display of stylistic alternates ([=font specific=], OpenType feature: <span class="tag">salt <<font-feature-index>></span>).
 
 			<div class="featex">
 				<img alt="stylistic alternate example" src="images/salt.png" width="300" height="58">
 			</div>
 		</dd>
 
-		<dt><dfn id="styleset" title="styleset">styleset(<<feature-value-name>>#)</dfn>
-		<dd>Enables display with stylistic sets ([=font specific=], OpenType feature: <span class="tag">ss<<feature-index>></span>
+		<dt><dfn id="styleset" title="styleset">styleset(<<font-feature-value-name>>#)</dfn>
+		<dd>Enables display with stylistic sets ([=font specific=], OpenType feature: <span class="tag">ss<<font-feature-index>></span>
 			OpenType currently defines <span class="tag">ss01</span> through <span class="tag">ss20</span>).
 
 			<div class="featex">
@@ -5928,20 +5928,20 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 			</div>
 		</dd>
 
-		<dt><dfn id="character-variant" title="character-variant">character-variant(<<feature-value-name>>#)</dfn>
-		<dd>Enables display of specific character variants ([=font specific=], OpenType feature: <span class="tag">cv<<feature-index>></span>
+		<dt><dfn id="character-variant" title="character-variant">character-variant(<<font-feature-value-name>>#)</dfn>
+		<dd>Enables display of specific character variants ([=font specific=], OpenType feature: <span class="tag">cv<<font-feature-index>></span>
 			OpenType currently defines <span class="tag">cv01</span> through <span class="tag">cv99</span>).</dd>
 
-		<dt><dfn id="swash" title="swash">swash(<<feature-value-name>>)</dfn>
-		<dd>Enables display of swash glyphs ([=font specific=], OpenType feature: <span class="tag">swsh <<feature-index>>, cswh <<feature-index>></span>).
+		<dt><dfn id="swash" title="swash">swash(<<font-feature-value-name>>)</dfn>
+		<dd>Enables display of swash glyphs ([=font specific=], OpenType feature: <span class="tag">swsh <<font-feature-index>>, cswh <<font-feature-index>></span>).
 
 			<div class="featex">
 				<img alt="swash example" src="images/swsh.png" width="380" height="64">
 			</div>
 		</dd>
 
-		<dt><dfn id="ornaments" title="ornaments">ornaments(<<feature-value-name>>)</dfn>
-		<dd>Enables replacement of default glyphs with ornaments, if provided in the font ([=font specific=], OpenType feature: <span class="tag">ornm <<feature-index>></span>).
+		<dt><dfn id="ornaments" title="ornaments">ornaments(<<font-feature-value-name>>)</dfn>
+		<dd>Enables replacement of default glyphs with ornaments, if provided in the font ([=font specific=], OpenType feature: <span class="tag">ornm <<font-feature-index>></span>).
 			Some fonts may offer ornament glyphs as alternates for a wide collection of characters; however, displaying arbitrary
 			characters (e.g., alphanumerics) as ornaments is poor practice as it distorts the semantics of the data. Font designers
 			are encouraged to encode all ornaments (except those explicitly encoded in the Unicode Dingbats blocks, etc.) as
@@ -5952,8 +5952,8 @@ Alternates and swashes: the 'font-variant-alternates' property</h3>
 			</div>
 		</dd>
 
-		<dt><dfn id="annotation" title="annotation">annotation(<<feature-value-name>>)</dfn>
-		<dd>Enables display of alternate annotation forms ([=font specific=], OpenType feature: <span class="tag">nalt <<feature-index>></span>).
+		<dt><dfn id="annotation" title="annotation">annotation(<<font-feature-value-name>>)</dfn>
+		<dd>Enables display of alternate annotation forms ([=font specific=], OpenType feature: <span class="tag">nalt <<font-feature-index>></span>).
 
 			<div class="featex">
 				<img alt="alternate annotation form example" src="images/nalt.png" width="350" height="62">
@@ -6514,7 +6514,7 @@ Overall shorthand for font rendering: the 'font-variant!!property' property</h3>
 
 	<pre class="propdef">
 	Name: font-variant
-	Value:	normal | none | [ [ <<common-lig-values>> || <<discretionary-lig-values>> || <<historical-lig-values>> || <<contextual-alt-values>> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<<feature-value-name>>) || historical-forms || styleset(<<feature-value-name>>#) || character-variant(<<feature-value-name>>#) || swash(<<feature-value-name>>) || ornaments(<<feature-value-name>>) || annotation(<<feature-value-name>>) ] || [ <<numeric-figure-values>> || <<numeric-spacing-values>> || <<numeric-fraction-values>> || ordinal || slashed-zero ] || [ <<east-asian-variant-values>> || <<east-asian-width-values>> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]
+	Value:	normal | none | [ [ <<common-lig-values>> || <<discretionary-lig-values>> || <<historical-lig-values>> || <<contextual-alt-values>> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<<font-feature-value-name>>) || historical-forms || styleset(<<font-feature-value-name>>#) || character-variant(<<font-feature-value-name>>#) || swash(<<font-feature-value-name>>) || ornaments(<<font-feature-value-name>>) || annotation(<<font-feature-value-name>>) ] || [ <<numeric-figure-values>> || <<numeric-spacing-values>> || <<numeric-fraction-values>> || ordinal || slashed-zero ] || [ <<east-asian-variant-values>> || <<east-asian-width-values>> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]
 	Initial: normal
 	Applies to: all elements and text
 	Inherited: yes


### PR DESCRIPTION
Fixes #9926.

Descriptor values in `<font-feature-value-type>` rules are currently defined with:

  > Each declaration’s value must match the grammar `<integer [0,∞]>+` [...]

https://drafts.csswg.org/css-fonts-4/#font-feature-values-syntax

As commented in the referenced issue, `[0,∞]` is not appropriate for all `<feature-value-name>`.

This PR makes use of `<feature-index>` but renamed to `<font-feature-index>`, which is similar to the suggestion to rename `<family-name>`, in order to avoid using generic production names for specific contexts. 

Similarly, `<feature-value-name>` is also renamed to `<font-feature-value-name>`.