### PR TITLE
[css-view-transitions-2] Ensure that element qualifies to be a scope for scoped VT

### DIFF
--- a/css-view-transitions-2/Overview.bs
+++ b/css-view-transitions-2/Overview.bs
@@ -631,14 +631,9 @@ Note: An <code>element.startViewTransition()</code> call does not update
 			Otherwise, if |callbackOptions| is a {{StartViewTransitionOptions}}, then set |viewTransition|'s [=update callback=]
 			to |callbackOptions|'s {{StartViewTransitionOptions/update}}.
 
-		1. If [=this=]'s [=principal box=] is [=element-not-rendered|not rendered=],
-			or is an <a spec="css-display-3">internal table box</a> other than ''display/table-cell'',
-			or is an <a spec="css-display-3">internal ruby box</a>
-			or a <a spec="css-display-3" lt="atomic inline">non-atomic</a> <a spec="css-display-3">inline-level</a> box,
+		1. If [=this=] does not [=qualify to be a view transition scope=],
 			then [=skip the view transition|skip=] |viewTransition| with an "{{InvalidStateError}}" {{DOMException}},
 			and return |viewTransition|.
-
-			Note: This ensures that [=this=] has a [=principal box=] and qualifies for [=layout containment=].
 
 		1. If [=this=] is not the [=/root element|document root element=],
 			force [=this=] to have both [=layout containment=] and [=view transition scoping=] for the duration of the transition.
@@ -1156,9 +1151,21 @@ and by applying ''view-transition-group'' to the internal element referencing th
 	than the rest of the document.)
 
 	In order to host a [=scoped view transition=],
-	an element must qualify for [=layout containment=],
-	which will be applied automatically,
+	an element must [=qualify to be a view transition scope=],
+	which ensures it qualifies for [=layout containment=]
+	(which will be applied automatically),
 	so its painted output can be captured as an atomic unit.
+
+	An {{Element}} |element| <dfn export lt="qualify to be a view transition scope|qualifies to be a view transition scope">qualifies to be a view transition scope</dfn>
+	if all of the following are true:
+
+	* |element| is [=/connected=];
+	* |element|'s [=principal box=] is [=element-not-rendered|rendered=];
+	* |element|'s [=principal box=] is not an <a spec="css-display-3">internal table box</a> other than ''display/table-cell'';
+	* |element|'s [=principal box=] is not an <a spec="css-display-3">internal ruby box</a>;
+	* |element|'s [=principal box=] is not a <a spec="css-display-3" lt="atomic inline">non-atomic</a> <a spec="css-display-3">inline-level</a> box.
+
+	Note: This ensures that |element| is connected, has a [=principal box=], and qualifies for [=layout containment=].
 
 	[=View transitions=] whose [=ViewTransition/root element=] is the [=document element=]
 	are <em>not</em> [=scoped view transitions=].
@@ -2448,6 +2455,10 @@ It has the following [=struct/items=]:
 
 			Note: this ensures that any changes to the DOM scheduled by other skipped transitions are done before the old state for this transition is captured.
 
+		1. If |transition|'s [=ViewTransition/root element=] does not [=qualify to be a view transition scope=],
+			then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
+
 		1. [=Capture the old state=] for |transition|.
 
 			If failure is returned, then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
@@ -2480,6 +2491,10 @@ It has the following [=struct/items=]:
 			Note: This happens if |transition| was [=skip the view transition|skipped=] before this point.
 
 		1. Set |transition|'s [=relevant global object's=] [=associated document=]'s [=document/rendering suppression for view transitions=] to false.
+
+		1. If |transition|'s [=ViewTransition/root element=] does not [=qualify to be a view transition scope=],
+			then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
 
 		1. If |transition|'s [=ViewTransition/initial snapshot containing block size=] is not equal to the [=snapshot containing block size=],
 			then [=skip the view transition|skip=] |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
@@ -3330,6 +3345,10 @@ To <dfn>adjust nested view transition group transform</dfn> given a |transform| 
 		To <dfn>handle transition frame</dfn> given a {{ViewTransition}} |transition|:
 
 		1. Let |document| be |transition|'s [=relevant global object's=] [=associated document=].
+
+		1. If |transition|'s [=ViewTransition/root element=] does not [=qualify to be a view transition scope=],
+			then [=skip the view transition=] for |transition| with an "{{InvalidStateError}}" {{DOMException}} in |transition|'s [=relevant Realm=],
+			and return.
 
 		1. Let |hasActiveAnimations| be a boolean, initially false.
 


### PR DESCRIPTION
[css-view-transitions-2] Ensure that element qualifies to be a scope for scoped VT

Fixes #14416 