### PR TITLE
[selectors-5] Add grammar of class prefix selector

### DIFF
--- a/selectors-5/Overview.bs
+++ b/selectors-5/Overview.bs
@@ -560,12 +560,17 @@ Grammar</h2>
 
 	<pre class=prod>
 	<dfn>&lt;combinator></dfn> = '>' | '+' | '~' | [ '|' '|' ] | [ / <<wq-name>> / ]
+	<dfn>&lt;class-selector></dfn> = '.' <<ident-token>> '*'?
 	</pre>
 
 	<ul>
 	<li id="white-space">
 		White space is forbidden:
 		* Between the components of a <<combinator>>.
+		* Between any of the components of a <<class-selector>>.
+	<li>
+		In <<class-selector>>, '*' must be omitted
+		if <<ident-token>> does not end with an hyphen (- U+002D).
 	</ul>
 
 


### PR DESCRIPTION
Follow-up on 966052c, which defined the [class prefix selector](https://drafts.csswg.org/selectors-5/#class-prefix) as a general term. This pull request provides the [grammar](https://drafts.csswg.org/selectors-5/#grammar) specifics using the CSS value definition syntax.