### PR TITLE
[css-animations-1][css-transitions-1] Add .pseudoTarget to AnimationEvent and TransitionEvent

### DIFF
--- a/css-animations-1/Overview.bs
+++ b/css-animations-1/Overview.bs
@@ -932,6 +932,13 @@ Attributes</h4>
 
 			The <a>un-initialized value</a> of this attribute MUST be
 			<code>null</code>.
+
+			Note: {{AnimationEvent/pseudoTarget}} and {{AnimationEvent/pseudoElement}} are intentionally
+			not equivalent. Because {{AnimationEvent/pseudoTarget}} returns a {{CSSPseudoElement}}
+			object, it is subject to retargeting and encapsulation. Therefore, if the event's target
+			is a pseudo-element inside a shadow tree, {{AnimationEvent/pseudoTarget}} will
+			return <code>null</code> when observed from outside the shadow tree, while
+			{{AnimationEvent/pseudoElement}} will still contain the pseudo-element's name.
 	</dl>
 
 	<dfn dfn-type=constructor for=AnimationEvent>AnimationEvent(type, animationEventInitDict)</dfn> is an <a>event constructor</a>.

--- a/css-transitions-1/Overview.bs
+++ b/css-transitions-1/Overview.bs
@@ -1343,6 +1343,13 @@ associated with transitions.
     The <a>un-initialized value</a> of this attribute MUST be
     <code>null</code>.
 
+    Note: {{TransitionEvent/pseudoTarget}} and {{TransitionEvent/pseudoElement}} are intentionally
+    not equivalent. Because {{TransitionEvent/pseudoTarget}} returns a {{CSSPseudoElement}}
+    object, it is subject to retargeting and encapsulation. Therefore, if the event's target
+    is a pseudo-element inside a shadow tree, {{TransitionEvent/pseudoTarget}} will
+    return <code>null</code> when observed from outside the shadow tree, while
+    {{TransitionEvent/pseudoElement}} will still contain the pseudo-element's name.
+
 
 <code id="TransitionEvent-constructor"><dfn constructor
 for="TransitionEvent">TransitionEvent(type, transitionEventInitDict)</dfn></code>


### PR DESCRIPTION
As resolved in w3c/csswg-drafts#12163, add .pseudoTarget to selected event types and describe the initialization process for it.