### PR TITLE
[css-sizing-4] Add the `frame-sizing` property

### DIFF
--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -1253,8 +1253,6 @@ Responsively-sized iframes: the 'frame-sizing' property</h3>
 		but will be updated to ''500px'' once the iframe's document loads.
 	</div>
 
-	Issue: Should this apply even when ''contain:size'' isn't specified?
-
 	In addition,
 	the internal document can call {{window/requestResize()|window.requestResize()}};
 	if the document has the required <{meta}> element


### PR DESCRIPTION
[css-sizing-4] Add the `frame-sizing` property

Based on the resolutions at:
https://github.com/w3c/csswg-drafts/issues/1771#issuecomment-3806716273

* Add the `frame-sizing` property.
* Remove the `from-element` keyword added by #13099.
* Clarified the `<meta>` tag is immutable.