### PR TITLE
[css-forms-1] Introduce slider-fill-lower and slider-fill-upper

### DIFF
--- a/css-forms-1/Overview.bs
+++ b/css-forms-1/Overview.bs
@@ -199,19 +199,33 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
     <tbody>
       <tr>
         <td>`<progress>`</td>
-        <td rowspan=4>
+        <td>
         <pre>
-        ├─ ''::slider-track''
-        │  └─ ''::slider-fill''
-        └─ ''::slider-thumb''
+        └─ ''::slider-track''
+           ├─ ''::slider-fill-lower'' (aliased as ''::slider-fill'')
+           └─ ''::slider-fill-upper''
         </pre>
         </td>
       </tr>
       <tr>
         <td>`<meter>`</td>
+        <td>
+        <pre>
+        └─ ''::slider-track''
+           └─ ''::slider-fill''
+        </pre>
+        </td>
       </tr>
       <tr>
         <td>`<input type=checkbox switch>`</td>
+        <td rowspan="2">
+        <pre>
+        ├─ ''::slider-track''
+        │  ├─ ''::slider-fill-lower'' (aliased as ''::slider-fill'')
+        │  └─ ''::slider-fill-upper''
+        └─ ''::slider-thumb''
+        </pre>
+        </td>
       </tr>
       <tr>
         <td>`<input type=range>`</td>
@@ -376,13 +390,20 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
       The ''::slider-track'' pseudo-element represents the portion containing
       both the progressed and unprogressed portions of the control.
 
-    <dt><dfn>::slider-fill</dfn>
+    <dt><dfn>::slider-fill-lower</dfn>
     <dd>
-      The ''::slider-fill'' pseudo-element represents
+      The ''::slider-fill-lower'' pseudo-element represents
       the portion containing the progressed portion of the control.
+
+      This pseudo-element is aliased as <dfn>::slider-fill</dfn> for ease-of-authoring.
 
       When the progress of control is indeterminate (like with ''&lt;progress>''),
       the user agent must give this portion an inline-size of zero.
+
+    <dt><dfn>::slider-fill-upper</dfn>
+    <dd>
+      The ''::slider-fill-upper'' pseudo-element represents
+      the portion containing the non-progressed portion of the control.
   </dl>
 
   These pseudo-elements are [=fully styleable pseudo-elements=] and their structure is the following:
@@ -390,9 +411,15 @@ spec:css-forms-1; type:value; for:/; text:::placeholder
   ```
       <input type="range">
       ├─ ::slider-track
-      │  └─ ::slider-fill
+      │  ├─ ::slider-fill-lower (::slider-fill)
+      │  └─ ::slider-fill-upper
       └─ ::slider-thumb
   ```
+
+  Note: The exact structure depends on the specific kind of [=slider-like controls=]. <{meter}> just has a slider-fill
+  instead of -lower and -upper, and <{progress}> doesn't have the slider-thumb.
+
+  Issue(12419): The naming of '':slider-fill-lower'' and '':slider-fill-upper'' need bikeshedding.
 
   The list of [=slider-like controls=] depends on the host language. For HTML, this corresponds to:
 


### PR DESCRIPTION
Per resolution in https://github.com/w3c/csswg-drafts/issues/12419

This also clarifies that meter keeps the single fill pseudo and that progress doesn't have a thumb.
