### PR TITLE
[css-mixins-1] Make defaultValue member of FunctionParameter non-nullable

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -2276,7 +2276,7 @@ interface CSSFunctionRule : CSSGroupingRule {
 dictionary FunctionParameter {
 	required CSSOMString name;
 	required CSSOMString type;
-	CSSOMString? defaultValue;
+	CSSOMString defaultValue;
 };
 </pre>
 


### PR DESCRIPTION
This is already optional so there's no need to have it nullable as well.

This matches the [behavior of Chrome](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/css_function_rule.idl;l=8) (the only implementer at time of writing) and matches the [behavior expected by WPT](https://github.com/web-platform-tests/wpt/blob/3db1450c66f9e44c5ebfe825e43d39a850a154fa/css/css-mixins/at-function-cssom.html#L242) (note that a missing `defaultValue` is undefined in the returned object, rather than `null`)