### PR TITLE
[css-view-transitions-2] replace `contain: view-transition` with `view-transition-scope: all`

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -2535,7 +2535,7 @@ It has the following [=struct/items=]:
 
 			1. If any [=flat tree=] [=inclusive ancestor=] of this |element|,
 				up to but not including |transition|'s [=ViewTransition/root element=],
-				has ''contain: view-transition'',
+				has ''view-transition-scope: all'',
 				[=continue=].
 
 			1. If |element| has more than one [=box fragment=], then [=continue=].


### PR DESCRIPTION
@vmpstr, it looks like one occurrence slipped through the earlier replacement.