### PR TITLE
[css-gaps-1] Add spec text for assigning gap decorations to suppressed gaps for fragmentation #13754

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -2351,6 +2351,8 @@ Changes since the <a href="https://www.w3.org/TR/2026/WD-css-gaps-1-20260227/">2
 			(<a href="https://github.com/w3c/csswg-drafts/issues/13648">Issue 13648</a>,
 			<a href="https://github.com/w3c/csswg-drafts/issues/13649">Issue 13649</a>)
 		<li>Updated with links to additional WPTs.
+		<li>Clarified that gaps suppressed due to fragmentation still consume gap decoration values.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/13754">Issue 13754</a>)
 	</ul>
 
 <h3 id="changes-20250417">

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1399,11 +1399,7 @@ Fragmentation</h3>
 	[[css-align-3#column-row-gap]] specifies that gaps disappear
 	where they coincide with a [=fragmentation break=].
 	Because there is no gap in such locations,
-	no [=gap decoration=] is drawn there.
-	However, the suppressed gap still consumes a decoration from the
-	[=assign gap decoration values|assignment pattern=], so that the association
-	between gaps and their corresponding decorations remains consistent
-	across fragmented and unfragmented contexts.
+	no [=gap decoration=] is drawn in them either.
 
 	<wpt>
 		flex/fragmentation/flex-gap-decorations-fragmentation-001.html
@@ -1814,6 +1810,11 @@ Assigning gap decoration values to gaps</h3>
 	A given set of [=collapsed gutters=] consume exactly one [=gap decoration=]; the next [=gap decoration=]
 	is applied to the next gutter (or set of [=collapsed gutters=]). Therefore, [=collapsed gutters=] are treated as a
 	single [=gap=] for decoration purposes.
+
+	A gap that is <a href="#fragmentation">suppressed</a> because it coincides with a [=fragmentation break=]
+	still consumes a gap decoration value from the pattern, even though no decoration
+	is drawn there. This preserves a consistent association between gaps and decorations across
+	fragmented and unfragmented contexts.
 
 	<div algorithm>
 		To <dfn>assign gap decoration values</dfn> to a list of |gaps| using a list of |values|:

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1399,7 +1399,11 @@ Fragmentation</h3>
 	[[css-align-3#column-row-gap]] specifies that gaps disappear
 	where they coincide with a [=fragmentation break=].
 	Because there is no gap in such locations,
-	no [=gap decoration=] is drawn in them either.
+	no [=gap decoration=] is drawn there.
+	However, the suppressed gap still consumes a decoration from the
+	[=assign gap decoration values|assignment pattern=], so that the association
+	between gaps and their corresponding decorations remains consistent
+	across fragmented and unfragmented contexts.
 
 	<wpt>
 		flex/fragmentation/flex-gap-decorations-fragmentation-001.html

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -1811,7 +1811,7 @@ Assigning gap decoration values to gaps</h3>
 	is applied to the next gutter (or set of [=collapsed gutters=]). Therefore, [=collapsed gutters=] are treated as a
 	single [=gap=] for decoration purposes.
 
-	A gap that is <a href="#fragmentation">suppressed</a> because it coincides with a [=fragmentation break=]
+	A gap that is suppressed due to <a href="#fragmentation">fragmentation</a>
 	still consumes a gap decoration value from the pattern, even though no decoration
 	is drawn there. This preserves a consistent association between gaps and decorations across
 	fragmented and unfragmented contexts.


### PR DESCRIPTION
 This PR adds spec text clarifying the behavior of gap decorations when a gap is suppressed at a fragmentation break. Per #13754, the suppressed gap still consumes a decoration from the assignment pattern, even though no decoration is drawn there. This preserves a consistent association between gaps and decorations across fragmented and unfragmented contexts.