### PR TITLE
[css-text-3][css-text-4] Re-introduce dfn for `word-wrap`

### DIFF
--- a/css-text-3/Overview.bs
+++ b/css-text-3/Overview.bs
@@ -4747,7 +4747,7 @@ Overflow Wrapping: the 'overflow-wrap' ('word-wrap') property</h3>
 			</wpt>
 	</dl>
 
-	For legacy reasons, UAs must treat 'word-wrap'
+	For legacy reasons, UAs must treat <dfn property>word-wrap</dfn>
 	as a [=legacy name alias=] of the 'overflow-wrap' property.
 
 	<wpt>

--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -8224,7 +8224,7 @@ Overflow Wrapping: the 'overflow-wrap' ('word-wrap') property</h3>
 	to opt out of relaxing the ''keep-all'' and ''word-break/auto-phrase'' restrictions
 	as allowed by ''overflow-wrap: normal''?
 
-	For legacy reasons, UAs must treat 'word-wrap'
+	For legacy reasons, UAs must treat <dfn property>word-wrap</dfn>
 	as a [=legacy name alias=] of the 'overflow-wrap' property.
 
 	<wpt>


### PR DESCRIPTION
The `word-wrap` property was moved out of the definition table (addressing issue #11544). But the property still needs to be defined somewhere for references to it to keep working, and for crawling tools to understand that it is a legacy name alias of `overflow-wrap`.

This adds back the missing `<dfn property>` to re-create the definition and fix the references to `word-wrap` that the specs contain.

Feel free to proceed otherwise and put the `<dfn>` elsewhere. The issue here is that there needs to remain a `<dfn>` for the property somewhere.