### PR TITLE
[mediaqueries-5] Lift parens to <media-in-parens>

### DIFF
--- a/mediaqueries-5/Overview.bs
+++ b/mediaqueries-5/Overview.bs
@@ -897,9 +897,9 @@ Syntax</h2>
 	<dfn>&lt;media-not></dfn> = not <<media-in-parens>>
 	<dfn>&lt;media-and></dfn> = and <<media-in-parens>>
 	<dfn>&lt;media-or></dfn> = or <<media-in-parens>>
-	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | <<media-feature>> | <<general-enclosed>>
+	<dfn>&lt;media-in-parens></dfn> = ( <<media-condition>> ) | ( <<media-feature>> ) | <<general-enclosed>>
 
-	<dfn>&lt;media-feature></dfn> = ( [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ] )
+	<dfn>&lt;media-feature></dfn> = [ <<mf-plain>> | <<mf-boolean>> | <<mf-range>> ]
 	<dfn>&lt;mf-plain></dfn> = <<mf-name>> : <<mf-value>>
 	<dfn>&lt;mf-boolean></dfn> = <<mf-name>>
 	<dfn>&lt;mf-range></dfn> = <<mf-name>> <<mf-comparison>> <<mf-value>>


### PR DESCRIPTION
This change was made to level 4 in 1af56e0 but was never carried over to level 5. This is relied on by the `<if-test>` grammar in css-values-5
