### PR TITLE
[css-values-5] Fix and rename random grammar

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -2286,7 +2286,7 @@ Generating a Random Numeric Value: the ''random()'' function</h3>
 	optionally limiting the possible values to a step between those limits:
 
 	<pre class=prod>
-	&lt;random()> = random( <<random-key>>? , <<calc-sum>>, <<calc-sum>>, <<calc-sum>>? )
+	&lt;random()> = random( <<random-base-value>>? , <<calc-sum>>, <<calc-sum>>, <<calc-sum>>? )
 	</pre>
 
 	See [[#random-evaluation]] and [[#random-caching]]
@@ -2294,12 +2294,12 @@ Generating a Random Numeric Value: the ''random()'' function</h3>
 	Its arguments are:
 
 	<dl>
-		: <<random-key>>
-		:: The optional <<random-key>>
+		: <<random-base-value>>
+		:: The optional <<random-base-value>>
 			controls which [=random functions=] in the document
 			will share a [=random base value=]
 			and which will get distinct values.
-			If <<random-key>> is omitted,
+			If <<random-base-value>> is omitted,
 			it behaves as ''random()/auto''.
 
 			See [[#random-caching]] for a full description of this value.
@@ -2426,7 +2426,7 @@ Picking a Random Item From a List: the ''random-item()'' function</h3>
 	from among its list of items.
 
 	<pre class=prod>
-	&lt;random-item()> = random-item( <<random-key>> , [ <<declaration-value>>? ]# )
+	&lt;random-item()> = random-item( <<random-base-value>> , [ <<declaration-value>>? ]# )
 	</pre>
 
 	The ''random-item()'' function's [=argument grammar=] is:
@@ -2438,11 +2438,11 @@ Picking a Random Item From a List: the ''random-item()'' function</h3>
 	See [[#random-evaluation]] and [[#random-caching]]
 	for details on how the function is evaluated.
 
-	The <em>required</em> <<random-key>>
+	The <em>required</em> <<random-base-value>>
 	is interpreted identically to ''random()''.
 	(See [[#random-caching]] for details.)
 
-	Note: The <<random-key>> argument is required in ''random-item()'',
+	Note: The <<random-base-value>> argument is required in ''random-item()'',
 	but optional in ''random()'',
 	for parsing reasons
 	(it's impossible to tell whether ''random-item(--foo, --bar, --baz)''
@@ -2572,7 +2572,7 @@ Evaluating Random Values</h3>
 
 
 <h3 id=random-caching>
-Sharing (Or Not) Random Values: the <<random-key>> value</h3>
+Sharing (Or Not) Random Values: the <<random-base-value>> value</h3>
 
 	CSS is a declarative language,
 	so functions don't have a specific “time” when they're evaluated;
@@ -2590,18 +2590,18 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 	will return <em>different</em> [=random base value=] from each other
 	(unless they are, randomly, the same).
 
-	The <<random-key>> value controls this behavior,
+	The <<random-base-value>> value controls this behavior,
 	and defaults to ''random()/auto'' when omitted.
 	It's syntax is as follows, and interpreted as described below:
 
 	<pre class=prod>
-		<dfn><<random-key>></dfn> = auto | <<random-name>> | fixed <<number [0,1]>>
-		<dfn><<random-cache-key>></dfn> =  <<dashed-ident>> || element-scoped
+		<dfn><<random-base-value>></dfn> = auto | <<random-name>> | fixed <<number [0,1]>>
+		<dfn><<random-name>></dfn> =  <<dashed-ident>> || element-scoped
 		                       || [ property-scoped | property-index-scoped | <<random-ua-ident>> ]
 		<dfn><<random-ua-ident>></dfn> = <<custom-ident>>
 	</pre>
 
-	<dl dfn-type=value dfn-for="random(),random-item(),<random-key>">
+	<dl dfn-type=value dfn-for="random(),random-item(),<random-base-value>">
 		: <dfn>auto</dfn>
 		:: The [=random function=] is roughly “as random as possible”:
 			the [=random cache name=], and thus the result,
@@ -2612,8 +2612,8 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 			This is equivalent to specifying ''element-scoped property-index-scoped'',
 			and simplifies in exactly the same way.
 
-		: <dfn><<random-cache-key>></dfn>
-		:: The <<random-cache-key>> specifies the [=random cache name=],
+		: <dfn><<random-name>></dfn>
+		:: The <<random-name>> specifies the [=random cache name=],
 			allowing it to be explicitly shared (or not)
 			with other uses of [=random functions=].
 			Every [=random function=] using the same [=random cache name=]
@@ -2621,7 +2621,7 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 			every one using a <em>different</em> [=random cache name=]
 			will get unrelated random values.
 
-			<ul dfn-for="random(),random-item(),<random-key>,<random-cache-key>">
+			<ul dfn-for="random(),random-item(),<random-base-value>,<random-name>">
 			<li>The <<dashed-ident>> gives the value an explicit name.
 				If omitted, this part of the name is null.
 			<li><dfn>element-scoped</dfn> adds an element-specific identifier
@@ -2685,7 +2685,7 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 		}
 		</pre>
 
-		Depending on what <<random-key>> you provide
+		Depending on what <<random-base-value>> you provide
 		in place of the ''???'',
 		you'll get significantly different behavior for the elements:
 
@@ -2832,7 +2832,7 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 	* Each instance of a [=random function=] in styles
 		has an associated <dfn>random base value</dfn>.
 
-		If the [=random function's=] <<random-key>> is ''fixed <<number>>'',
+		If the [=random function's=] <<random-base-value>> is ''fixed <<number>>'',
 		the [=random base value=] is that number.
 
 		Otherwise, the [=random base value=] is a pseudo-random real number
@@ -2966,15 +2966,15 @@ Sharing (Or Not) Random Values: the <<random-key>> value</h3>
 
 
 <h4 id=random-simplify>
-Simplification of <<random-key>></h4>
+Simplification of <<random-base-value>></h4>
 
 	At parse time,
-	certain transformations are performed on the <<random-key>> of a [=random function=]:
+	certain transformations are performed on the <<random-base-value>> of a [=random function=]:
 
-	* If the <<random-key>> is ''auto'' (or omitted),
+	* If the <<random-base-value>> is ''auto'' (or omitted),
 		it's turned into ''element-scoped property-index-scoped''.
 		(And then subject to the below transformations.)
-	* If the <<random-key>> contains ''property-scoped'' or ''property-index-scoped'',
+	* If the <<random-base-value>> contains ''property-scoped'' or ''property-index-scoped'',
 		that keyword is replaced by a <<random-ua-ident>>:
 		either <css>ua-PROPERTY</css> with PROPERTY being the property the value was parsed as,
 		or <css>ua-PROPERTY-INDEX</css> with PROPERTY as the previous
@@ -2985,7 +2985,7 @@ Simplification of <<random-key>></h4>
 		before any canonicalization/reordering might occur
 		that could shuffle the values around.
 
-	If the <<random-key>> contains a <<random-ua-ident>>,
+	If the <<random-base-value>> contains a <<random-ua-ident>>,
 	this must not be omitted in the serialization of the value,
 	even if this would normally be valid per the
 	[=serialize a CSS value|"shortest serialization principle"=].
@@ -2995,7 +2995,7 @@ Simplification of <<random-key>></h4>
 		specifying ''margin: random(10px, 20px) random(10px, 20px)''
 		will cause the top and bottom margins to be one random value,
 		and the left and right margins to be another random value.
-		The omitted <<random-key>>s get rewritten at parse-time
+		The omitted <<random-base-value>>s get rewritten at parse-time
 		to ''element-scoped ua-margin-1'' and ''element-scoped ua-margin-2'',
 		respectively,
 		before they expand into the 'margin' longhands.
@@ -3015,7 +3015,7 @@ Simplification of <<random-key>></h4>
 	If a ''random()'' function can't be fully [=simplify a calculation tree|simplified=]
 	by [=computed value=] time,
 	then its arguments are maximally simplified,
-	and its specified <<random-key>>
+	and its specified <<random-base-value>>
 	is replaced with ''fixed BASE'',
 	where <css>BASE</css> is the function's [=random base value=].
 


### PR DESCRIPTION
The [`random-*()`](https://drafts.csswg.org/css-values-5/#random) grammar is slightly broken since 33682af.

They now take a [`<random-key>`](https://drafts.csswg.org/css-values-5/#typedef-random-key) argument renamed from `<random-cache-key>`. It still produces `auto | <random-name> | fixed <number [0,1)>` but `<random-name>` is left undefined, because its definition and production rule now use `<random-cache-key>`, which was probably not intentional.

This PR tries to fix this but since `fixed <number [0,1)>` is not a random (cache) key but a random base value, and since `auto` produces but is not a random name, and resolves to a random base value, I suggest to introduce `<random-base-value>` to replace `<random-key>`.