### PR TITLE
[css-gaps-1]: Make initial value of interior insets '0' #13137

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -526,7 +526,6 @@ Pairing gap intersection points into segments</h4>
 	A <a>gap decoration</a> is painted between each pair of endpoints identified using the steps above.
 
 	The following examples illustrate various settings for the <a href="#break">*-rule-break</a> properties.
-	To make the differences more apparent, the <a href="#inset">*-rule-*-inset</a> properties are set to ''0''.
 
 	<div class="example">
 		<pre>
@@ -537,7 +536,6 @@ Pairing gap intersection points into segments</h4>
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 				rule-break: none;
-				rule-inset: 0px;
 			}
 		</pre>
 		<figure>
@@ -558,7 +556,6 @@ Pairing gap intersection points into segments</h4>
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 				rule-break: spanning-item;
-				rule-inset: 0px;
 			}
 		</pre>
 		<figure>
@@ -579,7 +576,6 @@ Pairing gap intersection points into segments</h4>
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 				rule-break: intersection;
-				rule-inset: 0px;
 			}
 		</pre>
 		<figure>
@@ -600,7 +596,6 @@ Pairing gap intersection points into segments</h4>
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 				rule-break: none;
-				rule-inset: 0px;
 			}
 		</pre>
 		<figure>
@@ -629,7 +624,6 @@ Pairing gap intersection points into segments</h4>
 				row-rule: 6px solid red;
 				column-rule: 6px solid blue;
 				rule-break: intersection;
-				rule-inset: 0px;
 			}
 		</pre>
 		<figure>
@@ -656,8 +650,8 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 
 	<pre class='propdef'>
 		Name: column-rule-edge-inset-start, column-rule-edge-inset-end, row-rule-edge-inset-start, row-rule-edge-inset-end
-		Value: ''auto'' | <<length-percentage>>
-		Initial: ''auto''
+		Value: <<length-percentage>>
+		Initial: ''0''
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>grid lanes containers</a>
 		Inherited: no
 		Percentages: refer to the <a>crossing gap width</a>
@@ -666,8 +660,8 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 
 	<pre class='propdef'>
 		Name: column-rule-interior-inset-start, column-rule-interior-inset-end, row-rule-interior-inset-start, row-rule-interior-inset-end
-		Value: ''auto'' | <<length-percentage>>
-		Initial: ''auto''
+		Value: <<length-percentage>>
+		Initial: ''0''
 		Applies to: <a>grid containers</a>, <a>flex containers</a>, <a>multicol containers</a>, and <a>grid lanes containers</a>
 		Inherited: no
 		Percentages: refer to the <a>crossing gap width</a>
@@ -677,18 +671,12 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 	These properties can be used to offset the endpoints of <a>gap decorations</a> relative to the
 	<a>gap intersection points</a> which would normally determine their endpoints.
 
+	<p>An <dfn>edge gap intersection point</dfn> is any [=gap intersection point=] at the content edges of the container.</p>
+	<p>An <dfn>interior gap intersection point</dfn> is any [=gap intersection point=] that is not an [=edge gap intersection point=].</p>
 	For the interior properties, 
 	a value of ''-50%'' places the <a>gap decoration</a> endpoint in the center of the intersection,
 	and a value of ''0'' places the <a>gap decoration</a> endpoint at the edge of the intersection.
 
-	<dl dfn-for=rule-inset dfn-type=value>
-		<dt><dfn>auto</dfn>
-		<dd>
-			The used value of ''auto'' is ''0'' for edge properties and ''-50%'' for interior properties.
-	</dl>
-
-	<p>An <dfn>edge gap intersection point</dfn> is any [=gap intersection point=] at the content edges of the container.</p>
-	<p>An <dfn>interior gap intersection point</dfn> is any [=gap intersection point=] that is not an [=edge gap intersection point=].</p>
 	<p>A <dfn>decoration segment</dfn> refers to any segment that connects a pair of adjacent [=gap intersection points=].</p>
 	<p>A <dfn>start endpoint</dfn> and <dfn>end endpoint</dfn> refer to the two endpoints of a given [=decoration segment=].
 	A given [=start endpoint=] and [=end endpoint=] can be either an [=edge gap intersection point=] or an [=interior gap intersection point=].</p>
@@ -755,7 +743,7 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 
 	<pre class='propdef shorthand'>
 		Name: column-rule-inset-start, row-rule-inset-start
-		Value: auto | <<length-percentage>>
+		Value: <<length-percentage>>
 		Applies to: 'column-rule-edge-inset-start' and 'column-rule-interior-inset-start' for 'column-rule-inset-start',
 			'row-rule-edge-inset-start' and 'row-rule-interior-inset-start' for 'row-rule-inset-start'
 	</pre>
@@ -765,7 +753,7 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 
 	<pre class='propdef shorthand'>
 		Name: column-rule-inset-end, row-rule-inset-end
-		Value: auto | <<length-percentage>>
+		Value: <<length-percentage>>
 		Applies to: 'column-rule-edge-inset-end' and 'column-rule-interior-inset-end' for 'column-rule-inset-end',
 			'row-rule-edge-inset-end' and 'row-rule-interior-inset-end' for 'row-rule-inset-end'
 	</pre>


### PR DESCRIPTION
This PR updates the initial value of '*-interior-insets' from '-50%' to '0', following the resolution from issue #13137. It also removes the auto keyword as a valid value for the property.