### PR TITLE
[css-scroll-snap-1] Support scroll snap for single-axis scroll containers #14018 

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -302,6 +302,9 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#scroll-snap-type}
     how <a href="#snap-strictness">strictly</a> it <a>snaps</a>,
     and <a href="#snap-axis">which axes</a> are considered.
     If no strictness value is specified, ''proximity'' is assumed.
+    A [=single-axis scroll container=] only establishes snap positions
+    in its [=scrollable axis=];
+    specifying 'scroll-snap-type' for an axis in which the box does not scroll has no effect.
 
     <div class="example">
       In this example, snapping to headings is enabled in the <a>block axis</a>
@@ -402,15 +405,14 @@ Scroll Snap Strictness: the ''scroll-snap-type/none'', ''proximity'', and ''mand
     content in between can become inaccessible
     in cases where it is longer than the screen.
 
-    A box <dfn export>captures snap positions</dfn>
-    if it is a <a>scroll container</a>
-    <em>or</em> has a value other than ''scroll-snap-type/none'' for 'scroll-snap-type'.
-    If a box’s nearest <a lt="captures snap positions">snap-position capturing</a> ancestor
+    A box <dfn export lt="captures snap positions|capture snap positions">captures snap positions</dfn>
+    in a given axis if it is a <a>scroll container</a> [=scrollable axis|scrollable=] in that axis.
+    In each axis, if a box’s nearest <a lt="captures snap positions">snap-position capturing</a> ancestor
     on its <a>containing block chain</a>
-    is a <a>scroll container</a> with a non-''scroll-snap-type/none'' value for 'scroll-snap-type',
-    that is the box’s <dfn export local-lt="snap container">scroll snap container</dfn>.
+    has a non-''scroll-snap-type/none'' value for 'scroll-snap-type' in that axis,
+    that is the box’s <dfn export local-lt="snap container">scroll snap container</dfn> for that axis.
     Otherwise, the box has no <a>scroll snap container</a>,
-    and its <a>snap positions</a> do not trigger <a>snapping</a>.
+    and its <a>snap positions</a> do not trigger <a>snapping</a> in that axis.
 
 <h4 id="re-snap" dfn export lt="re-snap">
 Re-snapping After Layout Changes</h4>
@@ -678,7 +680,7 @@ Scroll Snapping Alignment: the 'scroll-snap-align' property {#scroll-snap-align}
     The 'scroll-snap-align' property specifies
     the box’s <a>snap position</a> as an alignment of
     its <a>snap area</a> (as the <a>alignment subject</a>)
-    within its <a>snap container’s</a> <a>snapport</a> (as the <a>alignment container</a>).
+    within its <a>snap container’s</a> <a>snapport</a> (as the <a>alignment container</a>) for each axis.
     The two values specify the snapping alignment
     in the <a>block axis</a> and <a>inline axis</a>, respectively,
     as determined by the [=snap container=]’s [=writing mode=].

--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -302,6 +302,9 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#scroll-snap-type}
     how <a href="#snap-strictness">strictly</a> it <a>snaps</a>,
     and <a href="#snap-axis">which axes</a> are considered.
     If no strictness value is specified, ''proximity'' is assumed.
+    A [=single-axis scroll container=] only establishes snap positions
+    in its [=scrollable axis=];
+    specifying 'scroll-snap-type' for an axis which is not one of the box's [=scrollable axis|scrollable axes=] has no effect.
 
     <div class="example">
       In this example, snapping to headings is enabled in the <a>block axis</a>
@@ -402,15 +405,14 @@ Scroll Snap Strictness: the ''scroll-snap-type/none'', ''proximity'', and ''mand
     content in between can become inaccessible
     in cases where it is longer than the screen.
 
-    A box <dfn export>captures snap positions</dfn>
-    if it is a <a>scroll container</a>
-    <em>or</em> has a value other than ''scroll-snap-type/none'' for 'scroll-snap-type'.
-    If a box’s nearest <a lt="captures snap positions">snap-position capturing</a> ancestor
+    A box <dfn export lt="captures snap positions|capture snap positions">captures snap positions</dfn>
+    in a given axis if it is a <a>scroll container</a> [=scrollable axis|scrollable=] in that axis.
+    In each axis, if a box’s nearest <a lt="captures snap positions">snap-position capturing</a> ancestor
     on its <a>containing block chain</a>
-    is a <a>scroll container</a> with a non-''scroll-snap-type/none'' value for 'scroll-snap-type',
-    that is the box’s <dfn export local-lt="snap container">scroll snap container</dfn>.
+    has a non-''scroll-snap-type/none'' value for 'scroll-snap-type' in that axis,
+    that is the box’s <dfn export local-lt="snap container">scroll snap container</dfn> for that axis.
     Otherwise, the box has no <a>scroll snap container</a>,
-    and its <a>snap positions</a> do not trigger <a>snapping</a>.
+    and its <a>snap positions</a> do not trigger <a>snapping</a> in that axis.
 
 <h4 id="re-snap" dfn export lt="re-snap">
 Re-snapping After Layout Changes</h4>
@@ -678,7 +680,7 @@ Scroll Snapping Alignment: the 'scroll-snap-align' property {#scroll-snap-align}
     The 'scroll-snap-align' property specifies
     the box’s <a>snap position</a> as an alignment of
     its <a>snap area</a> (as the <a>alignment subject</a>)
-    within its <a>snap container’s</a> <a>snapport</a> (as the <a>alignment container</a>).
+    within its <a>snap container’s</a> <a>snapport</a> (as the <a>alignment container</a>) for each axis.
     The two values specify the snapping alignment
     in the <a>block axis</a> and <a>inline axis</a>, respectively,
     as determined by the [=snap container=]’s [=writing mode=].

--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -683,7 +683,7 @@ Scroll Snapping Alignment: the 'scroll-snap-align' property {#scroll-snap-align}
     within its <a>snap container’s</a> <a>snapport</a> (as the <a>alignment container</a>) for each axis.
     The two values specify the snapping alignment
     in the <a>block axis</a> and <a>inline axis</a>, respectively,
-    as determined by the [=snap container=]’s [=writing mode=].
+    as determined by the [=writing mode=] of the box’s nearest ancestor <a>scroll container</a> on its <a>containing block chain</a>.
     If only one value is specified, the second value defaults to the same value.
 
     Values are defined as follows:
@@ -715,8 +715,8 @@ Scroll Snapping Alignment: the 'scroll-snap-align' property {#scroll-snap-align}
             in the specified axis.
     </dl>
 
-    Start and end alignments are resolved
-    with respect to the [=writing mode=] of the [=snap container=]
+    In each axis, start and end alignments are resolved
+    with respect to the [=writing mode=] of the [=snap container=] for that axis
     unless the [=scroll snap area=] is larger than the [=snapport=],
     in which case they are resolved with respect to the [=writing mode=] of the box itself.
     (This allows items in a container to have consistent snap alignment in general,


### PR DESCRIPTION
[css-scroll-snap-1] Support scroll snap for single-axis scroll containers #14018 

Clarify scroll snapping behavior when an intermediate container is a single-axis scroll container:
- A single-axis scroll container only establishes snap positions in its scrollable axis; specifying `scroll-snap-type` in a non-scrollable axis has no effect.
- Snap position capturing and snap container resolution are evaluated per-axis, allowing unconsumed snap axes to propagate to ancestor scroll containers.