### PR TITLE
[css-navigation-1] Add examples

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -385,69 +385,6 @@ functional pseudo-class
 that matches link elements that link to a certain URL
 that is related to a navigation that is currently active.
 
-<div class="example">
-
-A an example of the '':active-navigation()'' pseudo-class
-is this example which creates a view transition between
-a item in a list that contains a link (in this document)
-and the details page for that link (in a different document).
-This transition works even when the navigation is a back/forward navigation
-and even if the user has used a language selector UI
-to change the page into a different language (and thus change the URL).
-The use of the '':link-to()'' pseudo-class ensures that
-the view transition animations from or to the correct item in the list
-by matching the relevant parts of the navigation URL to the link URL.
-
-<pre highlight=css>
-@view-transition {
-  /* allow cross-document view transitions */
-  navigation: auto;
-}
-
-@route --movie-details-with-id {
-  /* match URLs like /en/movie/123 which is the English page
-     about a movie with ID 123.  Be careful to specify the
-     language part with a "*" but the ID part with a named
-     :id parameter so that matching will require equal IDs
-     but allow differences of language. */
-  pattern: url-pattern("/*/movie/:id");
-}
-
-/* capture the overall area representing the movie, and a
-   sub-area for its poster image */
-
-/* match an element with class movie-container with a child
-   link that links to a movie whose id is the same as the
-   movie we are currently navigating to or from.  (lang can
-   be different, though.)
-
-   This depends on the --movie-details-with-id route
-   declaring the ID but not the language with a named
-   parameter, and the use of the 'with' keyword.
-
-   This means that both the of the link and the other URL of
-   the current navigation match the URL pattern defined by
-   the "@route --movie-details-with-id" rule, and that the
-   id named group from both matches be the same.  (However,
-   the URLs can be different because the * part of the
-   match, containing the language, can be different.)
-   */
-.movie-container:has(
-    > .movie-title:active-navigation(with --movie-details-with-id)) {
-
-  view-transition-name: movie-container;
-
-  > .movie-poster {
-    view-transition-name: movie-poster;
-  }
-
-  /* leave the default cross-fade animation for both image
-     captures */
-}
-</pre>
-
-</div>
-
 The '':active-navigation()'' pseudo-class takes a single argument, a <<active-navigation-condition>>,
 and the pseudo-class matches any element where:
 * the element matches '':any-link''
@@ -494,6 +431,69 @@ the following steps return true:
             ISSUE: Need to formally define equality of ordered maps.
 
     1. Return true.
+
+<div class="example">
+
+A an example of the '':active-navigation()'' pseudo-class
+is this example which creates a view transition between
+a item in a list that contains a link (in this document)
+and the details page for that link (in a different document).
+This transition works even when the navigation is a back/forward navigation
+and even if the user has used a language selector UI
+to change the page into a different language (and thus change the URL).
+The use of the '':link-to()'' pseudo-class ensures that
+the view transition animations from or to the correct item in the list
+by matching the relevant parts of the navigation URL to the link URL.
+
+<pre highlight=css>
+@view-transition {
+  /* allow cross-document view transitions */
+  navigation: auto;
+}
+
+@route --movie-detail {
+  /* match URLs like /en/movies/123 which is the English page
+     about a movie with ID 123.  Be careful to specify the
+     language part with a "*" but the ID part with a named
+     :id parameter so that matching will require equal IDs
+     but allow differences of language. */
+  pattern: url-pattern("/*/movies/:id");
+}
+
+/* capture the overall area representing the movie, and a
+   sub-area for its poster image */
+
+/* match an element with class movie-container with a child
+   link that links to a movie whose id is the same as the
+   movie we are currently navigating to or from.  (lang can
+   be different, though.)
+
+   This depends on the --movie-detail route
+   declaring the ID but not the language with a named
+   parameter, and the use of the 'with' keyword.
+
+   This means that both the of the link and the other URL of
+   the current navigation match the URL pattern defined by
+   the "@route --movie-detail" rule, and that the
+   id named group from both matches be the same.  (However,
+   the URLs can be different because the * part of the
+   match, containing the language, can be different.)
+   */
+.movie-container:has(
+    > .movie-title:active-navigation(with --movie-detail)) {
+
+  view-transition-name: movie-container;
+
+  > .movie-poster {
+    view-transition-name: movie-poster;
+  }
+
+  /* leave the default cross-fade animation for both image
+     captures */
+}
+</pre>
+
+</div>
 
 NOTE: Some of the design discussion for this feature has been in
 <a href="https://github.com/w3c/csswg-drafts/issues/13163">w3c/csswg-drafts#13163</a>.

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -226,6 +226,58 @@ which can be ''document'', ''stylesheet'', or a URL, is:
 
 </dl>
 
