### PR TITLE
[css-values-4][editorial] Oversight

### DIFF
--- a/css-values-4/Overview.bs
+++ b/css-values-4/Overview.bs
@@ -2098,7 +2098,7 @@ Font-relative Lengths: the ''em'', ''rem'', ''ex'', ''rex'', ''cap'', ''rcap'', 
 	the element’s own metrics when used in 'line-height'.)
 
 	Note: Most properties defined in [[css-fonts-4]] are [=font-affecting properties=],
-	as is 'math-scale'.
+	as is 'math-depth'.
 	(This isn't necessarily an exhaustive list.)
 
 	When used outside the context of an element


### PR DESCRIPTION
Fixes an oversight in 8f01339, which referenced `math-scale` as a font-affecting property, but this property does not exist, if I am not mistaken.

This commit replaces it with [`math-depth`](https://w3c.github.io/mathml-core/#propdef-math-depth), which was referenced in the related issue (#14306).