### PR TITLE
[selectors] Move column combinator to Selectors 5

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -4456,7 +4456,7 @@ Grammar</h2>
 	<dfn>&lt;simple-selector></dfn> = <<type-selector>> | <<subclass-selector>>
 
 
-	<dfn>&lt;combinator></dfn> = '>' | '+' | '~' | [ '|' '|' ]
+	<dfn>&lt;combinator></dfn> = '>' | '+' | '~'
 
 	<dfn noexport>&lt;wq-name></dfn> = <<ns-prefix>>? <<ident-token>>
 	<dfn noexport>&lt;ns-prefix></dfn> = [ <<ident-token>> | '*' ]? '|'
@@ -4501,7 +4501,6 @@ Grammar</h2>
 		* Between the components of an <<attr-matcher>>.
 		* Between the <<compound-selector>> or <<pseudo-compound-selector>>s
 			in a <<complex-selector-unit>>
-		* Between the components of a <<combinator>>.
 
 		Whitespace is <em>required</em>
 		between two <<complex-selector-unit>>s

--- a/selectors-5/Overview.bs
+++ b/selectors-5/Overview.bs
@@ -469,6 +469,22 @@ Reference combinators <code>/ref/</code></h3>
 	</div>
 
 
+<h2 id="grammar" oldids="formal-syntax">
+Grammar</h2>
+
+	This module extends the CSS grammar of selectors with:
+
+	<pre class=prod>
+	<dfn>&lt;combinator></dfn> = '>' | '+' | '~' | [ '|' '|' ] | [ / <<wq-name>> / ]
+	</pr>
+
+	<ul>
+	<li id="white-space">
+		White space is forbidden:
+		* Between the components of a <<combinator>>.
+	</ul>
+
+
 <h2 id="changes">
 Changes</h2>
 


### PR DESCRIPTION
4e393db moved [§ Grid-Structural Selectors](https://drafts.csswg.org/selectors-5/#grid-structural-selectors) from Selectors 4 to 5 but `<combinator>` still produces `'|' '|'` and a corresponding item in the list of places where whitespaces are forbidden.

This PR moves them in Selectors 5.

Note that I am not sure if whitespaces are forbidden in the new `/ref/` combinator.