### PR TITLE
[view-transitions-2] Do not access box fragments on things that don't fragment

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2536,7 +2536,7 @@ It has the following [=struct/items=]:
 				has ''contain: view-transition'',
 				[=continue=].
 
-			1. If |element| has more than one [=box fragment=], then [=continue=].
+			1. If |element|'s [=principal box=] has more than one [=box fragment=], then [=continue=].
 
 				Note: We might want to enable transitions for fragmented elements in future versions.
 				See [#8900](https://github.com/w3c/csswg-drafts/issues/8900).
@@ -2626,7 +2626,7 @@ It has the following [=struct/items=]:
 				or |element| is [=element-not-rendered|not rendered=],
 				then [=continue=].
 
-			1. If |element| has more than one [=box fragment=], then [=continue=].
+			1. If |element|'s [=principal box=] has more than one [=box fragment=], then [=continue=].
 
 			1. If |usedTransitionNames| [=list/contains=] |transitionName|,
 				then return failure.
@@ -3398,7 +3398,7 @@ To <dfn>adjust nested view transition group transform</dfn> given a |transform| 
 
 					- |capturedElement|'s [=new element=] is [=element-not-rendered|not rendered=].
 
-					- |capturedElement| has more than one [=box fragment=].
+					- |capturedElement|'s [=new element=]'s [=principal box=] has more than one [=box fragment=].
 
 					Note: Other rendering constraints are enforced via |capturedElement|'s [=new element=] being [=captured in a view transition=].
 


### PR DESCRIPTION
Fixes #11991

Neither elements nor captured elements can fragment. Only boxes do that.

I'm making this care about the principal box here, since fragmenting any other boxes that might be created for an element inside of its principal box will also fragment the principal box (to my knowledge).
If I'm wrong on that, we might need to check what exactly is intended here.