### PR TITLE
[css-box-4] Remove flex and grid from margin-trim, as resolved in #13731

### DIFF
--- a/css-box-4/Overview.bs
+++ b/css-box-4/Overview.bs
@@ -375,12 +375,12 @@ Margins at Container Edges: the 'margin-trim' property {#margin-trim}
 
 	<pre class="propdef">
 		Name: margin-trim
-		Value: none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]
+		Value: none | block | [ block-start || block-end ]
 		Initial: none
-		Applies to: [=block containers=], [=multi-column containers=], [=flex containers=], [=grid containers=]
+		Applies to: [=block containers=], [=multi-column containers=]
 		Inherited: no
 		Percentages: N/A
-		Computed value: a set of zero to four keywords indicating which sides to trim
+		Computed value: a set of zero to two keywords indicating which sides to trim
 		Animation type: discrete
 	</pre>
 
@@ -410,29 +410,16 @@ Margins at Container Edges: the 'margin-trim' property {#margin-trim}
 			It also truncates any descendant margins collapsed with such a margin
 			(but not its own, its siblings’, or its ancestors’).
 
-		<dt><dfn>inline-start</dfn>
-		<dt><dfn>inline-end</dfn>
-			For [=in-flow=] boxes contained by this box,
-			margins adjacent to the box’s specified edges
-			are truncated to zero.
-			(However, these values do not apply to [=block containers=])
-
 		<dt><dfn>block</dfn>
 		<dd>
 			Computes to ''block-start block-end''.
-
-		<dt><dfn>inline</dfn>
-		<dd>
-			Computes to ''inline-start inline-end''.
 	</dl>
 
 	Note: Following the shortest-serialization principle,
-	[=computed values=] equivalent to ''margin-trim/block'' or ''margin-trim/inline''
-	will serialize as those keywords.
+	[=computed values=] equivalent to ''margin-trim/block''
+	will serialize as that keyword.
 
-	Adjacency is not sensitive to space governed by box alignment [[!CSS-ALIGN-3]],
-	and ignores collapsed boxes (see [[css-flexbox-1#visibility-collapse]])
-	and tracks ([[css-grid-1#auto-repeat]]).
+	Adjacency is not sensitive to space governed by box alignment [[!CSS-ALIGN-3]].
 
 	Note: See also the 'margin-break' property,
 	which applies to the box’s own margins
@@ -460,8 +447,7 @@ Trimming Block Container Content</h4>
 		<li>Any margin collapsed with these margins.
 	</ul>
 
-	It has no effect on the [=inline-axis=] margins of [=block-level=] descendants,
-	nor on any margins of [=inline-level=] descendants.
+	It has no effect on any margins of [=inline-level=] descendants.
 <!--
 
 	It also affects floats
@@ -490,31 +476,6 @@ Trimming Block Container Content</h4>
 	ISSUE(3256): Floats definition needs more work.
 
 -->
-
-<h4 id="margin-trim-flex">
-Trimming Flex Container Content</h4>
-
-	For [=flex containers=] specifically,
-	'margin-trim' discards
-	<ul>
-		<li>the corresponding margin of each [=flex item=] on the closest [=flex line=]
-			when trimming an edge parallel to the [=main axis=]
-		<li>the corresponding margin of the first/last [=flex item=] on each [=flex line=]
-			when trimming an edge parallel to the [=cross axis=]
-	</ul>
-
-	This process ignores any [=collapsed flex items=].
-
-<h4 id="margin-trim-grid">
-Trimming Grid Container Content</h4>
-
-	For [=grid containers=] specifically,
-	'margin-trim' discards
-	the corresponding margin of each [=grid item=]
-	in the [=grid track=] adjacent to the relevant [=box edge=].
-
-	This process ignores any [=collapsed grid tracks=].
-	It does not otherwise ignore any empty [=grid tracks=].
 
 Padding {#paddings}
 =======


### PR DESCRIPTION
[css-box-4] Remove flex and grid from margin-trim, as resolved in issue #13731