### PR TITLE
[css-values-4] Correct example range in mod function explanation

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -3417,7 +3417,7 @@ Stepped Value Functions: ''round()'', ''mod()'', and ''rem()''</h3>
 	<div class=example>
 		For example, ''mod(18px, 5px)'' resolves to the value ''3px'',
 		because subtracting ''5px * 3'' from ''18px'' yields ''3px'',
-		which is the only such value between ''0px'' and ''3px''.
+		which is the only such value between ''0px'' and ''5px''.
 
 		Similarly, ''mod(-140deg, -90deg)'' resolves to the value ''-50deg'',
 		because adding ''-90deg * 1'' to ''-140deg'' yields ''-50deg'',


### PR DESCRIPTION
Fix a mistake in an example for the `mod` function where the correct **B** value is `5px`.