### PR TITLE
[css-color-4] Corrections for Raytrace GMA #14029

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -6300,8 +6300,8 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 		<li>if |origin_rgb| is not in gamut
 			<ul>
 				<!-- we do, so perform chroma reduction -->
-				<li>let |low| be 0.0 + 1E-6 <a href="#raytrace-footnote-1"><sup>1</sup></a></li>
-				<li>let |high| be 1.0 - 1E-6 <a href="#raytrace-footnote-2"><sup>2</sup></a></li>
+				<li>let |low| be 0.0 + 1E-12 <a href="#raytrace-footnote-1"><sup>1</sup></a></li>
+				<li>let |high| be 1.0 - 1E-12 <a href="#raytrace-footnote-2"><sup>2</sup></a></li>
 				<li>let |last| be |origin_rgb|</li>
 				<li>for (i=0; i&lt;4; i++)
 					<ul>
@@ -6339,7 +6339,7 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 		<li>let clip(|color|) be a function which converts |color| to |destination|,
 		clamps each component to the bounds of the reference range for that component
 		and returns the result</li>
-		<li>set |clipped| to clip(|current|)</li>
+		<li>set |clipped| to clip(|origin_rgb|)</li>
 		<li>return |clipped| as the gamut mapped color</li>
 	</ol>
 
@@ -6366,7 +6366,7 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 				<li>let |d| be |b| - |a|</li>
 				<li>let |direction| <i>[i]</i> be |d|</li>
 				<!--  Non parallel cases -->
-				<li>if abs(|d|) < 1E-12
+				<li>if abs(|d|) > 1E-12 <a href="#raytrace-footnote-7"><sup>7</sup></a></li>
 					<ul>
 						<li>let |inv_d| be 1 / |d|</li>
 						<li>let |t1| be (|bmin| <i>[i]</i> - |a| ) * |inv_d| </li>
@@ -6392,7 +6392,7 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 		<li>if |tnear| &lt; 0
 			<ul>
 				<li>let |tnear| be |tfar|
-					<a href="#raytrace-footnote-7"><sup>7</sup></a>
+					<a href="#raytrace-footnote-8"><sup>8</sup></a>
 				</li>
 			</ul>
 		</li>
@@ -6416,7 +6416,7 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 			It is assumed the minimum value is 0
 			and that all channels have the same minimum.
 			The value should be small relative to the unit type.
-			64 bit could easily be as small as 1e-14, but 1e-6 is fine in practice.</li>
+			The specifed value of 1e-12 is for 64-bit, but for 32-bit, 1e-6 should be used.</li>
 		<li id="raytrace-footnote-2">
 			1.0 represents the maximum in-gamut channel value,
 			and it is assumed all channels have the same maximum.</li>
@@ -6438,7 +6438,10 @@ Sample Pseudocode for the Ray Trace Gamut Mapping</h4>
 			this simplifies to a single constant
 			rather than a 3-element array.</li>
 		<li id="raytrace-footnote-7">
-			favoring the first intersection in the direction |start| -> |end| .
+			The value should be small relative to the unit type.
+			The specifed value of 1e-12 is for 64-bit, but for 32-bit, 1e-6 should be used.</li>
+		<li id="raytrace-footnote-8">
+			favoring the first intersection in the direction |start| -> |end| .</li>
 	</ol>
 
 </div>


### PR DESCRIPTION
1. Sign was wrong on delta threshold within the ray trace pseudocode: `<` should have been `>`.
2. Update gamut surface distance threshold from `1e-6` to `1e-12` which allows for better hue preservation in certain cases when using 64-bit unit types.
3. Values are presented from the 64-bit perspective, footnotes should clarify this and offer proper 32-bit values as well. This should be done for both the ray trace delta threshold and the gamut surface distance threshold.
4. Update `clip(|current|)` to `clip(|origin_rgb|)` as `current` doesn't exist in the context of the pseudocode.

[css-spec-shortname-1] Brief description which should also include the #issuenum-or-URL and/or link to relevant CSSWG minutes.

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.
