### PR TITLE
Only run publish workflows on w3c/csswg-drafts, not forks

### DIFF
--- a/.github/auto-publish-template.yml
+++ b/.github/auto-publish-template.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   publish-TR-{{shortname}}:
     name: Publish {{shortname}}
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/generate-auto-publish-workflows.py
+++ b/.github/generate-auto-publish-workflows.py
@@ -94,7 +94,7 @@ def main():
 
         # Write workflow file
         filename = workflows_dir / f"{spec['shortname']}.yml"
-        filename.write_text(content, encoding="utf-8")
+        filename.write_text(content, encoding="utf-8", newline="\n")
         print(f"Generated {filename}")
 
 

--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build-specs:
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/css-color-4.yml
+++ b/.github/workflows/css-color-4.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   publish-TR-css-color-4:
     name: Publish css-color-4
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/css-color-5.yml
+++ b/.github/workflows/css-color-5.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   publish-TR-css-color-5:
     name: Publish css-color-5
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/css-color-hdr-1.yml
+++ b/.github/workflows/css-color-hdr-1.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   publish-TR-css-color-hdr-1:
     name: Publish css-color-hdr-1
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/css-fonts-4.yml
+++ b/.github/workflows/css-fonts-4.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   publish-TR-css-fonts-4:
     name: Publish css-fonts-4
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/css-fonts-5.yml
+++ b/.github/workflows/css-fonts-5.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   publish-TR-css-fonts-5:
     name: Publish css-fonts-5
+    if: github.repository == 'w3c/csswg-drafts'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Based on the example at: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository

Also included is a fix to generate-auto-publish-workflows.py so that it generates Unix-style line endings when run on Windows.