### PR TITLE
enable auto-publication for css-color-5

### DIFF
--- a/.github/workflows/css-color-5.yml
+++ b/.github/workflows/css-color-5.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish css-color-5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: bikeshed


### PR DESCRIPTION
That PR adds a GitHub action to publish css-color-5 through [echidna](https://labs.w3.org/echidna/) after each commit.
It relies on [spec-prod](https://github.com/w3c/spec-prod/) to build the spec and submit it to echidna.

I already generated the token for css-color-5 and added it as a repository secret.

Also, as discussed, the will be able [to disable that action if needed and re-enable it later](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows).