### PR TITLE
[css-color-5] update serialization example for RCS with nested none

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -3516,6 +3516,16 @@ while the serialization of the computed value
 is the string "color(srgb 0.5 0 0.3)".
 </div>
 
+<div class="example" id="ex-serial-rcs-hsl">
+For example, the serialization of the declared value of
+
+<pre class="lang-css">hsl(from hsl(0deg 10% 50%) h s l);</pre>
+
+is the string "hsl(from hsl(0deg 10% 50%) h s l)",
+while the serialization of the computed value
+is the string "color(srgb 0.55 0.45 0.45)".
+</div>
+
 <div class="example" id="ex-serial-rcs-nested-none">
 For example, the serialization of the declared value of
 
@@ -3523,7 +3533,15 @@ For example, the serialization of the declared value of
 
 is the string "hsl(from hsl(none 10% 50%) h s l)",
 while the serialization of the computed value
-is the string "color(srgb 0.55 0.45 0.45)".
+is the string "hsl(none 10% 50%)".
+
+The computed value carries forward the [=missing=] hue,
+giving an ''hsl()'' [=relative color=]
+whose hue is itself [=missing=].
+Because the resolved value contains [=missing color components=],
+the serialization uses the modern ''hsl()'' form,
+yielding the string "hsl(none none none / none)"
+rather than ''color(srgb 0.55 0.45 0.45)''.
 </div>
 
 <div class="example" id="ex-serial-rcs-alpha-none">


### PR DESCRIPTION
see: https://github.com/w3c/csswg-drafts/issues/10151#issuecomment-2162739580

> `none` in calculations is converted to 0 when converting a color to a different color space. It is still preserved otherwise, and is still preserved when used as the whole value of a component.

The spec was updated to match that resolution but it seems that this example was overlooked.

I've split the existing example in two as the original example showcased two aspects:
- `none` becomes zero
- `hsl` in RCS without `none` is serialized as `color(srgb ...)` 
