### PR TITLE
Build issues lists (Disposition of Comments) in CI

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -57,6 +57,12 @@ jobs:
             SHORT_DATE="$(date --date=@"$TIMESTAMP" --utc +%F)"
             bikeshed -f spec "$file" "${file%Overview.bs}index.html" --md-date="$SHORT_DATE" --md-Text-Macro="BUILTBYGITHUBCI foo"
           done
+      - name: Build issues lists
+        run: |
+          for file in ./**/*.bsi ./**/issues-*.txt; do
+            echo "  $file"
+            bikeshed issues-list "$file" || true
+          done
       - name: Build index & symlinks
         run: python ./bin/build-index.py
       - run: rm -rf ./.git{,attributes,ignore}


### PR DESCRIPTION
Adds a workflow step that runs `bikeshed issues-list` on all `.bsi` and `issues-*.txt `source files, regenerating the Disposition of Comments HTML pages during deployment. Files that aren’t valid issues-list input are silently skipped.

The legacy draft server was doing this on each push. This brings the GitHub Pages build to parity.

Relates to https://github.com/w3c/csswg-drafts/issues/12054