### PR TITLE
[css-inline-3] Percentage line-height should not be scaled by text-fit

### DIFF
--- a/css-inline-3/Overview.bs
+++ b/css-inline-3/Overview.bs
@@ -952,7 +952,7 @@ Line Spacing: the 'line-height' property</h3>
 	Initial: normal
 	Applies to: non-replaced inline boxes and SVG <a>text content elements</a>
 	Inherited: yes
-	Percentages: see below
+	Percentages: computed relative to ''1em''
 	Computed value: the specified keyword, a number, or a computed <<length>> value
 	Animation type: by computed value type
 	</pre>
@@ -990,8 +990,7 @@ Line Spacing: the 'line-height' property</h3>
 		<dt><dfn><<percentage [0,∞]>></dfn>
 		<dd>
 			The [=preferred line height=]
-			is this percentage of the element's used 'font-size'.
-			The [=computed value=] of the property
+			and [=computed value=] of the property
 			is this percentage of the element's computed 'font-size'.
 			Negative values are illegal.
 	</dl>


### PR DESCRIPTION
[css-inline-3] Percentage line-height should not be scaled by text-fit

`line-height: <percentage>` is treated as a fixed value. See https://drafts.csswg.org/css-inline/#issue-af10b7fe .
So it's difficult to scale it by `text-fit` property.

This reverts a part of https://github.com/w3c/csswg-drafts/pull/13616.

https://github.com/w3c/csswg-drafts/issues/12888
