### PR TITLE
[css-borders-4] Handle rectangle, self-intersecting, and non-uniform outset corners in the contoured path algorithm

### DIFF
--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1580,8 +1580,8 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 		1. Let |virtualEndRadius| be <code>|outsetAdjustedEndRadius| - |uniformVirtualOutset|</code>.
 		1. Let |virtualStartInset| be <code>-|uniformVirtualOutset|</code>.
 		1. Let |virtualEndInset| be <code>-|uniformVirtualOutset|</code>.
-		1. Let |vectorToVirtualCornerOuterV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|insetStart| + |uniformVirtualOutset|</code>.
-		1. Let |vectorToVirtualCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|insetEnd| + |uniformVirtualOutset|</code>.
+		1. Let |vectorToVirtualCornerOuterV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|insetEnd| + |uniformVirtualOutset|</code>.
+		1. Let |vectorToVirtualCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|insetStart| + |uniformVirtualOutset|</code>.
 		1. Let |virtualCornerOuter| be |cornerOuter|, [=point extended by vectors|extended by=] « |vectorToVirtualCornerOuterV3|, |vectorToVirtualCornerOuterV2| ».
 
 		1. Return the [=border-aligned corner clip-out path=] given 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1789,7 +1789,7 @@ Interpolating corner shapes</h4>
 
 Since a <<corner-shape-value>> can always be expressed by a ''superellipse()'' with an [=superellipse parameter=] variable, interpolating between two
 <<corner-shape-value>>s is done by interpolating the [=superellipse parameter=] itself.
-Since it uses a <code>log2</code>, interpolating it linearly would result in an effect where concave corners interpolate at a much higher velocity than convex corners.
+Since the bevel, round, and straight corner shapes correspond to parameter values of 0, 1, and infinity, respectively, interpolating between them linearly would make the transition from a bevel to a straight corner shape appear to start very quickly and slow down toward the end.
 To balance that, the <dfn>superellipse interpolation</dfn> formula describes how a [=superellipse parameter=] is converted to a value between 0 and 1, and vice versa:
 
 <div algorithm="superellipse-param-to-interpolation-value">

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -675,12 +675,12 @@ Corners</h2>
 
 	To compute the <dfn export>outset-adjusted border radius</dfn> given the 2-dimensional [=size=]'s |edge|, |radius|, and |outset|:
 		1. Let |coverage| be <code>2 * min(|radius|'s [=width=] / |edge|'s [=width=], |radius|'s [=height=] / |edge|'s [=height=])</code>.
-		1. Let |adustedRadiusWidth| be the [=adjusted radius dimension=] given |coverage|, |radius|'s [=width=], and |outset|'s [=width=].
-		1. Let |adustedRadiusHeight| be the [=adjusted radius dimension=] given |coverage|, |radius|'s [=height=], and |outset|'s [=height=].
-		1. Return (|adustedRadiusWidth|, |adustedRadiusHeight|).
+		1. Let |adjustedRadiusWidth| be the [=adjusted radius dimension=] given |coverage|, |radius|'s [=width=], and |outset|'s [=width=].
+		1. Let |adjustedRadiusHeight| be the [=adjusted radius dimension=] given |coverage|, |radius|'s [=height=], and |outset|'s [=height=].
+		1. Return (|adjustedRadiusWidth|, |adjustedRadiusHeight|).
 
 	To compute the <dfn>adjusted radius dimension</dfn> given numbers |coverage|, |radius|, and |outset|:
-		1. If |radius| is greater than |spread|, or if |coverage| is greater than 1, then return <code>|radius| + |outset|</code>.
+		1. If |radius| is greater than |outset|, or if |coverage| is greater than 1, then return <code>|radius| + |outset|</code>.
 		1. Let |ratio| be <code>|radius| / |outset|</code>.
 		1. Return <code>|radius| + |outset| * (1 - (1 - |ratio|)<sup>3</sup> * (1 - |coverage|<sup>3</sup>))</code>.
 
@@ -898,7 +898,7 @@ Corner Sizing: the 'border-*-*-radius' properties</h3>
 
 		<figcaption>
 			The two values of ''border-top-left-radius: 55pt 25pt''
-			define the curvature of the corner.
+			define the size of the corner.
 		</figcaption>
 	</figure>
 
@@ -1191,15 +1191,15 @@ Corner Shaping: the 'corner-*-shape' properties</h3>
 			when |K| is 0 it's a diamond with perfectly flat sides.
 
 		* Negative values define concave curves,
