### PR TITLE
[css-cascade-5] Clarify the scope of layers

### DIFF
--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1229,7 +1229,7 @@ Cascade Layers</h3>
 	In the same way that [=cascade origins=] provide a balance of power
 	between user and author styles,
 	<dfn export local-lt="layer">cascade layers</dfn> provide a structured way
-	to organize and balance concerns within a single origin and context.
+	to organize and balance concerns within a single [=origin=] and [=context=].
 	Rules within a single [=cascade layer=] cascade together,
 	without interleaving with style rules outside the layer.
 

--- a/css-cascade-5/Overview.bs
+++ b/css-cascade-5/Overview.bs
@@ -1229,7 +1229,7 @@ Cascade Layers</h3>
 	In the same way that [=cascade origins=] provide a balance of power
 	between user and author styles,
 	<dfn export local-lt="layer">cascade layers</dfn> provide a structured way
-	to organize and balance concerns within a single origin.
+	to organize and balance concerns within a single origin and context.
 	Rules within a single [=cascade layer=] cascade together,
 	without interleaving with style rules outside the layer.
 


### PR DESCRIPTION
I.e. the scope is origin and context, as noted [before](https://drafts.csswg.org/css-cascade-5/#cascade-layering) the updated text:

  > Declarations within **each origin and context** can be explicitly assigned to a cascade layer.
  
In my opinion, an example would help to better capture what this means:

  > Given the following markup:
  >
  > ```html
  > <style>
  >   @layer one { p::after { content: 'one wins' } }
  >   @layer two { p::after { content: 'two wins' } }
  > </style>
  > <p>Result: </p>
  > <div>
  >   <template>
  >     <style>
  >       @layer two { p::after { content: 'two wins' } }
  >       @layer one { p::after { content: 'one wins' } }
  >     </style>
  >     <p>Result: </p>
  >   </template>
  > </div>
  > ```
  >
  > The `@layer` rules in the light tree do not affect the `@layer` rules declared in the shadow tree. 
  >
  > In the light tree, the result is `two wins`. In the shadow tree, it is `one wins`.