### PR TITLE
[css-anchor-position-1] Depluralize anchors-* in 'position-visibility' and only check default anchor #10201

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -2219,8 +2219,8 @@ Conditional Hiding: the 'position-visibility' property {#position-visibility}
 
 <pre class=propdef>
 Name: position-visibility
-Value: always | [ anchors-valid || anchors-visible || no-overflow ]
-Initial: anchors-visible
+Value: always | [ anchor-valid || anchor-visible || no-overflow ]
+Initial: anchor-visible
 Applies to: [=absolutely positioned boxes=]
 Percentages: n/a
 Inherited: no
@@ -2239,23 +2239,14 @@ depending on some commonly needed layout conditions.
 		(The box is displayed without regard for its anchors
 		or its overflowing status.)
 
-	: <dfn>anchors-valid</dfn>
+	: <dfn>anchor-valid</dfn>
 	::
-		If any of the box's [=required anchor references=]
-		do not resolve to a [=target anchor element=],
+		If the box references the [=default anchor box=]
+		(e.g. using 'position-area', 'anchor()' or 'anchor-size()' functions, or ''anchor-center''),
+		but the [=default anchor box=] cannot be resolved,
 		the box's 'visibility' property computes to ''force-hidden''.
 
-		Issue: What is a <dfn dfn for>required anchor reference</dfn>?
-		''anchor()'' functions that don't have a fallback value;
-		the default anchor *sometimes*?
-		Need more detail here.
-
-		Issue: <em>Any</em> anchors are missing,
-		or <em>all</em> anchors are missing?
-		I can see use-cases for either, potentially.
-		Do we want to make a decision here, or make it controllable somehow?
-
-	: <dfn>anchors-visible</dfn>
+	: <dfn>anchor-visible</dfn>
 	::
 		If the box has a [=default anchor box=]
 		but that [=anchor box=] is [=invisible=] or [=clipped by intervening boxes=],
@@ -2703,6 +2694,14 @@ No Privacy issues have been raised against this document.
 
 Changes {#changes}
 =======
+
+Significant changes since the <a href="https://www.w3.org/TR/2026/WD-css-anchor-position-1-20260327/">27 March 2026 Working Draft</a>:
+* Defined ''position-visibility/anchor-valid'' to (like ''position-visibility/anchor-valid'') only check the [=default anchor box=].
+	(<a href="https://github.com/w3c/csswg-drafts/issues/10201">Issue 10201</a>)
+* Renamed <css>anchors-valid</css> and <css>anchors-visible</css>
+	to ''position-visibility/anchor-valid'' and ''position-visibility/anchor-visible''
+	since they only reference the [=default anchor box=].
+	(<a href="https://github.com/w3c/csswg-drafts/issues/10201">Issue 10201</a>)
 
 Significant changes since the <a href="https://www.w3.org/TR/2026/WD-css-anchor-position-1-20260130/">30 January 2026 Working Draft</a>:
 * Added ''position-area/match-parent'' value to 'position-area'.


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/10201. While making the edits I noticed that the renaming would make `anchors-visible` inconsistent with `anchor-valid`, so opening a PR to check with the WG whether we want to:
* Rename both.
* Rename only one. :(
* Rename both and add legacy aliases.
* Something else.