### PR TITLE
[css-lists-3] Update algorithm for initial counter in reversed list

### DIFF
--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -1148,7 +1148,7 @@ Instantiating Counters</h4>
 
 	1. Let |num| be 0.
 
-	2. Let |first| be true.
+	2. Let |lastNonZeroIncrementNegated| be 0.
 
 	3. For each element or pseudo-element |el| that increments or
 		sets the same counter in the same [=scope=]:
@@ -1156,9 +1156,8 @@ Instantiating Counters</h4>
 		1. Let |incrementNegated| be |el|'s 'counter-increment' integer value for this counter,
 			multiplied by -1.
 
-		2. If |first| is true,
-			then add |incrementNegated| to |num| and
-			set |first| to false.
+		2. If |incrementNegated| is not zero,
+			then set |lastNonZeroIncrementNegated| to |incrementNegated|.
 
 		3. If |el| sets this counter with 'counter-set',
 			then add that integer value to |num| and
@@ -1166,7 +1165,9 @@ Instantiating Counters</h4>
 
 		4. Add |incrementNegated| to |num|.
 
-	4. Return |num|.
+	4. Add |lastNonZeroIncrementNegated| to |num|.
+
+	5. Return |num|.
 
 	Note: Only [=reversed=] counters can be instantiated without an initial value.
 


### PR DESCRIPTION
This PR updates the algorithm for instantiating reversed counters to use the last non-zero increment instead of just the first element's increment.

Fix #6797

For context, we are implementing the reversed counters in Chromium.
- MERGED - 7126701: [css-lists] Apply new algorithm for initial counter in reversed list | https://chromium-review.googlesource.com/c/chromium/src/+/7126701
- WIP - 7482809: [css-lists] Fix initial value for reversed CSS counters | https://chromium-review.googlesource.com/c/chromium/src/+/7482809

cc. @danielsakhapov 