### PR TITLE
[css-text-decor-4] Updated the value for `text-decoration-inset`

### DIFF
--- a/css-text-decor-4/Overview.bs
+++ b/css-text-decor-4/Overview.bs
@@ -867,7 +867,7 @@ Trimming, Expanding, and Shifting Text Decoration Lines: the 'text-decoration-in
 
 	<pre class="propdef">
 	Name: text-decoration-inset
-	Value: <<length>>{1,2} | auto
+	Value: <<length-percentage>>{1,2} | auto
 	Initial: 0
 	Applies to: all elements
 	Inherited: no
@@ -887,11 +887,17 @@ Trimming, Expanding, and Shifting Text Decoration Lines: the 'text-decoration-in
 	Values have the following meanings:
 
 	<dl dfn-type=value dfn-for=text-decoration-inset>
-		<dt><dfn><<length>></dfn></dt>
+		<dt><dfn><<length-percentage>></dfn></dt>
 		<dd>
 			Adjusts the start or end endpoint of the affected line decorations.
 			Positive values move the endpoint inward (trimming),
 			negative values move it outward (extending).
+
+			A percentage value specifies the size of the inset as a percentage of
+			the used 'font-size'.
+
+			Note: A percentage will inherit as a relative value,
+			and will therefore scale with changes in the font as it inherits.
 
 			<div class="example">
 				<p>The following example offsets an extra thick underline


### PR DESCRIPTION
The value is now: `<length-percentage>{1,2} | auto` As discussed in [Issue #https://github.com/w3c/csswg-drafts/issues/8403](https://github.com/w3c/csswg-drafts/issues/8403) And Firefox [Issue ](https://bugzilla.mozilla.org/show_bug.cgi?id=2044602#c1)