### PR TITLE
[css-cascade-6] fix `@import` definition

### DIFF
--- a/css-cascade-6/Overview.bs
+++ b/css-cascade-6/Overview.bs
@@ -96,7 +96,7 @@ Importing Style Sheets: the ''@import'' rule</h2>
 		        [[ layer | layer( <<layer-name>> ) ]
 		         || [ scope | scope( <<scope-start>> | <<scope-boundaries>> ) ]
 		         || <<supports-import-condition>>]?
-		        <<media-import-condition>> ;
+		        <<media-import-condition>>? ;
 
 		<dfn export>&lt;supports-import-condition></dfn> = supports( [ <<supports-condition>> | <<declaration>> ] )
 		<dfn export>&lt;media-import-condition></dfn> = <<media-query-list>></pre>


### PR DESCRIPTION
see: https://github.com/w3c/csswg-drafts/pull/13698

By the current definition:

`media-import-condition = <media-query-list>`

`media-query-list = <media-query>#`

So removing the `?` in the `@import` syntax definition made a media query required as `#` is one or more.