### PR TITLE
[css-conditional-5] Fix autolinks to `<supports-env-fn>`

### DIFF
--- a/css-conditional-5/Overview.bs
+++ b/css-conditional-5/Overview.bs
@@ -124,7 +124,7 @@ Extensions to the ''@supports'' rule</h2>
 		<dfn>&lt;supports-font-format-fn></dfn> = font-format( <<font-format>> )
 		<dfn>&lt;supports-at-rule-fn></dfn> = at-rule( <<at-keyword-token>> )
 		<dfn>&lt;supports-named-feature-fn></dfn> = named-feature( <<ident>> )
-		<dfn function lt="env()" for="@supports">&lt;supports-env-fn></dfn> = env( <<ident>> )
+		<dfn>&lt;supports-env-fn></dfn> = env( <<ident>> )
 	</pre>
 
 	: <<supports-condition-name>>
@@ -2077,7 +2077,7 @@ Changes since the <a href="https://www.w3.org/TR/2024/WD-css-conditional-5-20241
 	<!-- to  21 October -->
 	<li>
 		Extended [=supports queries=] to express [=environment variable=] capabilities
-		via ''@supports/env()''.
+		via ''env()'', see <<supports-env-fn>>.
 		(<a href="https://github.com/w3c/csswg-drafts/issues/3576">#3576</a>)
 	</li>
 	<li>Clarified that the last @supports-condition in document order wins


### PR DESCRIPTION
The markup replaced the definition of the `<supports-env-fn>` type with a scoped `env()` function definition. This created broken links within the spec because `<<supports-env-fn>>` no longer worked as a result.

It also created another exported definition for the `env()` function (less of a problem since it was scoped to `@supports`, but it does not seem needed), and confused tools that attempt to extract grammar syntaxes from CSS specs, see:
  https://github.com/w3c/webref/issues/1886

This update gets back to a regular `<dfn>` and adjusts the reference in the changelog.
