### PR TITLE
[css-cascade-6][editorial] Fix the number of primary effects of `@scope` on style rules

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -304,7 +304,7 @@ Scoping Styles: the ''@scope'' rule</h3>
 <h4 id="scope-effects">
 Effects of ''@scope''</h4>
 
-	The ''@scope'' [=at-rule=] has three primary effects
+	The ''@scope'' [=at-rule=] has these primary effects
 	on the [=style rules=] it contains:
 
 	* The [=style rules=] in an ''@scope'' <<rule-list>>


### PR DESCRIPTION
This sentence is followed by 4 list items (emphasize added):

  > The `@scope` at-rule has **three** primary effects on the style rules it contains:

This PR replaces *three*, which seems to be an oversight, with *these*.