+<div class="example">
+This rule:
+<pre highlight=css>
+@route --movie-detail {
+  pattern: url-pattern("/movies/:id");
+}
+</pre>
+defines an ''@route'' rule that associates
+the name <code>--movie-detail</code>
+with any URL that matches the [=URL pattern=] <code>/movies/:id</code>.
+
+Any of the following URLs (relative to the style sheet) match:
+
+<ul>
+  <li><code>/movies/123</code></li>
+  <li><code>/movies/456</code></li>
+  <li><code>/movies/something</code></li>
+</ul>
+
+These URLs will not match:
+
+<ul>
+  <li><code>/movies/123/</code> — The trailing slash is not matched by the pattern</li>
+  <li><code>/movies/456/extra</code> — The <code>/extra</code> is not matched by the pattern</li>
+</ul>
+</div>
+
+<div class="example">
+To have the <code>--movie-details</code> route
+match only numeric <code>:id</code> values,
+define the route eiter as:
+
+<pre highlight=css>
+@route --movie-detail {
+  pattern: url-pattern("/movies/:id(\\d+)");
+}
+</pre>
+
+or as:
+
+<pre highlight=css>
+@route --movie-detail {
+  pattern: url-pattern("/movies/(\\d+)");
+}
+</pre>
+
+This way, <code>/movies/something</code> won’t be matched by the route.
+
+NOTE: Even though the capture groups are not currently exposed,
+it is recommended to give the capture groups a name for future use.
+</div>
+
 <div class="issue">
 Should the default always be ''stylesheet''?
 For use of ''url-pattern()'' in ''@navigation'',

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -42,6 +42,36 @@ url: https://drafts.csswg.org/css-view-transitions-1/#capture-the-image
 
 <h2 id="url-patterns-in-css">Defining URL patterns in CSS</h2>
 
+<h3 id="route-value-type">The <<route-location>> value type</h3>
+
+<pre class="prod def" dfn-type="type" nohighlight>
+<dfn><<route-location>></dfn> = <<route-name>> | <<url-pattern()>> | <<url>>
+<dfn><<route-name>></dfn> = <<dashed-ident>>
+</pre>
+
+A <<route-location>> is defined to
+<dfn for="route-location">match</dfn> a [=/URL=]-or-null <var>input</var> if <var>input</var> is non-null, and:
+
+<dl class=switch>
+
+: the <<route-location>> is a <<route-name>>
+:: [=URL pattern/match|match a URL pattern=] is non-null given
+    <var>urlPattern</var> as
+    the [=URL pattern=] represented by the ''@route'' rule referenced by the name and
+    <var>input</var> as <var>input</var>.
+
+: the <<route-location>> is a <<url-pattern()>>
+:: [=URL pattern/match|match a URL pattern=] is non-null given
+    <var>urlPattern</var> as
+    the [=URL pattern=] represented by the function (see
+    [=create a URL pattern for url-pattern()=]) and
+    <var>input</var> as <var>input</var>.
+
+: the <<route-location>> is a <<url>>
+:: The given [=/URL=] [=url/equals=] <var>input</var>.
+
+</dl>
+
 <h3 id="at-route">Declaring named URL patterns: the ''@route'' rule</h3>
 
 The <dfn at-rule id="at-ruledef-route">@route</dfn> rule