-			roughly opposite of what you get with positive values:
-			a |K| of -1 gives a nearly elliptical "scoop"
-			that's roughly the opposite of a |K| of 1,
+			exact opposite of what you get with positive values:
+			a |K| of -1 gives an elliptical "scoop"
+			that's the opposite of a |K| of 1,
 			a |K| of -2 gives a "squircle" scoop,
 			a |K| of negative infinity gives a square scoop,
 			etc.
 
 		(Note that most literature on superellipses
-		will write the equation with a simpler <math display=inline><msup><mi>x</mi><mi>K</mi></msup></math> exponent.
+		will write the equation with a simpler <math display=inline><msup><mi>x</mi><mi>n</mi></msup></math> exponent.
 		The <math display=inline><msup><mi>x</mi><msup><mn>2</mn><mi>K</mi></msup></msup></math> form
 		was chosen here
 		to make the argument ranges easier to reason about:
@@ -1521,6 +1521,16 @@ The <dfn for="two-dimensional vector">perpendicular</dfn> of a [=two-dimensional
 
 The <dfn>vector between two points</dfn>, given {{DOMPoint}}s |a| and |b|, is <code>(|b|'s {{DOMPointReadOnly/x}} - |a|'s {{DOMPointReadOnly/x}}, |b|'s {{DOMPointReadOnly/y}} - |a|'s {{DOMPointReadOnly/y}})</code>. 
 
+<div algorithm="sum-vectors">
+To <dfn for="two-dimensional vector list">sum</dfn> a [=/list=] of [=two-dimensional vector=]s |vectors|:
+	1. Let |x| be <code>0</code>.
+	1. Let |y| be <code>0</code>.
+	1. [=list/For each=] |v| in |vectors|:
+		1. Increment |x| by |v|[0];
+		1. Increment |y| by |v|[1];
+	1. Return <code>(|x|, |y|)</code>.
+</div>
+
 <h5 id=contour-path>Computing a contoured path</h5>
 
 This algorithm describes how to compute a path with shaped corners (a path that is either inset or outset from the original).
@@ -1532,97 +1542,198 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 	1. Let |borderRect| be |element|'s [=border box=].
 	1. Let |unshapedTargetRect| be |borderRect|, inset by |topInset|, |rightInset|, |bottomInset|, |leftInset|.
 		
-			Note: If this is a shadow or 'overflow-clip-margin', the insets would have negative values and |unshapedTargetRect| would become an outset of |borderRect|.
+		Note: If this is a shadow or 'overflow-clip-margin', the insets would have negative values and |unshapedTargetRect| would become an outset of |borderRect|.
 
 	1. Let |path| be a path that contains |unshapedTargetRect|.
 
 	1. Let |scaleFactor| be the [=opposite corner scale factor=] given |element|.
 
-	1. Let |adjustedRadius| be the following steps given a property |P|, and numbers |insetX| and |insetY|:
+	1. Let |constrainedRadius| be the following steps, given a property |P|:
 		1. Let |radius| be |element|'s [=used value=] of |P|.
-		1. If |insetX| and |insetY| are zero, return |radius|.
-		1. If |insetX| or |insetY| are positive, then return <code>(|radius|'s [=width=] ⋅ |scaleFactor|, |radius|'s [=height=] ⋅ |scaleFactor|)</code>.
-		1. Let |adjustedRadiusInOutsetCoordinates| be the [=outset-adjusted border radius=] given |borderRect|'s size, |radius|, and <code>(-|insetX|, -|insetY|)</code>.
-		1. Return <code>(|adjustedRadiusInOutsetCoordinates|'s [=width=] - |insetX|, |adjustedRadiusInOutsetCoordinates|'s [=height=] - |insetY|)</code>.
+		1. Return <code>(|radius|'s [=width=] ⋅ |scaleFactor|, |radius|'s [=height=] ⋅ |scaleFactor|)</code>.
 
-	1. Let |adjustedTopRightRadius| be the |adjustedRadius| given 'border-top-right-radius', |insetRight|, and |insetTop|.
-	1. Let |adjustedBottomRightRadius| be the |adjustedRadius| given 'border-bottom-right-radius', |insetRight|, and |insetBottom|.
-	1. Let |adjustedBottomLeftRadius| be the |adjustedRadius| given 'border-bottom-left-radius', |insetLeft|, and |insetBottom|.
-	1. Let |adjustedTopLeftRadius| be the |adjustedRadius| given 'border-top-left-radius', |insetLeft|, and |insetTop|.
+	1. Let |topRightRadius| be the |constrainedRadius| given 'border-top-right-radius'.
+	1. Let |bottomRightRadius| be the |constrainedRadius| given 'border-bottom-right-radius'.
+	1. Let |bottomLeftRadius| be the |constrainedRadius| given 'border-bottom-left-radius'.
+	1. Let |topLeftRadius| be the |constrainedRadius| given 'border-top-left-radius'.
 
-	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given 
-		|borderRect|'s right, |borderRect|'s top,
-		<code>(-|adjustedTopRightRadius|[0], 0)</code>, <code>(0, |adjustedTopRightRadius|[1])</code>,
-		|element|'s [=computed value|computed=] 'corner-top-right-shape',
-		|topInset|, and |rightInset|.
+	1. Let |outsetAdjustedRadius| be the following steps, given a radius |radius|, and numbers |insetX| and |insetY|:
+		1. If |insetX| or |insetY| is positive, or if |insetX| and |insetY| are zero, return |radius|.
+		1. Return the [=outset-adjusted border radius=] given |borderRect|'s size, |radius|, and <code>(-|insetX|, -|insetY|)</code>.
 
-	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given 
-		|borderRect|'s right, |borderRect|'s bottom,
-		<code>(0, -|adjustedBottomRightRadius|[1])</code>, <code>(-|adjustedBottomRightRadius|[0], 0)</code>,
-		|element|'s [=computed value|computed=] 'corner-bottom-right-shape',
-		|rightInset|, and |bottomInset|.
+	1. Let |outsetAdjustedTopRightRadius| be the |outsetAdjustedRadius| given |topRightRadius|, |insetRight|, and |insetTop|.
+	1. Let |outsetAdjustedBottomRightRadius| be the |outsetAdjustedRadius| given |bottomRightRadius|, |insetRight|, and |insetBottom|.
+	1. Let |outsetAdjustedBottomLeftRadius| be the |outsetAdjustedRadius| given |bottomLeftRadius|, |insetLeft|, and |insetBottom|.
+	1. Let |outsetAdjustedTopLeftRadius| be the |outsetAdjustedRadius| given |topLeftRadius|, |insetLeft|, and |insetTop|.
+
+	1. Let |adjustedClipOutPath| be the following steps, given
+		numbers |outsetAdjustedStartRadius|, |outsetAdjustedEndRadius|,
+		|startRadius|, |endRadius|,
+		|startInset|, and |endInset|,
+		a {{DOMPointReadOnly}} |cornerOuter|,
+		[=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|,
+		a [=superellipse parameter=] |K|:
+		1. If |insetStart| or |insetEnd| is positive, or if |insetStart| and |insetEnd| are zero:
+			1. Return the [=border-aligned corner clip-out path=] given 
+				|startRadius|, |endRadius|,
+				|startInset|, |endInset|,
+				|cornerOuter|,
+				|normalizedV3|, |normalizedV2|,
+				|K|.
+		1. Let |uniformVirtualOutset| be <code>min(|outsetAdjustedStartRadius| - |startRadius|, |outsetAdjustedEndRadius| - |endRadius|)</code>.
+		1. Let |virtualStartRadius| be <code>|outsetAdjustedStartRadius| - |uniformVirtualOutset|</code>.
+		1. Let |virtualEndRadius| be <code>|outsetAdjustedEndRadius| - |uniformVirtualOutset|</code>.
+		1. Let |virtualStartInset| be <code>-|uniformVirtualOutset|</code>.
+		1. Let |virtualEndInset| be <code>-|uniformVirtualOutset|</code>.
+		1. Let |vectorToVirtualCornerOuterV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|insetStart| + |uniformVirtualOutset|</code>.
+		1. Let |vectorToVirtualCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|insetEnd| + |uniformVirtualOutset|</code>.
+		1. Let |virtualCornerOuter| be |cornerOuter|, [=point extended by vectors|extended by=] « |vectorToVirtualCornerOuterV3|, |vectorToVirtualCornerOuterV2| ».
+
+		1. Return the [=border-aligned corner clip-out path=] given 
+			|virtualStartRadius|, |virtualEndRadius|,
+			|virtualStartInset|, |virtualEndInset|,
+			|virtualCornerOuter|,
+			|normalizedV3|, |normalizedV2|,
+			|K|.
+
+	1. Clip out from |path|, the |adjustedClipOutPath| given
+		|outsetAdjustedTopRightRadius|'s [=height=] ,|outsetAdjustedTopRightRadius|'s [=width=],
+		|topRightRadius|'s [=height=] ,|topRightRadius|'s [=width=],
+		|topInset|, |rightInset|,
+		a {{DOMPointReadOnly}} at <code>(|borderRect|'s right, |borderRect|'s top)</code>,
+		<code>(-1, 0)</code>, <code>(0, 1)</code>,
+		|element|'s [=computed value|computed=] 'corner-top-right-shape'.
+
+	1. Clip out from |path|, the |adjustedClipOutPath| given
+		|outsetAdjustedBottomRightRadius|'s [=width=] ,|outsetAdjustedBottomRightRadius|'s [=height=],
+		|bottomRightRadius|'s [=width=], |bottomRightRadius|'s [=height=],
+		|rightInset|, |bottomInset|,
+		a {{DOMPointReadOnly}} at <code>(|borderRect|'s right, |borderRect|'s bottom)</code>,
+		<code>(0, -1)</code>, <code>(-1, 0)</code>,
+		|element|'s [=computed value|computed=] 'corner-bottom-right-shape'.
 		
-	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given 
-		|borderRect|'s left, |borderRect|'s bottom,
-		<code>(|adjustedBottomLeftRadius|[0], 0)</code>, <code>(0, -|adjustedBottomLeftRadius|[1])</code>,
-		|element|'s [=computed value|computed=] 'corner-bottom-left-shape',
-		|bottomInset|, and |leftInset|.
+	1. Clip out from |path|, the |adjustedClipOutPath| given
+		|outsetAdjustedBottomLeftRadius|'s [=height=] ,|outsetAdjustedBottomLeftRadius|'s [=width=],
+		|bottomLeftRadius|'s [=height=], |bottomLeftRadius|'s [=width=],
+		|bottomInset|, |leftInset|,
+		a {{DOMPointReadOnly}} at <code>(|borderRect|'s left, |borderRect|'s bottom)</code>,
+		<code>(1, 0)</code>, <code>(0, -1)</code>,
+		|element|'s [=computed value|computed=] 'corner-bottom-left-shape'.
 		
-	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given 
-		|borderRect|'s left, |borderRect|'s top,
-		<code>(0, |adjustedTopLeftRadius|[1])</code>, <code>(|adjustedTopLeftRadius|[0], 0)</code>,
-		|element|'s [=computed value|computed=] 'corner-top-left-shape',
-		|leftInset|, and |topInset|.
+	1. Clip out from |path|, the |adjustedClipOutPath| given
+		|outsetAdjustedTopLeftRadius|'s [=width=] ,|outsetAdjustedTopLeftRadius|'s [=height=],
+		|topLeftRadius|'s [=width=], |topLeftRadius|'s [=height=],
+		|leftInset|, |topInset|,
+		a {{DOMPointReadOnly}} at <code>(|borderRect|'s left, |borderRect|'s top)</code>,
+		<code>(0, 1)</code>, <code>(1, 0)</code>,
+		|element|'s [=computed value|computed=] 'corner-top-left-shape'.
 
 	1. Return |path|.
 
-To get the <dfn>border-aligned corner clip-out path</dfn> given a {{DOMPointReadOnly}} |originalCornerOuter|, a [=two-dimensional vector=] |vectorTowardsStart|, a [=two-dimensional vector=] |vectorTowardsEnd|, a [=superellipse parameter=] |curvature|, and numbers |startInset| and |endInset|:
-	1. If |curvature| is ∞, then return an empty path.
-	1. Let |clampedHalfCorner| be the [=normalized superellipse half corner=] given <code>clamp(|curvature|, -1, 1)</code>.
-	1. Let |originalCornerStart| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |vectorTowardsStart| ».
-	1. Let |originalCornerEnd| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |vectorTowardsEnd| ».
-	1. Let |originalCornerCenter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |vectorTowardsStart|, |vectorTowardsEnd| ».
-	1. Let |extendStart| be a [=vector between two points|vector between=] |originalCornerStart| and |originalCornerCenter|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] |startInset|.
-	1. Let |extendEnd| be a [=vector between two points|vector between=] |originalCornerEnd| and |originalCornerCenter|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] |endInset|.
+To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRadius|, |endRadius|, |startInset|, |endInset|, a {{DOMPointReadOnly}} |originalCornerOuter|, [=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|, a [=superellipse parameter=] |K|:
+	1. Assert <code>|startInset| ⋅ |endInset|</code> greater than or equal to zero.
+	1. If |startInset| or |endInset| is less than zero, then assert |startInset| equal to |endInset|.
+
+	1. If |K| is ∞, then return an empty path.
+
+	1. Let |originalCornerV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] |endRadius|.
+	1. Let |originalCornerV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] |startRadius|.
+
+	1. Let |originalCornerStart| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV3| ».
+	1. Let |originalCornerEnd| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV2| ».
+	1. Let |originalCornerCenter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV3|, |originalCornerV2| ».
+
+	1. Let |mapPointToCorner| be the following steps, given numbers |x| and |y|, {{DOMPointReadOnly}} |start|, |end|, and |center|:
+		1. Let |v1| be  [=vector between two points|the vector between=] |center| and |end|, [=two-dimensional vector/scale|scaled by=] |x|.
+		1. Let |v4| be  [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |y|.
+		1. Return the {{DOMPointReadOnly}} at <code>(|x|, |y|)</code>, [=point extended by vectors|extended by=] « |v1|, |v4| ».
+
+	1. Let |curvePath| be the following steps, given {{DOMPointReadOnly}} |start|, |outer|, |end|, and |center|:
+		1. Let |path| be a path, starting at |start|.
+		1. If |K| is -∞:
+			1. Extend |path| to |center|.
+			1. Extend |path| to |end|.
+		1. Otherwise:
+			1. Let |n| be <code>2<sup>abs(|K|)</sup></code>.
+			1. Let |curveCenter| be |outer| if |K| is less than zero, |center| otherwise.
+			1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
+				extend |path| to the result of calling |mapPointToCorner| given <code>|T|<sup>1/|n|</sup></code> and <code>(1 - |T|)<sup>1/|n|</sup></code>, |start|, |end|, and |curveCenter|.
+		1. Return |path|.
+
+	1. If |startInset| and |endInset| are zero:
+		1. Let |path| be |curvePath| given |originalCornerStart|, |originalCornerOuter|, |originalCornerEnd|, |originalCornerCenter|.
+		1. Return |path|.
+
+	1. Let |clampedHalfCornerX| be the [=normalized superellipse half corner=] given <code>clamp(|K|, -1, 1)</code>.
+	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
+
+	1. Let |startPseudoNormalVectorUnmapped| be the [=two-dimensional vector=] <code>((1 - |controlPointX|) ⋅ |startRadius|, |controlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |endPseudoNormalVectorUnmapped| be the [=two-dimensional vector=] <code>(|controlPointX| ⋅ |startRadius|, (1 - |controlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+
+	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|startPseudoNormalVectorUnmapped|[0] ⋅ |startInset|</code>.
+	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|startPseudoNormalVectorUnmapped|[1] ⋅ |startInset|</code>.
+	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|endPseudoNormalVectorUnmapped|[0] ⋅ |endInset|</code>.
+	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|endPseudoNormalVectorUnmapped|[1] ⋅ |endInset|</code>.
+
+	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetStartV2| ».
+	1. Let |adjustedCornerOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetStartV2| ».
+	1. Let |adjustedCornerEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetEndV2| ».
+	1. Let |adjustedCornerCenter| be |originalCornerCenter|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetEndV2| ».
+	
+	1. If |startInset| or |endInset| is greater than zero:
+		1. Let |path| be |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+		1. Return |path|.
+
+	1. Let |extendStart| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] |startInset|.
+	1. Let |extendEnd| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] |endInset|.
+
 	1. Let |clipStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |extendStart| ».
 	1. Let |clipEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |extendEnd| ».
 	1. Let |clipOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |extendStart|, |extendEnd| ».
-	1. Let |vectorFromStartToControlPoint| be the the [=two-dimensional vector=] <code>(2 ⋅ |clampedHalfCorner| - 0.5, 1.5 - 2 ⋅ |clampedHalfCorner|)</code>.
-	1. Let |singlePixelVectorFromStartToControlPoint| be the |vectorFromStartToControlPoint|, [=two-dimensional vector/normalize|normalized=].
-	1. Let <code>|strokeA|, |strokeB|</code> be the [=two-dimensional vector/perpendicular=] of |singlePixelVectorFromStartToControlPoint|.
-	1. Let |offset1| be [=vector between two points|the vector between=] |originalCornerStart| and |outerCorner|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] <code>|startInset| ⋅ |strokeA|</code>.
-	1. Let |offset2| be [=vector between two points|the vector between=] |outerCorner| and |originalCornerEnd|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] <code>|startInset| ⋅ |strokeB|</code>.
-	1. Let |offset3| be [=vector between two points|the vector between=] |originalCornerEnd| and |originalCornerCenter|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] <code>|endInset| ⋅ |strokeB|</code>.
-	1. Let |offset4| be [=vector between two points|the vector between=] |originalCornerCenter| and |originalCornerStart|, [=two-dimensional vector/normalize|normalized=] and [=two-dimensional vector/scale|scaled by=] <code>|endInset| ⋅ |strokeA|</code>.
-	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |offset1|, |offset2| ».
-	1. Let |adjustedCornerEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |offset3|, |offset4| ».
-	1. Let |adjustedCornerCenter| be |originalCornerCenter|, [=point extended by vectors|extended by=] « |offset4|, |offset1| ».
-	1. Let |adjustedCornerOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |offset2|, |offset3| ».
-	1. Let |curveCenter| be |adjustedCornerOuter| if |curvature| is less than 0, |adjustedCornerCenter| otherwise.
-	1. Let |mapPointToCorner| be the following steps: given numbers |x| and |y|:
-		1. Let |v1| be  [=vector between two points|the vector between=] |curveCenter| and |adjustedCornerEnd|, [=two-dimensional vector/scale|scaled by=] |x|.
-		1. Let |v2| be  [=vector between two points|the vector between=] |curveCenter| and |adjustedCornerStart|, [=two-dimensional vector/scale|scaled by=] |y|.
-		1. Return the {{DOMPointReadOnly}} at <code>(|x|, |y|)</code>, [=point extended by vectors|extended by=] « |v1|, |v2| ».
 
-	1. Let |controlPoint| be the result of calling |mapPointToCorner| given |vectorFromStartToControlPoint|'s {{DOMPointReadOnly/y}} and <code>1 - |unitVectorFromStartToControlPoint|'s {{DOMPointReadOnly/x}}</code>.
-	1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be <code>adjustedCornerStart</code>.
-	1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be <code>adjustedCornerEnd</code>.
-
+	1. If |K| is greater than zero:
+		1. Let |controlPoint| be |mapPointToCorner| given |controlPointX| and |controlPointX|, |adjustedCornerStart|, |adjustedCornerEnd|, and |adjustedCornerCenter|.
+		1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+		1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+			
 			Note: |axisAlignedCornerStart| and |axisAlignedCornerEnd| act as "miters" when rendering an outset.
 			They are a straight extension of the curve's tangent, intersecting with the unshaped target rect.
-	
-	1. Let |path| be a path, starting at |axisAlignedCornerStart|.
-	1. If |curvature| is -∞:
-		1. Extend |path| to |adjustedCornerStart|.
-		1. Extend |path| to |adjustedCornerCenter|.
-		1. Extend |path| to |adjustedCornerEnd|.
-	1. Otherwise:
-		1. Let |K| be <code>0.5<sup>-abs(|curvature|)</sup></code>.
-		1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
-				extend |path| to the result of calling |mapPointToCorner| given <code>|T|<sup>|K|</sup></code> and <code>(1 - |T|)<sup>|K|</sup></code>.
 
-	1. Extend |path| to |axisAlignedCornerEnd|.
-	1. Extend |path| to |clipOuter|.
+		1. Let |path| be a path, starting at |axisAlignedCornerStart|.
+		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+		1. Extend |path| to |axisAlignedCornerEnd|.
+		1. Return |path|.
+
+	1. Let |startPseudoNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
+	1. Let |endPseudoNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
+
+	1. Let |startPseudoTangentVector| be the [=two-dimensional vector/perpendicular=] of |startPseudoNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
+	1. Let |endPseudoTangentVector| be the [=two-dimensional vector/perpendicular=] of |endPseudoNormalVector|.
+
+	1. Let |startMiter| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startPseudoTangentVector| »)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+	1. Let |endMiter| be the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endPseudoTangentVector| »)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+
+	1. Let |path| be a path, starting at |startMiter|.
+
+	1. If <code>-|startInset|</code> is less than |startRadius|, and <code>-|endInset|</code> is less than |endRadius|:
+		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+		1. Extend |path| to |endMiter|.
+		1. Return |path|.
+
+	1. Let |startMiterIntersection| be the intersection between the segment <code>(|startMiter|, |adjustedCornerStart|)</code> and the line <code>(|endMiter|, |adjustedCornerEnd|)</code>.
+	1. If |startMiterIntersection| is not undefined:
+		1. Extend |path| to |startMiterIntersection|.
+		1. Extend |path| to |endMiter|.
+		1. Return |path|.
+
+	1. Let |endMiterIntersection| be the intersection between the segment <code>(|endMiter|, |adjustedCornerEnd|)</code> and the line <code>(|startMiter|, |adjustedCornerStart|)</code>.
+	1. If |endMiterIntersection| is not undefined:
+		1. Extend |path| to |endMiterIntersection|.
+		1. Extend |path| to |endMiter|.
+		1. Return |path|.
+
+	1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+	1. Extend |path| to |endMiter|.
 	1. Return |path|.
 </div>
 
