### PR TITLE
[css-text-4] `text-fit` should inherit

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -9749,7 +9749,7 @@ Text fitting: the 'text-fit' property</h3>
 	Value: [ none | grow | shrink ] [consistent | per-line | per-line-all]? <<percentage>>?
 	Initial: none
 	Applies to: <a>block containers</a>
-	Inherited: no
+	Inherited: yes
 	Percentages: N/A
 	Computed value: specified keywords or computed <<percentage>> value
 	Canonical order: per grammar


### PR DESCRIPTION
It should be inherited like other text-* properties in order to apply it to anonymous blocks.

This addresses the last paragraph of https://github.com/w3c/csswg-drafts/issues/2528#issuecomment-3636441522 .
