### PR TITLE
[css-spec-shortname-1] Respect "WebDriver BiDi media feature value"

### DIFF
--- a/mediaqueries-4/Overview.bs
+++ b/mediaqueries-4/Overview.bs
@@ -49,6 +49,7 @@ spec:css-values-3; type:grammar; text:|
 spec:css-values-3; type:grammar; text:?
 spec:css-conditional-3; type:at-rule; text:@media
 spec:selectors-4; type:selector; text::hover
+spec:webdriver-bidi; type:dfn; text:WebDriver BiDi media feature value
 </pre>
 
 <pre class=biblio>
@@ -995,8 +996,17 @@ Evaluating Media Queries {#evaluating}
 			so that new syntax additions do not invalidate too much of a <<media-condition>> in older user agents.</span>
 
 		<dt><<media-feature>>
-		<dd>
-			The result is the result of evaluating the specified media feature.
+		<dd algorithm="evaluate media feature">
+				To get the result of evaluating a <<media-feature>> |media feature| in the given {{Document}} |document|:
+
+				1. Let |media feature name| be the |media feature|'s <<mf-name>>.
+
+				1. Let |emulated value| be the result of evaluating the <a>WebDriver BiDi media feature value</a> for the
+					|document| and |media feature name|.
+
+				1. If |emulated value| is not null, return |emulated value|.
+
+				1. Otherwise, return the result of evaluating the specified media feature.
 	</dl>
 
 	If the result of any of the above productions


### PR DESCRIPTION
Respect ["WebDriver BiDi media feature value"](https://w3c.github.io/webdriver-bidi/#webdriver-bidi-media-feature-value)'s value introduced in https://github.com/w3c/webdriver-bidi/pull/1076. Allow for users to emulate media feature values.