### PR TITLE
[css-values-5] Remove a closed issue denote on ident() fallback

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2175,10 +2175,16 @@ Constructing <<custom-ident>> values: the ''ident()'' function</h3>
 	<dfn><<ident-arg>></dfn> = <<string>> | <<integer>> | <<ident>>
 	</pre>
 
-	Issue(w3c/csswg-drafts#11424): Should we allow a fallback value?
-
 	The ''ident()'' function can be used as a value for any property or function argument
 	that accepts a <<custom-ident>>.
+
+	Note: Unlike ''var()'' or ''attr()'',
+	which retrieve data from elsewhere that might not exist,
+	''ident()'' computes its result entirely from its provided arguments.
+	Therefore, no fallback argument is provided.
+	To handle cases where an [=arbitrary substitution function=] substituted into ''ident()''
+	might produce an invalid result,
+	use ''first-valid()''.
 
 	<div class=example>
 		In the following example,


### PR DESCRIPTION
This removes the open issue marker(whether `ident()` should allow a fallback value #11424) as it seemed to be resolved without any change.
I also added a short Note explaining why there's no fallback, since authors familiar with var()/attr() might wonder. Happy to drop the Note if it feels unnecessary!