### PR TITLE
Convert Makefiles and shell scripts to use spec-generator URLs

### DIFF
--- a/bin/bikeshed-curl
+++ b/bin/bikeshed-curl
@@ -1,2 +1,2 @@
-curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F output=err
-curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F force=1 > Overview.html
+curl https://www.w3.org/publications/spec-generator/ -F file=@Overview.bs -F type=bikeshed-spec -F output=messages
+curl https://www.w3.org/publications/spec-generator/ -F file=@Overview.bs -F type=bikeshed-spec -F die-on=nothing > Overview.html

--- a/css-backgrounds-3/Makefile
+++ b/css-backgrounds-3/Makefile
@@ -7,11 +7,8 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 cdate =
 status =
@@ -43,11 +40,11 @@ opts =
 
 all: check Overview.html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: Overview.err
 	@cat $<
-	@if egrep -v '^(Warning:|\(Processed in .* seconds\)|No errors)' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-box-3/Makefile
+++ b/css-box-3/Makefile
@@ -9,18 +9,14 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 date ?=
 status ?= ED
 group ?= CSS
 opts ?=
 target ?= Overview
-markup ?= html
 cdate ?= $(date)
 
 
@@ -37,14 +33,13 @@ cdate ?= $(date)
 %.html: %.bs
 	@echo "- Calling Bikeshed to generate $@..."
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=html -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
+	 -F type=bikeshed-spec -F output=html $(opts) https://www.w3.org/publications/spec-generator/
 %.err: %.bs
 	@echo "- Calling Bikeshed to check $<..."
 	@rm -f $@
 	@touch $@
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=err -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
-	@sed -i 's/\\033\[[0-9;]*m//g' $@
+	  -F type=bikeshed-spec -F output=messages $(opts) https://www.w3.org/publications/spec-generator/
 
 # For Dispositions of Comments in css3-background:
 %.html: %.txt; awk -f issues-txt-to-html.awk $< >$@
@@ -61,13 +56,12 @@ cdate ?= $(date)
 
 all: check $(target).html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: $(target).err
 	@cat $<
 	@echo
-	@if egrep -qv '^(Warning:|\(Processed in .* seconds\)|No errors)' $< &&\
-	  ! egrep -q '[^A-Z]* Successfully generated' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-inline-3/Makefile
+++ b/css-inline-3/Makefile
@@ -7,18 +7,14 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 cdate ?=
 status ?=
 group ?= CSS
 opts ?=
 target ?= Overview
-markup ?= html
 
 %.html: %.src.html
 	@echo "Calling post-processor to generate $@..."
@@ -31,11 +27,11 @@ markup ?= html
 	-F group=$(group) -F method=file -F date=$(cdate) -F status=$(status) \
 	$(opts) -o $@ https://www.w3.org/Style/Group/process.cgi
 %.html: %.bs
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=html \
-	-F paragraph=$(markup) $(opts) -o $@ http://api.csswg.org/bikeshed/
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=html \
+	-F type=bikeshed-spec $(opts) -o $@ https://www.w3.org/publications/spec-generator/
 %.err: %.bs
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=err \
-	-F paragraph=$(markup) $(opts) -o $@ http://api.csswg.org/bikeshed/
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=messages \
+	-F type=bikeshed-spec $(opts) -o $@ https://www.w3.org/publications/spec-generator/
 
 # For Dispositions of Comments in css3-background:
 %.html: %.txt; awk -f issues-txt-to-html.awk $< >$@
@@ -52,11 +48,11 @@ markup ?= html
 
 all: check $(target).html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: $(target).err
 	@cat $<
-	@if egrep -qv '^(Warning:|\(Processed in .* seconds\)|No errors)' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-mobile/Makefile
+++ b/css-mobile/Makefile
@@ -9,18 +9,14 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 date ?=
 status ?= ED
 group ?= CSS
 opts ?=
 target ?= Overview
-markup ?= html
 cdate ?= $(date)
 
 
@@ -37,14 +33,13 @@ cdate ?= $(date)
 %.html: %.bs
 	@echo "- Calling Bikeshed to generate $@..."
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=html -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
+	 -F output=html -F type=bikeshed-spec $(opts) https://www.w3.org/publications/spec-generator/
 %.err: %.bs
 	@echo "- Calling Bikeshed to check $<..."
 	@rm -f $@
 	@touch $@
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=err -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
-	@sed -i 's/\\033\[[0-9;]*m//g' $@
+	 -F output=messages -F type=bikeshed-spec $(opts) https://www.w3.org/publications/spec-generator/
 
 # For Dispositions of Comments in css3-background:
 %.html: %.txt; awk -f issues-txt-to-html.awk $< >$@
