### PR TITLE
[css-overflow-3] Note that overflow applies to replaced elements

### DIFF
--- a/css-overflow-3/Overview.bs
+++ b/css-overflow-3/Overview.bs
@@ -434,7 +434,7 @@ Managing Overflow: the 'overflow-x', 'overflow-y', and 'overflow' properties</h3
 		Name: overflow-x, overflow-y, overflow-block, overflow-inline
 		Value: visible | hidden | clip | scroll | auto
 		Initial: ''visible''
-		Applies to: block containers [[!CSS2]], flex containers [[!CSS3-FLEXBOX]], grid containers [[!CSS3-GRID-LAYOUT]]
+		Applies to: block containers [[!CSS2]], flex containers [[!CSS3-FLEXBOX]], grid containers [[!CSS3-GRID-LAYOUT]] and replaced elements
 		Inherited: no
 		Logical property group: overflow
 		Percentages: N/A
@@ -461,7 +461,7 @@ Managing Overflow: the 'overflow-x', 'overflow-y', and 'overflow' properties</h3
 		Name: overflow
 		Value: <<'overflow-block'>>{1,2}
 		Initial: visible
-		Applies to: block containers [[!CSS2]], flex containers [[!CSS3-FLEXBOX]], and grid containers [[!CSS3-GRID-LAYOUT]]
+		Applies to: block containers [[!CSS2]], flex containers [[!CSS3-FLEXBOX]], grid containers [[!CSS3-GRID-LAYOUT]] and replaced elements
 		Inherited: no
 		Percentages: N/A
 		Computed value: see individual properties


### PR DESCRIPTION
The spec description of overflow and browsers agree that it has effects on replaced elements.

(Well, WebKit doesn't agree, but Chrome and Firefox do.)

Example HTML that showcases this:
```html
<!DOCTYPE html>
<img style="width: 300px; height: 300px; object-fit: cover; overflow: visible;" src="https://upload.wikimedia.org/wikipedia/commons/0/0d/Great_Wave_off_Kanagawa2.jpg">
```