### PR TITLE
[animation-triggers-1] animation-trigger property value syntax #12399

### DIFF
--- a/animation-triggers-1/Overview.bs
+++ b/animation-triggers-1/Overview.bs
@@ -559,7 +559,7 @@ urlPrefix: https://www.w3.org/TR/web-animations-1/; type: dfn
 
 	<pre class=propdef>
 	Name: animation-trigger
-	Value: [ none | [ <<dashed-ident>> <<animation-action>>+ ]+ ]#
+	Value: [ none | [ <<dashed-ident>> <<animation-action>>+ ] ]#
 	Initial: none
 	Applies to: all elements
 	Inherited: no


### PR DESCRIPTION
Only one trigger per animation.
This updates the syntax of the property to reflect that , in a comma-separated list of animation-triggers, only one trigger is allowed per animation.

related to issue #12399

On March 25, 2026: 

> RESOLVED: we allow one trigger per animation for now, throw in JS if someone tries to add more than one, and have an explicit intent to allow multiple in the future

Copy the above line into the Title and replace with the relevant details. Fill in any additional details here. See https://github.com/w3c/csswg-drafts/blob/master/CONTRIBUTING.md for more info.

Note: PR is failing because I am not listed as being in the CSSWG "Estelle did not make IPR commitments for this group."
