### PR TITLE
[css-cascade-6] Fix syntax of the `<scope-boundaries>` type

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -665,7 +665,7 @@ Syntax of ''@scope''</h4>
 
 	with <<scope-boundaries>> defined as:
 	<pre class="prod def">
-	<dfn export>&lt;scope-boundaries></dfn> =  [ ( <<scope-start>> ) ] ? [ to ( <<scope-end>> ) ]?
+	<dfn export>&lt;scope-boundaries></dfn> =  [ ( <<scope-start>> ) ]? [ to ( <<scope-end>> ) ]?
 	</pre>
 
 	and where:


### PR DESCRIPTION
This update removes the space introduced before the `?` multiplier and that makes the syntax invalid.
