### PR TITLE
[css-view-transitions-2] Exclude `-ua-*` and `none` in types

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2039,7 +2039,7 @@ The [=@view-transition/types=] descriptor
 
 		: <dfn><<custom-ident>>+</dfn>
 		:: Sets the [=ViewTransition/active types=] for the transition to the specified custom identifiers,
-			 excluding `none` and identifiers starting with the string "ua-".
+			 excluding `none` and identifiers starting with the string "-ua-".
 	</dl>
 
 	Note: the [=@view-transition/types=] descriptor only applies to the {{Document}} in which it is defined.

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2423,7 +2423,13 @@ It has the following [=struct/items=]:
 
 		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
 
-		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
+		1. Let |types| be a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
+
+		1. [=list/Remove=] "`none`" from |types|.
+
+		1. [=list/Remove=] all items from |types| that start with the string "`-ua-`".
+
+		1. Return |types|.
 	</div>
 
 ## [=Setup view transition|Setup single-document view transition=] ## {#setup-view-transition-algorithm}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2038,8 +2038,8 @@ The [=@view-transition/types=] descriptor
 		:: No transition types are set.
 
 		: <dfn><<custom-ident>>+</dfn>
-		:: Sets the [=ViewTransition/active types=] for the transition to the specified custom identifiers,
-			 excluding `none` and identifiers starting with the string "-ua-".
+		:: Sets the [=ViewTransition/active types=] for the transition to the specified custom identifiers.
+			 The <<custom-ident>> `none`, as well as any <<custom-ident>> starting with `-ua-`, are ignored.
 	</dl>
 
 	Note: the [=@view-transition/types=] descriptor only applies to the {{Document}} in which it is defined.
@@ -2423,13 +2423,7 @@ It has the following [=struct/items=]:
 
 		1. If |typesDescriptor|'s [=computed value=] is ''@view-transition/type/none'', then return a [=/set=] « ».
 
-		1. Let |types| be a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
-
-		1. [=list/Remove=] "`none`" from |types|.
-
-		1. [=list/Remove=] all items from |types| that start with the string "`-ua-`".
-
-		1. Return |types|.
+		1. Return a [=/set=] of strings corresponding to |typesDescriptor|'s [=computed value=].
 	</div>
 
 ## [=Setup view transition|Setup single-document view transition=] ## {#setup-view-transition-algorithm}

--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2033,6 +2033,15 @@ The [=@view-transition/types=] descriptor
 	The '<dfn for="@view-transition">types</dfn>' descriptor sets the [=ViewTransition/active types=] for the transition
 	when capturing or performing the transition, equivalent to calling {{Document/startViewTransition(callbackOptions)}} with that {{StartViewTransitionOptions/types}}.
 
+	<dl dfn-type=value dfn-for="@view-transition/types">
+		: <dfn>none</dfn>
+		:: No transition types are set.
+
+		: <dfn><<custom-ident>>+</dfn>
+		:: Sets the [=ViewTransition/active types=] for the transition to the specified custom identifiers,
+			 excluding `none` and identifiers starting with the string "ua-".
+	</dl>
+
 	Note: the [=@view-transition/types=] descriptor only applies to the {{Document}} in which it is defined.
 	The author is responsible for using their chosen set of types in both documents.
 


### PR DESCRIPTION
Based on resolution https://github.com/w3c/csswg-drafts/issues/9534#issuecomment-1802364085
Closes #14081
