### PR TITLE
[css-animations-2][css-transitions-2] Add animation property to AnimationEvent and TransitionEvent interfaces.

### DIFF
--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -885,7 +885,7 @@ the corresponding CSS Animation object.
 
 ### IDL Definition ### {#interface-animationevent-idl}
 
-Add animation to the {{AnimationEvent}} interface and {{AnimationEventInit}} dictionary as follows:
+Add {{AnimationEvent/animation}} to the {{AnimationEvent}} interface and {{AnimationEventInit}} dictionary as follows:
 
 <pre class="idl">
 [Exposed=Window]

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -878,9 +878,6 @@ expressed in milliseconds, it must be divided by 1,000 to produce a value in
 seconds before being assigned to the {{AnimationEvent/elapsedTime}} member of
 the {{AnimationEvent}}.
 
-When an event is dispatched, its {{AnimationEvent/animation}} attribute is initialized to
-the corresponding CSS Animation object.
-
 ## The <code>AnimationEvent</code> Interface ## {#interface-animationevent}
 
 ### IDL Definition ### {#interface-animationevent-idl}

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -905,7 +905,7 @@ Add attribute descriptions as follows:
 <dl dfn-type=attribute dfn-for=AnimationEvent>
   <dt><dfn>animation</dfn>
   <dd>
-    The CSS Animation corresponding to the animation that fired the event.
+    The CSS Animation that fired the event.
 </dl>
 
 # DOM Interfaces # {#interface-dom}

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -883,7 +883,7 @@ the corresponding CSS Animation object.
 
 ## The <code>AnimationEvent</code> Interface ## {#interface-animationevent}
 
-### IDL Definition
+### IDL Definition ### {#interface-animationevent-idl}
 
 Add animation to the {{AnimationEvent}} interface and {{AnimationEventInit}} dictionary as follows:
 

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -878,6 +878,36 @@ expressed in milliseconds, it must be divided by 1,000 to produce a value in
 seconds before being assigned to the {{AnimationEvent/elapsedTime}} member of
 the {{AnimationEvent}}.
 
+When an event is dispatched, its {{AnimationEvent/animation}} attribute is initialized to
+the corresponding CSS Animation object.
+
+## The AnimationEvent Interface
+
+### IDL Definition
+
+Add animation to the {{AnimationEvent}} interface and {{AnimationEventInit}} dictionary as follows:
+
+<pre class="idl">
+[Exposed=Window]
+partial interface AnimationEvent {
+  readonly attribute CSSAnimation? animation;
+};
+
+partial dictionary AnimationEventInit {
+  CSSAnimation? animation = null;
+};
+</pre>
+
+### Attributes
+
+Add attribute descriptions as follows:
+
+<dl dfn-type=attribute dfn-for=AnimationEvent>
+  <dt><dfn>animation</dfn>
+  <dd>
+    The CSS Animation corresponding to the animation that fired the event.
+</dl>
+
 # DOM Interfaces # {#interface-dom}
 
 ## The CSSAnimation interface ## {#the-CSSAnimation-interface}

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -881,7 +881,7 @@ the {{AnimationEvent}}.
 When an event is dispatched, its {{AnimationEvent/animation}} attribute is initialized to
 the corresponding CSS Animation object.
 
-## The AnimationEvent Interface
+## The <code>AnimationEvent</code> Interface ## {#interface-animationevent}
 
 ### IDL Definition
 

--- a/css-animations-2/Overview.bs
+++ b/css-animations-2/Overview.bs
@@ -898,7 +898,7 @@ partial dictionary AnimationEventInit {
 };
 </pre>
 
-### Attributes
+### Attributes ### {#interface-animationevent-attributes}
 
 Add attribute descriptions as follows:
 

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -582,6 +582,33 @@ the {{TransitionEvent}}.
 
 </div>
 
+When an event is dispatched, its {{TransitionEvent/animation}} attribute is initialized to
+the corresponding CSS Transition object.
+
+## Interface {{TransitionEvent}} ## {#interface-transitionevent}
+
+Add animation to the {{TransitionEvent}} interface and {{TransitionEventInit}} dictionary as follows:
+
+### IDL Definition ### {#interface-transitionevent-idl}
+
+<pre class="idl">
+[Exposed=Window]
+partial interface TransitionEvent {
+  readonly attribute CSSTransition? animation;
+};
+
+partial dictionary TransitionEventInit {
+  CSSTransition? animation = null;
+};
+</pre>
+
+### Attributes ### {#interface-transitionevent-attributes}
+
+Add attribute descriptions as follows:
+
+:   <code class='attribute-name'><dfn attribute for="TransitionEvent" id="Events-TransitionEvent-animation">animation</dfn></code>
+::  The CSS Transition corresponding to the transition that fired the event.
+
 # DOM Interfaces # {#interface-dom}
 
 ## The CSSTransition interface ## {#the-CSSTransition-interface}

--- a/css-transitions-2/Overview.bs
+++ b/css-transitions-2/Overview.bs
@@ -582,9 +582,6 @@ the {{TransitionEvent}}.
 
 </div>
 
-When an event is dispatched, its {{TransitionEvent/animation}} attribute is initialized to
-the corresponding CSS Transition object.
-
 ## Interface {{TransitionEvent}} ## {#interface-transitionevent}
 
 Add animation to the {{TransitionEvent}} interface and {{TransitionEventInit}} dictionary as follows:


### PR DESCRIPTION
- [css-animations-2] Add animation property to AnimationEvent interface.
- [css-transitions-2] Add animation property to TransitionEvent interface.

It's regarding https://github.com/w3c/csswg-drafts/issues/9010

The wpt case is [here](https://phabricator.services.mozilla.com/D293582). It will be upstreamed upon landing in the Mozilla repo.