### PR TITLE
[motion-1][editorial] Re-use `<radial-extent>` in `<ray-size>` keywords

### DIFF
--- a/motion-1/Overview.bs
+++ b/motion-1/Overview.bs
@@ -349,7 +349,7 @@ as a straight line emerging from a point at some defined angle:
 <pre class=prod>
 <dfn>ray()</dfn> = ray( <<angle>> && <<ray-size>>? && contain? && [at <<position>>]? )
 
-<dfn>&lt;ray-size></dfn> = closest-side | closest-corner | farthest-side | farthest-corner | sides
+<dfn>&lt;ray-size></dfn> = <<radial-extent>> | sides
 </pre>
 
 Its arguments are:


### PR DESCRIPTION
The semantics of `ray()` are quite close to gradient functions so I think it is ok to re-use `<radial-extent>` from CSS Images.