### PR TITLE
[css-overflow-4] Clarify when `block-ellipsis` affects a line box

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -808,7 +808,7 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 		so no ellipsis will be shown:
 
 		```html
-		<div style="continue: collapse; max-lines: 2; block-ellipsis: auto">
+		<div style="continue: collapse; max-height: 2lh; block-ellipsis: auto">
 		  Line 1
 		  <div style="display: flow-root">Line 2</div>
 		  <!-- the clamp point is here -->


### PR DESCRIPTION
As per #12826, this patch clarifies and adds examples for when the `block-ellipsis` property affects a line box.

This incorporates an edit suggested by @fantasai in #12825 after that PR had been closed.
