### PR TITLE
[css-view-transitions-2] ViewTransition.types should be [SameObject]

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -692,7 +692,7 @@ the active view transition of an element is exposed to script via a property on 
 			readonly attribute Promise<undefined> ready;
 			readonly attribute Promise<undefined> finished;
 			undefined skipTransition();
-			[SameObject] attribute ViewTransitionTypeSet types;
+			[SameObject] readonly attribute ViewTransitionTypeSet types;
 			readonly attribute Element transitionRoot;
 			undefined waitUntil(Promise<any> promise);
 		};


### PR DESCRIPTION
types attribute is marked as [SameObject] but not readonly, which is invalid as per webidl spec