### PR TITLE
[css-color-5] Add missing groups in <light-dark-image> syntax

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -2795,7 +2795,7 @@ or any other color or monochrome output device which has been characterized.
 	<pre class='prod'>
 		<dfn export>light-dark()</dfn> = <<light-dark-color>> | <<light-dark-image>>
 		<dfn export><<light-dark-color>></dfn> = light-dark(<<color>>, <<color>>)
-		<dfn export><<light-dark-image>></dfn> = light-dark(<<image>> | none, <<image>> | none) 
+		<dfn export><<light-dark-image>></dfn> = light-dark( [ <<image>> | none ] , [ <<image>> | none ] ) 
 	</pre>
 
 	For the color form, this function computes to the computed value of the first color,


### PR DESCRIPTION
Follow-up on 100146f. 

https://drafts.csswg.org/css-color-5/#typedef-light-dark-image

@yisibl, `<image> | none` must be grouped because `<image> | none , <image> | none` is equivalent to `<image> | [ none , <image> ] | none`.

  > Juxtaposition is stronger than the double ampersand, the double ampersand is stronger than the double bar, and the double bar is stronger than the bar.

https://drafts.csswg.org/css-values-4/#component-combinators