### PR TITLE
[css-values-5][editorial] Oversights in 5ef76ec

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2767,13 +2767,13 @@ Sharing (Or Not) Random Values: the <<random-cache-key>> value</h3>
 		If you want the values to be completely uncorrelated,
 		give them distinct names (''--foo'' vs ''--bar'')
 		or mix in additional information that will uniquify their [=random cache names=]
-		(specifying ''--foo property'', or omitting the <<random-cache-key>> argument entirely)
+		(specifying ''--foo property-scoped'', or omitting the <<random-cache-key>> argument entirely)
 	</div>
 
 	<details class=note id=auto-naming-details>
 		<summary>Details about how ''random()/auto'' works</summary>
 
-		The ''random()/auto'' value is identical to specifying ''--foo element property index'',
+		The ''random()/auto'' value is identical to specifying ''--foo element-scoped property-index-scoped'',
 		just with an unobservable name that you can't manually match with a <<dashed-ident>>.
 
 		<em>Usually</em>, this ensures that every instance of a [=random function=],


### PR DESCRIPTION
The `property` and `index` keywords were changed to [`property-scoped` and `property-index-scoped`](https://drafts.csswg.org/css-values-5/#typedef-random-name) in 5ef76ec.