### PR TITLE
[cssom-1] Append only one newline in @media rule block

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1974,7 +1974,7 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
    <li>The serialization of the {{CSSKeyframesRule/name}} attribute. If the attribute is a CSS wide keyword, or the value <css>default</css>, or the value <css>none</css>,
     then it is [=serialized as a string=]. Otherwise, it is <a lt="serialize an identifier">serialized as an identifier</a>.
    <li>The string "<code> { </code>", i.e., a single SPACE (U+0020), followed by LEFT CURLY BRACKET (U+007B), followed by a single SPACE (U+0020).
-   <li>The result of performing <a>serialize a CSS rule</a> on each rule in the rule's {{CSSKeyframesRule/cssRules}} list, separated by a newline and indented by two spaces.</li>
+   <li>The result of performing <a>serialize a CSS rule</a> on each rule in the rule's {{CSSKeyframesRule/cssRules}} list, preceded by a newline and indented by two spaces.</li>
    <li>A newline, followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D)</li>
   </ol>
 


### PR DESCRIPTION
The [current algorithm](https://drafts.csswg.org/cssom-1/#serialize-a-css-rule) definition requires adding two newlines:

  > 3. A single SPACE (U+0020), followed by the string "{", i.e., LEFT CURLY BRACKET (U+007B), followed by **a newline**.
  > 4. The result of performing serialize a CSS rule on each rule in the rule’s cssRules list, filtering out empty strings, indenting each item with two spaces, all joined with newline.
  > 5. **A newline**, followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D)

Based on [WPT tests](https://github.com/web-platform-tests/wpt/blob/master/css/cssom/serialize-media-rule.html) and the [original commit](https://github.com/w3c/csswg-drafts/pull/728) of the current version, I think this is an obvious bugfix.