### PR TITLE
[css-speech-1][editorial] Replace deprecated `<uri>` by `<url>`

### DIFF
--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -752,7 +752,7 @@ The 'cue-before' and 'cue-after' properties</h3>
 
 	<pre class=propdef>
 	Name: cue-before, cue-after
-	Value: <<uri>> <<decibel>>? | none
+	Value: <<url>> <<decibel>>? | none
 	Initial: none
 	Applies to: all elements
 	Inherited: no
@@ -775,9 +775,9 @@ The 'cue-before' and 'cue-after' properties</h3>
 	compared to SSML's <code>audio</code> element.
 
 	<dl dfn-type=value dfn-for="cue-before,cue-after">
-		<dt><dfn><<uri>></dfn>
+		<dt><dfn><<url>></dfn>
 		<dd>
-			The URI designates an auditory icon resource.
+			The <l spec=url>[=/URL=]</l> designates an auditory icon resource.
 			When a user agent is not able to render the specified auditory icon
 			(e.g. missing file resource, or unsupported audio codec),
 			it is recommended to produce an alternative cue, such as a bell sound.


### PR DESCRIPTION
CSS Speech is the only remaining CSS spec that still references the CSS2 [`<uri>`](https://drafts.csswg.org/css2/#value-def-uri), after its replacement by [`<url>`](https://drafts.csswg.org/css-values-4/#url-value) in CSS Namespaces. Based on #649, it appears to be an editorial change.