### PR TITLE
[css-view-transitions-2] Change view transition pseudo elements to be fully styleable

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -1257,7 +1257,7 @@ and by applying ''view-transition-group'' to the internal element referencing th
 
 	Several of the [=view transition pseudo-elements=]
 	are <dfn>named view transition pseudo-elements</dfn>,
-	which are [=functional pseudo-element|functional=] [=tree-abiding pseudo-element|tree-abiding=] [=view transition pseudo-elements=]
+	which are [=functional pseudo-element|functional=] [=fully styleable pseudo-elements|fully styleable=] [=view transition pseudo-elements=]
 	associated with a [=view transition name=].
 	These pseudo-elements take a <<pt-name-selector>> as their argument,
 	and their syntax follows the pattern:
@@ -1291,7 +1291,7 @@ and by applying ''view-transition-group'' to the internal element referencing th
 ### View Transition Tree Root: the ''::view-transition'' pseudo-element ### {#view-transition-pseudo}
 
 	The <dfn>::view-transition</dfn> [=pseudo-element=]
-	is a [=tree-abiding pseudo-element=] that is also a [=pseudo-element root=].
+	is a [=fully styleable pseudo-element=] that is also a [=pseudo-element root=].
 	If its [=originating element=] is the document's [=document element=],
 	its [=containing block=] is the [=snapshot containing block=].
 


### PR DESCRIPTION
Tree-abiding pseudo-elements are not necessarily fully styleable and one would need to manually specify what CSS properties can apply to them.

Fixes https://github.com/w3c/csswg-drafts/issues/12983