### PR TITLE
[web-animations-1][editorial]: Pass correct value to "set the associated effect of an animation"

### DIFF
--- a/web-animations-1/Overview.bs
+++ b/web-animations-1/Overview.bs
@@ -4729,7 +4729,7 @@ The {{Animation}} interface {#the-animation-interface}
 
       3. Run the procedure to [=set the associated effect of an animation=]
           on |animation|
-          passing |source| as the <var ignore>new effect</var>.
+          passing |effect| as the <var ignore>new effect</var>.
 
       <div dfn-type=argument class=parameters
            dfn-for="Animation/Animation(effect, timeline)">


### PR DESCRIPTION
The existing specification passes `source`, which is not defined anywhere. Presumably the author meant to pass `effect` instead.