### PR TITLE
[css-image-animation] Define what state 'running' starts from

### DIFF
--- a/css-image-animation-1/Overview.bs
+++ b/css-image-animation-1/Overview.bs
@@ -146,6 +146,10 @@ Controlling Image Animations: the 'image-animation' property {#image-animation}
 			If images are added to the element while the computed value is ''running'',
 			the timeline starts at the time of the least recent addition to the group.
 
+			If the element is created or made visible after having previously been set to ''display: none'',
+			with images already added and with 'image-animation' already set to ''running'',
+			the timeline starts when the element is included in the layout.
+
 			If this property is switched to ''running'' from another value,
 			the beginnig of this timeline is set
 			so that the animation continues from the state that was displayed


### PR DESCRIPTION
This is in response to https://github.com/w3c/csswg-drafts/issues/13429.