### PR TITLE
[css-navigation-1] Refactor processing model

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -23,6 +23,8 @@ url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-naviga
     type: dfn; spec: html; text: from entry;
 url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-navigation-api
     type: dfn; spec: html; text: navigation API;
+url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-current-entry
+    type: dfn; spec: html; text: current entry; for: navigation API;
 url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#ongoing-navigate-event
     type: dfn; spec: html; text: ongoing navigate event;
 url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigation-transition
@@ -31,6 +33,8 @@ url: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-act
     type: dfn; spec: html; text: activation;
 url: https://html.spec.whatwg.org/multipage/browsing-the-web.html#has-been-revealed
     type: dfn; spec: html; text: has been revealed;
+url: https://html.spec.whatwg.org/multipage/browsing-the-web.html#ongoing-navigation
+    type: dfn; spec: html; text: ongoing navigation;
 url: https://drafts.csswg.org/css-view-transitions-1/#capture-the-image
     type: dfn; spec: css-view-transitions-1; text: capture the image;
 </pre>
@@ -225,7 +229,7 @@ intentionally does not provide a serialization.
 </pre>
 
 A <<route-location>> is defined to
-<dfn for="route-location">match</dfn> a URL <var>input</var> if:
+<dfn for="route-location">match</dfn> a [=/URL=]-or-null <var>input</var> if <var>input</var> is non-null, and:
 
 <dl class=switch>
 
@@ -243,7 +247,7 @@ A <<route-location>> is defined to
     <var>input</var> as <var>input</var>.
 
 : the <<route-location>> is a <<url>>
-:: The given URL [=url/equals=] <var>input</var>.
+:: The given [=/URL=] [=url/equals=] <var>input</var>.
 
 </dl>
 
@@ -389,31 +393,14 @@ as follows:
 :: The result is the result of the child subexpression.
 
 : <<navigation-location-test>>
-::    : at: <<route-location>>
-    :: The result is true if
-        the [=current at URL=] <var>at</var> of the document is non-null and
-        the <<route-location>> [=route-location/matches=] <var>at</var>.
-
-    : with: <<route-location>>
-    :: The result is true if
-        the [=current with URL=] <var>other</var> of the document is non-null and
-        the <<route-location>> [=route-location/matches=] <var>other</var>.
-
-    : from: <<route-location>>
-    :: The result is true if
-        the [=current from URL=] <var>from</var> of the document is non-null and
-        the <<route-location>> [=route-location/matches=] <var>from</var>.
-
-    : to: <<route-location>>
-    :: The result is true if
-        the [=current to URL=] <var>to</var> of the document is non-null and
-        the <<route-location>> [=route-location/matches=] <var>to</var>.
+::  The result is true if
+        the <<route-location>> [=route-location/matches=] [=current navigation URL=] of the document given the <<navigation-relation>>.
 
 : <<navigation-location-between-test>>
 ::    : between: <<route-location>> and <<route-location>>
     :: The result is true if
-        the [=current from URL=] <var>from</var> of the document is non-null,
-        the [=current to URL=] <var>to</var> of the document is non-null,
+        the [=current navigation URL=] <var>from</var> of the document given ''from'' is non-null,
+        the [=current navigation URL=] <var>to</var> of the document ''to'' is non-null,
         one of the two <<route-location>>s
         [=route-location/matches=] <var>from</var>,
         and the other of the two <<route-location>>s
@@ -424,24 +411,15 @@ as follows:
     :: True if the [=current navigation type=] is {{NavigationType/traverse}}.
     : history: back
     :: True if the [=current navigation type=] is {{NavigationType/traverse}} and
-        the [=current navigation delta=] is less than 0.
+        the document's [=current navigation state=]'s [=navigation state/new index=] is less than its [=navigation state/old index=].
     : history: forward
     :: True if the [=current navigation type=] is {{NavigationType/traverse}} and
-        the [=current navigation delta=] is greater than 0.
+        the document's [=current navigation state=]'s [=navigation state/new index=] is greater than its [=navigation state/old index=].
     : history: reload
     :: True if the [=current navigation type=] is {{NavigationType/reload}}.
 
 : <<navigation-phase-test>>
