### PR TITLE
[css-forms-1] Add styles for `::color-swatch`

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -808,8 +808,6 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
 
   ISSUE: This section needs refining with implementation.
 
-  ISSUE(11837): Color input styles need refining.
-
 ## Basics ## {#stylesheet-basics}
 
 ```css
@@ -817,6 +815,7 @@ input,
 textarea,
 button,
 ::file-selector-button,
+::color-swatch,
 select,
 meter,
 progress {
@@ -1023,6 +1022,27 @@ select:disabled,
 input:is([type="color"], [type="button"], [type="reset"], [type="submit"]):disabled,
 input[type="file"]:disabled::file-selector-button {
   color: color-mix(currentColor 50%, transparent);
+}
+```
+
+## Color Input ## {#stylesheet-color}
+
+```css
+input[type="color"] {
+	padding: 0;
+	overflow: clip;
+}
+
+::color-swatch {
+	inline-size: stretch;
+	block-size: stretch;
+
+	/* These prevent forced dark mode or forced colors mode from changing the background. */
+	color-scheme: light only;
+	forced-color-adjust: none;
+
+	/* Uses a linear gradient to handle showing the alpha channel of chosen color */
+	background: linear-gradient(control-value()), linear-gradient(to bottom right, black 50%, white 50%);
 }
 ```
 


### PR DESCRIPTION
These styles along with the existing ones will create an output approximately like:

<img width="108" height="107" alt="image" src="https://github.com/user-attachments/assets/43bfea74-99fc-437d-b5a2-6cfce2334a77" />

Fixes #12142

