### PR TITLE
[css-forms-1] Update structure and styles for temporal input

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -568,13 +568,13 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
 
     ```
     <input type="date">
-    ├─ ::field-text
-    │  ├─ ::field-component (08)
-		│  ├─ ::field-separator (/)
-    │  ├─ ::field-component (22)
-    │  ├─ ::field-separator (/)
-    │  └─ ::field-component (2024)
-    └─ ::picker-icon
+      ├─ ::field-text
+      │  ├─ ::field-component (08)
+      │  ├─ ::field-separator (/)
+      │  ├─ ::field-component (22)
+      │  ├─ ::field-separator (/)
+      │  └─ ::field-component (2024)
+      └─ ::picker-icon
     ```
   </div>
 
@@ -1118,27 +1118,15 @@ select {
 }
 ```
 
-### Temporal inputs ### {#stylesheet-temporal-inputs}
+### Text inputs ### {#stylesheet-text-inputs}
 
 ```css
-input[type="date"]::field-text,
-input[type="datetime-local"]::field-text,
-input[type="month"]::field-text,
-input[type="time"]::field-text,
-input[type="week"]::field-text {
+input::field-text {
 	display: flow !important;
 }
 
-input[type="date"]::field-component,
-input[type="date"]::field-separator,
-input[type="datetime-local"]::field-component,
-input[type="datetime-local"]::field-separator,
-input[type="month"]::field-component,
-input[type="month"]::field-separator,
-input[type="time"]::field-component,
-input[type="time"]::field-separator,
-input[type="week"]::field-component,
-input[type="week"]::field-separator {
+input::field-component,
+input::field-separator {
 	position: static !important;
 }
 ```


### PR DESCRIPTION
::field-component and ::field-separator are now children of ::field-text.

Also applies default styles.

Per https://github.com/w3c/csswg-drafts/issues/13355