### PR TITLE
[web-animations-2] calling play() for a finite timeline should reset the start time to the current time

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -654,8 +654,10 @@ as CSS Animations [[CSS-ANIMATIONS-1]].
 
     </dl>
 
-1.  If |has finite timeline| and |previous current time| is unresolved:
-    *   Set the flag |auto align start time| to true.
+1.  If |has finite timeline| and |auto-rewind| is true:
+
+    1.   Set the flag |auto align start time| to true.
+    1.   Set the |animation|'s <a>hold time</a> to |previous current time|.
 
     Note: If play is called for a CSS animation during style update,
     the |animation|'s [=animation/start time=] cannot be reliably calculated until post layout since the start time is to align with the start or end of the animation range (depending on the [=playback rate=]).


### PR DESCRIPTION
Address https://github.com/w3c/csswg-drafts/issues/11469.