### PR TITLE
[css-spec-shortname-1] Respect "WebDriver BiDi viewport meta state"

### DIFF
--- a/css-viewport-1/Overview.bs
+++ b/css-viewport-1/Overview.bs
@@ -36,6 +36,8 @@ spec: fenced-frames; urlPrefix: https://wicg.github.io/fenced-frame/
 		text:error
 		text:remote end steps
 		text:success
+	spec:webdriver-bidi; type:dfn;
+		text:WebDriver BiDi viewport meta state
 </pre>
 
 <h2 id="intro">
@@ -818,3 +820,10 @@ The [=remote end steps=] are:
 	<li>Return [=success=] with data <code>null</code>.
 	</li>
 </ol>
+
+<h3 id="automation-viewport">Automation of the viewport <code class=html>&lt;meta&gt;</code> element</h3>
+
+If <a spec="WEBDRIVER-BIDI">WebDriver BiDi viewport meta state</a> for the given the `viewport` meta element's
+associated {{Document}} is true, the user agent MUST use the `viewport` meta element.
+
+Otherwise, the user agent MAY use the `viewport` meta element.


### PR DESCRIPTION
Respect "WebDriver BiDi viewport meta state" (TODO: link) 's value introduced in https://github.com/w3c/webdriver-bidi/pull/1073. Allow for users to force-use the viewport meta. Required for unblocking mobile emulation.