-::    : phase: loading
-    :: The navigation is not yet {{NavigationTransition/committed}}. For a cross-document navigation, this means the old page is still active.
-        The ''from'' and ''at'' URLs are equal to each other, as well as the ''to'' and ''with'' URLs.
-    : phase: ready
-    :: The old page is still active, but the response for the new page is ready.
-
-        NOTE: Only applies to cross-document navigations.
-    : phase: committed
-    :: The navigation is not yet {{NavigationTransition/committed}}. For a cross-document navigation, this means the new page has been activated. 
-        The ''to'' and ''at'' URLs are equal to each other, as well as the ''with'' and ''from'' URLs.
+:: The [=current navigation state=] is not null, and its [=navigation state/phase=] matches the given ''phase'' value.
 
 : <<general-enclosed>>
 ::
@@ -450,15 +428,6 @@ as follows:
     Authors must not use <<general-enclosed>> in their stylesheets.
     <span class='note'>It exists only for future-compatibility,
     so that new syntax additions do not invalidate too much of a <<navigation-condition>> in older user agents.</span>
-
-A <dfn>document's navigation API</dfn> is
-the result of the following steps on <var>document</var>:
-
-1. Let <var>window</var> be the {{Window}} whose [=associated Document=] is <var>document</var>, or null if there is no such {{Window}}.
-
-1. If <var>window</var> is null, return null.
-
-1. Return <var>window</var>'s [=navigation API=].
 
 The condition of the ''@navigation'' rule
 is the result of the <<navigation-condition>> in its prelude.
@@ -500,7 +469,9 @@ This specification defines a new
 <dfn id="trigger-link-pseudo" selector>'':trigger-link''</dfn>
 that matches link elements that trigger the current navigation.
 
-The ''trigger-link'' pseudo-class matches an [^a^] or [^area^] element which is the {{NavigateEvent/sourceElement}} of an [=ongoing navigate event=].
+The '':trigger-link'' pseudo-class matches any element where both:
+* the element matches '':any-link''
+* the [=current navigation state=] is not null, and element is its [=navigation state/source element=].
 
 Issue: should this apply to forms or submit buttons?
 
@@ -624,36 +595,25 @@ and the pseudo-class matches any element where:
 <dfn><<navigation-relation>></dfn> = at | with | from | to
 </pre>
 
-NOTE: The ''link-href'' keyword is an explicit way to represent the default,
-but there is no difference between specifying it explicitly or omitting it.
-
 ISSUE: Should we use ''at''/''with''/''from''/''to'' or
 ''current''/''other''/''from''/''to''?
-
-The <dfn>active navigation URL</dfn> for an <<active-navigation-condition>> is:
-<dl class=switch>
-<dt>If the <<navigation-relation>> is ''at''
-<dd>The [=current at URL=] of the document
-<dt>If the <<navigation-relation>> is ''with'' or is omitted
-<dd>The [=current with URL=] of the document
-<dt>If the <<navigation-relation>> is ''from''
-<dd>The [=current from URL=] of the document
-<dt>If the <<navigation-relation>> is ''to''
-<dd>The [=current to URL=] of the document
-</dl>
 
 An <<active-navigation-condition>> matches the target <var>linkTarget</var> of the link when
 the following steps return true:
 1. Let <var>navigationURL</var> be
-    the [=active navigation URL=] of the <<active-navigation-condition>>
+    the [=current navigation URL=] of the document given the <<navigation-relation>> in <<active-navigation-condition>> (default ''with'').
+
 1. If <var>navigationURL</var> is null, return false.
+1. If ''link-href'' is present, or a <<route-location>> is not provided:
+    1. Return true if <var>linkTarget</var> [=url/equals=] <var>navigationURL</var>; Otherwise false.
+
 1. If a <<route-location>> is present:
     1. Let <var>targetMatchResult</var> be the result of
-        [=URL pattern/match|match a URL pattern=]
+        [=URL pattern/match|matching a URL pattern=]
         given <var>urlPattern</var> and <var>linkTarget</var>.
 
     1. Let <var>navigationMatchResult</var> be the result of
