### PR TITLE
[css-values-5] Fix dfn of `<size-keyword>` type

### DIFF
--- a/css-values-5/Overview.bs
+++ b/css-values-5/Overview.bs
@@ -3522,7 +3522,7 @@ calc-size/interpolate-size-parsing.html
 	The [=calc-size basis=] values are:
 
 	<dl dfn-type=value dfn-for="calc-size()">
-		: <dfn>&lt;size-keyword</dfn>
+		: <dfn dfn-type=type>&lt;size-keyword></dfn>
 		::
 			Indicates that the ''calc-size()'' is basing its size off of the specified keyword.
 			Represents any sizing keywords allowed in the context


### PR DESCRIPTION
The final `>` was missing. Also, Bikeshed is looking for a type, not a value.