@@ -61,13 +56,12 @@ cdate ?= $(date)
 
 all: check $(target).html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: $(target).err
 	@cat $<
 	@echo
-	@if egrep -qv '^(Warning:|\(Processed in .* seconds\)|No errors)' $< &&\
-	  ! egrep -q '[^A-Z]* Successfully generated' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-print/Makefile
+++ b/css-print/Makefile
@@ -9,18 +9,14 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 date ?=
 status ?= ED
 group ?= CSS
 opts ?=
 target ?= Overview
-markup ?= html
 cdate ?= $(date)
 
 
@@ -37,14 +33,13 @@ cdate ?= $(date)
 %.html: %.bs
 	@echo "- Calling Bikeshed to generate $@..."
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=html -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
+	 -F output=html -F type=bikeshed-spec $(opts) https://www.w3.org/publications/spec-generator/
 %.err: %.bs
 	@echo "- Calling Bikeshed to check $<..."
 	@rm -f $@
 	@touch $@
 	@curl -o $@ -s -L -F file=@$< -F md-date=$(cdate) -F md-status=$(status) \
-	 -F output=err -F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/
-	@sed -i 's/\\033\[[0-9;]*m//g' $@
+	 -F output=messages -F type=bikeshed-spec $(opts) https://www.w3.org/publications/spec-generator/
 
 # For Dispositions of Comments in css3-background:
 %.html: %.txt; awk -f issues-txt-to-html.awk $< >$@
@@ -61,13 +56,12 @@ cdate ?= $(date)
 
 all: check $(target).html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: $(target).err
 	@cat $<
 	@echo
-	@if egrep -qv '^(Warning:|\(Processed in .* seconds\)|No errors)' $< &&\
-	  ! egrep -q '[^A-Z]* Successfully generated' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-regions-1/Makefile
+++ b/css-regions-1/Makefile
@@ -1,16 +1,24 @@
-# use this command line now, or a local bikeshed
+# Use this command with local bikeshed:
+# bikeshed spec Overview.bs Overview.html
 
-# curl http://api.csswg.org/bikeshed/ -F file=@Overview.src.html > Overview.html
+# spec-generator can be used, but sending only Overview.bs will lose img width/height generation
+# curl https://www.w3.org/publications/spec-generator/ -F type=bikeshed-spec -F file=@Overview.bs > Overview.html
 
-%.html: %.src.html
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=html \
-	-F paragraph=$(markup) $(opts) -o $@ http://api.csswg.org/bikeshed/
-%.err: %.src.html
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=err \
-	-F paragraph=$(markup) $(opts) http://api.csswg.org/bikeshed/ >$@
+target ?= Overview
+
+%.html: %.bs
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=html \
+	-F type=bikeshed-spec $(opts) -o $@ https://www.w3.org/publications/spec-generator/
+%.err: %.bs
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=messages \
+	-F type=bikeshed-spec $(opts) https://www.w3.org/publications/spec-generator/ >$@
 
 all: check Overview.html
 
-check: Overview.err
-	@if test -s $<; then false; else true; fi
+check: $(target).err
 	@cat $<
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
+
+clean:
+	rm -f $(target).html $(target).err

--- a/css-shapes-1/Makefile
+++ b/css-shapes-1/Makefile
@@ -1,3 +1,5 @@
-# use this command line now, or a local bikeshed
+# Use this command with local bikeshed:
+# bikeshed spec Overview.bs Overview.html
 
-# curl http://api.csswg.org/bikeshed/ -F file=@Overview.src.html > Overview.html
+# spec-generator can be used, but sending only Overview.bs will lose img width/height generation
+# curl https://www.w3.org/publications/spec-generator/ -F type=bikeshed-spec -F file=@Overview.bs > Overview.html

--- a/css-template-1/Makefile
+++ b/css-template-1/Makefile
@@ -11,18 +11,14 @@
 # http://www.w3.org/TR/[YEAR]/CR-[SHORTNAME]-[CDATE]/
 # Or set that URL to [VERSION] and call Make as: make status=CR
 #
-#
-# Possible other options to add to the curl command below:
-# -F ids=on
-# -F omitdchtml=on
-# e.g., like this: make opts="-F ids=on -F omitdchtml=on"
+# Additional options may be specified via opts, e.g.:
+# make opts='-F md-prepare-for-tr=yes'
 
 date ?=
 status ?=
 group ?= CSS
 opts ?=
 target ?= Overview
