### PR TITLE
[css-masking-1] Re-allow specifying `fill` before other `mask-border-slice` component values

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -1587,7 +1587,7 @@ The 'mask-mode' and 'mask-type' properties must have no affect on the <a>mask bo
 
 <pre class=propdef>
 Name: mask-border-slice
-Value: [ <<number>> | <<percentage>> ]{1,4} fill?
+Value: [ <<number>> | <<percentage>> ]{1,4} && fill?
 Initial: 0
 Applies to: All elements. In SVG, it applies to <a>container elements</a> excluding the <a element>defs</a> element, all <a>graphics elements</a> and the <a element>use</a> element
 Inherited: no


### PR DESCRIPTION
Moved from https://github.com/w3c/fxtf-drafts/pull/530.

This PR re-allows specifying `fill` before the other component values of [`mask-border-slice`](https://drafts.csswg.org/css-masking-1/#propdef-mask-border-slice), like in [`border-image-slice`](https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice).

This is not allowed since this [commit](https://github.com/w3c/fxtf-drafts/commit/7af5acb2b6d290a3fa9508cf76af05b772057b23#diff-aacf1a334bd4ec16c705bf164f6bc873cbaee4b25944da51f00184c321b84562L1167-L1171), but I think it was unintentional.

Basically, this commit moved the property definition table of `mask-box-image-slice` from `masking/Masking.src.html`:

  > ```html
  > <tr>
  >   <th>Name:
  >   <td><dfn>mask-box-image-slice</dfn>
  > <tr>
  >   <th><a href="#values">Value</a>:
  >   <td>[<var>&lt;number&gt;</var> | <var>&lt;percentage&gt;</var>]{1,4} &amp;&amp; fill?
  > ```

... to `masking/Overview.src.html`:

  > **Name:** `mask-box-image-slice`
  > **Value:** `[<<number>> | <<percentage>>]{1,4} fill?`

An later `mask-box-image-slice` was renamed to `mask-border-slice`.