### PR TITLE
[cssom-1] Change CSSStyleSheetInit's `baseURL` type to nullable #12078

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1091,7 +1091,7 @@ interface CSSStyleSheet : StyleSheet {
 };
 
 dictionary CSSStyleSheetInit {
-  DOMString baseURL = null;
+  DOMString? baseURL = null;
   (MediaList or DOMString) media = "";
   boolean disabled = false;
 };


### PR DESCRIPTION
This PR fixes: #12078

This PR updates the `baseURL` in CSSStyleSheetInit dictionary to be nullable to align with the default value null.

The previous definition used DOMString baseURL = null;, but in WebIDL, [DOMString](https://webidl.spec.whatwg.org/#idl-DOMString) is not nullable by default. To correctly support null as a default value, the type should be explicitly defined as `DOMString?`.