### PR TITLE
[selectors-4] Fix URL of link to CSS Basic UI module

### DIFF
--- a/selectors-4/Overview.bs
+++ b/selectors-4/Overview.bs
@@ -5428,7 +5428,7 @@ Changes Since Level 3</h3>
 	<p>
 		<em>The following selectors
 		were previously in
-		<a href="https://www/w3/org/TR/css-ui-3">CSS Basic UI 3</a> 
+		[[CSS3UI inline]]
 		and have been moved to the main Selectors 4 specification 
 		for ease of reference.</em>
 	</p>


### PR DESCRIPTION
There was a typo in the link to CSS Basic UI 3 introduced recently (`/` used in the domain name instead of `.`), see: https://github.com/w3c/csswg-drafts/commit/513d6f77cc23254734db5ab575de8876bd850339#diff-ff7e41817bff012f3ddff1f611038e554675a63acfb0ae367398437958b0baf4R5397

The URL should also have a final `/` to avoid a redirect.

This update rather uses `[[CSS3UI inline]]` to let Bikeshed generate the URL and avoid any mistake.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
