### PR TITLE
[css-inline-3] Unify dominant-baseline and alignment-baseline values. #13327

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -633,7 +633,7 @@ Dominant Baselines: the 'dominant-baseline' property</h3>
 
 	<pre class="propdef">
 	Name: dominant-baseline
-	Value: auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top
+	Value: auto | <<baseline-metric>>
 	Initial: auto
 	Applies to: block containers, inline boxes, table rows, grid containers, flex containers, and SVG <a>text content elements</a>
 	Inherited: yes
@@ -654,9 +654,17 @@ Dominant Baselines: the 'dominant-baseline' property</h3>
 	in the box’s <a>alignment context</a>;
 	see (''alignment-baseline: baseline'' and [[CSS-ALIGN-3]]).
 
+	The <dfn><<baseline-metric>></dfn> value, which identifies
+	specific baseline metrics, expands to
+
+	<pre class=prod>
+		<<baseline-metric>> = text-bottom | alphabetic | ideographic | middle
+		                    | central | mathematical | hanging | text-top
+	</pre>
+
 	Values have the following meanings:
 
-	<dl dfn-for=dominant-baseline dfn-type=value>
+	<dl dfn-for="dominant-baseline,<<baseline-metric>>" dfn-type=value>
 		<dt><dfn>auto</dfn>
 		<dd>
 			Equivalent to ''dominant-baseline/alphabetic'' in <a>horizontal writing modes</a>
@@ -790,7 +798,7 @@ Alignment Baseline Type: the 'alignment-baseline' longhand</h4>
 
 	<pre class="propdef">
 	Name: alignment-baseline
-	Value: baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top
+	Value: baseline | <<baseline-metric>>
 	Initial: baseline
 	Applies to: inline-level boxes, flex items, grid items, table cells, and SVG <a>text content elements</a>
 	Inherited: no
@@ -802,46 +810,9 @@ Alignment Baseline Type: the 'alignment-baseline' longhand</h4>
 	This property specifies the box’s <dfn export>alignment baseline</dfn>:
 	the [=baseline=] used to align the box
 	prior to applying its [=post-alignment shift=]
-	(if applicable).
-
-	Values are defined as follows:
-
-	<dl dfn-for="alignment-baseline,vertical-align" dfn-type=value>
-		<dt><dfn>baseline</dfn>
-		<dd>
-			Use the <a>dominant baseline</a> choice of the parent.
-
-		<dt><dfn>text-bottom</dfn>
-		<dd>
-			Use the [=text-under baseline=].
-
-		<dt><dfn>alphabetic</dfn>
-		<dd>
-			Use the [=alphabetic baseline=].
-
-		<dt><dfn>ideographic</dfn>
-		<dd>
-			Use the [=ideographic-under baseline=].
-
-		<dt><dfn>middle</dfn>
-		<dd>
-			In general, use the [=x-middle baselines=];
-			except under ''text-orientation: upright''
-			(where the [=alphabetic=] and [=x-height=] baselines are essentially meaningless)
-			use the [=central baseline=] instead.
-
-		<dt><dfn>central</dfn>
-		<dd>
-			Use the [=central baseline=].
-
-		<dt><dfn>mathematical</dfn>
-		<dd>
-			Use the [=math baseline=].
-
-		<dt><dfn>text-top</dfn>
-		<dd>
-			Use the [=text-over baseline=].
-	</dl>
+	(if applicable). Values have the same meanings as for 'dominant-baseline';
+	the <dfn for=alignment-baseline value>baseline</dfn> keyword uses the
+	<a>dominant baseline</a> choice of the parent.
 
 	When performing [=baseline alignment=],
 	these values specify which [=baseline=] of the box is aligned
@@ -3097,6 +3068,10 @@ Changes</h2>
 		<li>Renamed “invisible line boxes” to [=phantom line boxes=]
 			for <a href="https://www.w3.org/TR/CSS2/visuren.html#phantom-line-box">consistency with CSS2</a>
 			and to help clarify that they are “invisible” to layout, not just painting.
+		<li>Extracted keywords of 'dominant-baseline' and 'alignment-baseline' (except
+			''dominant-baseline/auto'' and ''alignment-baseline/baseline'') into <<baseline-metric>>,
+			thereby adding ''dominant-baseline/hanging'' to 'alignment-baseline'.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/13327">Issue 13327</a>)
 	</ul>
 
 	Changes since the


### PR DESCRIPTION
Addresses #13327 by pulling out the baseline metric keywords (except `auto` and `baseline`) into a new type called `<baseline-metric>`, and used that in both `dominant-baseline` and `alignment-baseline`. The immediate effect of this is to add the `hanging` keyword to `alignment-baseline` which previously did not have it.

This change is modeled after the existing `<text-edge>` type and associated language of the `line-fit-edge` and `text-box-edge` properties.