### PR TITLE
[css-backgrounds-4][editorial] Sort `background-origin` and `background-clip` values in canonical order

### DIFF
--- a/css-backgrounds-4/Overview.bs
+++ b/css-backgrounds-4/Overview.bs
@@ -1775,8 +1775,8 @@ Backgrounds Shorthand: the 'background' property</h3>
 	of values where
 
 	<pre class=prod>
-	<dfn>&lt;bg-layer></dfn> = <<bg-image>> || <<bg-position>> [ / <<bg-size>> ]? || <<repeat-style>> || <<attachment>> || <<bg-clip>> || <<visual-box>>
-	<dfn>&lt;final-bg-layer></dfn> =  <<bg-image>> || <<bg-position>> [ / <<bg-size>> ]? || <<repeat-style>> || <<attachment>> || <<bg-clip>> || <<visual-box>> || <<'background-color'>></pre>
+	<dfn>&lt;bg-layer></dfn> = <<bg-image>> || <<bg-position>> [ / <<bg-size>> ]? || <<repeat-style>> || <<attachment>> || <<visual-box>> || <<bg-clip>>
+	<dfn>&lt;final-bg-layer></dfn> =  <<bg-image>> || <<bg-position>> [ / <<bg-size>> ]? || <<repeat-style>> || <<attachment>> || <<visual-box>> || <<bg-clip>> || <<'background-color'>></pre>
 
 	Note: A color is permitted in <<final-bg-layer>>, but not in <<bg-layer>>.
 


### PR DESCRIPTION
The [grammar](https://drafts.csswg.org/css-backgrounds-4/#typedef-bg-layer) is `... || <bg-clip> || <visual-box> || ...` but historically, the canonical order, which is defined with *"per grammar"*, has always put `background-origin` before `background-clip` ([WPT](https://wpt.fyi/results/css/css-backgrounds/parsing/background-valid.html)):

```js
element.style.background = 'content-box padding-box';
[...element.style]; // ..., 'background-origin', 'background-clip'
```

And `background-origin` has priority over `background-clip` to match `<visual-box>`.

  > If two `<visual-box>` values are present, then the first sets `background-origin` and the second `background-clip`.