### PR TITLE
[css-style-attr] Fix typo

### DIFF
--- a/css-style-attr-1/Overview.src.html
+++ b/css-style-attr-1/Overview.src.html
@@ -192,7 +192,7 @@ style data: it is merely an invalid token.</p>
 
 <div class="note">
 <p>Although the grammar allows it,
-no at-rule valid in style attributes is define at the moment.
+at the moment no at-rule is defined to be valid in style attributes.
 The forward-compatible parsing rules are such that a declaration following an at-rule
 is not ignored:
 <pre>&lt;span style="@unsupported { splines: reticulating } color: green"></pre>


### PR DESCRIPTION
No grammar valid in spec is use at the moment.