@@ -299,36 +329,6 @@ to serialize <var>f</var>'s contents.
 
 NOTE: This is defined this way because {{URLPattern}}
 intentionally does not provide a serialization.
-
-<h3 id="route-value-type">The <<route-location>> value type</h3>
-
-<pre class="prod def" dfn-type="type" nohighlight>
-<dfn><<route-location>></dfn> = <<route-name>> | <<url-pattern()>> | <<url>>
-<dfn><<route-name>></dfn> = <<dashed-ident>>
-</pre>
-
-A <<route-location>> is defined to
-<dfn for="route-location">match</dfn> a [=/URL=]-or-null <var>input</var> if <var>input</var> is non-null, and:
-
-<dl class=switch>
-
-: the <<route-location>> is a <<route-name>>
-:: [=URL pattern/match|match a URL pattern=] is non-null given
-    <var>urlPattern</var> as
-    the [=URL pattern=] represented by the ''@route'' rule referenced by the name and
-    <var>input</var> as <var>input</var>.
-
-: the <<route-location>> is a <<url-pattern()>>
-:: [=URL pattern/match|match a URL pattern=] is non-null given
-    <var>urlPattern</var> as
-    the [=URL pattern=] represented by the function (see
-    [=create a URL pattern for url-pattern()=]) and
-    <var>input</var> as <var>input</var>.
-
-: the <<route-location>> is a <<url>>
-:: The given [=/URL=] [=url/equals=] <var>input</var>.
-
-</dl>
 
 <h2 id="link-navigation-pseudo-classes">Pseudo-classes for links</h2>
 

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -464,6 +464,97 @@ selector no longer applies, and those links revert back to <code>lime</code>.
 
 <div class="example">
 
+In the following examples, all links that link to the <code>--movie-detail</code> route,
+get a <code>lime</code> color when a navigation is in progress.
+
+<pre highlight=css>
+@route --movie-detail {
+  pattern: url-pattern("/movies/:id");
+}
+
+:active-navigation(--movie-detail) {
+  color: lime;
+}
+</pre>
+
+By adding the following selectors that use a <<navigation-relation>>,
+the behavior changes a bit.
+
+<pre highlight=css>
+:active-navigation(from --movie-detail) {
+  color: hotpink;
+}
+
+:active-navigation(to --movie-detail) {
+  color: yellow;
+}
+</pre>
+
+When navigating from <code>/movies/1</code> to <code>/movies/2</code>:
+
+<ul>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+	with any <code>:id</code>
+  	get a <code>lime</code> color
+	during the navigation.
+  </li>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+  	whose target is <code>/movies/1</code>
+	<em>(the “from” page)</em>
+  	get a <code>hotpink</code> color
+	during the navigation.
+  </li>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+  	whose target is <code>/movies/2</code>
+	<em>(the “to” page)</em>
+  	get a <code>yellow</code> color
+	during the navigation.
+  </li>
+</ul>
+
+When navigating from <code>/movies/2</code> to <code>/</code>:
+
+<ul>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+	with any <code>:id</code>
+  	get a <code>lime</code> color
+	during the navigation.
+  </li>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+  	whose target is <code>/movies/3</code>
+	<em>(the “from” page)</em>
+  	get a <code>hotpink</code> color
+	during the navigation.
+  </li>
+</ul>
+
+When navigating from <code>/</code> to <code>/movies/3</code>:
+
+<ul>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+	with any <code>:id</code>
+  	get a <code>lime</code> color
+	during the navigation.
+  </li>
+  <li>
+  	Links that link to the <code>--movie-detail</code> route
+  	whose target is <code>/movies/3</code>
+	<em>(the “to” page)</em>
+  	get a <code>yellow</code> color
+	during the navigation.
+  </li>
+</ul>
+
+</div>
+
+<div class="example">
+
 A an example of the '':active-navigation()'' pseudo-class
 is this example which creates a view transition between
 a item in a list that contains a link (in this document)

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -339,7 +339,6 @@ This specification defines a new
 that matches link elements that link to a certain URL.
 
 <div class="example">
