### PR TITLE
[css-view-transitions-2] Fix typo regarding types manipulation.

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2852,7 +2852,7 @@ It has the following [=struct/items=]:
 	1. Set |outboundTransition|'s [=ViewTransition/active types=] to |transitionTypesFromRule|.
 
 		Note: the [=ViewTransition/active types=] are not shared between documents.
-		Manipulating the {{ViewTransition/types}} in the new document does not affect the types in |newDocument|,
+		Manipulating the {{ViewTransition/types}} in the old document does not affect the types in |newDocument|,
 		which would be read from the [=@view-transition/types=] descriptor once |newDocument| is revealed.
 
 		Note: the {{ViewTransition}} is skipped once the old document is hidden.


### PR DESCRIPTION
It should be manipulation of types in the _old_ document won't carry over to the new document