### PR TITLE
[css-gaps-1] Adding missing shorthands for `inset` properties #13531

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1001,6 +1001,15 @@ Adjusting gap decoration endpoints: The 'rule-inset' properties</h3>
 
 	Sets the 'column-rule-interior-inset' and 'row-rule-interior-inset' properties to the same value.
 
+	<pre class='propdef shorthand'>
+		Name: rule-edge-inset-start, rule-edge-inset-end, rule-interior-inset-start, rule-interior-inset-end
+		Value: <<length-percentage>>
+		Applies to: Same as 'column-rule-edge-inset-start', 'column-rule-edge-inset-end', 'column-rule-interior-inset-start', 'column-rule-interior-inset-end', 'row-rule-edge-inset-start', 'row-rule-edge-inset-end', 'row-rule-interior-inset-start', and 'row-rule-interior-inset-end'
+	</pre>
+
+	These shorthands set the corresponding ''column-'' and ''row-'' properties to the same value.
+	For example, 'rule-edge-inset-start' sets both 'column-rule-edge-inset-start' and 'row-rule-edge-inset-start' to the same value.
+
 	<wpt>
 		parsing/rule-edge-inset-bidirectional-shorthand.html
 		parsing/rule-edge-interior-inset-computed.html


### PR DESCRIPTION
This PR adds the missing shorthands based on #13531.
