### PR TITLE
[css-view-transitions-2] Spec view-transition-scope

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -639,7 +639,7 @@ Note: An <code>element.startViewTransition()</code> call does not update
 			[=Skip the view transition|skip=] |viewTransition| with an "{{InvalidStateError}}" {{DOMException}}.
 
 		1. If [=this=] is not the [=/root element|document root element=],
-			force [=this=] to have ''view-transition-scope: auto'' for the duration of the transition.
+			force [=this=] to have both [=layout containment=] and [=view transition scoping=] for the duration of the transition.
 
 		1. If |document|'s [=active view transition=] is not null and its [=outbound post-capture steps=] is not null,
 			then:
@@ -956,7 +956,8 @@ the active view transition of an element is exposed to script via a property on 
 
 		: <dfn>auto</dfn>
 		:: Discoverability of 'view-transition-name' is limited to the subtree of this element.
-			Specifically, any transitions that originate outside of the element
+			This is done by applying <dfn>view transition scoping</dfn>.
+			Such scoping means that any transitions that originate outside of the element
 			will not discover a non-none 'view-transition-name' either on this element
 			or in its flat-tree descedants.
 
@@ -1017,6 +1018,11 @@ the active view transition of an element is exposed to script via a property on 
 				```
 			</div>
 	</dl>
+
+	Note: Most elements running or planning to run a [=scoped view transition=]
+	should use ''view-transition-scope: auto'', to ensure that their
+	[=document-scoped view transition names=] don't accidentally interfere with
+	other [=scoped view transitions=] in the ancestor chain.
 
 # Nested View Transition Groups # {#nested-vt}
 


### PR DESCRIPTION
[css-view-transitions-2] Spec view-transition-scope

These are tentative edits pending #13123 but replaces `contain: view-transitions` which is also not agreed upon.