### PR TITLE
[css-cascade-6][editorial] Syntax cleanup

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -93,12 +93,12 @@ Importing Style Sheets: the ''@import'' rule</h2>
 
 <pre class='prod'>
 		@import [ <<url>> | <<string>> ]
-		        [[ layer | layer(<<layer-name>>) ]
+		        [[ layer | layer( <<layer-name>> ) ]
 		         || [ scope | scope( <<scope-start>> | <<scope-boundaries>> ) ]
 		         || <<supports-import-condition>>]?
-		        <<media-import-condition>>?;
+		        <<media-import-condition>> ;
 
-		<dfn export>&lt;supports-import-condition></dfn> = [ supports( [ <<supports-condition>> | <<declaration>> ] ) ]
+		<dfn export>&lt;supports-import-condition></dfn> = supports( [ <<supports-condition>> | <<declaration>> ] )
 		<dfn export>&lt;media-import-condition></dfn> = <<media-query-list>></pre>
 
 	where:
@@ -658,7 +658,7 @@ Syntax of ''@scope''</h4>
 	The syntax of the ''@scope'' rule is:
 
 	<pre class="prod def">
-	@scope <<scope-boundaries>>? {
+	@scope <<scope-boundaries>> {
 	  <<block-contents>>
 	}
 	</pre>


### PR DESCRIPTION
`<media-query-list>` and `<scope-boundaries>` represent a list of zero or more component values so I removed the `?` multiplier for their use in `@import` and `@scope`.