### PR TITLE
[css-speech][editorial] Enforce positive `<generic-voice>` variant using range notation

### DIFF
--- a/css-speech-1/Overview.bs
+++ b/css-speech-1/Overview.bs
@@ -942,7 +942,7 @@ The 'voice-family' property</h3>
 	by specifying match criteria.
 	See the <a href="#voice-selection">voice selection</a> section on this topic.
 
-	<dfn><<generic-voice>></dfn> = <<age>>? <<gender>> <<integer>>?
+	<dfn><<generic-voice>></dfn> = <<age>>? <<gender>> <<integer [1,∞]>>?
 
 	Note: Although the functionality provided by this property is similar to
 	the <a href="https://www.w3.org/TR/speech-synthesis11/#edef_voice"><code>voice</code> element</a>


### PR DESCRIPTION
The `<integer>` representing a `voice-family` variant is restricted to non-negative values in prose:

  > **`<integer>`**
  >
  > An integer indicating the preferred variant (e.g. "the second male child voice"). **Only positive integers (i.e. excluding zero) are allowed.** The value 1 refers to the first of all matching voices.

But the [`<generic-voice>`](https://drafts.csswg.org/css-speech-1/#typedef-generic-voice) production rule does not enforce it with a range notation.