### PR TITLE
[selectors-5][editorial] Add formal definition and production rule of :local-link()

### DIFF
--- a/selectors-5/Overview.bs
+++ b/selectors-5/Overview.bs
@@ -66,9 +66,14 @@ The Local Link Pseudo-class '':local-link''</h3>
 	</div>
 
 	As a functional pseudo-class,
-	'':local-link()'' can also accept a non-negative integer as its sole argument,
-	which, if the document's URL belongs to a hierarchical scheme,
-	indicates the number of path levels to match:
+	<dfn id='local-link-functional-pseudo' lt=':local-link()'>:local-link()</dfn> can also accept a non-negative integer as its sole argument.
+
+	<pre class=prod>
+		<l>'':local-link()''</l> = :local-link( <<level>> )
+	</pre>
+
+	If the document's URL belongs to a hierarchical scheme,
+	<<level>> indicates the number of path levels to match:
 
 	<ul>
 		<li>'':local-link(0)'' represents a link element whose target is in the same origin as the document's URL


### PR DESCRIPTION
This PR wraps the first occurrence of `:local-link()` in `<dfn>` and adds a production rule, following [`:heading`/`:heading()`](https://drafts.csswg.org/selectors-5/#headings) as an example.

`:local-link` has an associated `<dfn>` but `:local-link()` does not. So `@webref/css` includes the first, not the second.

I am aware that there are [discussions](https://github.com/w3c/csswg-drafts/issues/10975) about renaming them, but this "in-between" state is confusing.