-
 A simple example of a '':link-to()'' selector is this one,
 which matches any links that link to the site's homepage:
 
@@ -349,6 +348,28 @@ which matches any links that link to the site's homepage:
 }
 </pre>
 
+Because there is no dynamic part in the homepage URL,
+you can also pass in a <<url>> directly:
+
+<pre highlight=css>
+:link-to(url("/")) {
+  font-weight: bold;
+}
+</pre>
+
+Passing in a named route is also possible:
+
+<pre highlight=css>
+@route --homepage {
+  pattern: url-pattern("/");
+}
+
+:link-to(--homepage) {
+  font-weight: bold;
+}
+</pre>
+
+All three variants here match the same elements.
 </div>
 
 The '':link-to()'' pseudo-class takes a single argument, a <<route-location>>,

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -434,6 +434,36 @@ the following steps return true:
 
 <div class="example">
 
+The difference between '':link-to()'' and '':active-navigation()''
+is that the latter is only active while a navigation is in progress.
+
+Consider this example:
+
+<pre highlight=css>
+@route --homepage {
+  pattern: url-pattern("/");
+}
+
+:link-to(--homepage) {
+  color: lime;
+}
+
+:active-navigation(--homepage) {
+  color: hotpink;
+}
+</pre>
+
+Links that link to the <code>--homepage</code> get a <code>lime</code> color.
+When navigating to or from the <code>--homepage</code>,
+their color changes to <code>hotpink</code> for as long as the animation is active.
+
+Once the navigation has completed, the '':active-navigation()''
+selector no longer applies, and those links revert back to <code>lime</code>.
+
+</div>
+
+<div class="example">
+
 A an example of the '':active-navigation()'' pseudo-class
 is this example which creates a view transition between
 a item in a list that contains a link (in this document)

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -44,7 +44,7 @@ url: https://drafts.csswg.org/css-view-transitions-1/#capture-the-image
 <h3 id="at-route">Declaring named URL patterns: the ''@route'' rule</h3>
 
 The <dfn at-rule id="at-ruledef-route">@route</dfn> rule
-is an at-rule that associates a name with a [=URL pattern=].
+is an at-rule that associates an author-defined name with a [=URL pattern=].
 This name can be referenced in ''@navigation'' rules
 and in '':active-navigation()'' pseudo-classes.
 
@@ -76,10 +76,6 @@ the last one is used and the others are ignored.
 If a rule has both a valid <<pattern-descriptor>>
 and a valid <<init-descriptor>>
 then it is ignored.
-
-This rule associates an author-defined keyword with a URL pattern,
-so that any URL that matches one of the URL patterns
-matches the route named by the keyword.
 
 The ''@route'' rule can be defined in one of two ways:
 

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -123,18 +123,18 @@ but it could also be added back later if we need it.
 Either this rule:
 <pre highlight=css>
 @route --movie-list {
-  pattern: url-pattern("/movie-list");
+  pattern: url-pattern("/movies");
 }
 </pre>
 or this rule:
 <pre highlight=css>
 @route --movie-list {
-  pathname: "/movie-list";
+  pathname: "/movies";
 }
 </pre>
 define an ''@route'' rule that associates
 the name <code>--movie-list</code>
-with the URL <code>"/movie-list"</code> resolved relative to the style sheet.
+with the URL <code>"/movies"</code> resolved relative to the style sheet.
 </div>
 
 NOTE: The bracing syntax also allows for future expansion if needed.

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -71,6 +71,7 @@ Any other descriptors are ignored.
 <dfn><<base-descriptor>></dfn> = base-url : stylesheet | document | <<url>>
 </pre>
 