-         [=URL pattern/match|match a URL pattern=] given
+         [=URL pattern/match|matching a URL pattern=] given
          <var>urlPattern</var> and <var>navigationURL</var>.
 
     1. If <var>navigationMatchResult</var> or <var>targetMatchResult</var> is null, return false.
@@ -671,185 +631,111 @@ the following steps return true:
 
     1. Return true.
 
-1. Otherwise:
-
-    1. Return true if <var>linkTarget</var> [=url/equals=] <var>navigationURL</var>.
-
-    1. Return false.
-
 NOTE: Some of the design discussion for this feature has been in
 <a href="https://github.com/w3c/csswg-drafts/issues/13163">w3c/csswg-drafts#13163</a>.
 
-<h2 id="current-nav-urls">Definitions of current navigation state</h2>
+<h2 id="processing-model">Processing model</h2>
 
-Both the ''@navigation'' rule and the '':link-to()'' pseudo-class
-rely on the following definitions of [=current at URL=]
-the [=current with URL=], [=current from URL=], and [=current to URL=].
+The at rules and pseudo-classes defined in this document rely on the [=current navigation state=].
 
-The <dfn>current from URL</dfn> of a [=/document=] is a URL or null.
-It is defined as follows:
+A <dfn>navigation state</dfn> is a [=struct=] with the following items:
 
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=transition=] is non-null,
-    its [=from entry=]'s {{NavigationHistoryEntry/url}}.
+<dl dfn-for="navigation state">
+    : <dfn>old URL</dfn>
+    : <dfn>new URL</dfn>
+    :: a [=/URL=]
+    
+    : <dfn>type</dfn>
+    :: a {{NavigationType}}
+    
+    : <dfn>old index</dfn>
+    : <dfn>new index</dfn>
+    :: an integer
 
-    NOTE: This part is for when the old document in the navigation
-    is still the current document.
+    : <dfn>phase</dfn>
+    :: `loading`, `ready`, or `committed`.
 
-1. If the [=document's navigation API=] of the document is non-null,
-    its [=activation=] is non-null,
-    the activation's {{NavigationActivation/from}} is non-null, and
-    the document's [=has been revealed=] is false or
-    was false at the start of the current [=task=],
-    the activation's {{NavigationActivation/from}}'s
-    {{NavigationHistoryEntry/url}}.
+    : <dfn>source element</dfn>
+    :: null or an {{Element}}.
+</dl>
 
-    NOTE: This part is for when the new document in the navigation
-    has become the current document.
+<div algorithm>
+To get the <dfn>current navigation state</dfn> of a {{Document}} |document|:
 
-1. Otherwise, null.
+1. If |document| is not [=Document/fully active=], return null.
 
-    NOTE: The previous two branches can also produce null results.
+1. Let |navigation| be |document|'s [=relevant global object=]'s [=navigation API=].
 
-The <dfn>current to URL</dfn> of a [=/document=] is a URL or null.
-It is defined as follows:
+1. Let |activation| be |navigation|'s {{Navigation/activation}}.
 
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=ongoing navigate event=] is non-null:
+1. If |document| has not [=has been revealed|been revealed=]:
+    1. If |activation| is null, return null.
 
-    1. if the {{pageswap}} event has fired since that navigation began,
-        and its {{PageSwapEvent/activation}} was non-null,
-        and that {{PageSwapEvent/activation}}'s
-        {{NavigationActivation/entry}}'s
-        {{NavigationHistoryEntry/url}} is non-null,
-        then that
-        {{NavigationHistoryEntry/url}}.
+    1. [=Assert=]: |activation|'s {{NavigationActivation/entry}} is not null.
 
