### PR TITLE
[css-forms] Remove redundant ToC entry

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -639,10 +639,6 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
 
 # Styling Widgets # {#styling-widgets}
 
-## Widget Accent Colors: the 'accent-color' property ## {#accent-color}
-
-  The 'accent-color' property is defined in [[!CSS-UI-4]].
-
 ## Switching form control sizing: the 'field-sizing' property ## {#field-sizing}
 
   <pre class=propdef>


### PR DESCRIPTION
No need to introduce a section in the css-forms-1 spec just to say that accent-color is defined in another spec.