### PR TITLE
[css-color-4] Fix discrepency in ΔE2000 sample implementation (#13322)

### DIFF
--- a/css-color-4/deltaE2000.js
+++ b/css-color-4/deltaE2000.js
@@ -100,8 +100,8 @@ function deltaE2000 (reference, sample) {
 	// Four possibilities for hue weighting factor,
 	// depending on the angles, to get the correct sign
 	let hdash;
-	if (Cdash1 == 0 && Cdash2 == 0) {
-		hdash = hsum;   // which should be zero
+	if (Cdash1 * Cdash2 === 0) {
+		hdash = hsum;
 	}
 	else if (habs <= 180) {
 		hdash = hsum / 2;


### PR DESCRIPTION
As per discussion in https://github.com/w3c/csswg-drafts/issues/13322, the discrepancy in implementation between the sample code in section of 19.1. ΔE2000 versus ISO/CIE 11664-6:2014 and Sharma et al., 2005, appears to be in error.

This PR resolves this by adjusting the sample implementation to match ISO/CIE 11664-6:2014 and Sharma et al., 2005.
