### PR TITLE
[css-images-4] Add logical directions for linear-gradient()

### DIFF
--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -1107,11 +1107,14 @@ Linear Gradients: the ''linear-gradient()'' notation {#linear-gradients}
 	when interpolating colors on the gradient line.
 	See [[css-color-4#interpolation]].
 
+	This level also adds the ability to define the gradient’s direction
+	relative to the current block and inline directions.
+
 	<pre class=prod>
 		<dfn>&lt;linear-gradient-syntax></dfn> =
 			[ [ <<angle>> | <<zero>> | to <<side-or-corner>> ] || <<color-interpolation-method>> ]? ,
 			<<color-stop-list>>
-		<dfn>&lt;side-or-corner></dfn> = [left | right] || [top | bottom]
+		<dfn>&lt;side-or-corner></dfn> = [ [left | right] || [top | bottom] ] | [ [inline-start | inline-end] || [block-start | block-end] ]
 	</pre>
 
 	<wpt>


### PR DESCRIPTION
Takes some care of #974 for the time being.
I'd guess these will need more rigorous definitions once the whole spec text for this section gets copied over to level 4, but like this there's at least a mention of it.