### PR TITLE
[animation-triggers-1] Clarify timeline-trigger-source: none

### DIFF
--- a/animation-triggers-1/Overview.bs
+++ b/animation-triggers-1/Overview.bs
@@ -315,10 +315,11 @@ urlPrefix: https://www.w3.org/TR/web-animations-1/; type: dfn
 
 	The 'timeline-trigger-source' property
 	specifies the [=timeline trigger's=] associated [=timeline=].
-	Values have the same meaning as those of 'animation-timeline',
-	except that ''timeline-trigger-source/none''
-	instead causes the corresponding entry in the [=coordinated value list=]
-	to not define a [=timeline trigger=].
+	Values have the same meaning as those of 'animation-timeline'.
+
+	Note: With ''timeline-trigger-source/none'', the trigger is not associated
+	with a [=timeline=]. A [=timeline trigger=] with no [=timeline=] is not able
+	to perform any <<animation-action>> as it is not able to monitor or change state. 
 
 ### The Activation Range: the 'timeline-trigger-activation-range' property ### {#timeline-trigger-activation-range-prop}
 

--- a/animation-triggers-1/Overview.bs
+++ b/animation-triggers-1/Overview.bs
@@ -317,9 +317,10 @@ urlPrefix: https://www.w3.org/TR/web-animations-1/; type: dfn
 	specifies the [=timeline trigger's=] associated [=timeline=].
 	Values have the same meaning as those of 'animation-timeline'.
 
-	Note: With ''timeline-trigger-source/none'', the trigger is not associated
-	with a [=timeline=]. A [=timeline trigger=] with no [=timeline=] is not able
-	to perform any <<animation-action>> as it is not able to monitor or change state. 
+	Note: With ''timeline-trigger-source/none'', 
+	the trigger is not associated with a [=timeline=]. 
+	A [=timeline trigger=] with no [=timeline=] is not able to perform any <<animation-action>> 
+	as it is not able to monitor or change state. 
 
 ### The Activation Range: the 'timeline-trigger-activation-range' property ### {#timeline-trigger-activation-range-prop}
 


### PR DESCRIPTION
The intent with `timeline-trigger-source` was to match `animation-timeline` in terms of the meaning of `none` and `auto`.
