### PR TITLE
[css-text-5] Only accept `none` as a standalone keyword for `text-fit`

### DIFF
--- a/css-text-5/Overview.bs
+++ b/css-text-5/Overview.bs
@@ -36,7 +36,7 @@ Text fitting: the 'text-fit' property</h3>
 
 	<pre class="propdef">
 	Name: text-fit
-	Value: [ none | grow | shrink ] [consistent | per-line | per-line-all]? <<percentage>>?
+	Value: none | [ grow | shrink ] [ consistent | per-line | per-line-all ]? <<percentage>>?
 	Initial: none
 	Applies to: <a>block containers</a>
 	Inherited: yes


### PR DESCRIPTION
@tkent-google, could you tell me if this is an oversight in #13616?

Each of `consistent | per-line | per-line-all` is explicitly defined as having no effect if `none` is specified. My understanding is that no scaling factor is applied with `none`, so I do not see how `none <percentage>` could be useful.

https://drafts.csswg.org/css-text-4/#propdef-text-fit