### PR TITLE
[css-color-hdr-1][css-flexbox-2][editorial] Set range notation with i…

### DIFF
--- a/css-color-hdr-1/Overview.bs
+++ b/css-color-hdr-1/Overview.bs
@@ -585,7 +585,7 @@ Mixing Dynamic Range Limits: the ''dynamic-range-limit-mix()'' function {#dynami
 	Its syntax is as follows:
 
 	<pre class='prod'>
-		<dfn>hdr-color()</dfn> = color-hdr([ <<color>> && <<number [0,infinity]>>? ]#{2})
+		<dfn>hdr-color()</dfn> = color-hdr([ <<color>> && <<number [0,∞]>>? ]#{2})
 	</pre>
 
 	<div class="example" id="ex-hdr-color-simple">

--- a/css-flexbox-2/Overview.bs
+++ b/css-flexbox-2/Overview.bs
@@ -2230,7 +2230,7 @@ Minimum Flex Lines: the 'flex-line-count' property</h3>
 
 	<pre class='propdef'>
 	Name: flex-line-count
-	Value: <<integer [1, infinity]>>
+	Value: <<integer [1,∞]>>
 	Initial: 1
 	Applies to: [=multi-line=] [=flex containers=]
 	Inherited: no


### PR DESCRIPTION
This PR replaces the only two (recent) occurrences of `infinity` in production numeric ranges, with `∞`.

[§ 5.1. Range Restrictions and Range Definition Notation](https://drafts.csswg.org/css-values-4/#numeric-ranges) mentions `∞` but not `infinity`.

Or perhaps you would prefer to explicitly allow both?