### PR TITLE
[css-anchor-position-1] Specify scroll offset snapshot timing #10796

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1056,6 +1056,10 @@ while still allowing as much freedom to anchor to various elements as possible,
 [=anchor positioning=] uses a combination of [=remembered scroll offsets=]
 and [=compensating for scroll=].
 
+The scroll offsets which are used to compute [=remembered scroll offsets=] and
+[=default scroll shift=] are snapshotted when asked to
+[=run snapshot post-layout state steps=].
+
 <div class=note>
 	The details here are technical, but the gist is:
 
@@ -1216,10 +1220,6 @@ specifically, the [=default anchor element=]:
 	it is additionally shifted by the [=default scroll shift=],
 	as if affected by a [=transform=]
 	(before any other transforms).
-
-	Issue: Define the precise timing of the snapshot:
-	updated each frame,
-	before style recalc.
 
 	Issue: Similar to [=remembered scroll offset=],
 	can we pay attention to transforms on the [=default anchor element=]?

--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1056,9 +1056,8 @@ while still allowing as much freedom to anchor to various elements as possible,
 [=anchor positioning=] uses a combination of [=remembered scroll offsets=]
 and [=compensating for scroll=].
 
-The scroll offsets which are used to compute [=remembered scroll offsets=] and
-[=default scroll shift=] are snapshotted when asked to
-[=run snapshot post-layout state steps=].
+The scroll offsets which are used to compute [=remembered scroll offsets=] and [=default scroll shift=] 
+are snapshotted when asked to [=run snapshot post-layout state steps=].
 
 <div class=note>
 	The details here are technical, but the gist is:


### PR DESCRIPTION
Specify that scroll offsets are snapshotted when asked to run snapshot post-layout state steps.

Also see HTML PR[1] for when "run snapshot post-layout state steps" are expected to be run.

[1] https://github.com/whatwg/html/pull/11613/
