### PR TITLE
[css-text-decor-5] Updated the syntax of `alpha()`

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1811,7 +1811,7 @@ Relative alpha colors refer to an origin color, and only change the alpha channe
 The grammar of the ''alpha()'' function, new in this level, is as follows:
 
 <pre class='prod'>
-<dfn>alpha()</dfn> = alpha([from <<color>>] / [<<alpha-value>>])
+<dfn>alpha()</dfn> = alpha(from <<color>> / [<<alpha-value>> | none])
 </pre>
 
 

--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -1811,8 +1811,7 @@ Relative alpha colors refer to an origin color, and only change the alpha channe
 The grammar of the ''alpha()'' function, new in this level, is as follows:
 
 <pre class='prod'>
-<dfn>alpha()</dfn> = alpha([from <<color>>]
-					[ / [<<alpha-value>> | none] ]? )
+<dfn>alpha()</dfn> = alpha([from <<color>>] / [<<alpha-value>>])
 </pre>
 
 


### PR DESCRIPTION
Updated the syntax of`alpha()` function to have the `<alpha>` value required

Based upon [issue #14070](https://github.com/w3c/csswg-drafts/issues/14070)