### PR TITLE
[animation-triggers-1][editorial] `/` must be written literally

### DIFF
--- a/animation-triggers-1/Overview.bs
+++ b/animation-triggers-1/Overview.bs
@@ -391,7 +391,7 @@ urlPrefix: https://www.w3.org/TR/web-animations-1/; type: dfn
 
 	<pre class="propdef shorthand">
 	Name: timeline-trigger
-	Value: none | [ <<'timeline-trigger-name'>> <<'timeline-trigger-source'>> <<'timeline-trigger-activation-range'>> [ '/' <<'timeline-trigger-active-range'>> ]? ]#
+	Value: none | [ <<'timeline-trigger-name'>> <<'timeline-trigger-source'>> <<'timeline-trigger-activation-range'>> [ / <<'timeline-trigger-active-range'>> ]? ]#
 	</pre>
 
 	The 'timeline-trigger' [=shorthand property=]


### PR DESCRIPTION
  > 6. Slashes (/) [...] are written literally. Other delimiters must be written enclosed in single quotes (such as '+').

https://drafts.csswg.org/css-values-4/#component-types

Note that CSS V&U could also say:

  > Delimiters must be written enclosed in single quotes, but slashes and [...] can be written literally.

If not explicitly allowed, it seems legitimate to consider a slash written between quotes as invalid, although it was valid before.

As always with the CSS value definition syntax, the UX via `@property/syntax` and custom function parameters should probably be considered.