### PR TITLE
[css-color-5] Add the `none` keyword to `light-dark()`

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2795,7 +2795,7 @@ or any other color or monochrome output device which has been characterized.
 	<pre class='prod'>
 		<dfn export>light-dark()</dfn> = <<light-dark-color>> | <<light-dark-image>>
 		<dfn export><<light-dark-color>></dfn> = light-dark(<<color>>, <<color>>)
-		<dfn export><<light-dark-image>></dfn> = light-dark(<<image>>, <<image>>) 
+		<dfn export><<light-dark-image>></dfn> = light-dark(<<image>> | none, <<image>> | none) 
 	</pre>
 
 	For the color form, this function computes to the computed value of the first color,


### PR DESCRIPTION
Fixes: https://github.com/w3c/csswg-drafts/issues/12513#issuecomment-4113020766

This means that `light-dark(url(foo.png), none)` will be a valid value. The `none` keyword is equivalent to `linear-gradient(transparent)`, but is more intuitive.

This also makes conditional checks in `@supports` more concise:

```css
@supports ( background: light-dark(none, none) ) { }
```

In addition, `none` is also supported in `-webkit-cross-fade()`, See: https://github.com/web-platform-tests/wpt/blob/0efed9003fb6c920d404928776fc9a400bb78560/css/css-images/cross-fade-legacy-crash.html#L8

