### PR TITLE
[css-overflow-4] Don't clamp by height with `line-clamp: <integer>`

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -1182,7 +1182,7 @@ Forcing a Break After a Set Number of Lines: the 'max-lines' property</h3>
 	then, given a [=computed value=] of <var>N</var>:
 
 	- If the box is a [=line-clamp container=],
-		its [=line-based clamp point=] is set
+		its <dfn>line-based clamp point</dfn> is set
 		to the first possible clamp point after
 		its <var>N</var>th
 		descendant <a>in-flow</a> <a>line box</a>.
@@ -1568,13 +1568,11 @@ Handling of Excess Content: the 'continue' property</h3>
 	if its automatic block size were infinite.
 	If the [=block size=] would be infinite,
 	then there is no [=auto clamp point=].
-	Additionally,
-	when the [=line-clamp container=]'s [=block formatting context root=]
-	has a [=computed value=] of 'max-lines' other than ''max-lines/none'',
-	then that property determines the <dfn>line-based clamp point</dfn>.
-	The actual [=clamp point=] used is
-	either the [=auto clamp point=] or the [=line-based clamp point=],
-	choosing the earlier when both exist.
+
+	If the [=line-clamp container=]'s [=block formatting context root=]
+	has a [=computed value=] of 'max-lines' set to ''max-lines/none'',
+	then the actual [=clamp point=] is the [=auto clamp point=], if any.
+	Otherwise, the actual clamp point is the [=line-based clamp point=], if any.
 
 	<wpt>
 		line-clamp-011.html
@@ -1605,6 +1603,10 @@ Handling of Excess Content: the 'continue' property</h3>
 		webkit-line-clamp-with-line-height.html
 		webkit-line-clamp-with-max-height.html
 	</wpt>
+
+	Issue(12041): Having the actual [=clamp point=] be the earlier of
+	the [=line-based clamp point=] and the [=auto clamp point=], if both exist,
+	is a wanted behavior, but the syntax for it is still being worked out.
 
 	Within a [=line-clamp container=],
 	the following boxes and line boxes become [=invisible boxes=]:


### PR DESCRIPTION
As per the latest resolution on #12041, `line-clamp: <integer>` cannot clamp by both lines and height due to web compat issues with its prefixed `-webkit-line-clamp` alias. The behavior of clamping by lines and height, whichever comes earlier, is still wanted; but it needs an opt-in syntax that has not been decided yet.

Since neither the syntax of this behavior on the `line-clamp` shorthand, nor its mapping into its longhands, are yet clear, this PR disables this behavior –clamping only by the auto clamp point when `max-lines: none`, and only by the line-based clamp point otherwise– while adding an issue marker.

This change also moves the definition of "line-based clamp point" to the `max-lines` section.