### PR TITLE
[css2] Fix wording for magins collapsing

### DIFF
--- a/css2/Overview.bs
+++ b/css2/Overview.bs
@@ -5466,8 +5466,9 @@ resulting combined margin is called a <dfn data-lt="collapsed margin|collapsing 
 
     <li>top and bottom margins of a box that does not establish a new
     block formatting context and that has zero computed 'min-height', zero or ''height/auto''
-    computed 'height', and no
-    in-flow children
+    computed 'height', and either no
+    in-flow children or
+    only in-flow children whose margins also collapse
   </ul>
 </ul>
 


### PR DESCRIPTION
This matches the notes below that section and also matches implementations.
Consider:
```html
<!DOCTYPE html>
Foo
<p><span style="display: block; margin-block: 1em"></span></p>
Bar
```
The current spec suggests that, since this paragraph has an in-flow child, its margins should not collapse, when in reality, all the margins here collapse into a single `1em` gap, because there's nothing in-between.