### PR TITLE
Updates 'flow-tolerance' grammar to use `<length-percentage [0,∞]>` rather than `<length-percentage>`

### DIFF
--- a/css-grid-3/Overview.bs
+++ b/css-grid-3/Overview.bs
@@ -789,7 +789,7 @@ Placement Precision: the 'flow-tolerance' property</h3>
 
 	<pre class=propdef>
 	Name: flow-tolerance
-	Value: normal | <<length-percentage>> | infinite
+	Value: normal | <<length-percentage [0,∞]>> | infinite
 	Initial: normal
 	Percentages: relative to the [=grid-axis=] [=content box=] size of the [=grid lanes container=]
 	Inherited: no


### PR DESCRIPTION
Per @fantasai, this is what it should be. 

WPT has tests that expect this already like https://github.com/web-platform-tests/wpt/blob/96f30a183994d1474856b24d2bc9b0b2ee9a00ac/css/css-grid/grid-lanes/tentative/parsing/flow-tolerance-computed.html#L28.