### PR TITLE
[css-gaps-1]: Add section for serializing column-rule shorthand and update separator of longhands #12201

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1071,9 +1071,9 @@ Gap decoration color: The 'column-rule-color' and 'row-rule-color' properties</h
 	<pre class='prod'>
 		<dfn>&lt;line-color-list&gt;</dfn>          = <<line-color-or-repeat>>#
 
-		<dfn>&lt;auto-line-color-list&gt;</dfn>     = <<line-color-or-repeat>>#? ,
-											          <<auto-repeat-line-color>> ,
-											          <<line-color-or-repeat>>#?
+		<dfn>&lt;auto-line-color-list&gt;</dfn>     = [<<line-color-or-repeat>># , ]? 
+											          <<auto-repeat-line-color>>
+											          [ , <<line-color-or-repeat>># ]?
 
 		<dfn>&lt;line-color-or-repeat&gt;</dfn>     = [ <<color>> | <<repeat-line-color>> ]
 
@@ -1124,9 +1124,9 @@ Gap decoration style: The 'column-rule-style' and 'row-rule-style' properties</h
 	<pre class='prod'>
 		<dfn>&lt;line-style-list&gt;</dfn>          = <<line-style-or-repeat>>#
 
-		<dfn>&lt;auto-line-style-list&gt;</dfn>     = <<line-style-or-repeat>>#? ,
-											          <<auto-repeat-line-style>> ,
-											          <<line-style-or-repeat>>#?
+		<dfn>&lt;auto-line-style-list&gt;</dfn>     = [<<line-style-or-repeat>># , ]?
+											          <<auto-repeat-line-style>>
+											          [ , <<line-style-or-repeat>># ]?
 
 		<dfn>&lt;line-style-or-repeat&gt;</dfn>     = [ <<line-style>> | <<repeat-line-style>> ]
 
@@ -1175,9 +1175,9 @@ Gap decoration width: The 'column-rule-width' and 'row-rule-width' properties</h
 	<pre class='prod'>
 <dfn>&lt;line-width-list&gt;</dfn>          = <<line-width-or-repeat>>#
 
-		<dfn>&lt;auto-line-width-list&gt;</dfn>     = <<line-width-or-repeat>>#? ,
-											          <<auto-repeat-line-width>> ,
-											          <<line-width-or-repeat>>#?
+		<dfn>&lt;auto-line-width-list&gt;</dfn>     = [<<line-width-or-repeat>># , ]?
+											          <<auto-repeat-line-width>>
+											          [ , <<line-width-or-repeat>># ]?
 
 		<dfn>&lt;line-width-or-repeat&gt;</dfn>     = [ <<line-width>> | <<repeat-line-width>> ]
 


### PR DESCRIPTION
Per #12201, this PR introduces a section explaining how the `column-rule` shorthand is serialized from its longhand properties. It also changes the value separator for the longhand properties from spaces to commas to ensure consistency with the shorthand format.