### PR TITLE
[css-forms-1] Fix radio button checkmark styles

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -886,9 +886,12 @@ input[type=radio] {
     justify-content: center;
 }
 
-input[type=checkbox]:not([switch])::checkmark,
-input[type=radio]::checkmark {
+input[type=checkbox]:not([switch])::checkmark {
     content: '\2713' / '';
+}
+
+input[type=radio]::checkmark {
+    content: '';
 }
 
 input[type=checkbox]:not([switch], :checked)::checkmark {


### PR DESCRIPTION
The original styles always set a checkmark symbol for content, but this leads to it rendering for checked radios too.

<img width="160" height="124" alt="image" src="https://github.com/user-attachments/assets/3f3dd4b1-5a46-49e6-802c-147ab08a07d4" />

