### PR TITLE
[selectors-4][editorial] Clarify when multiple scoping roots are provided

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -2845,7 +2845,7 @@ The Reference Element Pseudo-class: '':scope''</h3>
 	with respect to one or more [=scoping roots=],
 	such as when calling the {{Element/querySelector()}} method in [[DOM]].
 	The <dfn id='scope-pseudo'>:scope</dfn> pseudo-class represents
-	this [=scoping root=],
+	one of these [=scoping roots=],
 	and may be either a true element
 	or a virtual one (such as a {{DocumentFragment}}).
 
@@ -4771,7 +4771,7 @@ Match a Selector Against a Tree</h3>
 			unless otherwise specified.
 
 		<li>
-			If [=scoping root=] were provided,
+			If [=scoping roots=] were provided,
 			then remove from the <var>candidate elements</var>
 			any elements that are not
 			<a>descendants</a> of at least one <a>scoping root</a>.


### PR DESCRIPTION
[§ 8.4. The Reference Element Pseudo-class: `:scope`](https://drafts.csswg.org/selectors-4/#the-scope-pseudo) defines that it represents _one or more scoping roots_, and what `:scope` represents when _zero or one_ scoping root is provided, but not when *more than one* scoping roots are provided. I hope the proposed change is obvious.

[§ 17.5. Match a Selector Against a Tree](https://drafts.csswg.org/selectors-4/#match-against-tree) defines that it takes *one or more scoping roots* but later at its step 2, it checks *if scoping root were provided*, which seems to be an oversight (singular subject, plural conjugation).