### PR TITLE
[cssom-1] Correct whitespace in `@font-face` serialization

### DIFF
--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -1898,10 +1898,10 @@ To <dfn export>serialize a CSS rule</dfn>, perform one of the following in accor
  <dd>
   The result of concatenating the following:
   <ol>
-   <li>The string "<code>@font-face {</code>", followed by a single SPACE (U+0020).</li>
+   <li>The string "<code>@font-face {</code>".</li>
    <li>If the '@font-face/font-family' descriptor is present:
     <ol>
-      <li>The string "<code>font-family:</code>", followed by a single SPACE (U+0020).</li>
+      <li>A single SPACE (U+0020), followed by the string "<code>font-family:</code>", followed by a single SPACE (U+0020).</li>
       <li>The result of performing <a>serialize a string</a> on the rule’s font family name.</li>
       <li>The string "<code>;</code>", i.e., SEMICOLON (U+003B).</li>
     </ol>


### PR DESCRIPTION
Without this, a `@font-face` without a `font-family` descriptor gets a double-space after the opening `{`.

See comment here: https://github.com/w3c/csswg-drafts/pull/13847/changes#r3166964885

cc: @svgeesus @emilio 