### PR TITLE
[css-conditional-5] Add env() for use with @supports

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -118,12 +118,13 @@ Extensions to the ''@supports'' rule</h2>
 		<dfn>&lt;supports-feature></dfn> = <<supports-selector-fn>>
 		                   | <<supports-font-tech-fn>> | <<supports-font-format-fn>>
 		                   | <<supports-at-rule-fn>> | <<supports-named-feature-fn>>
-		                   | <<supports-decl>>
+		                   | <<supports-env-fn>> | <<supports-decl>>
 		<dfn>&lt;supports-decl></dfn> = ( [ <<declaration>> | <<supports-condition-name>> ] )
 		<dfn>&lt;supports-font-tech-fn></dfn> = font-tech( <<font-tech>> )
 		<dfn>&lt;supports-font-format-fn></dfn> = font-format( <<font-format>> )
 		<dfn>&lt;supports-at-rule-fn></dfn> = at-rule( <<at-keyword-token>> )
 		<dfn>&lt;supports-named-feature-fn></dfn> = named-feature( <<ident>> )
+		<dfn function lt="env()" for="@supports">&lt;supports-env-fn></dfn> = env( <<ident>> )
 	</pre>
 
 	: <<supports-condition-name>>
@@ -155,6 +156,12 @@ Extensions to the ''@supports'' rule</h2>
 	::
 		The result is true if the UA
 		<a href="#dfn-support-named-feature">supports the named feature</a>
+		provided as an argument to the function.
+	
+	: <<supports-env-fn>>
+	::
+		The result is true if the UA
+		<a href="#dfn-support-env">supports the environment variable</a>
 		provided as an argument to the function.
 
 <h3 id="support-definition-ext">
@@ -216,6 +223,13 @@ Named conditions</h4>
 	A CSS processor is considered to
 	<dfn export for=CSS id="dfn-supports-condition-name">support a named condition</dfn>
 	when the related [=named supports condition=] returns true.
+
+<h4 id="support-definition-env">
+Environment variables</h4>
+
+	A CSS processor is considered to
+	<dfn export for=CSS id="dfn-support-env">support an environment variable</dfn>
+	if the <<ident>> is a supported [=environment variable=].
 
 <h2 id="when-rule">
 Generalized Conditional Rules: the ''@when'' rule</h2>
@@ -2045,6 +2059,11 @@ Changes since the <a href="https://www.w3.org/TR/2024/WD-css-conditional-5-20241
 
 <ul>
 	<!-- to  21 October -->
+	<li>
+		Extended [=supports queries=] to express [=environment variable=] capabilities
+		via ''@supports/env()''.
+		(<a href="https://github.com/w3c/csswg-drafts/issues/3576">#3576</a>)
+	</li>
 	<li>Clarified that the last @supports-condition in document order wins
 		(<a href="https://github.com/w3c/csswg-drafts/issues/12973">#12973</a>)
 	</li>


### PR DESCRIPTION
This adds `env()` for use with `@supports` to [css-conditional-5](https://drafts.csswg.org/css-conditional-5/)

Fixes #3576.