### PR TITLE
[cssom-1] font-family descriptor should not be serialized if not present, fix #13323

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1899,9 +1899,13 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
   The result of concatenating the following:
   <ol>
    <li>The string "<code>@font-face {</code>", followed by a single SPACE (U+0020).</li>
-   <li>The string "<code>font-family:</code>", followed by a single SPACE (U+0020).</li>
-   <li>The result of performing <a>serialize a string</a> on the rule’s font family name.</li>
-   <li>The string "<code>;</code>", i.e., SEMICOLON (U+003B).
+   <li>If the '@font-face/font-family' descriptor is present:
+    <ol>
+      <li>The string "<code>font-family:</code>", followed by a single SPACE (U+0020).</li>
+      <li>The result of performing <a>serialize a string</a> on the rule’s font family name.</li>
+      <li>The string "<code>;</code>", i.e., SEMICOLON (U+003B).</li>
+    </ol>
+   </li>
    <li>
     If the rule's associated source list is not empty, follow these substeps:
     <ol>


### PR DESCRIPTION
[cssom-1] Fixes #13323