### PR TITLE
[css-forms-1] Fix select option enabled selector

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -1010,10 +1010,10 @@ select option {
    * of making options tall. */
   white-space: nowrap;
 }
-select option:enabled:hover {
+select:enabled option:enabled:hover {
   background-color: color-mix(currentColor 10%, transparent);
 }
-select option:enabled:active {
+select:enabled option:enabled:active {
   background-color: color-mix(currentColor 20%, transparent);
 }
 select option:disabled {


### PR DESCRIPTION
option elements can match :enabled while inside a disabled select, so the option:enabled selectors also need to include select:enabled.

Fixes https://github.com/w3c/csswg-drafts/issues/13383