### PR TITLE
specify a different destination to avoid conflict with the filename used by spec-prod

### DIFF
--- a/.github/workflows/css-color-5.yml
+++ b/.github/workflows/css-color-5.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           TOOLCHAIN: bikeshed
           SOURCE: css-color-5/Overview.bs
+          DESTINATION: css-color-5/index.html
           BUILD_FAIL_ON: warning
           VALIDATE_MARKUP: false
           W3C_ECHIDNA_TOKEN: ${{ secrets.TR_TOKEN_CSS_COLOR_5 }}


### PR DESCRIPTION
`spec-prod` will rename the generated file to `Overview.html` when preparing the tarball sent to echidna. However, without the destination specified, it'll use `Overview.html` also which will create an error during the renaming.