### PR TITLE
[css-gaps-1]: Add more wpts for empty cells #12602

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1982,6 +1982,4 @@ Changes since the <a href="https://www.w3.org/TR/2025/WD-css-gaps-1-20250417/">1
 			(<a href="https://github.com/w3c/csswg-drafts/issues/12201">Issue 12201</a>)
 		<li> Added section for gap decorations next to empty grid areas.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/12602">Issue 12602</a>)
-		<li> Added more wpts for `rule-visibility-items`.
-			(<a href="https://github.com/w3c/csswg-drafts/issues/12602">Issue 12602</a>)
 	</ul>


### PR DESCRIPTION
This PR adds more wpts for empty cells, specifically on subgrid and the bi-directional rule-visibility-items shorthand property.