### PR TITLE
Rename view-transition-scope auto -> all.

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -939,7 +939,7 @@ the active view transition of an element is exposed to script via a property on 
 
 	<pre class="propdef">
 	Name: view-transition-scope
-	Value: none | auto
+	Value: none | all
 	Initial: none
 	Inherited: no
 	Percentages: n/a
@@ -954,7 +954,7 @@ the active view transition of an element is exposed to script via a property on 
 		: <dfn>none</dfn>
 		:: This property has no effect on 'view-transition-name' discoverability.
 
-		: <dfn>auto</dfn>
+		: <dfn>all</dfn>
 		:: Discoverability of 'view-transition-name' is limited to the subtree of this element.
 			This is done by applying <dfn>view transition scoping</dfn>.
 			Such scoping means that any transitions that originate outside of the element
@@ -964,7 +964,7 @@ the active view transition of an element is exposed to script via a property on 
 			<div class=example>
 				```html
 				<style>
-				.scope { view-transition-scope: auto; }
+				.scope { view-transition-scope: all; }
 				#a { view-transition-name: a; }
 				#b { view-transition-name: b; }
 				#c { view-transition-name: c; }
@@ -987,7 +987,7 @@ the active view transition of an element is exposed to script via a property on 
 				```
 			</div>
 
-			Note: Starting a transition implies that [=this=] element has ''view-transition-scope: auto''
+			Note: Starting a transition implies that [=this=] element has ''view-transition-scope: all''
 			for the duration of the transition.
 
 			<div class=example>
@@ -1011,7 +1011,7 @@ the active view transition of an element is exposed to script via a property on 
 				b.startViewTransition(); // Will discover "b" and "d" view-transition-names
 
 				// While b's transition is active and running, the following will only discover
-				// "a" and "d" view transition names, since b has a forced view-transition-scope: auto.
+				// "a" and "d" view transition names, since b has a forced view-transition-scope: all.
 				b.startViewTransition()
 				...
 				</script>
@@ -1020,7 +1020,7 @@ the active view transition of an element is exposed to script via a property on 
 	</dl>
 
 	Note: Most elements running or planning to run a [=scoped view transition=]
-	should use ''view-transition-scope: auto'', to ensure that their
+	should use ''view-transition-scope: all'', to ensure that their
 	[=document-scoped view transition names=] don't accidentally interfere with
 	other [=scoped view transitions=] in the ancestor chain.
 


### PR DESCRIPTION
[css-view-transitions-2] Rename view-transition-scope auto -> all.

Fixes #13123.