### PR TITLE
[css-pseudo-4] Preventing User Dictionary Leaks via ::spelling-error and ::grammar-error Performance Impacts

### DIFF
--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1387,8 +1387,11 @@ Security Considerations for Highlighting</h3>
   can leak information about the contents of a user's dictionary
   (which can include the user's name and even includes the contents of their address book!)
   UAs that implement ''::spelling-error'' and ''::grammar-error''
-  must prevent pages from being able to read
-  the styling of such highlighted segments.
+  must mitigate the following issues:
+  <ul>
+    <li>Pages attempting to directly read the styling of highlighted segments.</li>
+    <li>Pages attempting to track performance impacts of styling highlighted segments via programatic focusing and modification of text fields.</li>
+  </ul>
 
 <h2 id="treelike">
 Tree-Abiding Pseudo-elements</h2>

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1387,10 +1387,10 @@ Security Considerations for Highlighting</h3>
   can leak information about the contents of a user's dictionary
   (which can include the user's name and even includes the contents of their address book!)
   UAs that implement ''::spelling-error'' and ''::grammar-error''
-  must mitigate the following issues:
+  must mitigate the following attacks:
   <ul>
     <li>Pages attempting to directly read the styling of highlighted segments.</li>
-    <li>Pages attempting to track performance impacts of styling highlighted segments via programatic focusing and modification of text fields.</li>
+    <li>Pages attempting to track performance impacts of styling highlighted segments via programatic modification of text fields.</li>
   </ul>
 
 <h2 id="treelike">

--- a/css-pseudo-4/Overview.bs
+++ b/css-pseudo-4/Overview.bs
@@ -1389,8 +1389,8 @@ Security Considerations for Highlighting</h3>
   UAs that implement ''::spelling-error'' and ''::grammar-error''
   must mitigate the following attacks:
   <ul>
-    <li>Pages attempting to directly read the styling of highlighted segments.</li>
-    <li>Pages attempting to track performance impacts of styling highlighted segments via programatic modification of text fields.</li>
+    <li>Pages attempting to directly read the styling of highlighted segments.
+    <li>Pages attempting to track performance impacts of styling highlighted segments via programatic modification of text fields.
   </ul>
 
 <h2 id="treelike">


### PR DESCRIPTION
This proposal adds a new security concern to the section on ::spelling-error and ::grammar-error.

Although direct indicators of the ::spelling-error and ::grammar-error cannot be extracted, it’s possible to extract indirect information from browsers without rate limits on the application of these hints. In Chrome and Firefox, it’s possible to have an [autofocused](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autofocus) text area cycle programmatically through a series of misspelled words, and for the site to monitor indicators of rendering performance to notice when hints are applied. This allows sites (or their third-party embeds) to detect which words are or aren’t in the user’s dictionary, which could leak sensitive information stored there (for example, their contacts’ names). Safari already has rate limits in place which only check for and apply hints once per user interaction with the text field (e.g., a key input or click).

For details see: https://explainers-by-googlers.github.io/user-dictionary-leaks/

This just shipped for Chrome, and has been in Safari for quite some time.

https://github.com/w3ctag/design-reviews/issues/1148
https://github.com/WebKit/standards-positions/issues/546
https://github.com/mozilla/standards-positions/issues/1294