### PR TITLE
Replace root redirect with spec listing index page and build issues lists

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -57,6 +57,12 @@ jobs:
             SHORT_DATE="$(date --date=@"$TIMESTAMP" --utc +%F)"
             bikeshed -f spec "$file" "${file%Overview.bs}index.html" --md-date="$SHORT_DATE" --md-Text-Macro="BUILTBYGITHUBCI foo"
           done
+      - name: Build issues lists
+        run: |
+          for file in ./**/*.bsi ./**/issues-*.txt; do
+            echo "  $file"
+            bikeshed issues-list "$file" || true
+          done
       - name: Build index & symlinks
         run: python ./bin/build-index.py
       - run: rm -rf ./.git{,attributes,ignore}

--- a/bin/build-index.py
+++ b/bin/build-index.py
@@ -2,18 +2,19 @@
 All the drafts are built by the build-specs workflow itself.
 This handles the rest of the work:
 
-* creates a root page that just redirects to the draft server root listing.
+* creates an index page listing all specs
 * creates symlinks for unlevelled urls, linking to the appropriate levelled folder
-* builds timestamps.json, which provides a bunch of metadata about the specs which is consumed by some W3C tooling.
+* builds timestamps.json, which provides metadata about the specs
 """
 
+import glob
 import json
 import os
 import os.path
 import re
-import sys
 import subprocess
 from collections import defaultdict
+from datetime import datetime, timezone
 
 import bikeshed
 from html.parser import HTMLParser
@@ -122,6 +123,21 @@ def create_symlink(shortname, spec_folder):
         pass
 
 
+def format_timestamp(ts):
+    """Format a Unix timestamp as a human-readable date string."""
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%d")
+
+
+def escape_html(text):
+    """Escape HTML special characters."""
+    return (text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;"))
+
+
 CURRENT_WORK_EXCEPTIONS = {
     "css-conditional": 5,
     "css-easing": 2,
@@ -159,6 +175,9 @@ for entry in os.scandir("."):
 
         metadata["dir"] = entry.name
         metadata["currentWork"] = False
+        issues_files = sorted(f for f in glob.glob(os.path.join(entry.path, "issues-*.html"))
+                                  if not f.endswith(".bsi.html"))
+        metadata["issues"] = [os.path.basename(f) for f in issues_files]
         specgroups[metadata["shortname"]].append(metadata)
 
 # Reorder the specs with common shortname based on their level (or year, for
@@ -195,13 +214,359 @@ for shortname, specgroup in specgroups.items():
 with open('./timestamps.json', 'w') as f:
     json.dump(timestamps, f, indent = 2, sort_keys=True)
 
-with open("./index.html", mode='w', encoding="UTF-8") as f:
-    f.write("""
+# Build the index page
+
+# Flatten all specs into a single list with full metadata
+all_specs = []
+for shortname, specgroup in specgroups.items():
+    group_size = len(specgroup)
+    for spec in specgroup:
+        dir_name = spec["dir"]
+        ts = timestamps.get(dir_name, 0)
+        title = spec["title"] or dir_name
+
+        doc_links = []
+        for fname in spec.get("issues", []):
+            label = fname.replace("issues-", "").replace(".html", "")
+            doc_links.append((f"./{dir_name}/{fname}", label))
+
+        all_specs.append({
+            "shortname": shortname,
+            "dir": dir_name,
+            "title": title,
+            "ts": ts if isinstance(ts, int) else 0,
+            "currentWork": spec["currentWork"],
+            "level": spec["level"],
+            "group_size": group_size,
+            "doc_links": doc_links,
+        })
+
+# Sort by timestamp descending (most recent first) for default view
+all_specs.sort(key=lambda s: s["ts"], reverse=True)
+
+# Generate HTML for each spec
+REPO = "https://github.com/w3c/csswg-drafts"
+spec_items = []
+for spec in all_specs:
+    t = escape_html(spec["title"])
+    d = spec["dir"]
+    sn = spec["shortname"]
+    ts = spec["ts"]
+    lv = spec["level"]
+    gs = spec["group_size"]
+    date_str = format_timestamp(ts) if ts else ""
+    iso_date = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ") if ts else ""
+
+    cw = ' <span class="badge current-work">Current Work</span>' if spec["currentWork"] else ""
+
+    links = [
+        f'<a href="{REPO}/issues?q=is%3Aissue+is%3Aopen+label%3A{d}">Issues</a>',
+        f'<a href="{REPO}/pulls?q=is%3Apr+is%3Aopen+label%3A{d}">PRs</a>',
+        f'<a href="{REPO}/commits/main/{d}/">History</a>',
+    ]
+    for url, label in spec["doc_links"]:
+        links.append(f'<a href="{url}">DoC: {escape_html(label)}</a>')
+    links_html = ' <span class="sep">\u00b7</span> '.join(links)
+
+    spec_items.append(
+        f'    <div class="spec" data-ts="{ts}" data-shortname="{escape_html(sn)}"'
+        f' data-dir="{escape_html(d)}" data-level="{lv}" data-group-size="{gs}">\n'
+        f'      <div class="spec-main">\n'
+        f'        <span class="activity-dot" data-ts="{ts}"></span>\n'
+        f'        <a class="spec-title" href="./{d}/">{t}</a>{cw}\n'
+        f'        <code class="spec-shortname">{escape_html(d)}</code>\n'
+        f'        <time class="spec-date" datetime="{iso_date}" data-ts="{ts}">{date_str}</time>\n'
+        f'      </div>\n'
+        f'      <div class="spec-links">{links_html}</div>\n'
+        f'    </div>'
+    )
+
+specs_html = "\n".join(spec_items)
+
+HTML_START = """\
 <!doctype html>
-<meta charset=utf-8>
-<title>Redirecting to the Drafts listing...</title>
-<meta http-equiv=Refresh content="0; url='https://drafts.csswg.org'">
-<script>
-window.location.href = "https://drafts.csswg.org";
-</script>
-""")
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>CSS Working Group Editor Drafts</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 1.5em 1em;
+      color: #1f2328;
+      background: #fff;
+    }
+    h1 {
+      font-size: 1.5em;
+      font-weight: 600;
+      margin: 0 0 1em;
+    }
+    .search-bar {
+      position: sticky;
+      top: 0;
+      background: #fff;
+      padding: 0.5em 0 0.75em;
+      z-index: 10;
+    }
+    .search-bar input {
+      width: 100%;
+      padding: 0.6em 1em;
+      font-size: 1em;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      outline: none;
+      background: #f6f8fa;
+    }
+    .search-bar input:focus {
+      background: #fff;
+      border-color: #0366d6;
+      box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.15);
+    }
+    .controls {
+      display: flex;
+      gap: 0.5em;
+      align-items: center;
+      margin-bottom: 0.75em;
+      font-size: 0.85em;
+      color: #666;
+    }
+    .controls button {
+      background: none;
+      border: 1px solid #d1d5db;
+      padding: 0.25em 0.75em;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: inherit;
+      color: #444;
+    }
+    .controls button:hover { background: #f6f8fa; }
+    .controls button.active {
+      background: #0366d6;
+      color: #fff;
+      border-color: #0366d6;
+    }
+    .spec-count { margin-left: auto; }
+    #spec-list { margin-top: 0.25em; }
+    .spec {
+      padding: 0.6em 0;
+      border-bottom: 1px solid #eee;
+    }
+    .spec:last-child { border-bottom: none; }
+    .spec.hidden { display: none; }
+    .spec-main {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5em;
+      flex-wrap: wrap;
+    }
+    .activity-dot {
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      position: relative;
+      top: -1px;
+    }
+    .activity-dot.recent { background: #1a7f37; }
+    .activity-dot.moderate { background: #bf8700; }
+    .activity-dot.stale { background: #ccc; }
+    .spec-title {
+      color: #0366d6;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .spec-title:hover { text-decoration: underline; }
+    .badge {
+      font-size: 0.75em;
+      padding: 0.15em 0.5em;
+      border-radius: 3px;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .current-work {
+      background: #dafbe1;
+      color: #1a7f37;
+    }
+    .spec-shortname {
+      font-size: 0.8em;
+      color: #656d76;
+      background: #f6f8fa;
+      padding: 0.1em 0.4em;
+      border-radius: 3px;
+    }
+    .spec-date {
+      margin-left: auto;
+      font-size: 0.85em;
+      color: #656d76;
+      white-space: nowrap;
+    }
+    .spec-links {
+      margin-top: 0.2em;
+      padding-left: 1.5em;
+      font-size: 0.8em;
+    }
+    .spec-links a {
+      color: #656d76;
+      text-decoration: none;
+    }
+    .spec-links a:hover { color: #0366d6; text-decoration: underline; }
+    .sep { color: #ccc; margin: 0 0.15em; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .group-header {
+      font-weight: 600;
+      font-size: 0.9em;
+      padding: 1em 0 0.3em;
+      color: #1f2328;
+      border-bottom: 1px solid #d1d5db;
+    }
+    .grouped-spec { padding-left: 1.5em; }
+    .no-results {
+      padding: 2em;
+      text-align: center;
+      color: #666;
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS Working Group Editor Drafts</h1>
+  <div class="search-bar">
+    <input type="text" id="search" placeholder="Filter specifications\u2026" autofocus>
+  </div>
+  <div class="controls">
+    <button id="sort-recent" class="active">Recent</button>
+    <button id="sort-grouped">Grouped</button>
+    <span class="spec-count" id="spec-count"></span>
+  </div>
+  <div id="spec-list">
+"""
+
+HTML_END = """\
+  </div>
+  <div class="no-results" id="no-results">No matching specifications.</div>
+  <script>
+  (function() {
+    var searchInput = document.getElementById('search');
+    var specList = document.getElementById('spec-list');
+    var specs = Array.from(specList.querySelectorAll('.spec'));
+    var btnRecent = document.getElementById('sort-recent');
+    var btnGrouped = document.getElementById('sort-grouped');
+    var countEl = document.getElementById('spec-count');
+    var noResults = document.getElementById('no-results');
+    var totalCount = specs.length;
+
+    // Relative dates and activity dots
+    var now = Date.now() / 1000;
+    var DAY = 86400;
+    specs.forEach(function(el) {
+      var ts = parseInt(el.dataset.ts);
+      if (!ts) return;
+      var age = now - ts;
+      var dot = el.querySelector('.activity-dot');
+      var timeEl = el.querySelector('.spec-date');
+
+      if (age < 30 * DAY) dot.className = 'activity-dot recent';
+      else if (age < 180 * DAY) dot.className = 'activity-dot moderate';
+      else dot.className = 'activity-dot stale';
+
+      var rel;
+      if (age < DAY) rel = 'today';
+      else if (age < 2 * DAY) rel = 'yesterday';
+      else if (age < 7 * DAY) rel = Math.floor(age / DAY) + ' days ago';
+      else if (age < 30 * DAY) {
+        var w = Math.floor(age / (7 * DAY));
+        rel = w === 1 ? 'last week' : w + ' weeks ago';
+      } else if (age < 365 * DAY) {
+        var m = Math.floor(age / (30 * DAY));
+        rel = m === 1 ? 'last month' : m + ' months ago';
+      } else {
+        var y = Math.floor(age / (365 * DAY));
+        rel = y === 1 ? 'last year' : y + ' years ago';
+      }
+      timeEl.title = timeEl.textContent;
+      timeEl.textContent = rel;
+    });
+
+    function updateCount() {
+      var visible = specs.filter(function(s) { return !s.classList.contains('hidden'); }).length;
+      countEl.textContent = visible === totalCount ? totalCount + ' specs' : visible + ' of ' + totalCount;
+      noResults.style.display = visible === 0 ? 'block' : 'none';
+    }
+    updateCount();
+
+    // Search
+    searchInput.addEventListener('input', function() {
+      var q = searchInput.value.toLowerCase();
+      specs.forEach(function(el) {
+        var text = el.dataset.dir + ' ' + el.dataset.shortname + ' ' +
+                   el.querySelector('.spec-title').textContent.toLowerCase();
+        if (text.indexOf(q) >= 0) el.classList.remove('hidden');
+        else el.classList.add('hidden');
+      });
+      specList.querySelectorAll('.group-header').forEach(function(h) {
+        var sn = h.dataset.shortname;
+        var any = specs.some(function(s) {
+          return s.dataset.shortname === sn && !s.classList.contains('hidden');
+        });
+        h.style.display = any ? '' : 'none';
+      });
+      updateCount();
+    });
+
+    // Sort: Recent
+    function sortRecent() {
+      specList.querySelectorAll('.group-header').forEach(function(h) { h.remove(); });
+      specs.sort(function(a, b) { return parseInt(b.dataset.ts) - parseInt(a.dataset.ts); });
+      specs.forEach(function(el) {
+        el.classList.remove('grouped-spec');
+        specList.appendChild(el);
+      });
+      btnRecent.classList.add('active');
+      btnGrouped.classList.remove('active');
+    }
+
+    // Sort: Grouped
+    function sortGrouped() {
+      specList.querySelectorAll('.group-header').forEach(function(h) { h.remove(); });
+      specs.sort(function(a, b) {
+        var c = a.dataset.shortname.localeCompare(b.dataset.shortname);
+        if (c !== 0) return c;
+        return parseInt(a.dataset.level) - parseInt(b.dataset.level);
+      });
+      var lastSn = null;
+      specs.forEach(function(el) {
+        var sn = el.dataset.shortname;
+        var gs = parseInt(el.dataset.groupSize);
+        if (sn !== lastSn && gs > 1) {
+          var header = document.createElement('div');
+          header.className = 'group-header';
+          header.dataset.shortname = sn;
+          header.textContent = sn;
+          specList.appendChild(header);
+        }
+        if (gs > 1) el.classList.add('grouped-spec');
+        else el.classList.remove('grouped-spec');
+        specList.appendChild(el);
+        lastSn = sn;
+      });
+      btnGrouped.classList.add('active');
+      btnRecent.classList.remove('active');
+    }
+
+    btnRecent.addEventListener('click', sortRecent);
+    btnGrouped.addEventListener('click', sortGrouped);
+  })();
+  </script>
+</body>
+</html>
+"""
+
+with open("./index.html", mode='w', encoding="UTF-8") as f:
+    f.write(HTML_START)
+    f.write(specs_html)
+    f.write(HTML_END)


### PR DESCRIPTION
Instead of redirecting to drafts.csswg.org, `build-index.py` now generates an index page with search, sortable views, and per-spec resource links.

Features:
- Search/filter bar for finding specs instantly
- Recent (by date) and Grouped (by shortname family) sort modes
- Activity indicators and relative timestamps
- Per-spec links to GitHub issues, PRs, commit history
- Links to Disposition of Comments documents where they exist

Also adds a workflow step that runs `bikeshed issues-list` on all `.bsi` and `issues-*.txt` source files, regenerating the Disposition of Comments HTML pages during deployment.

Relates to https://github.com/w3c/csswg-drafts/issues/12054

<img width="962" height="733" alt="image" src="https://github.com/user-attachments/assets/1e59cec7-55ff-489f-8bd3-207be3a1a582" />
