### PR TITLE
[css-navigation-1] [editorial] Fix typo in selector

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -513,7 +513,7 @@ and the pseudo-class matches any element where both:
 * the element matches '':any-link''
 * the <<route-location>> [=route-location/matches=] the target of the link
 
-<h3 id="active-navigation-pseudo-class">The ''::active-navigation()'' pseudo-class</h3>
+<h3 id="active-navigation-pseudo-class">The '':active-navigation()'' pseudo-class</h3>
 
 This specification defines a new
 <dfn id="active-navigation-pseudo" selector>'':active-navigation()''</dfn>


### PR DESCRIPTION
It’s `:active-navigation()`, not `::active-navigation()`