### PR TITLE
[css-contain-2] `contentvisibilityautostatechange` event should bubble #11310 

### DIFF
--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -2288,6 +2288,7 @@ interface ContentVisibilityAutoStateChangeEvent : Event {
 	readonly attribute boolean skipped;
 };
 dictionary ContentVisibilityAutoStateChangeEventInit : EventInit {
+	boolean bubbles = true;
 	boolean skipped = false;
 };
 </pre>


### PR DESCRIPTION
Resolves #11310 

The `contentvisibilityautostatechange` event was [proposed to bubble](https://github.com/vmpstr/web-proposals/blob/main/explainers/cv-auto-event.md#proposal-contentvisibilityautostatechange), however, when [it was originally spec’d](https://github.com/w3c/csswg-drafts/pull/7515) this was missed. This is likely because [`EventInit`](https://dom.spec.whatwg.org/#dictdef-eventinit) defaults `bubbles` to `false`. There does not seem to be any discussion about changing this between the proposal and the original specification (in [the TAG review](https://github.com/w3ctag/design-reviews/issues/756), [the CSSWG discussion](https://github.com/w3c/csswg-drafts/issues/7384#issuecomment-1176847043), or the standards positions for [WebKit](https://github.com/WebKit/standards-positions/issues/33) or [Gecko](https://github.com/mozilla/standards-positions/issues/664)).

As far as implementations go, there is an interop issue:

- Blink, who proposed, designed, and spec’d the feature, has the event bubble.
- WebKit and Gecko follow the spec and do not make the event bubble.

**This pull request specifies that, as proposed, it should in fact bubble.** There’s been no discussion and therefore no consensus on making this amendment… this is just an interop issue that I’ve known of for over a year now that I’d like to stop caveating [everywhere I write about it](https://12daysofweb.dev/2024/css-content-visibility/#:~:text=a%20discrepancy) or use the feature (since a workaround potentially is necessary). Also, not sure if this is how or where this change needs to happen — I’m happy to be directed elsewhere!

If accepted, I’m happy to create some WPTs and file bugs against WebKit and Gecko.