### PR TITLE
[css-scrol-snap-2][editorial] Link "snap target" to its definition

### DIFF
--- a/css-scroll-snap-2/Overview.bs
+++ b/css-scroll-snap-2/Overview.bs
@@ -231,7 +231,7 @@ Issue: The ':snapped' pseudo-class is being dropped in favor of a
 The Snapped-element Pseudo-class: '':snapped'' {#snapped}
 -------------------------------------------------------
 
-The <dfn selector>:snapped</dfn> pseudo-class matches any scroll snap targets,
+The <dfn selector>:snapped</dfn> pseudo-class matches any [=snap targets=],
 regardless of axis.
 The longform physical and logical pseudo-class selectors
 allow for more finite snapped children styling


### PR DESCRIPTION
I was reading the definition of [`:snapped`](https://drafts.csswg.org/css-scroll-snap-2/#selectordef-snapped):

  > The `:snapped` pseudo-class matches any scroll snap targets [...]

And I did not known what a "scroll snap target" was. So I looked for its definition but I only found the definition of ["snap target"](https://drafts.csswg.org/css-scroll-snap-2/#snap-target). I presume that all snap targets are implicitly scroll snap targets, so I also removed the explicit "scroll" qualifier.