### PR TITLE
[css-navigation-1] Fix abstract

### DIFF
--- a/css-navigation-1/Overview.bs
+++ b/css-navigation-1/Overview.bs
@@ -9,8 +9,8 @@ ED: https://drafts.csswg.org/css-navigation-1/
 !Issue Tracking: <a href="https://github.com/w3c/csswg-drafts/issues/12594">w3c/csswg-drafts#12594</a>
 Editor: L. David Baron, Google https://www.google.com/, https://dbaron.org/, w3cid 15393
 Editor: Noam Rosenthal, Google https://www.google.com/, w3cid 121539
-Abstract: This module contains conditional CSS rules for styling conditioned on the current URL
-        or conditioned on the status of navigating between particular URLs.
+Abstract: This module contains conditional CSS rules for styling
+        conditioned on the status of navigating between particular URLs.
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
This spec no longer offers rules for styling conditioned on the current URL.