### PR TITLE
[css-fonts-4][editorial] Linkify references to `@font-face` descriptors

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -2699,8 +2699,8 @@ The <dfn id="at-font-face-rule">''@font-face''</dfn> rule</h3>
 	Like properties in a declaration block,
 	declarations of any descriptors that are not supported by the user agent
 	must be ignored.
-	''@font-face'' rules require a font-family
-	and src descriptor;
+	''@font-face'' rules require a '@font-face/font-family'
+	and '@font-face/src' descriptor;
 	if either of these are missing,
 	the ''@font-face'' rule must not be considered
 	when performing the <a href="#font-matching-algorithm">font matching algorithm</a>.


### PR DESCRIPTION
[§ 4.1 The @font-face rule](https://drafts.csswg.org/css-fonts-4/#font-face-rule) includes *font-family* and *src* as plain-text references to the corresponding `@font-face` descriptors, making them difficult to spot when scanning the text, which is relatively long.