### PR TITLE
[css-mixins-1] Fix space placement in serialize a CSSFunctionRule

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -2356,16 +2356,15 @@ return the concatenation of the following:
 			followed by the string <code>"returns"</code>,
 			followed by a single SPACE (U+0020).
 		* The result of performing [=serialize a CSS type=]
-			on that [=custom function/return type|type=],
-			followed by a single SPACE (U+0020).
+			on that [=custom function/return type|type=].
 
-	6. A single LEFT CURLY BRACKET (U+007B),
-		followed by a SPACE (U+0020).
+	6. A single SPACE (U+0020),
+		followed by a LEFT CURLY BRACKET (U+007B).
 
 	7. The result of performing [=serialize a CSS rule=]
 		on each rule in cssRules,
 		filtering out empty strings,
-		all joined by a single SPACE (U+0020).
+		each preceded by a single SPACE (U+0020).
 
 		Note: [=Serialize a CSS rule=] can return an empty string
 			when serializing an empty {{CSSFunctionDeclarations}} rule.


### PR DESCRIPTION
By moving the space from step 5 to the start of step 6 we ensure that there is a space before the '{' regardless of whether we serialize the return type (i.e. "--foo() {..." rather than "--foo(){...")

By moving the space from after the '{' in step 6 to before the first serialized rule in step 7 we ensure that there is only one space (the one in step 8) between the '{' and '}' in the case that there are no rules.

Both of these changes are [expected in WPT](https://github.com/web-platform-tests/wpt/blob/019cc73c5ed906f7b72a93ab31af3d599df53fea/css/css-mixins/at-function-cssom.html#L300)