### PR TITLE
[css-color-5][css-color-4] Consistent mention of `display-p3-linear` in `color(...)` syntax

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -4194,66 +4194,69 @@ The Predefined Display P3 Color Space: the ''display-p3'' keyword</h3>
 <h3 id="predefined-display-p3-linear">
 The Predefined Linear-Light Display P3 Color Space: the ''display-p3-linear'' keyword</h3>
 
+	<dl dfn-type=value dfn-for="color()">
+		<dt><dfn>display-p3-linear</dfn>
+		<dd>
+			The ''display-p3-linear'' predefined color space
+			is the same as ''display-p3''
+			<em>except</em> that the transfer function
+			is linear-light (there is no gamma-encoding).
 
-	The <dfn id='display-p3-linear-space' export>display-p3-linear</dfn> predefined color space
-	is the same as ''display-p3''
-	<em>except</em> that the transfer function
-	is linear-light (there is no gamma-encoding).
+			It has the following characteristics:
 
-	It has the following characteristics:
-
-	<table id="prr-color-display-p3-linear">
-		<thead>
+			<table id="prr-color-display-p3-linear">
+				<thead>
 					<tr>
 						<td></td>
 						<td>x</td>
 						<td>y</td>
 					</tr>
 				</thead>
-		<tr><th>Red chromaticity</th><td>0.680</td><td>0.320</td></tr>
-		<tr><th>Green chromaticity</th><td>0.265</td><td>0.690</td></tr>
-		<tr><th>Blue chromaticity</th><td>0.150</td><td>0.060</td></tr>
-		<tr><th>White chromaticity</th> <td  colspan="2">[=D65=]</td></tr>
-		<tr><th>Transfer function</th><td colspan="2">unity, see below </td></tr>
-		<tr><th>White luminance</th><td colspan="2">80.0 cd/m<sup>2</sup></td></tr>
-		<tr><th>Black luminance</th><td colspan="2">0.80 cd/m<sup>2</sup></td></tr>
-		<tr><th>Image state</th><td colspan="2">display-referred</td></tr>
-		<tr>
-			<th>Percentages</th>
-			<td  colspan="2">Allowed for R, G and B</td>
-		</tr>
-		<tr>
-			<th>Percent reference range&nbsp;</th>
-			<td>for R,G,B: 0% = 0.0, 100% = 1.0</td>
-		</tr>
-	</table>
+				<tr><th>Red chromaticity</th><td>0.680</td><td>0.320</td></tr>
+				<tr><th>Green chromaticity</th><td>0.265</td><td>0.690</td></tr>
+				<tr><th>Blue chromaticity</th><td>0.150</td><td>0.060</td></tr>
+				<tr><th>White chromaticity</th> <td  colspan="2">[=D65=]</td></tr>
+				<tr><th>Transfer function</th><td colspan="2">unity, see below </td></tr>
+				<tr><th>White luminance</th><td colspan="2">80.0 cd/m<sup>2</sup></td></tr>
+				<tr><th>Black luminance</th><td colspan="2">0.80 cd/m<sup>2</sup></td></tr>
+				<tr><th>Image state</th><td colspan="2">display-referred</td></tr>
+				<tr>
+					<th>Percentages</th>
+					<td  colspan="2">Allowed for R, G and B</td>
+				</tr>
+				<tr>
+					<th>Percent reference range&nbsp;</th>
+					<td>for R,G,B: 0% = 0.0, 100% = 1.0</td>
+				</tr>
+			</table>
 
-	<pre class="lang-javascript">
-		cl = c;
-	</pre>
+			<pre class="lang-javascript">
+				cl = c;
+			</pre>
 
-	c is the red, green or blue component.
-	cl is the corresponding linear-light component, which is identical.
+			c is the red, green or blue component.
+			cl is the corresponding linear-light component, which is identical.
 
-	To avoid banding artifacts, a
-	<a href="#predefined-precision-table">higher precision is required</a>
-	for ''display-p3-linear'' than for ''display-p3''.
+			To avoid banding artifacts, a
+			<a href="#predefined-precision-table">higher precision is required</a>
+			for ''display-p3-linear'' than for ''display-p3''.
 
-	<div class="example" id="display-p3-linear-swatches">
-		For example, these are the same color
-		<pre class="lang-css">
-		<span class="swatch" style="--color: rgb(64.55% 2.065% 26.03%)"></span> color(display-p3 0.591 0.123 0.264)
-		<span class="swatch" style="--color: rgb(64.55% 2.065% 26.03%)"></span> color(display-p3-linear 0.3081 0.014 0.0567)
-		</pre>
-	</div>
+			<div class="example" id="display-p3-linear-swatches">
+				For example, these are the same color
+				<pre class="lang-css">
+				<span class="swatch" style="--color: rgb(64.55% 2.065% 26.03%)"></span> color(display-p3 0.591 0.123 0.264)
+				<span class="swatch" style="--color: rgb(64.55% 2.065% 26.03%)"></span> color(display-p3-linear 0.3081 0.014 0.0567)
+				</pre>
+			</div>
 
+	</dl>
 	<wpt>
-	display-p3-linear-001.html
-	display-p3-linear-002.html
-	display-p3-linear-003.html
-	display-p3-linear-004.html
-	display-p3-linear-005.html
-	display-p3-linear-006.html
+		display-p3-linear-001.html
+		display-p3-linear-002.html
+		display-p3-linear-003.html
+		display-p3-linear-004.html
+		display-p3-linear-005.html
+		display-p3-linear-006.html
 	</wpt>
 
 <h3 id="predefined-a98-rgb">

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1838,7 +1838,7 @@ The result of this function is in the color space of the origin color.
 		<dfn>&lt;colorspace-params></dfn> = [<<custom-params>> | <<predefined-rgb-params>> | <<xyz-params>>]
 		<dfn>&lt;custom-params></dfn> = <<dashed-ident>> [ <<number>> | <<percentage>> | none ]+
 		<dfn>&lt;predefined-rgb-params></dfn> = <<predefined-rgb>> [ <<number>> | <<percentage>> | none ]{3}
-		<dfn>&lt;predefined-rgb></dfn> = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020
+		<dfn>&lt;predefined-rgb></dfn> = srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020
 		<dfn>&lt;xyz-params></dfn> = <<xyz-space>> [ <<number>> | <<percentage>> | none ]{3}
 	</pre>
 


### PR DESCRIPTION
See: https://drafts.csswg.org/css-color-4/#color-function

```
`<predefined-rgb>` = srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020
```

While [css-color-5] didn't have `display-p3-linear`:

```
`<predefined-rgb>` = srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020
```

----

In [css-color-4] the entry for `display-p3-linear` didn't match the existing pattern for the other color spaces in that section.

This should also fix the link to the `display-p3-linear` definition in the `color(...)` syntax: https://drafts.csswg.org/css-color-4/#color-function

<img width="426" height="51" alt="Screenshot of the spec showing display-p3 as a link and display-p3-linear as text" src="https://github.com/user-attachments/assets/89215573-fe30-4016-910e-f7d9944d87c8" />