### PR TITLE
[css-fonts-4] Fix typo in <generic-family> overview

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -233,7 +233,7 @@ Font family: the 'font-family!!property' property</h3>
 
 			1.	Generics which apply to all Unicode characters
 				and will <em>always</em> match a locally installed font.
-				For example, ''monospaced''.
+				For example, ''monospace''.
 
 			2.	Generics which apply to all Unicode characters
 				but may not match to a locally installed font


### PR DESCRIPTION
`<generic-complete>`, which is a type of `<generic-family>`, has `monospace`; `monospaced` is considered to be a typo.