### PR TITLE
[scroll-animations-1] Fix ViewTimeline progress range calculation (#10960)

### DIFF
--- a/scroll-animations-1/Overview.bs
+++ b/scroll-animations-1/Overview.bs
@@ -739,10 +739,10 @@ spec:selectors-4; type:dfn; text:selector
 		the start of the ''animation-timeline-range/cover'' range
 	* |range| is
 		the [=scroll offset=] corresponding to
-		the start of the ''animation-timeline-range/cover'' range
+		the end of the ''animation-timeline-range/cover'' range
 		minus
 		the [=scroll offset=] corresponding to
-		the end of the ''animation-timeline-range/cover'' range
+		the start of the ''animation-timeline-range/cover'' range
 
 	If the 0% position and 100% position coincide
 	(i.e. the denominator in the [=timeline/current time=] formula is zero),


### PR DESCRIPTION
Reverses the operands in the ViewTimeline `range` definition so that progress is calculated using `end - start`, as confirmed in #10960.