### PR TITLE
[cssom-view] Remove a dangling scroll completion para

### DIFF
--- a/cssom-view-1/Overview.bs
+++ b/cssom-view-1/Overview.bs
@@ -2591,8 +2591,6 @@ Issue: In what order are scrollend events dispatched? Ordered based on scroll st
     1. Otherwise, <a>fire an event</a> named <var>type</var> at <var>target</var>.
 1. Empty <var>doc</var>'s <a>pending scroll events</a>.
 
-Whenever scrolling is <a lt="scroll completed">completed</a>, the user agent must run these steps:
-
 <h3 id=event-summary>Event summary</h3>
 
 <i>This section is non-normative.</i>


### PR DESCRIPTION
This seems like a leftover line from https://github.com/w3c/csswg-drafts/pull/12606.

