### PR TITLE
[web-animations-2][editorial] Fixed CSSNumericValue references

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -418,7 +418,7 @@ value of <var>time</var> is based on the first condition that matches:
     :   If <em>all</em> of the following conditions are true:
 
         *   The animation is associated with a [=progress-based timeline=], and
-        *   <var>time</var> is not a CSSNumeric value with percent units:
+        *   <var>time</var> is not a {{CSSNumericValue}} with percent units:
 
     ::  <a>throw</a> a <span class="exceptionname">TypeError</span>.
     ::  return false;
@@ -2841,7 +2841,7 @@ partial dictionary OptionalEffectTiming {
 Note: In this version of the spec, duration is not settable as a
 CSSNumericValue; however, duration may be returned as a CSSNumericValue when
 resolving the duration in {{AnimationEffect/getComputedTiming()}}. Future
-versions of the spec may enable setting the duration as a CSSNumeric value,
+versions of the spec may enable setting the duration as a {{CSSNumericValue}},
 where the unit is a valid time unit or percent.
 
 <div class="attributes">


### PR DESCRIPTION
Replaced the "CSSNumeric value" occurrences by `{{CSSNumericValue}}` references.

Fixes #13984