### PR TITLE
[cssom-1] Expose the CSS namespace beyond Window; pin existing partialls #14229

### DIFF
--- a/css-conditional-3/Overview.bs
+++ b/css-conditional-3/Overview.bs
@@ -898,6 +898,7 @@ interface CSSDocumentRule : CSSConditionRule {
 The {{CSS}} namespace holds useful CSS-related functions that do not belong elsewhere.
 
 <pre class='idl'>
+[Exposed=Window]
 partial namespace CSS {
   boolean supports(CSSOMString property, CSSOMString value);
   boolean supports(CSSOMString conditionText);

--- a/css-highlight-api-1/Overview.bs
+++ b/css-highlight-api-1/Overview.bs
@@ -234,6 +234,7 @@ Registering Custom Highlights</h3>
 	It stops being [=registered=] if it is later removed.
 
 	<xmp class="idl">
+	[Exposed=Window]
 	partial namespace CSS {
 		readonly attribute HighlightRegistry highlights;
 	};

--- a/css-images-4/Overview.bs
+++ b/css-images-4/Overview.bs
@@ -925,6 +925,7 @@ Using Out-Of-Document Sources: the <code>ElementSources</code> interface</h4>
 	The <a idl>elementSources</a> Map object provides this.
 
 	<pre class='idl'>
+		[Exposed=Window]
 		partial namespace CSS {
 			[SameObject] readonly attribute any elementSources;
 		};

--- a/cssom-1/Overview.bs
+++ b/cssom-1/Overview.bs
@@ -3440,9 +3440,9 @@ The <code>CSS.escape()</code> Method {#the-css.escape()-method}
 The <code>CSS</code> namespace holds useful CSS-related functions that do not belong elsewhere.
 
 <pre class=idl>
-[Exposed=Window]
+[Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 namespace CSS {
-  CSSOMString escape(CSSOMString ident);
+  [Exposed=Window] CSSOMString escape(CSSOMString ident);
 };
 </pre>
 


### PR DESCRIPTION
The CSS namespace was [Exposed=Window], which made css-typed-om's [Exposed=(Window, Worker)] partial invalid: WebIDL requires a partial's own exposure set to be a subset of the original definition's exposure set.

Widen the base namespace to (Window, Worker, PaintWorklet, LayoutWorklet) and pin every pre-existing member to the exposure it has today, so this is a no-op for everything except the css-typed-om numeric factories:

  * cssom-1: escape() pinned to [Exposed=Window]
  * css-conditional-3: supports() partial pinned to [Exposed=Window]
  * css-highlight-api-1: highlights partial pinned to [Exposed=Window]
  * css-images-4: elementSources partial pinned to [Exposed=Window]

This is being discussed in the issue #14229  and there is the corresponding css-typed-om-1 [PR 1177](https://github.com/w3c/css-houdini-drafts/pull/1177). 