### PR TITLE
[css-contain] Remove 'text-overflow' from paint-containment optimizations

### DIFF
--- a/css-contain-1/Overview.bs
+++ b/css-contain-1/Overview.bs
@@ -1099,7 +1099,7 @@ Possible Paint-Containment Optimizations</h4>
 		and could otherwise be skipped.
 
 	2. Unless the clipped content is made accessible via a separate mechanism
-		such as the 'overflow', 'resize', or 'text-overflow' properties,
+		such as the 'overflow' or 'resize' properties,
 		the UA can reserve "canvas" space for the box exactly the box's size.
 		(In similar, scrollable, situations, like ''overflow: hidden'',
 		it's possible to scroll to the currently-clipped content,
@@ -1135,7 +1135,7 @@ This appendix is <em>informative</em>.
 <h3 id="2024-06-25-changes">Changes from the
 <a href="https://www.w3.org/TR/2024/REC-css-contain-1-20240625/">Recommendation of 25 June 2024</a></h3>
 
-	No change yet.
+* Removed 'text-overflow' from the non-normative list of properties that are claimed to be able to reserve "canvas" space in section [[#containment-paint-opt]].
 
 <h3 id=old-changes oldids="2022-10-25-changes, 2020-12-22-changes, 2019-11-21-changes, 2019-04-30-changes, 2018-11-08-changes,2018-05-24-changes, 2017-08-08-changes, 2017-04-19-changes, fpwd-changes">
 Earlier Changes</h3>

--- a/css-contain-2/Overview.bs
+++ b/css-contain-2/Overview.bs
@@ -1535,7 +1535,7 @@ Possible Paint-Containment Optimizations</h4>
 		and could otherwise be skipped.
 
 	2. Unless the clipped content is made accessible via a separate mechanism
-		such as the 'overflow', 'resize', or 'text-overflow' properties,
+		such as the 'overflow' or 'resize' properties,
 		the UA can reserve "canvas" space for the box exactly the box's size.
 		(In similar, scrollable, situations, like ''overflow: hidden'',
 		it's possible to scroll to the currently-clipped content,
@@ -2692,6 +2692,7 @@ Changes from <a href="https://www.w3.org/TR/2022/WD-css-contain-2-20220917/">202
 	(<a href="https://github.com/w3c/csswg-drafts/issues/10433">Issue 10433</a>)
 * Make the 'content-visibility' property animatable.
 	(<a href="https://github.com/w3c/csswg-drafts/issues/8627">Issue 8627</a>)
+* Removed 'text-overflow' from the non-normative list of properties that are claimed to be able to reserve "canvas" space in section [[#containment-paint-opt]].
 
 <h3 id="changes-since-2020-12-16">
 Changes from <a href="https://www.w3.org/TR/2020/WD-css-contain-2-20201216/">2020-12-16 Working Draft</a>


### PR DESCRIPTION
Fixes #12157
