### PR TITLE
[css-navigation-1] [editorial] Move sections around

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -251,6 +251,179 @@ A <<route-location>> is defined to
 
 </dl>
 
+<h2 id="link-navigation-pseudo-classes">Pseudo-classes for links</h2>
+
+<h3 id="link-to-pseudo-class">The '':link-to()'' pseudo-class</h3>
+
+This specification defines a new
+<dfn id="link-to-pseudo" selector>'':link-to()''</dfn> functional pseudo-class
+that matches link elements that link to a certain URL.
+
+<div class="example">
+
+A simple example of a '':link-to()'' selector is this one,
+which matches any links that link to the site's homepage:
+
+<pre highlight=css>
+:link-to(url-pattern("/")) {
+  font-weight: bold;
+}
+</pre>
+
+</div>
+
+The '':link-to()'' pseudo-class takes a single argument, a <<route-location>>,
+and the pseudo-class matches any element where both:
+* the element matches '':any-link''
+* the <<route-location>> [=route-location/matches=] the target of the link
+
+<h3 id="active-navigation-pseudo-class">The '':active-navigation()'' pseudo-class</h3>
+
+This specification defines a new
+<dfn id="active-navigation-pseudo" selector>'':active-navigation()''</dfn>
+functional pseudo-class
+that matches link elements that link to a certain URL
+that is related to a navigation that is currently active.
+
+<div class="example">
+
+A an example of the '':active-navigation()'' pseudo-class
+is this example which creates a view transition between
+a item in a list that contains a link (in this document)
+and the details page for that link (in a different document).
+This transition works even when the navigation is a back/forward navigation
+and even if the user has used a language selector UI
+to change the page into a different language (and thus change the URL).
+The use of the '':link-to()'' pseudo-class ensures that
+the view transition animations from or to the correct item in the list
+by matching the relevant parts of the navigation URL to the link URL.
+
+<pre highlight=css>
+@view-transition {
+  /* allow cross-document view transitions */
+  navigation: auto;
+}
+
+@route --movie-details-with-id {
+  /* match URLs like /en/movie/123 which is the English page
+     about a movie with ID 123.  Be careful to specify the
+     language part with a "*" but the ID part with a named
+     :id parameter so that matching will require equal IDs
+     but allow differences of language. */
+  pattern: url-pattern("/*/movie/:id");
+}
+
+/* capture the overall area representing the movie, and a
+   sub-area for its poster image */
+
+/* match an element with class movie-container with a child
+   link that links to a movie whose id is the same as the
+   movie we are currently navigating to or from.  (lang can
+   be different, though.)
+
+   This depends on the --movie-details-with-id route
+   declaring the ID but not the language with a named
+   parameter, and the use of the 'with' keyword.
+
+   This means that both the of the link and the other URL of
+   the current navigation match the URL pattern defined by
+   the "@route --movie-details-with-id" rule, and that the
+   id named group from both matches be the same.  (However,
+   the URLs can be different because the * part of the
+   match, containing the language, can be different.)
+   */
+.movie-container:has(
+    > .movie-title:active-navigation(with --movie-details-with-id)) {
+
+  view-transition-name: movie-container;
+
+  > .movie-poster {
+    view-transition-name: movie-poster;
+  }
+
+  /* leave the default cross-fade animation for both image
+     captures */
+}
+</pre>
+
+</div>
+
+The '':active-navigation()'' pseudo-class takes a single argument, a <<active-navigation-condition>>,
+and the pseudo-class matches any element where:
+* the element matches '':any-link''
+* the target of the link matches the <<active-navigation-condition>>, as defined below.
+
+<pre class="prod def" dfn-type="type" nohighlight>
+<dfn><<active-navigation-condition>></dfn> =
+  <<navigation-relation>>? [ <<route-location>> | link-href ]?
+<dfn><<navigation-relation>></dfn> = at | with | from | to
+</pre>
+
+ISSUE: Should we use ''at''/''with''/''from''/''to'' or
+''current''/''other''/''from''/''to''?
+
+An <<active-navigation-condition>> matches the target <var>linkTarget</var> of the link when
+the following steps return true:
+1. Let <var>navigationURL</var> be
+    the [=current navigation URL=] of the document given the <<navigation-relation>> in <<active-navigation-condition>> (default ''with'').
+
+1. If <var>navigationURL</var> is null, return false.
+1. If ''link-href'' is present, or a <<route-location>> is not provided:
+    1. Return true if <var>linkTarget</var> [=url/equals=] <var>navigationURL</var>; Otherwise false.
+
+1. If a <<route-location>> is present:
+    1. Let <var>targetMatchResult</var> be the result of
+        [=URL pattern/match|matching a URL pattern=]
+        given <var>urlPattern</var> and <var>linkTarget</var>.
+
+    1. Let <var>navigationMatchResult</var> be the result of
+         [=URL pattern/match|matching a URL pattern=] given
+         <var>urlPattern</var> and <var>navigationURL</var>.
+
+    1. If <var>navigationMatchResult</var> or <var>targetMatchResult</var> is null, return false.
+
+    1. For each property <var>prop</var> of {{URLPatternResult}} that is a
+        {{URLPatternComponentResult}}:
+
+        1. If {{URLPatternComponentResult/groups}} of <var>prop</var> of
+            <var>targetMatchResult</var> is not equal to
+            {{URLPatternComponentResult/groups}} of <var>prop</var> of
+            <var>navigationMatchResult</var>,
+            then return false.
+
+            ISSUE: Need to formally define equality of ordered maps.
+
+    1. Return true.
+
+NOTE: Some of the design discussion for this feature has been in
+<a href="https://github.com/w3c/csswg-drafts/issues/13163">w3c/csswg-drafts#13163</a>.
+
+<h3 id="trigger-link-pseudo-class">The '':trigger-link'' pseudo-class</h3>
+
+This specification defines a new
+<dfn id="trigger-link-pseudo" selector>'':trigger-link''</dfn>
+that matches link elements that trigger the current navigation.
+
+The '':trigger-link'' pseudo-class matches any element where both:
+* the element matches '':any-link''
+* the [=current navigation state=] is not null, and element is its [=navigation state/source element=].
+
+Issue: should this apply to forms or submit buttons?
+
+<div class="example">
+
+A simple example of a '':trigger-link'' selector is this one,
+which sets the ''view-transition-name'' for an image thumbnail that is a child of the link that triggers the current navigation.
+
+
+<pre highlight=css>
+:trigger-link .thumb {
+  view-transition-name: active-image;
+}
+</pre>
+
+</div>
+
 <h2 id="conditional-navigation-queries">Conditional rules for navigation queries</h2>
 
 <h3 id="at-navigation">Navigation queries: the ''@navigation'' rule</h3>
