### PR TITLE
[css-env-1] Specify argument grammar for env() function

### DIFF
--- a/css-env-1/Overview.bs
+++ b/css-env-1/Overview.bs
@@ -297,6 +297,10 @@ The ''env()'' function's [=argument grammar=] is:
 	<dfn><<env-args>></dfn> = env( <<declaration-value>>, <<declaration-value>>? )
 </pre>
 
+Like ''var()'', a bare comma can be used with nothing following it,
+indicating that the second <<declaration-value>> was passed,
+just as an empty sequence.
+
 The ''env()'' function can be used in place of any part of a value in any property on any element,
 or any part of a value in any descriptor on any [=at-rule=],
 and in several other places where CSS values are allowed.


### PR DESCRIPTION
Specify [argument grammar](https://drafts.csswg.org/css-values-5/#argument-grammar) for env() function.