### PR TITLE
[css-scroll-snap-1] Add keyword "pair" to scroll-snap-type for snapping to the same element in X and Y axes

### DIFF
--- a/css-scroll-snap-1/Overview.bs
+++ b/css-scroll-snap-1/Overview.bs
@@ -288,7 +288,7 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#scroll-snap-type}
 
     <pre class="propdef">
     Name: scroll-snap-type
-    Value: none | [ x | y | block | inline | both ] [ mandatory | proximity ]?
+    Value: none | [ x | y | block | inline | both | pair ] [ mandatory | proximity ]?
     Initial: none
     Applies to: all elements
     Inherited: no
@@ -323,7 +323,7 @@ Scroll Snapping Rules: the 'scroll-snap-type' property {#scroll-snap-type}
     'scroll-snap-type' values are <em>not</em> propagated from HTML <{body}>.
 
 <h4 id="snap-axis">
-Scroll Snap Axis: the ''x'', ''y'', ''scroll-snap-type/block'', ''scroll-snap-type/inline'', and ''both'' values</h4>
+Scroll Snap Axis: the ''x'', ''y'', ''scroll-snap-type/block'', ''scroll-snap-type/inline'', ''both'', and ''pair'' values</h4>
 
     The <dfn noexport lt="axis value">axis values</dfn>
     specify what axis(es) are affected by <a>snap positions</a>,
@@ -357,6 +357,17 @@ Scroll Snap Axis: the ''x'', ''y'', ''scroll-snap-type/block'', ''scroll-snap-ty
             The <a>scroll container</a> <a>snaps</a> to <a>snap positions</a>
             in both of its axes independently
             (potentially snapping to different elements in each axis).
+
+        <dt><dfn>pair</dfn>
+        <dd>
+            The <a>scroll container</a> <a>snaps</a> to <a>snap positions</a>
+            in both of its axes together as a single 2D point belonging to a single <a>snap area</a>.
+
+            A <a>snap area</a> is only eligible as a <a>snap position</a> in a <a>scroll container</a>
+            with ''scroll-snap-type/pair'' if it specifies an alignment in both axes
+            (i.e. neither its block nor inline alignment in 'scroll-snap-align' computes to
+            ''scroll-snap-align/none''). <a>Snap areas</a> that specify alignment in only a single
+            axis are ignored.
     </dl>
 
 <h4 id="snap-strictness">


### PR DESCRIPTION
[css-scroll-snap-1] Add keyword "pair" to scroll-snap-type for snapping to the same element in X and Y axes #9519 
