### PR TITLE
[css-values-4] Remove duplicate definition for string values

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -668,12 +668,6 @@ Textual Data Types</h2>
 	(which includes character set conversion and [[css-syntax-3#escaping|escaping]]).
 	[[!UNICODE]] [[!CSS-SYNTAX-3]]
 
-	[=Strings=], denoted by <dfn id="string-value">&lt;string></dfn>,
-	are sequences of characters representing arbitrary textual data.
-	When written literally,
-	they are delimited by double quotes or single quotes,
-	and correspond to the <<string-token>> production. [[!CSS-SYNTAX-3]].
-
 	CSS <dfn export lt="CSS identifier | CSS ident | identifier | ident" for="CSS">identifiers</dfn>,
 	generically denoted by <dfn>&lt;ident></dfn>,
 	represent names,


### PR DESCRIPTION
This definition in [§ 4. Textual Data Types](https://drafts.csswg.org/css-values-4/#textual-values) currently makes bikeshed complain about a duplicate definition because the exact same paragraph is duplicated further down in [§ 4.4. Quoted Strings: the &lt;string> type](https://drafts.csswg.org/css-values-4/#strings).

I assume that's the right place for it, because it's right next to the definition for URL values, which are also mentioned but not defined in [§ 4. Textual Data Types](https://drafts.csswg.org/css-values-4/#textual-values).