+<!-- FIXME: What is “it” here? -->
 If two valid descriptors in a single rule have the same name,
 the last one is used and the others are ignored.
 If a rule has both a valid <<pattern-descriptor>>

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -348,15 +348,6 @@ which matches any links that link to the site's homepage:
 }
 </pre>
 
-Because there is no dynamic part in the homepage URL,
-you can also pass in a <<url>> directly:
-
-<pre highlight=css>
-:link-to(url("/")) {
-  font-weight: bold;
-}
-</pre>
-
 Passing in a named route is also possible:
 
 <pre highlight=css>
@@ -369,7 +360,30 @@ Passing in a named route is also possible:
 }
 </pre>
 
-All three variants here match the same elements.
+Because there is no dynamic part in the homepage URL,
+you might be tempted to pass in a <<url>> directly:
+
+<pre highlight=css>
+:link-to(url("/")) {
+  font-weight: bold;
+}
+</pre>
+
+However, <code>url("/")</code> won't match URLs such as
+<code>/#scroll-to-here</code> or <code>/?utm_id=something</code>
+so it is recommended to use the <<url-pattern()>>
+or <<route-location>> variants, or use the following alternative:
+
+<pre highlight=css>
+@route --homepage {
+  pathname: "/";
+  base-url: document;
+}
+
+:link-to(--homepage) {
+  font-weight: bold;
+}
+</pre>
 </div>
 
 The '':link-to()'' pseudo-class takes a single argument, a <<route-location>>,

--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -15,6 +15,7 @@ Abstract: This module contains conditional CSS rules for styling conditioned on 
 
 <pre class="link-defaults">
 spec:css-values-5; type:function; text:if()
+spec:urlpattern; type:dfn; for:/; text:pattern string
 </pre>
 
 <!-- FIXME: TEMPORARILY override non-exported definition -->
@@ -162,6 +163,35 @@ which can be used to match URLs.
 
 This function represents the [=URL pattern=] resulting from
 invoking [=create a URL pattern for url-pattern()=] with its string argument.
+
+The syntax used in the ''url-pattern()'' function follows that of [=URL Pattern=].
+It is a [=pattern string=] directly based on the syntax used by
+the popular <a href="https://github.com/pillarjs/path-to-regexp">path-to-regexp</a> JavaScript library.
+
+<div class="example">
+Pattern strings can contain capture groups, which by default match the shortest possible string,
+up to a component-specific separator (<code>/</code> in the pathname, <code>.</code> in the hostname).
+
+For example, the pathname pattern <code>"/movies/:id"</code>
+will match <code>"/movies/123"</code>
+but not <code>"/movies/123/cast"</code>.
+
+A regular expression enclosed in parentheses can also be used instead,
+so the pathname pattern <code>"/blog/:id(\\d+)"</code>
+will match <code>"/movies/123"</code>
+but not <code>"/movies/css"</code>.
+
+You may also omit the name of the capture group by using only a regular expression,
+for example <code>"/blog/(\\d+)"</code>.
+
+A group can also be made optional by using the <code>?</code> modifier or by wrapping it in braces.
+For example, the patterns <code>"/movies/:id?"</code> and <code>"/movies{/:id}"</code>
+will match both <code>"/movies"</code> and <code>"/movies/123"</code> (but not <code>"/movies/"</code>).
+
+A full wildcard <code>*</code> can also be used to match as much as possible,
+as in the pattern <code>"/*/movies"</code>.
+This too can be given a name, for example <code>"/*lang/movies"</code>.
+</div>
 
 The steps of the <dfn>create a URL pattern for url-pattern()</dfn> algorithm,
 given a string <var>arg</var> and


### PR DESCRIPTION
This PR adds many more examples to the `css-navigation-1` spec. To help readers grasp the examples, it also introduces a description _(with examples)_ for URLPattern’s [pattern string](https://urlpattern.spec.whatwg.org/#pattern-string).

Were needed, existing content was moved around to allow a more continuous read.