### PR TITLE
[css-gaps-1] Clarify decoration pattern continuity across flex lines #13633

### DIFF
--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -2030,6 +2030,9 @@ Assigning gap decoration values to gaps</h3>
 	is drawn there. This preserves a consistent association between gaps and decorations across
 	fragmented and unfragmented contexts.
 
+	Similarly, when a [=flex container=] wraps into multiple flex lines, the decoration pattern is assigned to gaps sequentially across the flexbox
+	and does not restart at the beginning of each flex line.
+
 	<div algorithm>
 		To <dfn>assign gap decoration values</dfn> to a list of |gaps| using a list of |values|:
 

--- a/css-gaps-1/Overview.bs
+++ b/css-gaps-1/Overview.bs
@@ -2575,6 +2575,8 @@ Changes since the <a href="https://www.w3.org/TR/2026/WD-css-gaps-1-20260227/">2
 			(<a href="https://github.com/w3c/csswg-drafts/issues/13697">Issue 13697</a>)
 		<li>Clarified that gaps suppressed due to fragmentation still consume gap decoration values.
 			(<a href="https://github.com/w3c/csswg-drafts/issues/13754">Issue 13754</a>)
+		<li>Clarified that decoration patterns do not restart at the beginning of each flex line.
+			(<a href="https://github.com/w3c/csswg-drafts/issues/13663">Issue 13663</a>)
 	</ul>
 
 <h3 id="changes-20250417">


### PR DESCRIPTION
Clarify in the `#assigning` section that gap decoration patterns are assigned sequentially across a flex container and do not restart at the beginning of each flex line.