### PR TITLE
[css-page-3][editorial] Set the initial page-margin-safety value to "none"

### DIFF
--- a/css-page-3/Overview.bs
+++ b/css-page-3/Overview.bs
@@ -2073,7 +2073,7 @@ Staying within the printable area: the '@page/page-margin-safety' property</h3>
 	Name: page-margin-safety
 	For: @page
 	Value: none | clamp | add
-	Initial: auto
+	Initial: none
 	Computed Value: as specified
 	</pre>
 


### PR DESCRIPTION
The definition table of [`page-margin-safety`](https://drafts.csswg.org/css-page-3/#descdef-page-page-margin-safety) has `auto` for its initial value, but it is not included in its value definition.