### PR TITLE
[css-lists-3] Revert "Change counter inheritance to only take from prev sibling if the counter doesn't exist on the parent"

### DIFF
--- a/css-lists-3/Overview.bs
+++ b/css-lists-3/Overview.bs
@@ -1029,31 +1029,29 @@ Inheriting Counters</h4>
 		To <dfn>inherit counters</dfn>
 		into an |element|:
 
-		1. If |element| is the [=tree/root=] of its document tree,
-			the element has an initially-empty [=CSS counters set=].
-			Return.
+		1. Let |element counters| be an initially empty [=CSS counters set=]
+			representing |element|’s own [=CSS counters set=].
 
-		2. Let |element counters|,
-			representing |element|’s own [=CSS counters set=],
-			be a copy of the [=CSS counters set=]
-			of |element|'s parent element.
+		2. If |element| is the [=tree/root=] of its document tree,
+			return.
+			(The element has an initially-empty counter map
+			and inherits nothing.)
 
-		3. Let |sibling counters| be the [=CSS counters set=]
-			of |element|'s preceding sibling (if it has one),
-			or an empty [=CSS counters set=] otherwise.
-
-			[=map/For each=] |counter| of |sibling counters|,
-			if |element counters| does not already contain a counter with the same [=CSS counter/name=],
-			append a copy of |counter| to |element counters|.
+		3. Let |counter source| be the [=CSS counters set=]
+			of |element|’s preceding sibling,
+			if it has one,
+			or else of |element|’s parent
+			if it does not.
 
 		4. Let |value source| be the [=CSS counters set=]
 			of the element immediately preceding |element| in [=tree order=].
 
-			[=map/For each=] |source counter| of |value source|,
-			if |element counters| [=set/contains=] a [=counter=]
-			with the same [=CSS counter/name=] and [=creator=],
-			then set the [=value=] of that counter
-			to |source counter|'s [=value=].
+		5. [=map/For each=] (|=CSS counter/name=|, |originating element|, |=value=|) of |value source|:
+			1. If |counter source| also [=set/contains=] a [=counter=]
+				with the same |=CSS counter/name=| and |originating element|,
+				then [=set/append=] a copy of |value source|’s [=counter=]
+				(|=CSS counter/name=|, |originating element|, |=value=|)
+				to |element counters|.
 	</div>
 
 	<div class='example' id='counter-inheritance-example'>


### PR DESCRIPTION
This reverts commit ad9a4bc6e6397b6fb66721828e66eb84e73a0c4f, per [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/5477#issuecomment-1843956580).

The WPTs (`counter-*.html`, `counters-*.html` and `counters-scope-*.html`) will be fixed in [the CL](https://chromium-review.googlesource.com/c/chromium/src/+/7594918).

Closes #5477 

cc. @danielsakhapov 