@@ -460,179 +633,6 @@ This specification defines an additional function for the ''if()'' function's
 ISSUE: This should probably have a more formal definition of the function,
 but I can't find the formal definitions of the existing ''if()'' functions
 to model it after.
-
-<h2 id="link-navigation-pseudo-classes">Pseudo-classes for links</h2>
-
-<h3 id="trigger-link-pseudo-class">The '':trigger-link'' pseudo-class</h3>
-
-This specification defines a new
-<dfn id="trigger-link-pseudo" selector>'':trigger-link''</dfn>
-that matches link elements that trigger the current navigation.
-
-The '':trigger-link'' pseudo-class matches any element where both:
-* the element matches '':any-link''
-* the [=current navigation state=] is not null, and element is its [=navigation state/source element=].
-
-Issue: should this apply to forms or submit buttons?
-
-<div class="example">
-
-A simple example of a '':trigger-link'' selector is this one,
-which sets the ''view-transition-name'' for an image thumbnail that is a child of the link that triggers the current navigation.
-
-
-<pre highlight=css>
-:trigger-link .thumb {
-  view-transition-name: active-image;
-}
-</pre>
-
-</div>
-
-<h3 id="link-to-pseudo-class">The '':link-to()'' pseudo-class</h3>
-
-This specification defines a new
-<dfn id="link-to-pseudo" selector>'':link-to()''</dfn> functional pseudo-class
-that matches link elements that link to a certain URL.
-
-<div class="example">
-
-A simple example of a '':link-to()'' selector is this one,
-which matches any links that link to the site's homepage:
-
-<pre highlight=css>
-:link-to(url-pattern("/")) {
-  font-weight: bold;
-}
-</pre>
-
-</div>
-
-The '':link-to()'' pseudo-class takes a single argument, a <<route-location>>,
-and the pseudo-class matches any element where both:
-* the element matches '':any-link''
-* the <<route-location>> [=route-location/matches=] the target of the link
-
-<h3 id="active-navigation-pseudo-class">The '':active-navigation()'' pseudo-class</h3>
-
-This specification defines a new
-<dfn id="active-navigation-pseudo" selector>'':active-navigation()''</dfn>
-functional pseudo-class
-that matches link elements that link to a certain URL
-that is related to a navigation that is currently active.
-
-<div class="example">
-
-A an example of the '':active-navigation()'' pseudo-class
-is this example which creates a view transition between
-a item in a list that contains a link (in this document)
-and the details page for that link (in a different document).
-This transition works even when the navigation is a back/forward navigation
-and even if the user has used a language selector UI
-to change the page into a different language (and thus change the URL).
-The use of the '':link-to()'' pseudo-class ensures that
-the view transition animations from or to the correct item in the list
-by matching the relevant parts of the navigation URL to the link URL.
-
-<pre highlight=css>
-@view-transition {
-  /* allow cross-document view transitions */
-  navigation: auto;
-}
-
-@route --movie-details-with-id {
-  /* match URLs like /en/movie/123 which is the English page
-     about a movie with ID 123.  Be careful to specify the
-     language part with a "*" but the ID part with a named
-     :id parameter so that matching will require equal IDs
-     but allow differences of language. */
-  pattern: url-pattern("/*/movie/:id");
-}
-
-/* capture the overall area representing the movie, and a
-   sub-area for its poster image */
-
-/* match an element with class movie-container with a child
-   link that links to a movie whose id is the same as the
-   movie we are currently navigating to or from.  (lang can
-   be different, though.)
-
-   This depends on the --movie-details-with-id route
-   declaring the ID but not the language with a named
-   parameter, and the use of the 'with' keyword.
-
-   This means that both the of the link and the other URL of
-   the current navigation match the URL pattern defined by
-   the "@route --movie-details-with-id" rule, and that the
-   id named group from both matches be the same.  (However,
-   the URLs can be different because the * part of the
-   match, containing the language, can be different.)
-   */
-.movie-container:has(
-    > .movie-title:active-navigation(with --movie-details-with-id)) {
-
-  view-transition-name: movie-container;
-
-  > .movie-poster {
-    view-transition-name: movie-poster;
-  }
-
-  /* leave the default cross-fade animation for both image
-     captures */
-}
-</pre>
-
-</div>
-
-The '':active-navigation()'' pseudo-class takes a single argument, a <<active-navigation-condition>>,
-and the pseudo-class matches any element where:
-* the element matches '':any-link''
-* the target of the link matches the <<active-navigation-condition>>, as defined below.
-
-<pre class="prod def" dfn-type="type" nohighlight>
-<dfn><<active-navigation-condition>></dfn> =
-  <<navigation-relation>>? [ <<route-location>> | link-href ]?
-<dfn><<navigation-relation>></dfn> = at | with | from | to
-</pre>
-
-ISSUE: Should we use ''at''/''with''/''from''/''to'' or
-''current''/''other''/''from''/''to''?
-
-An <<active-navigation-condition>> matches the target <var>linkTarget</var> of the link when
-the following steps return true:
-1. Let <var>navigationURL</var> be
-    the [=current navigation URL=] of the document given the <<navigation-relation>> in <<active-navigation-condition>> (default ''with'').
-
-1. If <var>navigationURL</var> is null, return false.
-1. If ''link-href'' is present, or a <<route-location>> is not provided:
-    1. Return true if <var>linkTarget</var> [=url/equals=] <var>navigationURL</var>; Otherwise false.
-
-1. If a <<route-location>> is present:
-    1. Let <var>targetMatchResult</var> be the result of
-        [=URL pattern/match|matching a URL pattern=]
-        given <var>urlPattern</var> and <var>linkTarget</var>.
-
-    1. Let <var>navigationMatchResult</var> be the result of
-         [=URL pattern/match|matching a URL pattern=] given
-         <var>urlPattern</var> and <var>navigationURL</var>.
-
-    1. If <var>navigationMatchResult</var> or <var>targetMatchResult</var> is null, return false.
-
-    1. For each property <var>prop</var> of {{URLPatternResult}} that is a
-        {{URLPatternComponentResult}}:
-
-        1. If {{URLPatternComponentResult/groups}} of <var>prop</var> of
-            <var>targetMatchResult</var> is not equal to
-            {{URLPatternComponentResult/groups}} of <var>prop</var> of
-            <var>navigationMatchResult</var>,
-            then return false.
-
-            ISSUE: Need to formally define equality of ordered maps.
-
-    1. Return true.
-
-NOTE: Some of the design discussion for this feature has been in
-<a href="https://github.com/w3c/csswg-drafts/issues/13163">w3c/csswg-drafts#13163</a>.
 
 <h2 id="processing-model">Processing model</h2>
 


### PR DESCRIPTION
This moves some sections around for, what I believe, leads to improved readability of the spec:

- Swapped the position of sections 2 and 3, so that people can get acquainted with the `<route-location>` and `urlpattern()` a bit more, before going into navigation queries.
- Moved `:trigger-link` down in the list of pseudo-class selectors.