### PR TITLE
[css-pseudo] Describe `.pseudoTarget` property for `CSSPseudoElement` #12163

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -29,6 +29,8 @@ spec:css-color-4; type:property; text:color
 spec:fill-stroke-3; type:property; text:stroke-width
 spec:css-lists-3; type:dfn; text:marker
 spec:css-backgrounds-3; type:property; text:box-shadow
+spec:dom; type:dfn; text:event
+spec:dom; type:dfn; text:event target
 </pre>
 
 <h2 id="intro">Introduction</h2>
@@ -1907,6 +1909,98 @@ and all other highlights are inactive.
 This avoids the potential
 ambiguity and privacy risks of returning a result
 that depends on the actual highlight state.
+
+<h2 id="event-extensions">Event Extensions</h2>
+
+  To support event handling on pseudo-elements, this specification extends specific event interfaces
+  to expose the [=pseudo-element=] that was the specific target of the event,
+  distinct from the [=event target=] (which remains the [=ultimate originating element=]).
+
+<h3 id="event-concepts">Concepts</h3>
+
+  An [=event=] has an <dfn>associated pseudo-element</dfn>,
+  which is either a {{CSSPseudoElement}} object or <code>null</code>.
+  Unless stated otherwise, it is <code>null</code>.
+
+<h3 id="pseudoTarget-attribute">The <code>pseudoTarget</code> Attribute</h3>
+
+  <pre class="idl">
+    interface mixin PseudoTargetEvent {
+        readonly attribute CSSPseudoElement? pseudoTarget;
+    };
+
+    MouseEvent includes PseudoTargetEvent;
+    PointerEvent includes PseudoTargetEvent;
+    FocusEvent includes PseudoTargetEvent;
+    AnimationEvent includes PseudoTargetEvent;
+    TransitionEvent includes PseudoTargetEvent;
+    KeyboardEvent includes PseudoTargetEvent;
+    TouchEvent includes PseudoTargetEvent;
+  </pre>
+
+  The <dfn attribute for="PseudoTargetEvent">pseudoTarget</dfn>
+  getter steps are to return [=this=]'s [=associated pseudo-element=].
+
+<h3 id="event-initialization">Initialization</h3>
+
+  To allow initialization of the {{PseudoTargetEvent/pseudoTarget}} attribute during event creation,
+  the following dictionaries are extended:
+
+  <pre class="idl">
+    partial dictionary MouseEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary PointerEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary FocusEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary AnimationEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary TransitionEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary KeyboardEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+
+    partial dictionary TouchEventInit {
+        CSSPseudoElement? pseudoTarget = null;
+    };
+  </pre>
+
+  When initializing an event object |E| using one of the dictionaries above,
+  set |E|'s [=associated pseudo-element=] to the value of the <code>pseudoTarget</code> dictionary member.
+
+<h3 id="ua-event-dispatch">User Agent Event Dispatch</h3>
+
+  <div algorithm="pseudo-event-dispatch">
+    When the user agent is to dispatch an event of a type supported by the {{PseudoTargetEvent/pseudoTarget}} attribute,
+    and the target of the interaction is a [=pseudo-element=],
+    the user agent must run the following steps <strong>before</strong> dispatching the event:
+
+    <ol>
+        <li> Let |originatingElement| be the [=ultimate originating element=] of the target [=pseudo-element=]. </li>
+        <li> Let |type| be the [=pseudo-element=]'s type (e.g., <code>"::before"</code>, <code>"::marker"</code>, etc.).</li>
+        <li> Let |pseudoInstance| be the result of running the steps to
+        <a href="#window-interface">retrieve a CSSPseudoElement</a> for |originatingElement| and |type|.
+
+        Note: This step ensures that |pseudoInstance| is the canonical {{CSSPseudoElement}} object for that pseudo-element.
+        It must be the same object instance that would be returned by calling <code>originatingElement.pseudo(type)</code>.
+        If the instance does not yet exist, these steps imply its creation. </li>
+        <li> Initialize the event's [=associated pseudo-element=] to |pseudoInstance|. </li>
+    </ol>
+
+    If the target of the interaction is not a [=pseudo-element=],
+    the [=associated pseudo-element=] remains <code>null</code>.
+  </div>
 
 <h2 id="css2-compat">
 Compatibility Syntax</h2>


### PR DESCRIPTION
As resolved in #12163, add `.pseudoTarget` property to selected event types and describe, based on the DOM spec for `.target`, the initialization process for it.