### PR TITLE
[css-overflow-4] Update bidi handling of ellipses

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -350,8 +350,6 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 		<dt id=overflow-string><<string>>
 		<dd>
 			Render the given string to represent clipped inline content.
-			The given string is treated as an independent paragraph
-			for bidi purposes.
 
 		<dt dfn-type=function><dfn>fade( [ <<length-percentage>> ] )</dfn>
 		<dd>
@@ -474,6 +472,17 @@ ellipsing details</h3>
 			then clip the rendering of the ellipsis itself
 			(on the same side that neutral characters on the line
 			would have otherwise been clipped with the ''text-overflow:clip'' value).
+
+		<li>
+			For bidi purposes, the ellipsis and string values must be treated
+			as if they were wrapped in an anonymous inline
+			with ''unicode-bidi: isolate''
+			which inherits ''direction'' from the block.
+
+			<wpt pathprefix="/css/css-ui/">
+				text-overflow-string-006.html
+				text-overflow-string-007.html
+			</wpt>
 	</ul>
 
 
@@ -821,7 +830,7 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	* The [=block overflow ellipsis=]
 		is wrapped in an anonymous inline
 		whose parent is the [=block container=]’s [=root inline box=].
-		This inline is assigned ''unicode-bidi: plaintext''
+		This inline is assigned ''unicode-bidi: isolate''
 		and ''line-height: 0''.
 
 		<wpt>
@@ -881,10 +890,7 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	* The anonymous inline of [=block overflow ellipsis=] is placed
 		after any remaining content,
 		after [[css-text-4#white-space-phase-2]],
-		as a direct child of the <a>block container</a>’s <a>root inline box</a>,
-		with the appropriate bidi embedding levels
-		given its directionality
-		and that of its parent.
+		as a direct child of the <a>block container</a>’s <a>root inline box</a>.
 
 		<wpt>
 			block-ellipsis-004.html


### PR DESCRIPTION
Updates the bidi handling of the `text-overflow` and `block-ellipsis` ellipses as per #12617.

(This PR assumes that bidi ellipses inherit the directionality from their block container, not from the bidi paragraph. See https://github.com/w3c/csswg-drafts/issues/12617#issuecomment-3922449994)