### PR TITLE
[css-overflow-4] Base the ellipses bidi handling on the bidi paragraph (#12617)

### DIFF
--- a/css-overflow-4/Overview.bs
+++ b/css-overflow-4/Overview.bs
@@ -473,11 +473,12 @@ ellipsing details</h3>
 			For bidi purposes, the ellipsis and string values must be treated
 			as if they were wrapped in an anonymous inline
 			with ''unicode-bidi: isolate''
-			which inherits ''direction'' from the block.
+			and with ''direction'' set to the [=bidi paragraph=]'s base directionality.
 
 			<wpt pathprefix="/css/css-ui/">
 				text-overflow-string-006.html
 				text-overflow-string-007.html
+				text-overflow-string-008.html
 			</wpt>
 	</ul>
 
@@ -884,8 +885,11 @@ Indicating Block-Axis Overflow: the 'block-ellipsis' property</h3>
 	* The [=block overflow ellipsis=]
 		is wrapped in an anonymous inline
 		whose parent is the [=block container=]’s [=root inline box=].
-		This inline is assigned ''unicode-bidi: isolate''
-		and ''line-height: 0''.
+		This inline is assigned
+		''line-height: 0'',
+		''unicode-bidi: isolate'',
+		and a value of 'direction' corresponding
+		to the [=bidi paragraph=]'s base directionality.
 
 		<wpt>
 			block-ellipsis-002.html


### PR DESCRIPTION
Fixes the bidi handling of `text-overflow` and `block-ellipsis` ellipsis to depend on the base directionality of the bidi paragraph (as was resolved in #12617), rather than inherit the `direction` value from the block container.