### PR TITLE
[csss-color-4] use html blockquotes

### DIFF
--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -21,6 +21,7 @@ Complain About: broken-links false
 Complain About: accidental-2119 true
 Inline Github Issues: title
 Default Highlight: css
+Markup Shorthands: markdown-blockquotes yes
 WPT Path Prefix: css/css-color/
 WPT Display: open
 </pre>

--- a/css-color-4/Overview.bs
+++ b/css-color-4/Overview.bs
@@ -21,7 +21,6 @@ Complain About: broken-links false
 Complain About: accidental-2119 true
 Inline Github Issues: title
 Default Highlight: css
-Markup Shorthands: markdown-blockquotes yes
 WPT Path Prefix: css/css-color/
 WPT Display: open
 </pre>
@@ -580,9 +579,11 @@ Accessibility and Conveying Information By Color</h3>
 	Authors should consider the W3C Web Content Accessibility Guidelines [[WCAG21]]
 	when using color in their documents.
 
-	> <a href="https://www.w3.org/TR/WCAG21/#use-of-color"><em>1.4.1 Use of Color:</em>
-	> Color is not used as the only visual means of conveying information,
-	> indicating an action, prompting a response, or distinguishing a visual element</a>
+	<blockquote>
+		<a href="https://www.w3.org/TR/WCAG21/#use-of-color"><em>1.4.1 Use of Color:</em>
+		Color is not used as the only visual means of conveying information,
+		indicating an action, prompting a response, or distinguishing a visual element</a>
+	</blockquote>
 
 
 <!--


### PR DESCRIPTION
~~@tabatkins is adding this metadata the preferred way to resolve the warning?~~
Edit: switched to `<blockquote>`

The warning originated on line 582:

https://github.com/w3c/csswg-drafts/blob/27fd597de31a8c43234f99f58983e4af3d1f9282/css-color-4/Overview.bs#L582-L584

