### PR TITLE
Add `light-dark()` and `none` to the image type, #12513

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -73,11 +73,13 @@ Value Definitions {#values}
 	The <<image>> value type denotes a 2D image. It can be a
 	<a section href="#url-notation">url reference</a>,
 	<a section href="#image-notation">image notation</a>,
-	<a section href="#gradients">gradient notation</a>
+	<a section href="#gradients">gradient notation</a>,
+	''light-dark()'',
 	or <a section href="#none">none</a> .
 	Its syntax is:
 
-	<pre class="prod"><dfn>&lt;image></dfn> = <<url>> | <<image()>> | <<image-set()>> | <<cross-fade()>> | <<element()>> | <<gradient>> | none </pre>
+	<pre class="prod"><dfn>&lt;image></dfn> = <<url>> | <<image()>> | <<image-set()>> | <<cross-fade()>> |
+			<<element()>> | <<gradient>> | <<light-dark-image>> | none </pre>
 
 	An <<image>> can be used in many CSS properties,
 	including the 'background-image', 'list-style-image', 'cursor' properties [[!CSS2]]
@@ -3040,6 +3042,8 @@ Changes Since the <a href="https://www.w3.org/TR/2025/WD-css-images-4-20250930/"
 
 <ul>
 	<li>Added the "none" keyword to the image type
+	(<a href="https://github.com/w3c/csswg-drafts/issues/12513">Issue 12513</a>)</li>
+	<li>Added the image form of light-dark() to the image type
 	(<a href="https://github.com/w3c/csswg-drafts/issues/12513">Issue 12513</a>)</li>
 </ul>
 


### PR DESCRIPTION
Adds the image form of `light-dark()`, which is [defined in CSS Color 5](https://drafts.csswg.org/css-color-5/#light-dark), to the image type, as [resolved](https://github.com/w3c/csswg-drafts/issues/12513#issuecomment-4040713109).

Also adds the `none` value to the image type (rather than special-casing it to `light-dark()`), as [suggested by @emilio](https://github.com/w3c/csswg-drafts/issues/12513#issuecomment-4113654690) and [supported by @tabatkins](https://github.com/w3c/csswg-drafts/issues/12513#issuecomment-4092448365).