### PR TITLE
[css-cascade-6] Disallow empty scope() functions

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -123,8 +123,9 @@ Importing Style Sheets: the ''@import'' rule</h2>
 		using the [=scoping roots=] and [=scoping limits=]
 		as described by [[#scope-limits]].
 
-		Using the ''scope'' keyword is equivalent to using
-		the ''scope()'' function with no arguments.
+		Note: The ''scope'' keyword behaves like a ''@scope'' rule with an empty prelude,
+		scoping the imported rules to the [=parent element=] of the [=owner node=]
+		of the stylesheet containing the ''@import'' rule.
 
 		Note: While the [=style rules=] within the imported stylesheet
 		become [=scoped=],
@@ -658,14 +659,14 @@ Syntax of ''@scope''</h4>
 	The syntax of the ''@scope'' rule is:
 
 	<pre class="prod def">
-	@scope <<scope-boundaries>> {
+	@scope <<scope-boundaries>>? {
 	  <<block-contents>>
 	}
 	</pre>
 
 	with <<scope-boundaries>> defined as:
 	<pre class="prod def">
-	<dfn export>&lt;scope-boundaries></dfn> =  [ ( <<scope-start>> ) ]? [ to ( <<scope-end>> ) ]?
+	<dfn export>&lt;scope-boundaries></dfn> =  [ [ ( <<scope-start>> ) ]? [ to ( <<scope-end>> ) ]? ]!
 	</pre>
 
 	and where:


### PR DESCRIPTION
In the #11237 discussion, we agreed that it makes sense to keep the syntax for scoped imports consistent with layered imports, and while things are mostly consistent already, one inconsistency remains:

 * `layer()` (with no argument) does not define an anonymous layer. You must use the `layer` keyword for this.
 * `scope()` (with no argument) *does* define an implicit scope. You can *also* use the `scope` keyword for this.

We should tighten this up by disallowing empty `scope()`.

With the reference to #scope-limits and its description of roots/limits, I think the correct behavior can be understood well enough from the normative text without further elaboration. However, I added a Note to make it more obvious.

Also, it's a bit awkward to have named productions that match empty/arbitrary streams; use an exclamation point (!) to require at least one value for `<<scope-boundaries>>`. (This has the effect of disallowing empty scope() functions.)
