### PR TITLE
[css-masking-1] Clarify how clipping and masking respond to fragmentation (#6383)

### DIFF
--- a/css-masking-1/Overview.bs
+++ b/css-masking-1/Overview.bs
@@ -556,6 +556,8 @@ For SVG elements without associated CSS layout box, the <a>used value</a> for ''
 
 For elements with associated CSS layout box, the <a>used value</a> for ''clip-path/fill-box'' is ''mask-clip/content-box'' and for ''clip-path/stroke-box'' and ''clip-path/view-box'' is ''mask-clip/border-box''.
 
+For [=fragmented=] CSS layout boxes (e.g. inline boxes spanning several lines or boxes spanning several [=page box|pages=] or [=multi-column container|columns=]), 'box-decoration-break' controls whether the reference box is determined for each fragment individually or is sliced together with the box's decorations.
+
 A computed value of other than ''clip-path/none'' results in the creation of a <a>stacking context</a> [[!CSS21]] the same way that CSS 'opacity' [[CSS3COLOR]] does for values other than ''1''.
 
 If the URI reference is not valid (e.g it points to an object that doesn't exist or the object is not a <a element>clipPath</a> element), no clipping is applied.
@@ -1194,7 +1196,9 @@ mask-image/mask-origin-1.html
 mask-image/mask-origin-3.html
 </wpt>
 
-For elements rendered as a single box, specifies the <dfn export>mask positioning area</dfn>. For elements rendered as multiple boxes (e.g., inline boxes on several lines, boxes on several pages) specifies which boxes 'box-decoration-break' operates on to determine the mask positioning area.
+Specifies the <dfn export>mask positioning area</dfn>.
+
+For [=fragmented=] boxes (e.g. inline boxes spanning several lines or boxes spanning several [=page box|pages=] or [=multi-column container|columns=]), 'box-decoration-break' controls whether the [=mask positioning area=] is determined for each fragment individually or is sliced together with the box's decorations.
 
 <div dfn-for=mask-origin dfn-type=value>
     : <dfn>content-box</dfn>


### PR DESCRIPTION
Also changed the wording so that it can link to css-break. Also because I didn't find this bit of the spec before, as I expected that Ctrl+F > "fragment" would tell me if there's any considerations for fragmentation.
