### PR TITLE
[css-navigation-1] Fix syntax of `<active-navigation-condition>`

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -489,7 +489,7 @@ and the pseudo-class matches any element where:
 
 <pre class="prod def" dfn-type="type" nohighlight>
 <dfn><<active-navigation-condition>></dfn> =
-  <<navigation-relation>>? [ <<navigation-location>> | link-href ] ?
+  <<navigation-relation>>? [ <<navigation-location>> | link-href ]?
 <dfn><<navigation-relation>></dfn> = at | with | from | to
 </pre>
 


### PR DESCRIPTION
The Value Definition Syntax does not allow spaces before the `?` multiplier.
