### PR TITLE
[css-viewport-1] Removes note that contradicts normative text for the zoom property (#14402)

### DIFF
--- a/css-viewport-1/Overview.bs
+++ b/css-viewport-1/Overview.bs
@@ -402,9 +402,6 @@ by the [=used value=] of 'zoom'.
 
 Note: This results in a magnification or minification effect.
 
-Note: Since this multiplication is on [=computed value=]s, it applies to
-all inherited properties such as 'line-height' and 'font-size'.
-
 Nested values of 'zoom' multiply, resulting in additional scaling of <<length>> values.
 The [=used value=] for zoom is always its [=effective zoom=].
 


### PR DESCRIPTION
Obvious bug fix as discussed in https://github.com/w3c/csswg-drafts/issues/14402.