### PR TITLE
[compositing] Point current-work symlink to compositing-2

### DIFF
--- a/bin/build-index.py
+++ b/bin/build-index.py
@@ -123,6 +123,7 @@ def create_symlink(shortname, spec_folder):
 
 
 CURRENT_WORK_EXCEPTIONS = {
+    "compositing": 2,
     "css-conditional": 5,
     "css-easing": 2,
     "css-grid": 2,


### PR DESCRIPTION
Without this exception, the default algorithm picks compositing-1 (“Refining”) over compositing-2 (“Exploring”) as the current work — causing the compositing symlink to point to compositing-1. The original fxtf-drafts infrastructure had compositing-2 as the current work, so this restores that behavior. Relates to https://github.com/w3c/csswg-drafts/issues/12054.