### PR TITLE
[filter-effects-1][editorial] Fix syntax of filter-function type

### DIFF
--- a/filter-effects-1/Overview.bs
+++ b/filter-effects-1/Overview.bs
@@ -367,8 +367,8 @@ equivalent to particular SVG <{filter}> elements.
 
 ## Supported Filter Functions ## {#supported-filter-functions}
 
-<pre class=prod><dfn>&lt;filter-function></dfn> = ''blur()'' | ''brightness()'' | ''contrast()'' | ''drop-shadow()'' | <br>
-  ''grayscale()'' | ''hue-rotate()'' | ''invert()'' | ''opacity()'' | ''sepia()'' | ''saturate()''</pre>
+<pre class=prod><dfn>&lt;filter-function></dfn> = <<blur()>> | <<brightness()>> | <<contrast()>> | <<drop-shadow()>> |
+  <<grayscale()>> | <<hue-rotate()>> | <<invert()>> | <<opacity()>> | <<sepia()>> | <<saturate()>></pre>
 
 Unless defined otherwise, omitted values default to the <a for=svg>initial value</a> for interpolation.
 


### PR DESCRIPTION
Fix for #13309. The `''foo''` special syntax does not work in production rules.
