### PR TITLE
Revert "[css-anchor-position-1] Specify scroll offset snapshot timing #10796"

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1075,9 +1075,6 @@ while still allowing as much freedom to anchor to various elements as possible,
 [=anchor positioning=] uses a combination of [=remembered scroll offsets=]
 and [=compensating for scroll=].
 
-The scroll offsets which are used to compute [=remembered scroll offsets=] and [=default scroll shift=] 
-are snapshotted when asked to [=run snapshot post-layout state steps=].
-
 <div class=note>
 	The details here are technical, but the gist is:
 
@@ -1238,6 +1235,10 @@ specifically, the [=default anchor element=]:
 	it is additionally shifted by the [=default scroll shift=],
 	as if affected by a [=transform=]
 	(before any other transforms).
+
+	Issue: Define the precise timing of the snapshot:
+	updated each frame,
+	before style recalc.
 
 	Issue: Similar to [=remembered scroll offset=],
 	can we pay attention to transforms on the [=default anchor element=]?


### PR DESCRIPTION
Reverts w3c/csswg-drafts#13675, I merged without realizing it depends on an unmerged HTML PR <https://github.com/whatwg/html/pull/11613>