### PR TITLE
[scroll-animations-1] Update the attributes of ViewTimeline startOffet and endOffset to be nullable (#13844)

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -824,8 +824,8 @@ spec:selectors-4; type:dfn; text:selector
 		interface ViewTimeline : ScrollTimeline {
 		  constructor(optional ViewTimelineOptions options = {});
 		  readonly attribute Element subject;
-		  readonly attribute CSSNumericValue startOffset;
-		  readonly attribute CSSNumericValue endOffset;
+		  readonly attribute CSSNumericValue? startOffset;
+		  readonly attribute CSSNumericValue? endOffset;
 		};
 	</pre>
 


### PR DESCRIPTION
Update `ViewTimeline.startOffset` and `ViewTimeline.endOffset` per the spec resolution.

Fixed #13844.