### PR TITLE
[css-2026] Added <url-set> for cursor property to Safe to Release pre-CR Exceptions

### DIFF
--- a/css-2026/Overview.bs
+++ b/css-2026/Overview.bs
@@ -992,7 +992,7 @@ Safe to Release pre-CR Exceptions</h2>
 
 		<li>The [=pseudo-classes=] '':scope'', '':defined'', '':focus-within'', '':dir()'', '':any-link'', '':open'', '':popover-open'', '':modal'', '':fullscreen'', '':placeholder-shown'', '':default'', '':valid'', '':invalid'', '':required'', '':optional'', and selector lists for the '':nth-child()'' and '':nth-last-child()'' [=pseudo-classes=], defined in [[!SELECTORS-4]]
 
-		<li>The 'accent-color' property and ''outline-color/auto'' value for the 'outline-color' property, defined in [[CSS-UI-4]]
+		<li>The 'accent-color' property, the ''outline-color/auto'' value for the 'outline-color' property, and the <<url-set>> data type for the <css>[[css-ui-4#cursor|cursor]]</css> property, defined in [[CSS-UI-4]]
 
 		<li>Everything in
 			<a href="https://www.w3.org/TR/css-animations-1/">CSS Animations Level 1</a>


### PR DESCRIPTION
Related resolution:
https://github.com/w3c/csswg-drafts/issues/12781#issuecomment-4070055887

Fixes #12781

Sebastian