### PR TITLE
[css-fonts-4] Use the ital axis when matching font-style: italic

### DIFF
--- a/css-fonts-4/Overview.bs
+++ b/css-fonts-4/Overview.bs
@@ -4455,14 +4455,16 @@ the 'ascent-override!!descriptor',
 					2. Otherwise, italic values above the desired italic value are checked in ascending order followed by
 						italic values below the desired italic value, until 0 is hit. Only positive values of italic values are checked
 						in this stage.
-					3. If no match is found, oblique values greater than or equal to 11deg are checked in ascending order
+					3. For variable fonts with an ital axis,
+						a match is created by setting the ital value to 1.
+					4. If no match is found, oblique values greater than or equal to 11deg are checked in ascending order
 						followed by oblique values below 11deg in descending order, until 0 is hit. Only positive values of oblique values
 						are checked in this stage.
 
 						ISSUE: The threshold for preferring oblique over normal <a href="https://github.com/w3c/csswg-drafts/issues/2295">should be lower than the average angle</a>.
 
-					4. If no match is found, italic values less than or equal to 0 are checked in descending order until a match is found.
-					5. If no match is found, oblique values less than or equal to 0deg are checked in descending order until a match is found.
+					5. If no match is found, italic values less than or equal to 0 are checked in descending order until a match is found.
+					6. If no match is found, oblique values less than or equal to 0deg are checked in descending order until a match is found.
 
 						<div class="example" id="ex-ascending-italic">
 							Similar to the <a href="#ex-ascending-stretch">previous example</a>, here is the conceptual distance graph for an element styled with "font-style: italic":
@@ -4486,6 +4488,7 @@ the 'ascent-override!!descriptor',
 							''font-synthesis-style/auto'',
 							then a fallback match is produced
 							by geometric shearing to the specified oblique value.
+							The ital axis is not used to satisfy an ''oblique'' request.
 						4. If no match is found, italic values greater than or equal to 1 are checked in ascending order
 							followed by italic values below 1 in descending order, until 0 is hit. Only positive values of italic values are checked in this stage.
 						5. If no match is found, oblique values less than or equal to 0deg are checked in descending order until a match is found.
@@ -4515,6 +4518,7 @@ the 'ascent-override!!descriptor',
 							Otherwise, if 'font-synthesis-style' has the value ''font-synthesis-style/auto'',
 							then a fallback match is produced
 							by geometric shearing to the specified oblique value.
+							The ital axis is not used to satisfy an ''oblique'' request.
 						4. If no match is found, italic values less than 1 are checked in descending order until 0 is hit,
 							followed by italic values above 1 in ascending order. Only positive values of italic values
 							are checked in this stage.


### PR DESCRIPTION
Closes #12836.

As discussed in #12836, the Font Matching Algorithm only has explicit variable-font instantiation text for the `slnt` axis in the oblique branches, while the `font-style` property definition already states that "the `ital` variation with a value of 1 is used to implement the italic values".

This change:

- Adds a step to the `italic` branch of the matching algorithm, mirroring the existing `slnt` sentence: "For variable fonts with an ital axis, a match is created by setting the ital value to 1."
- Clarifies in both `oblique` branches that the `ital` axis is not used to satisfy an oblique request (per @jfkthame's point in the issue, which @drott supported).

Consequence for fonts exposing both `slnt` and `ital` axes: the `italic` keyword sets `ital` to 1 (leaving `slnt` at its default), and `oblique` sets `slnt` (leaving `ital` at its default). This matches what Gecko ships today.

Implementation interest: Gecko already behaves this way; Chromium implementation is prepared in https://chromium-review.googlesource.com/c/chromium/src/+/8179764 pending this spec clarification (Chromium bug: https://issues.chromium.org/issues/40681464).
