### PR TITLE
[css-mixins-1] chore: added missing CSS values

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -1406,7 +1406,7 @@ but the mixin not use it.
 		}
 		@apply --two-column {
 			display: grid;
-			grid-template-columns: ;
+			grid-template-columns: 60px 60px;
 		}
 	}
 	</pre>
@@ -1551,7 +1551,7 @@ or potentially a fallback block.
 		}
 		@apply --two-column {
 			display: grid;
-			grid-template-columns: ;
+			grid-template-columns: 60px 60px;
 		}
 	}
 	</pre>


### PR DESCRIPTION
Two lines of CSS are missing values for their CSS properties on the [CSS mixins draft](https://drafts.csswg.org/css-mixins/). Missing those doesn't seem to be on purpose, not being related to that `mixin` and `macro` rule functionality, so they might only being be missing unexpectedly.