-        NOTE: This part <em>does</em> expose the result of redirects.
+    1. Return a new [=navigation state=] whose
+        [=navigation state/old URL=] is |activation|'s {{NavigationActivation/from}}'s {{NavigationHistoryEntry/url}},
+        [=navigation state/new URL=] is |activation|'s {{NavigationActivation/entry}}'s {{NavigationHistoryEntry/url}},
+        [=navigation state/type=] is |activation|'s {{NavigationActivation/navigationType}},
+        [=navigation state/old index=] is |activation|'s {{NavigationActivation/from}}'s {{NavigationHistoryEntry/index}},
+        [=navigation state/new index=] is |activation|'s {{NavigationActivation/entry}}'s {{NavigationHistoryEntry/index}},
+        [=navigation state/phase=] is `committed`,
+        and [=navigation state/source element=] is null.
 
-        NOTE: This part is not relevant to normal page rendering.
-        However, it can be relevant to what is rendered
-        when [=capturing the image=]
-        for a [[css-view-transitions-2#cross-document-view-transitions|cross-document view transition]].
+    Note: this means that navigations that occur before the page is revealed, e.g. calling {{History/pushState()}} in the head do not reflect in CSS.
 
-        ISSUE: Is the final "non-null" check needed?
+1. Let |navigateEvent| be the [=ongoing navigate event=] of |navigation|.
 
-    1. otherwise, the [=ongoing navigate event=]'s
-        {{NavigateEvent/destination}}'s
-        {{NavigationDestination/url}}
+1. Let |phase| be `loading`.
 
-        NOTE: This part does <em>not</em> expose the result of redirects.
+1. If |navigateEvent| is null and |navigation|'s [=traversing navigate event=] is not null:
+    1. Set |navigateEvent| to |navigation|'s [=traversing navigate event=].
 
-    ISSUE: This assumes that the [=ongoing navigate event=]
-    and the [=transition=] have the same lifetime,
-    but this isn't really
-    true if the event is intercepted.
-    After
-    <a href="https://github.com/whatwg/html/issues/11690">whatwg/html#11690</a> /
-    <a href="https://github.com/whatwg/html/pull/11692">whatwg/html#11692</a>.
-    we could probably define this more like "from" above.
-    But which lifetime is the one we want?
+    1. Set |phase| to `ready`.
 
-    NOTE: This part is for when the old document in the navigation
-    is still the current document.
+1. If |navigateEvent| is null, return null.
 
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=activation=] is non-null,
-    the document's [=has been revealed=] is false or
-    was false at the start of the current [=task=],
-    and the activation's {{NavigationActivation/entry}}'s
-    {{NavigationHistoryEntry/url}}.
+1. Return a new [=navigation state=] whose
+    [=navigation state/old URL=] is |document|'s [=Document/URL=],
+    [=navigation state/new URL=] is |navigateEvent|'s {{NavigateEvent/destination}}'s {{NavigationDestination/url}},
+    [=navigation state/type=] is |ongoingNavigateEvent|'s {{NavigateEvent/navigationType}},
+    [=navigation state/old index=] is |navigation|'s [=navigation API/current entry=]'s {{NavigationHistoryEntry/index}},
+    [=navigation state/new index=] is |navigateEvent|'s {{NavigateEvent/destination}}'s {{NavigationDestination/index}},
+    [=navigation state/phase=] is |phase|,
+    and [=navigation state/source element=] is |ongoingNavigateEvent|'s {{NavigateEvent/sourceElement}}.
 
-    NOTE: This part is for when the new document in the navigation
-    has become the current document.
+</div>
 
-    ISSUE: Does it make sense to expose this when
-    the activation's {{NavigationActivation/from}} is null,
-    and thus there is no [=current from URL=]?
+To get the <dfn>current navigation URL</dfn> given a {{Document}} |document| and a <<navigation-relation>> |relation|:
 
-1. Otherwise, null.
+1. Let |state| be |document|'s [=current navigation state=].
+1. If |state| is null, return null.
+1. Return the result of switching on |relation|:
 
-    NOTE: The previous two branches can also produce null results.
+<dl class=switch>
+: ''to''
+:: |state|'s [=navigation state/new URL=].
 
-ISSUE: The above definitions of from and to apparently don't work right
-if you start a same-document navigation (e.g., with {{History/pushState}})
-in the middle of a cross-document navigation.
+: ''from''
+:: |state|'s [=navigation state/old URL=].
 
-The <dfn>current at URL</dfn> of a [=/document=] is a URL or null.
-It is defined as follows:
+: ''at''
+:: |state|'s [=navigation state/new URL=] if |state|'s [=navigation state/phase=] is `committed`; Otherwise |state|'s [=navigation state/old URL=].
 
-1. ISSUE: Write this!  (It should be null if there is no active navigation,
-    and the same as the document's [=Document/URL=] if there is.)
+: ''with''
+:: |state|'s [=navigation state/old URL=] if |state|'s [=navigation state/phase=] is `committed`; Otherwise |state|'s [=navigation state/new URL=].
 
-The <dfn>current with URL</dfn> of a [=/document=] is a URL or null.
-It is defined as follows:
+</dl>
 
-1. ISSUE: Write this!  (It should be like [=current to URL=] and [=current from URL=]
-    but always referring to the other Document in the navigation.)
+To get the <dfn>current navigation type</dfn> of a [=/document=] |document|:
+    1. If |document|'s [=current navigation state=] is non-null, return its [=navigation state/type=].
+    1. Return null.
 
-The <dfn>current navigation type</dfn> of a [=/document=] is a {{NavigationType}} or null.
-It is defined as follows:
+The <dfn>traversing navigate event</dfn> is the [=ongoing navigate event=] which was reset when the [=ongoing navigation=] is set to `traversal`.
 
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=transition=] is non-null,
-    the transition's {{NavigationTransition/navigationType}}.
 
-    NOTE: This part is for when the old document in the navigation
-    is still the current document.
 
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=activation=] is non-null,
-    the document's [=has been revealed=] is false or
-    was false at the start of the current [=task=],
-    the activation's {{NavigationActivation/navigationType}}.
-
-    NOTE: This part is for when the new document in the navigation
-    has become the current document.
-
-1. Otherwise, null.
-
-The <dfn>current navigation delta</dfn> of a [=/document=] is a {{NavigationType}} or null.
-It is defined as follows:
-
-1. If the [=document's navigation API=] of the document is non-null and
-    its [=transition=] is non-null,
-
-    1. If the transition's {{NavigationTransition/navigationType}} is not {{NavigationType/traverse}}, null.
-
-    1. Otherwise,
-        the transition's {{NavigationTransition/to}}'s {{NavigationDestination/index}}
-        minus
-        the transition's {{NavigationTransition/from}}'s {{NavigationHistoryEntry/index}}.
-
-    NOTE: This part is for when the old document in the navigation
-    is still the current document.
-
-1. If the [=document's navigation API=] of the document is non-null,
-    its [=activation=] is non-null,
-    the activation's {{NavigationActivation/from}} is non-null, and
-    the document's [=has been revealed=] is false or
-    was false at the start of the current [=task=],
-
-    1. If the activation's {{NavigationActivation/navigationType}} is not {{NavigationType/traverse}}, null.
-
-    1. Otherwise,
-        the activation's {{NavigationActivation/entry}}'s {{NavigationHistoryEntry/index}}
-        minus
-        the activation's {{NavigationActivation/from}}'s {{NavigationHistoryEntry/index}}.
-
-    NOTE: This part is for when the new document in the navigation
-    has become the current document.
-
-1. Otherwise, null.
-
-ISSUE: Generally improve integration with the HTML spec for these definitions,
-instead of monkeypatching.
-This includes the interaction with [=has been revealed=]
-and the interaction with the {{pageswap}} event,
-and other things where this section links to non-exported definitions.
-
-ISSUE: Generally figure out if these definitions should care about
-the [=ongoing navigate event=] or the [=transition=].
+ISSUE: Improve integration with the HTML standard, especially the concept of [=traversing navigate event=] and unexported definitions.
 
 <h2 class="no-num" id="privacy">Privacy Considerations</h2>
 


### PR DESCRIPTION
- Use a struct for the "current navigation state" with a clear processing model, and refer to it from the different selectors.
- Prioritize cross-document navigations over invisible `pushState` calls.
