### PR TITLE
[css-easing-2][editorial] Fix path syntax in css-easing-2/images/linear-easing-curve.svg

### DIFF
--- a/css-easing-2/images/linear-easing-curve.svg
+++ b/css-easing-2/images/linear-easing-curve.svg
@@ -103,7 +103,7 @@
     <!-- Origin -->
     <text x="-25" y="25" class="axisValue">0</text>
     <!-- Curve -->
-    <path d="M 0 0, L 100 -40, L 200 -300, L 400 -400 " class="curve"/>
+    <path d="M 0 0 L 100 -40 L 200 -300 L 400 -400 " class="curve"/>
     <!-- Control point: P1 -->
     <circle cx="100" cy="-40" r="10" class="controlPoint"/>
     <text x="120" y="-40" dy="0.4em" class="pointLabel">P1</text>


### PR DESCRIPTION
Removes the commas from the path curve in this example image that were preventing rendering in Firefox. (It was rendering in Chrome fine, but that seems to be against spec (https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataBNF) which only allows whitespace between draw commands).

Marked this as editorial since it is only modifying an example image.