@@ -1682,7 +1793,7 @@ Since it uses a <code>log2</code>, interpolating it linearly would result in an 
 To balance that, the <dfn>superellipse interpolation</dfn> formula describes how a [=superellipse parameter=] is converted to a value between 0 and 1, and vice versa:
 
 <div algorithm="superellipse-param-to-interpolation-value">
-To compute the <dfn>normalized superellipse half corner</dfn> given a [=superellipse parameter=] |s|, return the first matching statement, switching on |s|:
+To compute the <dfn>normalized superellipse half corner</dfn> given a [=superellipse parameter=] |K|, return the first matching statement, switching on |K|:
 
 	<dl class=switch>
 		: -∞
@@ -1693,20 +1804,20 @@ To compute the <dfn>normalized superellipse half corner</dfn> given a [=superell
 
 		: Otherwise
 		::
-			1. Let |k| be <code>0.5<sup>abs(|s|)</sup></code>.
-			1. Let |convexHalfCorner| be <code>0.5<sup>1/|k|</sup></code>.
-			1. If |s| is less than 0, return <code>1 - |convexHalfCorner|</code>.
+			1. Let |n| be <code>2<sup>abs(|K|)</sup></code>.
+			1. Let |convexHalfCorner| be <code>0.5<sup>1/|n|</sup></code>.
+			1. If |K| is less than 0, return <code>1 - |convexHalfCorner|</code>.
 			1. Return |convexHalfCorner|.
 	</dl>
 </div>
 
 <div algorithm="superellipse-param-to-hull">
-	To compute the <dfn>normalized inner corner hull</dfn> given a [=superellipse parameter=] |curvature|:
+	To compute the <dfn>normalized inner corner hull</dfn> given a [=superellipse parameter=] |K|:
 
-	1. If |curvature| is greater than or equal to zero, return a triangle betwen « (1, 1), (1, 0), (0, 1) ».
+	1. If |K| is greater than or equal to zero, return a triangle betwen « (1, 1), (1, 0), (0, 1) ».
 	1. Let |axisLineA| be a line between <code>(1, 0)</code> and <code>(1, 1)</code>.
 	1. Let |axisLineB| be a line between <code>(0, 1)</code> and <code>(1, 1)</code>.
-	1. Let |normalizedHalfCorner| be the [=normalized superellipse half corner=] given |curvature|.
+	1. Let |normalizedHalfCorner| be the [=normalized superellipse half corner=] given |K|.
 	1. Let |halfCornerPoint| be <code>(|normalizedHalfCorner|, 1 - |normalizedHalfCorner|)</code>.
 	1. Let |lineFromCenterToHalfCorner| be a line between <code>(0, 0)</code> and |halfCornerPoint|.
 	1. Let |tangentLine| be the line perpendicular to |lineFromCenterToHalfCorner|, at |halfCornerPoint|.
@@ -1715,7 +1826,7 @@ To compute the <dfn>normalized superellipse half corner</dfn> given a [=superell
 	1. Return a pentagon between the points « (1, 1), (1, 0), |intersectionA|, |intersectionB|, (0, 1), (1, 1) ».
 </div>
 
-To interpolate a [=superellipse parameter=] |s| to an interpolation value between 0 and 1, return the [=normalized superellipse half corner=] given |s|.
+To interpolate a [=superellipse parameter=] |K| to an interpolation value between 0 and 1, return the [=normalized superellipse half corner=] given |K|.
 
 <div algorithm="convert interpolation value to superellipse parameter">
 	To convert a <<number [0,1]>> |interpolationValue| back to a [=superellipse parameter=], switch on |interpolationValue|:
@@ -1733,11 +1844,11 @@ To interpolate a [=superellipse parameter=] |s| to an interpolation value betwee
 		: Otherwise
 		::
 			1. Let |convexHalfCorner| be |interpolationValue|.
-			1. If |interpolationValue| is less than 0.5, set |convexHalfCorner| to 1 - |interpolationValue|.
-			1. Let |k| be <code>ln(0.5) / ln(|convexHalfCorner|)</code>.
-			1. Let |s| be <code>log2(|k|)</code>.
-			1. If |interpolationValue| is less than 0.5, return -|s|.
-			1. Return |s|.
+			1. If |interpolationValue| is less than 0.5, set |convexHalfCorner| to <code>1 - |interpolationValue|</code>.
+			1. Let |n| be <code>ln(0.5) / ln(|convexHalfCorner|)</code>.
+			1. Let |K| be <code>log2(|n|)</code>.
+			1. If |interpolationValue| is less than 0.5, return -|K|.
+			1. Return |K|.
 
 	</dl>
 </div>

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -781,7 +781,7 @@ Overlapping Curves</h3>
 	until none of them overlap.
 	The algorithm for reducing radii is as follows:
 
-	Let <var>f</var> = min(<var>L<sub>i</sub></var>/<var>S<sub>i</sub></var>),
+	Let <var>f</var> = min(1, <var>L<sub>i</sub></var> / <var>S<sub>i</sub></var>),
 	where <var>i</var> ∈ {top, right, bottom, left},
 	<var>S<sub>i</sub></var> is the sum of the two corresponding radii
 	of the corners on side <var>i</var>,
@@ -789,6 +789,7 @@ Overlapping Curves</h3>
 	and <var>L<sub>left</sub></var> = <var>L<sub>right</sub></var> = the height of the box.
 	If <var>f</var> &lt; 1, then all corner radii are reduced
 	by multiplying them by <var>f</var>.
+	The value of <var>f</var> is the <dfn>adjacent corner scale factor</dfn>.
 
 	Note: This formula ensures that quarter circles remain quarter circles
 	and large radii remain larger than smaller ones,
@@ -1546,16 +1547,10 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 
 	1. Let |path| be a path that contains |unshapedTargetRect|.
 
-	1. Let |scaleFactor| be the [=opposite corner scale factor=] given |element|.
-
-	1. Let |constrainedRadius| be the following steps, given a property |P|:
-		1. Let |radius| be |element|'s [=used value=] of |P|.
-		1. Return <code>(|radius|'s [=width=] ⋅ |scaleFactor|, |radius|'s [=height=] ⋅ |scaleFactor|)</code>.
-
-	1. Let |topRightRadius| be the |constrainedRadius| given 'border-top-right-radius'.
-	1. Let |bottomRightRadius| be the |constrainedRadius| given 'border-bottom-right-radius'.
-	1. Let |bottomLeftRadius| be the |constrainedRadius| given 'border-bottom-left-radius'.
-	1. Let |topLeftRadius| be the |constrainedRadius| given 'border-top-left-radius'.
+	1. Let |topRightRadius| be |element|'s [=used value=] of 'border-top-right-radius'.
+	1. Let |bottomRightRadius| be |element|'s [=used value=] of 'border-bottom-right-radius'.
+	1. Let |bottomLeftRadius| be |element|'s [=used value=] of 'border-bottom-left-radius'.
+	1. Let |topLeftRadius| be |element|'s [=used value=] of 'border-top-left-radius'.
 
 	1. Let |outsetAdjustedRadius| be the following steps, given a radius |radius|, and numbers |insetX| and |insetY|:
 		1. If |insetX| or |insetY| is positive, or if |insetX| and |insetY| are zero, return |radius|.
@@ -1761,28 +1756,70 @@ When concave 'corner-shape' values are present (the [=superellipse parameter=] i
 
 To prevent this, the four radii are constrained to prevent overlaps.
 This is done by computing a hull polygon for each of the opposite corners, and finding the highest downscale factor which, if applied to both corners, would make it so that the polygons would not intersect.
+The used values of all border radii must be proportionally reduced by multiplying them by the minimum of the [=opposite corner scale factor=] and the [=adjacent corner scale factor=].
 
 <div algorithm="constrain-radii-for-concave-corner-shape">
 To compute the <dfn>opposite corner scale factor</dfn> given an [=/element=] |element|:
 	1. Let |rect| be |element|'s [=border box=].
-	1. Let |topRightHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-right-shape',
-		mapped to the rectangle (|rect|'s [=width dimension=] - |element|'s [=computed value|computed=] horizontal 'border-top-right-radius', 0, |rect|'s [=computed value|computed=] 'border-top-right-radius').
-	1. Let |bottomRightHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
-		rotated by 90deg with (0.5, 0.5) as an origin,
-		and mapped to the rectangle (|rect|'s [=width dimension=] - |element|'s [=computed value|computed=] horizontal 'border-bottom-right-radius', |rect|'s [=height dimension=] - |element|'s [=computed value|computed=] vertical 'border-bottom-right-radius',
-		|element|'s [=computed value|computed=] 'border-bottom-right-radius').
-	1. Let |bottomLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
-		rotated by 180deg with (0.5, 0.5) as an origin,
-		and mapped to the rectangle (0, |rect|'s [=height dimension=] - |element|'s [=computed value|computed=] vertical 'border-bottom-left-radius',
-		|element|'s [=computed value|computed=] 'border-bottom-left-radius').
-	1. Let |topLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-left-shape',
-		rotated by 270deg with (0.5, 0.5) as an origin,
-		mapped to (0, 0, |element|'s [=computed value|computed=] 'border-top-left-radius').
+
+	1. Let |topRightRadius| be |element|'s [=computed value=] of 'border-top-right-radius'.
+	1. Let |bottomRightRadius| be |element|'s [=computed value=] of 'border-bottom-right-radius'.
+	1. Let |bottomLeftRadius| be |element|'s [=computed value=] of 'border-bottom-left-radius'.
+	1. Let |topLeftRadius| be |element|'s [=computed value=] of 'border-top-left-radius'.
+
+	1. Let |unmappedTopRightHull| be the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-right-shape',
+	1. Let |unmappedBottomRightHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
+	1. Let |unmappedBottomLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
+	1. Let |unmappedTopLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-left-shape',
+
+	1. Let |mapPolygonToCorner| be the following steps, given a [=/list=] of {{DOMPointReadOnly}} |polygon|, {{DOMPointReadOnly}} |start|, |end|, and |center|:
+		1. Let |mappedPolygon| be an empty [=/list=].
+		1. [=list/For each=] |p| in |polygon|:
+			1. Let |v1| be [=vector between two points|the vector between=] |center| and |end|, [=two-dimensional vector/scale|scaled by=] |p|'s {{DOMPointReadOnly/x}}.
+			1. Let |v4| be [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |p|'s {{DOMPointReadOnly/y}}.
+			1. Let |mappedPoint| be |center|, [=point extended by vectors|extended by=] « |v1|, |v4| ».
+			1. [=list/Append=] |mappedPoint| to |mappedPolygon|.
+		1. Return |mappedPolygon|.	
+
+	1. Let |topRightHull| be |mapPolygonToCorner| given |unmappedTopRightHull|,
+		{{DOMPointReadOnly}} at <code>(|rect|'s [=width dimension=] - |topRightRadius|'s [=width=], 0)</code>,
+		at <code>(|rect|'s [=width dimension=], |topRightRadius|'s [=height=])</code>,
+		and at <code>(|rect|'s [=width dimension=] - |topRightRadius|'s [=width=], |topRightRadius|'s [=height=])</code>.
+
+	1. Let |bottomRightHull| be |mapPolygonToCorner| given |unmappedBottomRightHull|,
+		{{DOMPointReadOnly}} at <code>(|rect|'s [=width dimension=], |rect|'s [=height dimension=] - |bottomRightRadius|'s [=height=])</code>,
+		at <code>(|rect|'s [=width dimension=] - |bottomRightRadius|'s [=width=], |rect|'s [=height dimension=])</code>,
+		and at <code>(|rect|'s [=width dimension=] - |bottomRightRadius|'s [=width=], |rect|'s [=height dimension=] - |bottomRightRadius|'s [=height=])</code>.
+
+	1. Let |bottomLeftHull| be |mapPolygonToCorner| given |unmappedBottomLeftHull|,
+		{{DOMPointReadOnly}} at <code>(|bottomLeftRadius|'s [=width=], |rect|'s [=height dimension=])</code>,
+		at <code>(0, |rect|'s [=height dimension=] - |bottomLeftRadius|'s [=height=])</code>,
+		and at <code>(|bottomLeftRadius|'s [=width=], |rect|'s [=height dimension=] - |bottomLeftRadius|'s [=height=])</code>.
+	
+	1. Let |topLeftHull| be |mapPolygonToCorner| given |unmappedTopLeftHull|,
+		{{DOMPointReadOnly}} at <code>(0, |topLeftRadius|'s [=height=])</code>,
+		at <code>(|topLeftRadius|'s [=width=], 0)</code>,
+		and at <code>(|topLeftRadius|'s [=width=], |topLeftRadius|'s [=height=])</code>.
+
 	1. Let |scaleFactorA| be the highest number which, if both |topLeftHull| and |bottomRightHull| were scaled by, using their first point as the origin, those polygons would not intersect.
 	1. Let |scaleFactorB| be the highest number which, if both |topRightHull| and |bottomLeftHull| were scaled by, using their first point as the origin, those polygons would not intersect.
 	1. Return <code>min(1, |scaleFactorA|, |scaleFactorB|)</code>.
 </div>
 
+<div algorithm="superellipse-param-to-hull">
+	To compute the <dfn>normalized inner corner hull</dfn> given a [=superellipse parameter=] |K|:
+
+	1. If |K| is greater than or equal to zero, return a triangle between the points « (1, 1), (1, 0), (0, 1) ».
+	1. Let |v4Line| be the line through the points <code>(0, 0)</code> and <code>(0, 1)</code>.
+	1. Let |v3Line| be the line through the points <code>(0, 0)</code> and <code>(1, 0)</code>.
+	1. Let |halfCornerX| be the [=normalized superellipse half corner=] given |K|.
+	1. Let |halfCornerPoint| be a point at <code>(|halfCornerX|, |halfCornerX|)</code>.
+	1. Let |diagonalLine| be the line through the points <code>(0, 0)</code> and <code>(1, 1)</code>.
+	1. Let |tangentLine| be the line perpendicular to |diagonalLine|, at |halfCornerPoint|.
+	1. Let |v4Intersection| be the intersection between |v4Line| and |tangentLine|.
+	1. Let |v3Intersection| be the intersection between |v3Line| and |tangentLine|.
+	1. Return a pentagon between the points « (1, 1), (1, 0), |v3Intersection|, |v4Intersection|, (0, 1) ».
+</div>
 
 <h4 id=corner-shape-interpolation>
 Interpolating corner shapes</h4>
@@ -1809,21 +1846,6 @@ To compute the <dfn>normalized superellipse half corner</dfn> given a [=superell
 			1. If |K| is less than 0, return <code>1 - |convexHalfCorner|</code>.
 			1. Return |convexHalfCorner|.
 	</dl>
-</div>
-
-<div algorithm="superellipse-param-to-hull">
-	To compute the <dfn>normalized inner corner hull</dfn> given a [=superellipse parameter=] |K|:
-
-	1. If |K| is greater than or equal to zero, return a triangle betwen « (1, 1), (1, 0), (0, 1) ».
-	1. Let |axisLineA| be a line between <code>(1, 0)</code> and <code>(1, 1)</code>.
-	1. Let |axisLineB| be a line between <code>(0, 1)</code> and <code>(1, 1)</code>.
-	1. Let |normalizedHalfCorner| be the [=normalized superellipse half corner=] given |K|.
-	1. Let |halfCornerPoint| be <code>(|normalizedHalfCorner|, 1 - |normalizedHalfCorner|)</code>.
-	1. Let |lineFromCenterToHalfCorner| be a line between <code>(0, 0)</code> and |halfCornerPoint|.
-	1. Let |tangentLine| be the line perpendicular to |lineFromCenterToHalfCorner|, at |halfCornerPoint|.
-	1. Let |intersectionA| be the intersection between |axisLineA| and |tangentLine|.
-	1. Let |intersectionB| be the intersection between |axisLineB| and |tangentLine|.
-	1. Return a pentagon between the points « (1, 1), (1, 0), |intersectionA|, |intersectionB|, (0, 1), (1, 1) ».
 </div>
 
 To interpolate a [=superellipse parameter=] |K| to an interpolation value between 0 and 1, return the [=normalized superellipse half corner=] given |K|.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1631,8 +1631,8 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 	1. Return |path|.
 
 To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRadius|, |endRadius|, |startInset|, |endInset|, a {{DOMPointReadOnly}} |originalCornerOuter|, [=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|, a [=superellipse parameter=] |K|:
-	1. Assert <code>|startInset| ⋅ |endInset|</code> greater than or equal to zero.
-	1. If |startInset| or |endInset| is less than zero, then assert |startInset| equal to |endInset|.
+	1. [=/Assert=] <code>|startInset| ⋅ |endInset|</code> greater than or equal to zero.
+	1. If |startInset| or |endInset| is less than zero, then [=/assert=] |startInset| equal to |endInset|.
 
 	1. If |K| is ∞, then return an empty path.
 
@@ -1667,13 +1667,13 @@ To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRa
 	1. Let |clampedHalfCornerX| be the [=normalized superellipse half corner=] given <code>clamp(|K|, -1, 1)</code>.
 	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
 
-	1. Let |startPseudoNormalVectorUnmapped| be the [=two-dimensional vector=] <code>((1 - |controlPointX|) ⋅ |startRadius|, |controlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
-	1. Let |endPseudoNormalVectorUnmapped| be the [=two-dimensional vector=] <code>(|controlPointX| ⋅ |startRadius|, (1 - |controlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |unmappedStartPseudoNormalVector| be the [=two-dimensional vector=] <code>((1 - |controlPointX|) ⋅ |startRadius|, |controlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |unmappedEndPseudoNormalVector| be the [=two-dimensional vector=] <code>(|controlPointX| ⋅ |startRadius|, (1 - |controlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
 
-	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|startPseudoNormalVectorUnmapped|[0] ⋅ |startInset|</code>.
-	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|startPseudoNormalVectorUnmapped|[1] ⋅ |startInset|</code>.
-	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|endPseudoNormalVectorUnmapped|[0] ⋅ |endInset|</code>.
-	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|endPseudoNormalVectorUnmapped|[1] ⋅ |endInset|</code>.
+	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartPseudoNormalVector|[0] ⋅ |startInset|</code>.
+	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartPseudoNormalVector|[1] ⋅ |startInset|</code>.
+	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndPseudoNormalVector|[0] ⋅ |endInset|</code>.
+	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndPseudoNormalVector|[1] ⋅ |endInset|</code>.
 
 	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetStartV2| ».
 	1. Let |adjustedCornerOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetStartV2| ».

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1553,8 +1553,8 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 	1. Let |topLeftRadius| be |element|'s [=used value=] of 'border-top-left-radius'.
 
 	1. Let |outsetAdjustedRadius| be the following steps, given a radius |radius|, and numbers |insetX| and |insetY|:
-		1. If |insetX| or |insetY| is positive, or if |insetX| and |insetY| are zero, return |radius|.
-		1. Return the [=outset-adjusted border radius=] given |borderRect|'s size, |radius|, and <code>(-|insetX|, -|insetY|)</code>.
+		1. Let |adjustedRadius| be the [=outset-adjusted border radius=] given |borderRect|'s size, |radius|, and the outset <code>(-|insetX|, -|insetY|)</code>.
+		1. Return the radius <code>(max(0, |adjustedRadius|'s [=width=]), max(0, |adjustedRadius|'s [=height=]))</code>.
 
 	1. Let |outsetAdjustedTopRightRadius| be the |outsetAdjustedRadius| given |topRightRadius|, |insetRight|, and |insetTop|.
 	1. Let |outsetAdjustedBottomRightRadius| be the |outsetAdjustedRadius| given |bottomRightRadius|, |insetRight|, and |insetBottom|.
@@ -1568,14 +1568,14 @@ To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numb
 		a {{DOMPointReadOnly}} |cornerOuter|,
 		[=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|,
 		a [=superellipse parameter=] |K|:
-		1. If |insetStart| or |insetEnd| is positive, or if |insetStart| and |insetEnd| are zero:
+		1. If |insetStart| and |insetEnd| are non-negative:
 			1. Return the [=border-aligned corner clip-out path=] given 
 				|startRadius|, |endRadius|,
 				|startInset|, |endInset|,
 				|cornerOuter|,
 				|normalizedV3|, |normalizedV2|,
 				|K|.
-		1. Let |uniformVirtualOutset| be <code>min(|outsetAdjustedStartRadius| - |startRadius|, |outsetAdjustedEndRadius| - |endRadius|)</code>.
+		1. Let |uniformVirtualOutset| be <code>max(0, min(|outsetAdjustedStartRadius| - |startRadius|, |outsetAdjustedEndRadius| - |endRadius|))</code>.
 		1. Let |virtualStartRadius| be <code>|outsetAdjustedStartRadius| - |uniformVirtualOutset|</code>.
 		1. Let |virtualEndRadius| be <code>|outsetAdjustedEndRadius| - |uniformVirtualOutset|</code>.
 		1. Let |virtualStartInset| be <code>-|uniformVirtualOutset|</code>.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1644,9 +1644,9 @@ To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRa
 	1. Let |originalCornerCenter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV3|, |originalCornerV2| ».
 
 	1. Let |mapPointToCorner| be the following steps, given numbers |x| and |y|, {{DOMPointReadOnly}} |start|, |end|, and |center|:
-		1. Let |v1| be  [=vector between two points|the vector between=] |center| and |end|, [=two-dimensional vector/scale|scaled by=] |x|.
-		1. Let |v4| be  [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |y|.
-		1. Return the {{DOMPointReadOnly}} at <code>(|x|, |y|)</code>, [=point extended by vectors|extended by=] « |v1|, |v4| ».
+		1. Let |v1| be [=vector between two points|the vector between=] |center| and |end|, [=two-dimensional vector/scale|scaled by=] |x|.
+		1. Let |v4| be [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |y|.
+		1. Return |center|, [=point extended by vectors|extended by=] « |v1|, |v4| ».
 
 	1. Let |curvePath| be the following steps, given {{DOMPointReadOnly}} |start|, |outer|, |end|, and |center|:
 		1. Let |path| be a path, starting at |start|.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1628,7 +1628,7 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
 
 	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
-	1. If |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
+	1. If |K| is smaller than or equal to 0, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
 	1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
 	1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
 	1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1592,6 +1592,15 @@ To compute the <dfn>border contour path</dfn> given an [=/element=] |element|, n
 	1. Return |path|.
 
 To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRadius|, |endRadius|, |startInset|, |endInset|, a {{DOMPointReadOnly}} |targetCornerOuter|, [=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|, a [=superellipse parameter=] |K|:
+
+	<div class="note">
+		This algorithm uses the following vector notation to work with corners independently of their orientation.
+		<figure>
+			<img src="images/corner-shape-notation.svg" width="200" height="200" alt="Corner vector notation">
+			<figcaption>The corner vector notation overlaid on the top-right corner.</figcaption>
+		</figure>
+	</div>
+
 	1. If |startRadius| or |endRadius| is zero, then return an empty path.
 	1. If |K| is ∞, then return an empty path.
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1474,15 +1474,11 @@ The 'corner' shorthand</h4>
 <h4 id=corner-shape-rendering>
 Rendering 'corner-shape'</h4>
 
-When rendering elements with shaped corners, the element's [=border contour path=] needs to be offset,
-based on [=border=], [=outline=], 'box-shadow', 'overflow-clip-margin' and more.
+When rendering elements with shaped corners, the corner curves for 'border', 'outline', 'box-shadow', 'overflow-clip-margin', etc. are offset from the element's [=outer contour=] by their respective insets.
 
-When rendering borders or outlines, the offset is aligned to the curve of the element's shape.
-When rendering 'box-shadow' or offsetting for 'overflow-clip-margin', the offset is also aligned to the same curve in the other direction, and the curve continues to the outer edge.
+An [=/element=]'s <dfn>outer contour</dfn> is the [=border contour path=] given |element| and an [=edge=] whose values are zero.
 
-An [=/element=] |element|'s <dfn>outer contour</dfn> is the [=border contour path=] given |element| and |element|'s [=border edge=].
-
-An [=/element=] |element|'s <dfn>inner contour</dfn> is the [=border contour path=] given |element| and |element|'s [=border width=].
+An [=/element=]'s <dfn>inner contour</dfn> is the [=border contour path=] given |element| and an [=edge=] whose values are the [=used value|used=] [=border width=].
 
 An [=/element=]'s [=border=] is rendered in the area between its [=outer contour=] and its [=inner contour=].
 
@@ -1490,11 +1486,12 @@ An [=/element=]'s [=outline=] follows the [=outer contour=] with the [=used valu
 The precise way in which it is rendered is implementation-defined.
 
 An [=/element=]'s [=overflow=] area is shaped by its [=inner contour=].
-An [=/element=]'s [=overflow clip edge=] is shaped by the [=border contour path=] given |element|, and an [=uniform inset from an outset=] given |element|'s [=used value|used=] 'overflow-clip-margin'.
 
-Each shadow of [=/element=]'s 'box-shadow' is shaped by the [=border contour path=] given |element|, and an [=uniform inset from an outset=] given the shadow's [=used value|used=] 'box-shadow-spread'.
+An [=/element=]'s [=overflow clip edge=] is shaped by the [=border contour path=] given |element|, and the [=inset between two edges|inset between=] |element|'s [=border edge=] and [=overflow clip edge=].
 
-An <dfn>uniform inset from an outset</dfn> given a number |outset| is an [=edge=] whose value is <code>-|outset|</code> in all directions.
+Each shadow of [=/element=]'s 'box-shadow' is shaped by the [=border contour path=] given |element|, and the [=inset between two edges|inset between=] |element|'s [=border edge=] and shadow's edge.
+
+The <dfn>inset between two edges</dfn>, given [=edges=] |originalEdge| and |targetEdge|, is an [=edge=] whose values are the signed insets from |originalEdge| to |targetEdge|, positive inward and negative outward.
 
 <h5 id=vector-math-helpers>Vector Math Helpers</h5>
 
@@ -1534,102 +1531,70 @@ To <dfn for="two-dimensional vector list">sum</dfn> a [=/list=] of [=two-dimensi
 
 <h5 id=contour-path>Computing a contoured path</h5>
 
-This algorithm describes how to compute a path with shaped corners (a path that is either inset or outset from the original).
+This algorithm describes how to compute a path with shaped corners.
 To avoid the complexities of defining how superellipses intersect, the algorithm simplifies the process by specifying that each corner is "clipped out" of the path.
 The specific implementation details of this clipping operation are left to implementations.
 
 <div algorithm="border-aligned-contour-path">
-To compute an [=/element=] |element|'s <dfn>border contour path</dfn> given numbers |topInset|, |rightInset|, |bottomInset|, |leftInset|:
+To compute the <dfn>border contour path</dfn> given an [=/element=] |element|, numbers |topInset|, |rightInset|, |bottomInset|, |leftInset|:
 	1. Let |borderRect| be |element|'s [=border box=].
-	1. Let |unshapedTargetRect| be |borderRect|, inset by |topInset|, |rightInset|, |bottomInset|, |leftInset|.
+	1. Let |targetRect| be |borderRect|, inset by |topInset|, |rightInset|, |bottomInset|, |leftInset|.
 		
-		Note: If this is a shadow or 'overflow-clip-margin', the insets would have negative values and |unshapedTargetRect| would become an outset of |borderRect|.
+		Note: If this is a shadow or 'overflow-clip-margin', the insets may have negative values, in which case |targetRect| would become an outset of |borderRect|.
 
-	1. Let |path| be a path that contains |unshapedTargetRect|.
+	1. Let |path| be a path that traces |targetRect|.
 
 	1. Let |topRightRadius| be |element|'s [=used value=] of 'border-top-right-radius'.
 	1. Let |bottomRightRadius| be |element|'s [=used value=] of 'border-bottom-right-radius'.
 	1. Let |bottomLeftRadius| be |element|'s [=used value=] of 'border-bottom-left-radius'.
 	1. Let |topLeftRadius| be |element|'s [=used value=] of 'border-top-left-radius'.
 
-	1. Let |outsetAdjustedRadius| be the following steps, given a radius |radius|, and numbers |insetX| and |insetY|:
+	1. Let |adjustedInset| be the following steps, given a radius |radius|, and numbers |insetX| and |insetY|:
 		1. Let |adjustedRadius| be the [=outset-adjusted border radius=] given |borderRect|'s size, |radius|, and the outset <code>(-|insetX|, -|insetY|)</code>.
-		1. Return the radius <code>(max(0, |adjustedRadius|'s [=width=]), max(0, |adjustedRadius|'s [=height=]))</code>.
+		1. Return the inset <code>(|radius|'s [=width=] - |adjustedRadius|'s [=width=], |radius|'s [=height=] - |adjustedRadius|'s [=height=])</code>.
 
-	1. Let |outsetAdjustedTopRightRadius| be the |outsetAdjustedRadius| given |topRightRadius|, |insetRight|, and |insetTop|.
-	1. Let |outsetAdjustedBottomRightRadius| be the |outsetAdjustedRadius| given |bottomRightRadius|, |insetRight|, and |insetBottom|.
-	1. Let |outsetAdjustedBottomLeftRadius| be the |outsetAdjustedRadius| given |bottomLeftRadius|, |insetLeft|, and |insetBottom|.
-	1. Let |outsetAdjustedTopLeftRadius| be the |outsetAdjustedRadius| given |topLeftRadius|, |insetLeft|, and |insetTop|.
+	1. Let |adjustedTopRightInset| be the |adjustedInset| given |topRightRadius|, |rightInset|, and |topInset|.
+	1. Let |adjustedBottomRightInset| be the |adjustedInset| given |bottomRightRadius|, |rightInset|, and |bottomInset|.
+	1. Let |adjustedBottomLeftInset| be the |adjustedInset| given |bottomLeftRadius|, |leftInset|, and |bottomInset|.
+	1. Let |adjustedTopLeftInset| be the |adjustedInset| given |topLeftRadius|, |leftInset|, and |topInset|.
 
-	1. Let |adjustedClipOutPath| be the following steps, given
-		numbers |outsetAdjustedStartRadius|, |outsetAdjustedEndRadius|,
-		|startRadius|, |endRadius|,
-		|startInset|, and |endInset|,
-		a {{DOMPointReadOnly}} |cornerOuter|,
-		[=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|,
-		a [=superellipse parameter=] |K|:
-		1. If |insetStart| and |insetEnd| are non-negative:
-			1. Return the [=border-aligned corner clip-out path=] given 
-				|startRadius|, |endRadius|,
-				|startInset|, |endInset|,
-				|cornerOuter|,
-				|normalizedV3|, |normalizedV2|,
-				|K|.
-		1. Let |uniformVirtualOutset| be <code>max(0, min(|outsetAdjustedStartRadius| - |startRadius|, |outsetAdjustedEndRadius| - |endRadius|))</code>.
-		1. Let |virtualStartRadius| be <code>|outsetAdjustedStartRadius| - |uniformVirtualOutset|</code>.
-		1. Let |virtualEndRadius| be <code>|outsetAdjustedEndRadius| - |uniformVirtualOutset|</code>.
-		1. Let |virtualStartInset| be <code>-|uniformVirtualOutset|</code>.
-		1. Let |virtualEndInset| be <code>-|uniformVirtualOutset|</code>.
-		1. Let |vectorToVirtualCornerOuterV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|insetEnd| + |uniformVirtualOutset|</code>.
-		1. Let |vectorToVirtualCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|insetStart| + |uniformVirtualOutset|</code>.
-		1. Let |virtualCornerOuter| be |cornerOuter|, [=point extended by vectors|extended by=] « |vectorToVirtualCornerOuterV3|, |vectorToVirtualCornerOuterV2| ».
-
-		1. Return the [=border-aligned corner clip-out path=] given 
-			|virtualStartRadius|, |virtualEndRadius|,
-			|virtualStartInset|, |virtualEndInset|,
-			|virtualCornerOuter|,
-			|normalizedV3|, |normalizedV2|,
-			|K|.
-
-	1. Clip out from |path|, the |adjustedClipOutPath| given
-		|outsetAdjustedTopRightRadius|'s [=height=] ,|outsetAdjustedTopRightRadius|'s [=width=],
+	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|topRightRadius|'s [=height=] ,|topRightRadius|'s [=width=],
-		|topInset|, |rightInset|,
-		a {{DOMPointReadOnly}} at <code>(|borderRect|'s right, |borderRect|'s top)</code>,
+		|adjustedTopRightInset|'s [=height=] ,|adjustedTopRightInset|'s [=width=],
+		a {{DOMPointReadOnly}} at <code>(|targetRect|'s right, |targetRect|'s top)</code>,
 		<code>(-1, 0)</code>, <code>(0, 1)</code>,
 		|element|'s [=computed value|computed=] 'corner-top-right-shape'.
 
-	1. Clip out from |path|, the |adjustedClipOutPath| given
-		|outsetAdjustedBottomRightRadius|'s [=width=] ,|outsetAdjustedBottomRightRadius|'s [=height=],
+	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|bottomRightRadius|'s [=width=], |bottomRightRadius|'s [=height=],
-		|rightInset|, |bottomInset|,
-		a {{DOMPointReadOnly}} at <code>(|borderRect|'s right, |borderRect|'s bottom)</code>,
+		|adjustedBottomRightInset|'s [=width=] ,|adjustedBottomRightInset|'s [=height=],
+		a {{DOMPointReadOnly}} at <code>(|targetRect|'s right, |targetRect|'s bottom)</code>,
 		<code>(0, -1)</code>, <code>(-1, 0)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-right-shape'.
 		
-	1. Clip out from |path|, the |adjustedClipOutPath| given
-		|outsetAdjustedBottomLeftRadius|'s [=height=] ,|outsetAdjustedBottomLeftRadius|'s [=width=],
+	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|bottomLeftRadius|'s [=height=], |bottomLeftRadius|'s [=width=],
-		|bottomInset|, |leftInset|,
-		a {{DOMPointReadOnly}} at <code>(|borderRect|'s left, |borderRect|'s bottom)</code>,
+		|adjustedBottomLeftInset|'s [=height=] ,|adjustedBottomLeftInset|'s [=width=],
+		a {{DOMPointReadOnly}} at <code>(|targetRect|'s left, |targetRect|'s bottom)</code>,
 		<code>(1, 0)</code>, <code>(0, -1)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-left-shape'.
 		
-	1. Clip out from |path|, the |adjustedClipOutPath| given
-		|outsetAdjustedTopLeftRadius|'s [=width=] ,|outsetAdjustedTopLeftRadius|'s [=height=],
+	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|topLeftRadius|'s [=width=], |topLeftRadius|'s [=height=],
-		|leftInset|, |topInset|,
-		a {{DOMPointReadOnly}} at <code>(|borderRect|'s left, |borderRect|'s top)</code>,
+		|adjustedTopLeftInset|'s [=width=] ,|adjustedTopLeftInset|'s [=height=],
+		a {{DOMPointReadOnly}} at <code>(|targetRect|'s left, |targetRect|'s top)</code>,
 		<code>(0, 1)</code>, <code>(1, 0)</code>,
 		|element|'s [=computed value|computed=] 'corner-top-left-shape'.
 
 	1. Return |path|.
 
-To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRadius|, |endRadius|, |startInset|, |endInset|, a {{DOMPointReadOnly}} |originalCornerOuter|, [=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|, a [=superellipse parameter=] |K|:
-	1. [=/Assert=] <code>|startInset| ⋅ |endInset|</code> greater than or equal to zero.
-	1. If |startInset| or |endInset| is less than zero, then [=/assert=] |startInset| equal to |endInset|.
-
+To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRadius|, |endRadius|, |startInset|, |endInset|, a {{DOMPointReadOnly}} |targetCornerOuter|, [=two-dimensional vector=]s |normalizedV3|, and |normalizedV2|, a [=superellipse parameter=] |K|:
+	1. If |startRadius| or |endRadius| is zero, then return an empty path.
 	1. If |K| is ∞, then return an empty path.
+
+	1. Let |vectorToOriginalCornerOuterV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>-|endInset|</code>.
+	1. Let |vectorToOriginalCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>-|startInset|</code>.
+	1. Let |originalCornerOuter| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |vectorToOriginalCornerOuterV3|, |vectorToOriginalCornerOuterV2| ».
 
 	1. Let |originalCornerV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] |endRadius|.
 	1. Let |originalCornerV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] |startRadius|.
@@ -1662,73 +1627,87 @@ To get the <dfn>border-aligned corner clip-out path</dfn> given numbers |startRa
 	1. Let |clampedHalfCornerX| be the [=normalized superellipse half corner=] given <code>clamp(|K|, -1, 1)</code>.
 	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
 
-	1. Let |unmappedStartPseudoNormalVector| be the [=two-dimensional vector=] <code>((1 - |controlPointX|) ⋅ |startRadius|, |controlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
-	1. Let |unmappedEndPseudoNormalVector| be the [=two-dimensional vector=] <code>(|controlPointX| ⋅ |startRadius|, (1 - |controlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
+	1. If |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
+	1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
+	1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
+	1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
+	
+	1. Let |startControlPointX| be <code>|bevelControlPointX| · (2 · |controlPointX|)</code> if |K| is less than zero, <code>1 - (1 - |bevelControlPointX|) · (2 · (1 - |controlPointX|))</code> otherwise.
+	1. Let |endControlPointX| be <code>2 ⋅ |controlPointX| - |startControlPointX|</code>.
+	
+	1. Let |unmappedStartNormalVector| be the [=two-dimensional vector=] <code>((1 - |startControlPointX|) ⋅ |startRadius|, |startControlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |unmappedEndNormalVector| be the [=two-dimensional vector=] <code>(|endControlPointX| ⋅ |startRadius|, (1 - |endControlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
 
-	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartPseudoNormalVector|[0] ⋅ |startInset|</code>.
-	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartPseudoNormalVector|[1] ⋅ |startInset|</code>.
-	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndPseudoNormalVector|[0] ⋅ |endInset|</code>.
-	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndPseudoNormalVector|[1] ⋅ |endInset|</code>.
+	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartNormalVector|[0] ⋅ |startInset|</code>.
+	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartNormalVector|[1] ⋅ |startInset|</code>.
+	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndNormalVector|[0] ⋅ |endInset|</code>.
+	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndNormalVector|[1] ⋅ |endInset|</code>.
 
 	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetStartV2| ».
 	1. Let |adjustedCornerOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetStartV2| ».
 	1. Let |adjustedCornerEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetEndV2| ».
 	1. Let |adjustedCornerCenter| be |originalCornerCenter|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetEndV2| ».
 	
-	1. If |startInset| or |endInset| is greater than zero:
+	1. If |startInset| and |endInset| are greater than or equal to zero, or |K| is greater than or equal to 1:
 		1. Let |path| be |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
 		1. Return |path|.
 
-	1. Let |extendStart| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] |startInset|.
-	1. Let |extendEnd| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] |endInset|.
+	1. Let |clipStart| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV3| ».
+	1. Let |clipEnd| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV2| ».
+	1. Let |clipOuter| be |targetCornerOuter|.
 
-	1. Let |clipStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |extendStart| ».
-	1. Let |clipEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |extendEnd| ».
-	1. Let |clipOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |extendStart|, |extendEnd| ».
-
-	1. If |K| is greater than zero:
+	1. If |K| is greater than or equal to zero:
 		1. Let |controlPoint| be |mapPointToCorner| given |controlPointX| and |controlPointX|, |adjustedCornerStart|, |adjustedCornerEnd|, and |adjustedCornerCenter|.
-		1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-		1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+		1. Let |path| be a path.
+
+		1. If |startInset| is less than zero:
+			1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+			1. Extend |path| to |axisAlignedCornerStart|.
+		
+		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+
+		1. If |endInset| is less than zero:
+			1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+			1. Extend |path| to |axisAlignedCornerEnd|.
 			
 			Note: |axisAlignedCornerStart| and |axisAlignedCornerEnd| act as "miters" when rendering an outset.
 			They are a straight extension of the curve's tangent, intersecting with the unshaped target rect.
 
-		1. Let |path| be a path, starting at |axisAlignedCornerStart|.
-		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-		1. Extend |path| to |axisAlignedCornerEnd|.
 		1. Return |path|.
 
-	1. Let |startPseudoNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
-	1. Let |endPseudoNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
+	1. Let |startNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
+	1. Let |endNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
 
-	1. Let |startPseudoTangentVector| be the [=two-dimensional vector/perpendicular=] of |startPseudoNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
-	1. Let |endPseudoTangentVector| be the [=two-dimensional vector/perpendicular=] of |endPseudoNormalVector|.
+	1. Let |startTangentVector| be the [=two-dimensional vector/perpendicular=] of |startNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
+	1. Let |endTangentVector| be the [=two-dimensional vector/perpendicular=] of |endNormalVector|.
 
-	1. Let |startMiter| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startPseudoTangentVector| »)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-	1. Let |endMiter| be the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endPseudoTangentVector| »)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+	1. Let |startMiter| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+	1. Let |endMiter| be the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
 
-	1. Let |path| be a path, starting at |startMiter|.
+	1. Let |path| be a path.
+	
+	1. If |startInset| is less than zero:
+		1. Extend |path| to |startMiter|.
 
-	1. If <code>-|startInset|</code> is less than |startRadius|, and <code>-|endInset|</code> is less than |endRadius|:
-		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-		1. Extend |path| to |endMiter|.
-		1. Return |path|.
+	1. If <code>-|endInset|</code> is greater than or equal to |startRadius|:
+		1. Let |startMiterIntersection| be the intersection between the segment <code>(|startMiter|, |adjustedCornerStart|)</code> and the line <code>(|endMiter|, |adjustedCornerEnd|)</code>.
+		1. If |startMiterIntersection| is not undefined:
+			1. Extend |path| to |startMiterIntersection|.
+			1. Extend |path| to |endMiter|.
+			1. Return |path|.
 
-	1. Let |startMiterIntersection| be the intersection between the segment <code>(|startMiter|, |adjustedCornerStart|)</code> and the line <code>(|endMiter|, |adjustedCornerEnd|)</code>.
-	1. If |startMiterIntersection| is not undefined:
-		1. Extend |path| to |startMiterIntersection|.
-		1. Extend |path| to |endMiter|.
-		1. Return |path|.
-
-	1. Let |endMiterIntersection| be the intersection between the segment <code>(|endMiter|, |adjustedCornerEnd|)</code> and the line <code>(|startMiter|, |adjustedCornerStart|)</code>.
-	1. If |endMiterIntersection| is not undefined:
-		1. Extend |path| to |endMiterIntersection|.
-		1. Extend |path| to |endMiter|.
-		1. Return |path|.
+	1. If <code>-|startInset|</code> is greater than or equal to |endRadius|:
+		1. Let |endMiterIntersection| be the intersection between the segment <code>(|endMiter|, |adjustedCornerEnd|)</code> and the line <code>(|startMiter|, |adjustedCornerStart|)</code>.
+		1. If |endMiterIntersection| is not undefined:
+			1. Extend |path| to |endMiterIntersection|.
+			1. Extend |path| to |endMiter|.
+			1. Return |path|.
 
 	1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-	1. Extend |path| to |endMiter|.
+
+	1. If |endInset| is less than zero:
+		1. Extend |path| to |endMiter|.
 	1. Return |path|.
 </div>
 

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1529,6 +1529,9 @@ To <dfn for="two-dimensional vector list">sum</dfn> a [=/list=] of [=two-dimensi
 	1. Return <code>(|x|, |y|)</code>.
 </div>
 
+The <dfn>dot product</dfn> of [=two-dimensional vector=]s |a| and |b|, is <code>|a|[0] ⋅ |b|[0] + |a|[1] ⋅ |b|[1]</code>. 
+
+
 <h5 id=contour-path>Computing a contoured path</h5>
 
 This algorithm describes how to compute a path with shaped corners.
@@ -1596,106 +1599,88 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 	1. Let |vectorToOriginalCornerOuterV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>-|startInset|</code>.
 	1. Let |originalCornerOuter| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |vectorToOriginalCornerOuterV3|, |vectorToOriginalCornerOuterV2| ».
 
-	1. Let |originalCornerV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] |endRadius|.
-	1. Let |originalCornerV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] |startRadius|.
+	1. Let |originalCornerStart| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV3| [=two-dimensional vector/scale|scaled by=] |endRadius| ».
+	1. Let |originalCornerEnd| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV2| [=two-dimensional vector/scale|scaled by=] |startRadius| ».
 
-	1. Let |originalCornerStart| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV3| ».
-	1. Let |originalCornerEnd| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV2| ».
-	1. Let |originalCornerCenter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |originalCornerV3|, |originalCornerV2| ».
+	1. Let |halfCornerX| be the [=normalized superellipse half corner=] given |K|.
+	1. Let |controlPointX| be <code>clamp(0, 1/(sqrt(2) - 1) ⋅ |halfCornerX| - 1/sqrt(2), 1)</code>.
 
+	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
+	1. If |K| is smaller than or equal to zero, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
+	
+	1. Let |startControlPointX| be |controlPointX|.
+	1. Let |endControlPointX| be |controlPointX|.
+	1. If |insetDiff| is not zero:
+		1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
+		1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
+		1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
+	
+		1. Set |startControlPointX| to <code>|bevelControlPointX| · (2 · |controlPointX|)</code> if |K| is less than zero, <code>1 - (1 - |bevelControlPointX|) · (2 · (1 - |controlPointX|))</code> otherwise.
+		1. Set |endControlPointX| to <code>2 ⋅ |controlPointX| - |startControlPointX|</code>.
+	
+	1. Let |unmappedStartNormalVector| be the [=two-dimensional vector=] <code>((1 - |startControlPointX|) ⋅ |startRadius|, |startControlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+	1. Let |unmappedEndNormalVector| be the [=two-dimensional vector=] <code>(|endControlPointX| ⋅ |startRadius|, (1 - |endControlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
+
+	1. Let |startNormalVector| be the [=two-dimensional vector list/sum=] of « |normalizedV3| [=two-dimensional vector/scale|scaled by=] |unmappedStartNormalVector|[0], |normalizedV2| [=two-dimensional vector/scale|scaled by=] |unmappedStartNormalVector|[1] ».
+	1. Let |endNormalVector| be the [=two-dimensional vector list/sum=] of « |normalizedV3| [=two-dimensional vector/scale|scaled by=] |unmappedEndNormalVector|[0], |normalizedV2| [=two-dimensional vector/scale|scaled by=] |unmappedEndNormalVector|[1] ».
+
+	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |startNormalVector| [=two-dimensional vector/scale|scaled by=] |startInset| ».
+	1. Let |adjustedCornerEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |endNormalVector| [=two-dimensional vector/scale|scaled by=] |endInset| ».
+
+	1. Let |startTangentVector| be the [=two-dimensional vector/perpendicular=] of |startNormalVector|, [=two-dimensional vector/scale|scaled by=] -1.
+	1. Let |endTangentVector| be the [=two-dimensional vector/perpendicular=] of |endNormalVector|.
+
+	1. Let |miterStart| be |adjustedCornerStart|.
+	1. Let |miterEnd| be |adjustedCornerEnd|.
+
+	1. If |startInset| is less than zero:
+		1. Let |clipStart| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV3| ».
+		1. Set |miterStart| to the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|clipStart|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+		1. If |K| is greater than or equal to zero, set |adjustedCornerStart| to |miterStart|.
+
+	1. If |endInset| is less than zero:
+		1. Let |clipEnd| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV2| ».
+		1. Set |miterEnd| to the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code> and <code>(|clipEnd|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+		1. If |K| is greater than or equal to zero, set |adjustedCornerEnd| to |miterEnd|.
+
+	1. Let |adjustedCornerDiagonalVector| be the [=vector between two points|vector between=] |adjustedCornerStart| and |adjustedCornerEnd|.
+	1. Let |adjustedCornerHeight| be the [=dot product=] of |adjustedCornerDiagonalVector| and |normalizedV2|.
+
+	1. Let |adjustedCornerOuter| be |adjustedCornerEnd|, [=point extended by vectors|extended by=] « |normalizedV2| [=two-dimensional vector/scale|scaled by=] <code>-|adjustedCornerHeight|</code> ».
+	1. Let |adjustedCornerCenter| be |adjustedCornerStart|, [=point extended by vectors|extended by=] « |normalizedV2| [=two-dimensional vector/scale|scaled by=] |adjustedCornerHeight| ».
+	
 	1. Let |mapPointToCorner| be the following steps, given numbers |x| and |y|, {{DOMPointReadOnly}} |start|, |end|, and |center|:
 		1. Let |v1| be [=vector between two points|the vector between=] |center| and |end|, [=two-dimensional vector/scale|scaled by=] |x|.
 		1. Let |v4| be [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |y|.
 		1. Return |center|, [=point extended by vectors|extended by=] « |v1|, |v4| ».
 
-	1. Let |curvePath| be the following steps, given {{DOMPointReadOnly}} |start|, |outer|, |end|, and |center|:
-		1. Let |path| be a path, starting at |start|.
-		1. If |K| is -∞:
-			1. Extend |path| to |center|.
-			1. Extend |path| to |end|.
-		1. Otherwise:
-			1. Let |n| be <code>2<sup>abs(|K|)</sup></code>.
-			1. Let |curveCenter| be |outer| if |K| is less than zero, |center| otherwise.
-			1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
-				extend |path| to the result of calling |mapPointToCorner| given <code>|T|<sup>1/|n|</sup></code> and <code>(1 - |T|)<sup>1/|n|</sup></code>, |start|, |end|, and |curveCenter|.
-		1. Return |path|.
+	1. Let |selfIntersection| be undefined.
+	1. If |K|, |startInset|, and |endInset| are less than zero:
+		1. If <code>-|endInset|</code> is greater than or equal to |startRadius|:
+			1. Set |selfIntersection| to the intersection between the segment <code>(|miterStart|, |adjustedCornerStart|)</code> and the line <code>(|miterEnd|, |adjustedCornerEnd|)</code>.
 
-	1. If |startInset| and |endInset| are zero:
-		1. Return |curvePath| given |originalCornerStart|, |originalCornerOuter|, |originalCornerEnd|, |originalCornerCenter|.
-
-	1. Let |clampedHalfCornerX| be the [=normalized superellipse half corner=] given <code>clamp(|K|, -1, 1)</code>.
-	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
-
-	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
-	1. If |K| is smaller than or equal to zero, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
-	1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
-	1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
-	1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
-	
-	1. Let |startControlPointX| be <code>|bevelControlPointX| · (2 · |controlPointX|)</code> if |K| is less than zero, <code>1 - (1 - |bevelControlPointX|) · (2 · (1 - |controlPointX|))</code> otherwise.
-	1. Let |endControlPointX| be <code>2 ⋅ |controlPointX| - |startControlPointX|</code>.
-	
-	1. Let |unmappedStartNormalVector| be the [=two-dimensional vector=] <code>((1 - |startControlPointX|) ⋅ |startRadius|, |startControlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
-	1. Let |unmappedEndNormalVector| be the [=two-dimensional vector=] <code>(|endControlPointX| ⋅ |startRadius|, (1 - |endControlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
-
-	1. Let |offsetStartV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartNormalVector|[0] ⋅ |startInset|</code>.
-	1. Let |offsetStartV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedStartNormalVector|[1] ⋅ |startInset|</code>.
-	1. Let |offsetEndV3| be |normalizedV3|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndNormalVector|[0] ⋅ |endInset|</code>.
-	1. Let |offsetEndV2| be |normalizedV2|, [=two-dimensional vector/scale|scaled by=] <code>|unmappedEndNormalVector|[1] ⋅ |endInset|</code>.
-
-	1. Let |adjustedCornerStart| be |originalCornerStart|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetStartV2| ».
-	1. Let |adjustedCornerOuter| be |originalCornerOuter|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetStartV2| ».
-	1. Let |adjustedCornerEnd| be |originalCornerEnd|, [=point extended by vectors|extended by=] « |offsetEndV3|, |offsetEndV2| ».
-	1. Let |adjustedCornerCenter| be |originalCornerCenter|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetEndV2| ».
-	
-	1. If |startInset| and |endInset| are greater than or equal to zero, or |K| is greater than or equal to 1:
-		1. Return |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-
-	1. Let |clipStart| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV3| ».
-	1. Let |clipEnd| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV2| ».
-
-	1. Let |miterStart| be |adjustedCornerStart|.
-	1. Let |miterEnd| be |adjustedCornerEnd|.
-
-	1. If |K| is greater than or equal to zero:
-		1. Let |controlPoint| be |mapPointToCorner| given |controlPointX| and |controlPointX|, |adjustedCornerStart|, |adjustedCornerEnd|, and |adjustedCornerCenter|.
-		1. Let |path| be a path.
-
-		1. If |startInset| is less than zero:
-			1. Set |miterStart| to the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-		
-		1. If |endInset| is less than zero:
-			1. Set |miterEnd| to the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
-			
-			Note: |miterStart| and |miterEnd| act as "miters" when rendering an outset.
-			They are a straight extension of the curve's tangent, intersecting with the unshaped target rect.
-	1. Otherwise:
-		1. Let |startNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
-		1. Let |endNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
-
-		1. Let |startTangentVector| be the [=two-dimensional vector/perpendicular=] of |startNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
-		1. Let |endTangentVector| be the [=two-dimensional vector/perpendicular=] of |endNormalVector|.
-
-		1. If |startInset| is less than zero:
-			1. Set |miterStart| to the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|clipStart|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-		
-		1. If |endInset| is less than zero:
-			1. Set |miterEnd| to the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code> and <code>(|clipEnd|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+		1. If <code>-|startInset|</code> is greater than or equal to |endRadius|, and |selfIntersection| is undefined:
+			1. Set |selfIntersection| to the intersection between the segment <code>(|miterEnd|, |adjustedCornerEnd|)</code> and the line <code>(|miterStart|, |adjustedCornerStart|)</code>.
 
 	1. Let |path| be a path, starting at |miterStart|.
 
-	1. Let |miterIntersection| be undefined.
-	1. If |K|, |startInset|, and |endInset| are less than zero:
-		1. If <code>-|endInset|</code> is greater than or equal to |startRadius|:
-			1. Set |miterIntersection| to the intersection between the line segment <code>(|miterStart|, |adjustedCornerStart|)</code> and the line <code>(|miterEnd|, |adjustedCornerEnd|)</code>.
-
-		1. If <code>-|startInset|</code> is greater than or equal to |endRadius|, and |miterIntersection| is undefined:
-			1. Set |miterIntersection| to the intersection between the line segment <code>(|miterEnd|, |adjustedCornerEnd|)</code> and the line <code>(|miterStart|, |adjustedCornerStart|)</code>.
-
-	1. If |miterIntersection| is undefined:
-		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-	1. Otherwise:
-		1. Extend |path| to |miterIntersection|.
+	1. If |selfIntersection| is a defined point:
+		1. Extend |path| to |selfIntersection|.
+	
+	1. Otherwise, if |K| is -∞:
+		1. Extend |path| to |adjustedCornerCenter|.
+	
+	1. Otherwise, if |K| is greater than zero or less than or equal to -1:
+		1. Let |n| be <code>2<sup>abs(|K|)</sup></code>.
+		1. Let |curveCenter| be |adjustedCornerOuter| if |K| is less than zero, |adjustedCornerCenter| otherwise.
+		1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
+			extend |path| to the result of calling |mapPointToCorner| given <code>|T|<sup>1/|n|</sup></code> and <code>(1 - |T|)<sup>1/|n|</sup></code>, |adjustedCornerStart|, |adjustedCornerEnd|, and |curveCenter|.
+	
+	1. Otherwise, if |K| is greater than -1 and less than zero:
+		1. Let |tangentIntersection| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+		1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
+			extend |path| to the result of calling |mapPointToCorner| given <code>1 - (1 - |T|)<sup>1/2</sup></code> and <code>1 - |T|<sup>1/2</sup></code>, |adjustedCornerStart|, |adjustedCornerEnd|, and |tangentIntersection|.
+		
 	1. Extend |path| to |miterEnd|.
 	1. Return |path|.
 </div>

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1542,7 +1542,7 @@ The specific implementation details of this clipping operation are left to imple
 To compute the <dfn>border contour path</dfn> given an [=/element=] |element|, numbers |topInset|, |rightInset|, |bottomInset|, |leftInset|:
 	1. Let |borderRect| be |element|'s [=border box=].
 	1. Let |targetRect| be |borderRect|, inset by |topInset|, |rightInset|, |bottomInset|, |leftInset|.
-		
+
 		Note: If this is a shadow or 'overflow-clip-margin', the insets may have negative values, in which case |targetRect| would become an outset of |borderRect|.
 
 	1. Let |path| be a path that traces |targetRect|.
@@ -1574,14 +1574,14 @@ To compute the <dfn>border contour path</dfn> given an [=/element=] |element|, n
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s right, |targetRect|'s bottom)</code>,
 		<code>(0, -1)</code>, <code>(-1, 0)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-right-shape'.
-		
+
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|bottomLeftRadius|'s [=height=], |bottomLeftRadius|'s [=width=],
 		|adjustedBottomLeftInset|'s [=height=], |adjustedBottomLeftInset|'s [=width=],
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s left, |targetRect|'s bottom)</code>,
 		<code>(1, 0)</code>, <code>(0, -1)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-left-shape'.
-		
+
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|topLeftRadius|'s [=width=], |topLeftRadius|'s [=height=],
 		|adjustedTopLeftInset|'s [=width=], |adjustedTopLeftInset|'s [=height=],
@@ -1607,17 +1607,17 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 
 	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
 	1. If |K| is smaller than or equal to zero, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
-	
+
 	1. Let |startControlPointX| be |controlPointX|.
 	1. Let |endControlPointX| be |controlPointX|.
 	1. If |insetDiff| is not zero:
 		1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> - |insetDiff|<sup>2</sup>)</code>.
 		1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> - |insetDiff|<sup>2</sup>)</code>.
 		1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
-	
+
 		1. Set |startControlPointX| to <code>|bevelControlPointX| · (2 · |controlPointX|)</code> if |K| is less than zero, <code>1 - (1 - |bevelControlPointX|) · (2 · (1 - |controlPointX|))</code> otherwise.
 		1. Set |endControlPointX| to <code>2 ⋅ |controlPointX| - |startControlPointX|</code>.
-	
+
 	1. Let |unmappedStartNormalVector| be the [=two-dimensional vector=] <code>((1 - |startControlPointX|) ⋅ |startRadius|, |startControlPointX| ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
 	1. Let |unmappedEndNormalVector| be the [=two-dimensional vector=] <code>(|endControlPointX| ⋅ |startRadius|, (1 - |endControlPointX|) ⋅ |endRadius|)</code>, [=two-dimensional vector/normalize|normalized=].
 
@@ -1666,21 +1666,21 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 
 	1. If |selfIntersection| is a defined point:
 		1. Extend |path| to |selfIntersection|.
-	
+
 	1. Otherwise, if |K| is -∞:
 		1. Extend |path| to |adjustedCornerCenter|.
-	
+
 	1. Otherwise, if |K| is greater than zero or less than or equal to -1:
 		1. Let |n| be <code>2<sup>abs(|K|)</sup></code>.
 		1. Let |curveCenter| be |adjustedCornerOuter| if |K| is less than zero, |adjustedCornerCenter| otherwise.
 		1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
 			extend |path| to the result of calling |mapPointToCorner| given <code>|T|<sup>1/|n|</sup></code> and <code>(1 - |T|)<sup>1/|n|</sup></code>, |adjustedCornerStart|, |adjustedCornerEnd|, and |curveCenter|.
-	
+
 	1. Otherwise, if |K| is greater than -1 and less than zero:
 		1. Let |tangentIntersection| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
 		1. For every |T| between 0 and 1, in an [=implementation-approximated=] manner,
 			extend |path| to the result of calling |mapPointToCorner| given <code>1 - (1 - |T|)<sup>1/2</sup></code> and <code>1 - |T|<sup>1/2</sup></code>, |adjustedCornerStart|, |adjustedCornerEnd|, and |tangentIntersection|.
-		
+
 	1. Extend |path| to |miterEnd|.
 	1. Return |path|.
 </div>
@@ -1732,7 +1732,7 @@ To compute the <dfn>opposite corner scale factor</dfn> given an [=/element=] |el
 			1. Let |v4| be [=vector between two points|the vector between=] |center| and |start|, [=two-dimensional vector/scale|scaled by=] |p|'s {{DOMPointReadOnly/y}}.
 			1. Let |mappedPoint| be |center|, [=point extended by vectors|extended by=] « |v1|, |v4| ».
 			1. [=list/Append=] |mappedPoint| to |mappedPolygon|.
-		1. Return |mappedPolygon|.	
+		1. Return |mappedPolygon|.
 
 	1. Let |topRightHull| be |mapPolygonToCorner| given |unmappedTopRightHull|,
 		{{DOMPointReadOnly}} at <code>(|rect|'s [=width dimension=] - |topRightRadius|'s [=width=], 0)</code>,
@@ -1748,7 +1748,7 @@ To compute the <dfn>opposite corner scale factor</dfn> given an [=/element=] |el
 		{{DOMPointReadOnly}} at <code>(|bottomLeftRadius|'s [=width=], |rect|'s [=height dimension=])</code>,
 		at <code>(0, |rect|'s [=height dimension=] - |bottomLeftRadius|'s [=height=])</code>,
 		and at <code>(|bottomLeftRadius|'s [=width=], |rect|'s [=height dimension=] - |bottomLeftRadius|'s [=height=])</code>.
-	
+
 	1. Let |topLeftHull| be |mapPolygonToCorner| given |unmappedTopLeftHull|,
 		{{DOMPointReadOnly}} at <code>(0, |topLeftRadius|'s [=height=])</code>,
 		at <code>(|topLeftRadius|'s [=width=], 0)</code>,

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1720,10 +1720,10 @@ To compute the <dfn>opposite corner scale factor</dfn> given an [=/element=] |el
 	1. Let |bottomLeftRadius| be |element|'s [=computed value=] of 'border-bottom-left-radius'.
 	1. Let |topLeftRadius| be |element|'s [=computed value=] of 'border-top-left-radius'.
 
-	1. Let |unmappedTopRightHull| be the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-right-shape',
-	1. Let |unmappedBottomRightHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
-	1. Let |unmappedBottomLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape',
-	1. Let |unmappedTopLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-left-shape',
+	1. Let |unmappedTopRightHull| be the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-right-shape'.
+	1. Let |unmappedBottomRightHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-right-shape'.
+	1. Let |unmappedBottomLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-bottom-left-shape'.
+	1. Let |unmappedTopLeftHull| be a the [=normalized inner corner hull=] given |element|'s [=computed value|computed=] 'corner-top-left-shape'.
 
 	1. Let |mapPolygonToCorner| be the following steps, given a [=/list=] of {{DOMPointReadOnly}} |polygon|, {{DOMPointReadOnly}} |start|, |end|, and |center|:
 		1. Let |mappedPolygon| be an empty [=/list=].

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1611,8 +1611,8 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 	1. Let |startControlPointX| be |controlPointX|.
 	1. Let |endControlPointX| be |controlPointX|.
 	1. If |insetDiff| is not zero:
-		1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
-		1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
+		1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> - |insetDiff|<sup>2</sup>)</code>.
+		1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> - |insetDiff|<sup>2</sup>)</code>.
 		1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
 	
 		1. Set |startControlPointX| to <code>|bevelControlPointX| · (2 · |controlPointX|)</code> if |K| is less than zero, <code>1 - (1 - |bevelControlPointX|) · (2 · (1 - |controlPointX|))</code> otherwise.

--- a/css-borders-4/Overview.bs
+++ b/css-borders-4/Overview.bs
@@ -1559,29 +1559,29 @@ To compute the <dfn>border contour path</dfn> given an [=/element=] |element|, n
 	1. Let |adjustedTopLeftInset| be the |adjustedInset| given |topLeftRadius|, |leftInset|, and |topInset|.
 
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
-		|topRightRadius|'s [=height=] ,|topRightRadius|'s [=width=],
-		|adjustedTopRightInset|'s [=height=] ,|adjustedTopRightInset|'s [=width=],
+		|topRightRadius|'s [=height=], |topRightRadius|'s [=width=],
+		|adjustedTopRightInset|'s [=height=], |adjustedTopRightInset|'s [=width=],
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s right, |targetRect|'s top)</code>,
 		<code>(-1, 0)</code>, <code>(0, 1)</code>,
 		|element|'s [=computed value|computed=] 'corner-top-right-shape'.
 
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|bottomRightRadius|'s [=width=], |bottomRightRadius|'s [=height=],
-		|adjustedBottomRightInset|'s [=width=] ,|adjustedBottomRightInset|'s [=height=],
+		|adjustedBottomRightInset|'s [=width=], |adjustedBottomRightInset|'s [=height=],
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s right, |targetRect|'s bottom)</code>,
 		<code>(0, -1)</code>, <code>(-1, 0)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-right-shape'.
 		
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|bottomLeftRadius|'s [=height=], |bottomLeftRadius|'s [=width=],
-		|adjustedBottomLeftInset|'s [=height=] ,|adjustedBottomLeftInset|'s [=width=],
+		|adjustedBottomLeftInset|'s [=height=], |adjustedBottomLeftInset|'s [=width=],
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s left, |targetRect|'s bottom)</code>,
 		<code>(1, 0)</code>, <code>(0, -1)</code>,
 		|element|'s [=computed value|computed=] 'corner-bottom-left-shape'.
 		
 	1. Clip out from |path|, the [=border-aligned corner clip-out path=] given
 		|topLeftRadius|'s [=width=], |topLeftRadius|'s [=height=],
-		|adjustedTopLeftInset|'s [=width=] ,|adjustedTopLeftInset|'s [=height=],
+		|adjustedTopLeftInset|'s [=width=], |adjustedTopLeftInset|'s [=height=],
 		a {{DOMPointReadOnly}} at <code>(|targetRect|'s left, |targetRect|'s top)</code>,
 		<code>(0, 1)</code>, <code>(1, 0)</code>,
 		|element|'s [=computed value|computed=] 'corner-top-left-shape'.
@@ -1621,14 +1621,13 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 		1. Return |path|.
 
 	1. If |startInset| and |endInset| are zero:
-		1. Let |path| be |curvePath| given |originalCornerStart|, |originalCornerOuter|, |originalCornerEnd|, |originalCornerCenter|.
-		1. Return |path|.
+		1. Return |curvePath| given |originalCornerStart|, |originalCornerOuter|, |originalCornerEnd|, |originalCornerCenter|.
 
 	1. Let |clampedHalfCornerX| be the [=normalized superellipse half corner=] given <code>clamp(|K|, -1, 1)</code>.
 	1. Let |controlPointX| be <code>1/(sqrt(2) - 1) ⋅ |clampedHalfCornerX| - 1/sqrt(2)</code>.
 
 	1. Let |insetDiff| be <code>clamp(-|startRadius|, |endInset| - |startInset|, |endRadius|)</code>.
-	1. If |K| is smaller than or equal to 0, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
+	1. If |K| is smaller than or equal to zero, and |insetDiff| is equal to <code>-|startRadius|</code> or |endRadius|, then return an empty path.
 	1. Let |bevelNormalVectorX| be <code>|endRadius| ⋅ |insetDiff| + |startRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
 	1. Let |bevelNormalVectorY| be <code>-|startRadius| ⋅ |insetDiff| + |endRadius| ⋅ sqrt(|startRadius|<sup>2</sup> + |endRadius|<sup>2</sup> + |insetDiff|<sup>2</sup>)</code>.
 	1. Let |bevelControlPointX| be <code>(|startRadius| ⋅ |bevelNormalVectorY|)/(|startRadius| ⋅ |bevelNormalVectorY| + |endRadius| ⋅ |bevelNormalVectorX|)</code>.
@@ -1650,64 +1649,54 @@ To compute the <dfn>border-aligned corner clip-out path</dfn> given numbers |sta
 	1. Let |adjustedCornerCenter| be |originalCornerCenter|, [=point extended by vectors|extended by=] « |offsetStartV3|, |offsetEndV2| ».
 	
 	1. If |startInset| and |endInset| are greater than or equal to zero, or |K| is greater than or equal to 1:
-		1. Let |path| be |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-		1. Return |path|.
+		1. Return |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
 
 	1. Let |clipStart| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV3| ».
 	1. Let |clipEnd| be |targetCornerOuter|, [=point extended by vectors|extended by=] « |normalizedV2| ».
-	1. Let |clipOuter| be |targetCornerOuter|.
+
+	1. Let |miterStart| be |adjustedCornerStart|.
+	1. Let |miterEnd| be |adjustedCornerEnd|.
 
 	1. If |K| is greater than or equal to zero:
 		1. Let |controlPoint| be |mapPointToCorner| given |controlPointX| and |controlPointX|, |adjustedCornerStart|, |adjustedCornerEnd|, and |adjustedCornerCenter|.
 		1. Let |path| be a path.
 
 		1. If |startInset| is less than zero:
-			1. Let |axisAlignedCornerStart| be the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-			1. Extend |path| to |axisAlignedCornerStart|.
+			1. Set |miterStart| to the intersection between the lines <code>(|adjustedCornerStart|, |controlPoint|)</code> and <code>(|clipStart|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
 		
-		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-
 		1. If |endInset| is less than zero:
-			1. Let |axisAlignedCornerEnd| be the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
-			1. Extend |path| to |axisAlignedCornerEnd|.
+			1. Set |miterEnd| to the intersection between the lines <code>(|adjustedCornerEnd|, |controlPoint|)</code> and <code>(|clipEnd|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
 			
-			Note: |axisAlignedCornerStart| and |axisAlignedCornerEnd| act as "miters" when rendering an outset.
+			Note: |miterStart| and |miterEnd| act as "miters" when rendering an outset.
 			They are a straight extension of the curve's tangent, intersecting with the unshaped target rect.
+	1. Otherwise:
+		1. Let |startNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
+		1. Let |endNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
 
-		1. Return |path|.
+		1. Let |startTangentVector| be the [=two-dimensional vector/perpendicular=] of |startNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
+		1. Let |endTangentVector| be the [=two-dimensional vector/perpendicular=] of |endNormalVector|.
 
-	1. Let |startNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetStartV3|, |offsetStartV2| ».
-	1. Let |endNormalVector| be the [=two-dimensional vector list/sum=] of « |offsetEndV3|, |offsetEndV2| ».
+		1. If |startInset| is less than zero:
+			1. Set |miterStart| to the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|clipStart|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
+		
+		1. If |endInset| is less than zero:
+			1. Set |miterEnd| to the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code> and <code>(|clipEnd|, |targetCornerOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
 
-	1. Let |startTangentVector| be the [=two-dimensional vector/perpendicular=] of |startNormalVector|, [=two-dimensional vector/scale|scaled by=] <code>-1</code>.
-	1. Let |endTangentVector| be the [=two-dimensional vector/perpendicular=] of |endNormalVector|.
+	1. Let |path| be a path, starting at |miterStart|.
 
-	1. Let |startMiter| be the intersection between the lines <code>(|adjustedCornerStart|, |adjustedCornerStart| [=point extended by vectors|extended by=] « |startTangentVector| »)</code> and <code>(|clipStart|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerStart|.
-	1. Let |endMiter| be the intersection between the lines <code>(|adjustedCornerEnd|, |adjustedCornerEnd| [=point extended by vectors|extended by=] « |endTangentVector| »)</code> and <code>(|clipEnd|, |clipOuter|)</code>. If the lines are parallel, let it be |adjustedCornerEnd|.
+	1. Let |miterIntersection| be undefined.
+	1. If |K|, |startInset|, and |endInset| are less than zero:
+		1. If <code>-|endInset|</code> is greater than or equal to |startRadius|:
+			1. Set |miterIntersection| to the intersection between the line segment <code>(|miterStart|, |adjustedCornerStart|)</code> and the line <code>(|miterEnd|, |adjustedCornerEnd|)</code>.
 
-	1. Let |path| be a path.
-	
-	1. If |startInset| is less than zero:
-		1. Extend |path| to |startMiter|.
+		1. If <code>-|startInset|</code> is greater than or equal to |endRadius|, and |miterIntersection| is undefined:
+			1. Set |miterIntersection| to the intersection between the line segment <code>(|miterEnd|, |adjustedCornerEnd|)</code> and the line <code>(|miterStart|, |adjustedCornerStart|)</code>.
 
-	1. If <code>-|endInset|</code> is greater than or equal to |startRadius|:
-		1. Let |startMiterIntersection| be the intersection between the segment <code>(|startMiter|, |adjustedCornerStart|)</code> and the line <code>(|endMiter|, |adjustedCornerEnd|)</code>.
-		1. If |startMiterIntersection| is not undefined:
-			1. Extend |path| to |startMiterIntersection|.
-			1. Extend |path| to |endMiter|.
-			1. Return |path|.
-
-	1. If <code>-|startInset|</code> is greater than or equal to |endRadius|:
-		1. Let |endMiterIntersection| be the intersection between the segment <code>(|endMiter|, |adjustedCornerEnd|)</code> and the line <code>(|startMiter|, |adjustedCornerStart|)</code>.
-		1. If |endMiterIntersection| is not undefined:
-			1. Extend |path| to |endMiterIntersection|.
-			1. Extend |path| to |endMiter|.
-			1. Return |path|.
-
-	1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
-
-	1. If |endInset| is less than zero:
-		1. Extend |path| to |endMiter|.
+	1. If |miterIntersection| is undefined:
+		1. Extend |path| to |curvePath| given |adjustedCornerStart|, |adjustedCornerOuter|, |adjustedCornerEnd|, |adjustedCornerCenter|.
+	1. Otherwise:
+		1. Extend |path| to |miterIntersection|.
+	1. Extend |path| to |miterEnd|.
 	1. Return |path|.
 </div>
 

--- a/css-borders-4/images/corner-shape-notation.svg
+++ b/css-borders-4/images/corner-shape-notation.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+	<g style="font-size: 24px; font-family: Menlo, Consolas, 'DejaVu Sans Mono', Monaco, monospace;">
+		<rect style="fill: white" width="400" height="400" />
+		<path style="fill: #e6e6e6" d="M0 100 H100 A200 200 0 0 1 300 300 V400 H0 Z" />
+		<g style="fill: none; stroke: #9d9d9d; stroke-width: 3;">
+			<path d="M 100 100 A 200 200 0 0 1 300 300" />
+			<path d="M100 100 H0" />
+			<path d="M300 300 V400" />
+		</g>
+		<path style="fill: none; stroke: #000000; stroke-width: 4;" d="m300 100v200h-200v-200z" />
+		<g style="fill: none; stroke: #ff0000; stroke-width: 5;">
+			<path d="M100 66 H280" />
+			<path d="M337 100 V280" />
+			<path d="M300 332 H120" />
+			<path d="M66 300 V120" />
+		</g>
+		<g style="fill: #ff0000">
+			<path d="M280 56 L300 66 L280 76 Z" />
+			<path d="M327 280 L337 300 L347 280 Z" />
+			<path d="M120 322 L100 332 L120 342 Z" />
+			<path d="M56 120 L66 100 L76 120 Z" />
+			<text x="196" y="55">v1</text>
+			<text x="348" y="198">v2</text>
+			<text x="196" y="361">v3</text>
+			<text x="27" y="198">v4</text>
+		</g>
+		<g style="fill: none; stroke: #ff00ff; stroke-width: 6;">
+			<path d="M235 100 H300" />
+			<path d="M300 100 V165" />
+			<path d="M100 300 H165" />
+			<path d="M100 300 V235" />
+		</g>
+		<g style="fill: #ff00ff">
+			<path d="M240 90 L220 100 L240 110 Z" />
+			<path d="M290 160 L300 180 L310 160 Z" />
+			<path d="M160 310 L180 300 L160 290 Z" />
+			<path d="M90 240 L100 220 L110 240 Z" />
+			<text x="220" y="135">V3</text>
+			<text x="258" y="178">V2</text>
+			<text x="158" y="282">V1</text>
+			<text x="115" y="240">V4</text>
+			<text x="115" y="205">(normalized)</text>
+		</g>
+		<g style="fill: #0000ff">
+			<circle cx="100" cy="100" r="10" />
+			<circle cx="300" cy="100" r="10" />
+			<circle cx="100" cy="300" r="10" />
+			<circle cx="300" cy="300" r="10" />
+			<text x="18" y="87">start</text>
+			<text x="311" y="87">outer</text>
+			<text x="311" y="326">end</text>
+			<text x="3" y="326">center</text>
+		</g>
+	</g>
+</svg>


### PR DESCRIPTION
- Refactored `border-aligned corner clip-out path` to:
  - Handle non-square corners by scaling the "normal" vectors.
  - Fix when the miter degenerates and self-intersects for concave corners. Fixed by calculating the miter lines as perpendicular to the "normal" vectors (AKA "tangent").
  (note: in square corners this results in the same miter points as the control-point method. When the corner is not square: in concave corners the miter points diverge from the control-point method, in convex corners the miter points are almost the same as the control-point method.)
  - Fix non uniform outset corners and mixed-inset-sign corners, by computing bevel corners as the tangent to 2 circles with center at corner-start and corner-end, and radius the 2 signed insets. All other intermediary corner shapes are adjusted accordingly and are also fixed.
  - Fix "ripple" issue for 0 < k < 1 by drawing a single superellipse curve without miter lines, ensuring C2 continuity.
  - Fix C1 discontinuity for -1 < k < 0 between the curve and miter lines by drawing an approximate superellipse that can be mapped to any case.
  - Fix C0 discontinuity in self-intersections as a result of the C1 continuity fix.
  - Respect "blue area rule" by avoiding the control point method.
  - All mixed-sign/non-uniform inset cases transition are C0 continuous.

- Refactored `Computing a contoured path` to:
  - Respect the `outset-adjusted border radius` for round corner compat.
    - Fixed by substituting the following algorithm:
      > 4. Let adjustedRadiusInOutsetCoordinates be the outset-adjusted border radius given borderRect’s size, radius, and (-insetX, -insetY).
      > 5. Return (adjustedRadiusInOutsetCoordinates’s width - insetX, adjustedRadiusInOutsetCoordinates’s height - insetY).

      with `adjustedInset`, which calculates the inset from the adjusted radius, and by computing the borderRect outer point from the targetRect and the adjusted inset.

- Applied `opposite corner scale factor` to the used value.
- Made various math fixes.
- Updated explanation for non-linear interpolation.
- Fixed some typos.

Fixes https://github.com/w3c/csswg-drafts/issues/13318
Fixes https://github.com/w3c/csswg-drafts/issues/14183
Fixes https://github.com/w3c/csswg-drafts/issues/14184
Fixes https://github.com/w3c/csswg-drafts/issues/14185
Fixes https://github.com/w3c/csswg-drafts/issues/14157

WPT tests:
- https://github.com/web-platform-tests/wpt/pull/61696
- [corner-shape-interpolation.html](https://github.com/web-platform-tests/wpt/blob/master/css/css-borders/corner-shape/corner-shape-interpolation.html) (already ok)

Questions:
- https://github.com/w3c/csswg-drafts/issues/14270

- https://github.com/w3c/csswg-drafts/issues/14158

### Desmos graph https://www.desmos.com/calculator/xaahq21qrk

screencasts:
current algorithm, chrome implementation:

https://github.com/user-attachments/assets/48523c7b-10b4-4d72-850d-fda7045e363b

circa proposed changes (old video, including only some of the fixes):

https://github.com/user-attachments/assets/78960c00-d2e3-4485-9f14-10db51c510b8

chrome bugs:
https://issues.chromium.org/issues/532190484
https://issues.chromium.org/issues/532199267
https://issues.chromium.org/issues/532163949