### PR TITLE
[css-text-4] Be explicit that we're using the script property AND its extension

### DIFF
--- a/css-text-4/Overview.bs
+++ b/css-text-4/Overview.bs
@@ -9509,7 +9509,7 @@ Handling Symbols and Punctuation</h4>
 	a [=typographic character unit=]
 	from the Unicode Symbols (S*) and Punctuation (P*) classes
 	is generally treated the same as a [=typographic letter unit=] of the same script
-	(or, if the character’s script property is Common,
+	(or, if the character’s [=extended script property=] is Common,
 	then as a [=typographic letter unit=] of the dominant script).
 
 	However, by typographic tradition
@@ -10669,7 +10669,7 @@ Inter-script Spacing</h4>
 					except those that belong to Unicode Punctuation [P*] [=general category=].
 				<li>CJK Strokes (U+31C0 to U+31EF).
 				<li>Katakana Phonetic Extensions (U+31F0 to U+31FF).
-				<li>All characters that have the Han [=script property=].
+				<li>All characters that have the Han [=extended script property=].
 			</ul>
 
 		<dt><dfn>non-ideographic letters</dfn>
@@ -12373,12 +12373,12 @@ Characters and Properties</h2>
 			in the <a href="https://www.unicode.org/reports/tr44/"><cite>Unicode Character Database</cite></a>
 			[[!UAX44]].
 
-		<dt><dfn lt="Unicode Script|Script property">script property</dfn>
+		<dt><dfn lt="Unicode Script|Extended script property">extended script property</dfn>
 		<dd>
 			Defined in <a href="http://www.unicode.org/reports/tr24/#Values">Unicode Standard Annex #24</a> [[!UAX24]] and given as the <code>Script</code> property
 			in the <a href="https://www.unicode.org/reports/tr44/"><cite>Unicode Character Database</cite></a>
 			[[!UAX44]].
-			(UAs must include any ScriptExtensions.txt assignments in this mapping.)
+			UAs must also include any ScriptExtensions.txt assignments in this mapping.
 
 		<dt><dfn lt="Unicode Vertical Orientation|Vertical Orientation">Vertical Orientation</dfn>
 		<dd>


### PR DESCRIPTION
This is otherwise easy to overlook.
As raised in https://github.com/w3c/csswg-drafts/pull/9503/changes#r1374127095