### PR TITLE
[web-animations-2] Auto-aligning the start time should apply a pending playback rate

### DIFF
--- a/web-animations-2/Overview.bs
+++ b/web-animations-2/Overview.bs
@@ -818,6 +818,8 @@ The procedure for <dfn export for="animation">calculating an auto-aligned start 
     1.  Set [=animation/start time=] to |start offset| if [=effective playback rate=] &ge; 0,
         and |end offset| otherwise.
 
+    1.  [=Apply any pending playback rate=] on |animation|.
+
     1.  Clear [=hold time=].
 
 


### PR DESCRIPTION
Throughout the Web Animations spec we typically [apply the pending playback rate](https://drafts.csswg.org/web-animations-1/#apply-any-pending-playback-rate) of an animation when setting its [start time](https://www.w3.org/TR/web-animations-1/#animation-start-time). It is an oversight not to do so within the procedure to [auto-aligning the start time](https://drafts.csswg.org/web-animations-2/#auto-aligning-start-time).

Addresses https://github.com/w3c/csswg-drafts/issues/14173.