### PR TITLE
Build markdown documents to HTML in the CI workflow

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.14"
           cache: 'pip'
 
-      - run: pip install bikeshed
+      - run: pip install bikeshed markdown
       - run: bikeshed update
 
       # The following chunk of code all stolen from andeubotella
@@ -63,6 +63,8 @@ jobs:
             echo "  $file"
             bikeshed issues-list "$file" || true
           done
+      - name: Build markdown
+        run: python ./bin/build-markdown.py
       - name: Build index & symlinks
         run: python ./bin/build-index.py
       - run: rm -rf ./.git{,attributes,ignore}

--- a/bin/build-markdown.py
+++ b/bin/build-markdown.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Convert markdown files in spec directories to HTML."""
+
+import glob
+import os
+import re
+
+import markdown
+
+TEMPLATE = """\
+<!doctype html>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+body {{ max-width: 50em; margin: 2em auto; padding: 0 1em; font-family: sans-serif; line-height: 1.6; }}
+code {{ background: #f4f4f4; padding: .1em .3em; border-radius: 3px; }}
+pre {{ background: #f4f4f4; padding: 1em; overflow: auto; border-radius: 3px; }}
+pre code {{ background: none; padding: 0; }}
+img {{ max-width: 100%; }}
+</style>
+{body}
+"""
+
+
+def extract_title(text):
+    m = re.search(r"^#\s+(.+)", text, re.MULTILINE)
+    return m.group(1).strip() if m else "Untitled"
+
+
+def main():
+    md = markdown.Markdown(extensions=["fenced_code", "tables"])
+
+    for md_file in sorted(glob.glob("*/*.md")):
+        if md_file.startswith("."):
+            continue
+
+        html_file = os.path.splitext(md_file)[0] + ".html"
+        if os.path.exists(html_file):
+            continue
+
+        with open(md_file, encoding="utf-8") as f:
+            text = f.read()
+
+        title = extract_title(text)
+        body = md.convert(text)
+        md.reset()
+
+        with open(html_file, "w", encoding="utf-8") as f:
+            f.write(TEMPLATE.format(title=title, body=body))
+
+        print(f"  {html_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The legacy draft server converts `.md` files in spec directories (explainers, transition documents, proposals, etc.) to HTML. This adds that conversion to the GitHub Actions workflow so the files are served from GitHub Pages.

A new `bin/build-markdown.py` script finds all `.md` files one level deep in spec directories and converts them to HTML using Python-Markdown, with a minimal stylesheet for readability. The workflow installs the `markdown` package and runs the script after building specs.

Relates to https://github.com/w3c/csswg-drafts/issues/12054