### PR TITLE
[css-forms-1] Add missing content property to radio checkmark

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -876,7 +876,6 @@ input:is([type=checkbox]:not([switch]), [type=radio]) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    content: '';
 }
 
 input[type=radio] {
@@ -888,6 +887,7 @@ input[type=checkbox]:not([switch]):checked::checkmark {
 }
 
 input[type=radio]:checked::checkmark {
+    content: '';
     background-color: currentColor;
     display: inline-block;
     border-radius: inherit;


### PR DESCRIPTION
[css-forms-1] Add missing content property to radio checkmark

Without this the radio's checkmark is never generated.