-markup ?= html
 cdate ?= $(date)
 
 %.html: %.src.html $(MAKEFILE_LIST) %.options
@@ -36,13 +32,13 @@ cdate ?= $(date)
 	-F group=$(group) -F method=file -F date=$(cdate) -F status=$(status) \
 	$(opts) -o $@ https://www.w3.org/Style/Group/process.cgi
 %.html: %.tmp
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=html \
-	-F paragraph=$(markup) $(opts) -o $@ http://api.csswg.org/bikeshed/
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=html \
+	-F type=bikeshed-spec $(opts) -o $@ https://www.w3.org/publications/spec-generator/
 %.err: %.tmp
 	rm -f $@
 	touch $@
-	curl -s -L -F file=@$< -F time=$(cdate) -F output=err \
-	-F paragraph=$(markup) $(opts) -o $@ http://api.csswg.org/bikeshed/
+	curl -s -L -F file=@$< -F md-date=$(cdate) -F output=messages \
+	-F type=bikeshed-spec $(opts) -o $@ https://www.w3.org/publications/spec-generator/
 
 %.tmp: %.bs $(MAKEFILE_LIST) %.options
 	cp $< $@
@@ -84,11 +80,11 @@ cdate ?= $(date)
 
 all: check $(target).html
 
-# egrep will exit with a zero exit code if there is anything left
+# fgrep will exit with a zero exit code if there is anything left
 check: $(target).err
 	@cat $<
-	@if egrep -qv '^(Warning:|\(Processed in .* seconds\)|No errors)' $<;\
-	 then false; else true; fi
+	@if fgrep -q '"messageType":"success"' $<;\
+	 then true; else false; fi
 
 
 # A handy shortcut:

--- a/css-transforms-1/Makefile
+++ b/css-transforms-1/Makefile
@@ -5,13 +5,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-transforms-2/Makefile
+++ b/css-transforms-2/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/css-viewport-1/Makefile
+++ b/css-viewport-1/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/cssom-1/Makefile
+++ b/cssom-1/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/cssom-view-1/Makefile
+++ b/cssom-view-1/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/filter-effects-2/Makefile
+++ b/filter-effects-2/Makefile
@@ -1,15 +1,16 @@
 # Use "make REMOTE=1" to use remote bikeshed
+# (note that relying on remote will lose image width/height generation)
 
 SOURCEFILE=Overview.bs
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif

--- a/selectors-nonelement-1/make.cmd
+++ b/selectors-nonelement-1/make.cmd
@@ -1,1 +1,1 @@
-@curl https://api.csswg.org/bikeshed/ -F file=@Overview.bs > Overview.html
+@curl https://www.w3.org/publications/spec-generator/ -F file=@Overview.bs -F type=bikeshed-spec > Overview.html

--- a/web-animations-css-integration/Makefile
+++ b/web-animations-css-integration/Makefile
@@ -7,13 +7,13 @@
 SOURCEFILE=Overview.src.html
 OUTPUTFILE=Overview.html
 PREPROCESSOR=bikeshed.py
-REMOTE_PREPROCESSOR_URL=https://api.csswg.org/bikeshed/
+REMOTE_PREPROCESSOR_URL=https://www.w3.org/publications/spec-generator/
 
 all: $(OUTPUTFILE)
 
 $(OUTPUTFILE): $(SOURCEFILE)
 ifneq (,$(REMOTE))
-	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) > "$@"
+	curl $(REMOTE_PREPROCESSOR_URL) -F file=@$(SOURCEFILE) -F type=bikeshed-spec > "$@"
 else
 	$(PREPROCESSOR) -f spec "$<" "$@"
 endif


### PR DESCRIPTION
This updates all scripts and Makefiles containing references to the discontinued `api.csswg.org/bikeshed` HTTP API, to instead use https://www.w3.org/publications/spec-generator/.

I have tested all of these to verify they produce nearly-identical results as the existing EDs.

I'm not sure how many of the Makefiles/scripts are actively used; some of the specs, possibly older ones, fail without the addition of `die-on=nothing`. Some rely on local `bikeshed` by default or include comments to that effect. In any cases where images are involved, I've made sure to comment that running with local bikeshed seems preferable, since then it will generate width/height attributes (which are present in the current EDs).

For details on how parameters were changed, see [Migrating Bikeshed HTTP API usage to spec‐generator](https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator#http-api). Note that some parameters referenced in the existing Makefiles, e.g. `paragraph`, didn't seem to be documented at all in the old HTTP API, so I have to assume they may have had no effect.