### PR TITLE
[css-sizing][css-anchor-position-1] Follow-up on consolidating sizing values with `<box-size>`

### DIFF
--- a/css-anchor-position-1/Overview.bs
+++ b/css-anchor-position-1/Overview.bs
@@ -1412,7 +1412,7 @@ The ''anchor-size()'' Function {#anchor-size-fn}
 ------------------------------
 
 <pre class="propdef partial">
-Name: width, height, min-width, min-height, max-width, max-height, top, left, right, bottom, margin-top, margin-left, margin-right, margin-bottom 
+Name: block-size, inline-size, width, height, min-block-size, min-inline-size, min-width, min-height, max-block-size, max-inline-size, max-width, max-height, top, left, right, bottom, margin-top, margin-left, margin-right, margin-bottom
 New values:	<<anchor-size()>>
 </pre>
 

--- a/css-sizing-3/Overview.bs
+++ b/css-sizing-3/Overview.bs
@@ -578,7 +578,7 @@ Sizing Values: the <<length-percentage>>, ''width/auto'' | ''max-width/none'', '
 	Values other than ''width/auto'' and ''max-width/none'' are grouped under the <<box-size>> production:
 
 	<pre class=prod>
-		<dfn><<box-size>></dfn> = <<length-percentage>> | stretch | min-content | max-content | fit-content
+		<dfn><<box-size>></dfn> = <<length-percentage [0,∞]>> | stretch | min-content | max-content | fit-content
 	</pre>
 
 	Note: The equivalent of <<box-size>> for Level 2 would be just <<length-percentage>> alone.
@@ -1030,7 +1030,7 @@ New Column Sizing Values: the ''column-width/stretch'', ''column-width/min-conte
 
 	<pre class="propdef partial">
 	Name: column-width
-	New values: <<box-size>>
+	Value: auto | <<box-size>>
 	Computed value: as specified, with <<length-percentage>> values computed
 	Animation type: by computed value type
 	</pre>

--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -193,13 +193,7 @@ ISSUE: [[css-sizing-3#sizing-values]]
 	thus expanding the <<box-size>> production as follows:
 
 	<pre class=prod>
-		<dfn><<box-size>></dfn> = <<length-percentage>> | stretch | contain | min-content | max-content | fit-content | fit-content() | calc-size()
-	</pre>
-
-
-	<pre class="propdef partial">
-	Name: width, height, min-width, min-height, max-width, max-height
-	New Values: contain | <nobr>fit-content(<<length-percentage [0,∞]>>)</nobr>
+		<dfn><<box-size>></dfn> = <<length-percentage [0,∞]>> | stretch | contain | min-content | max-content | fit-content | fit-content(<<length-percentage [0,∞]>>) | <<calc-size()>>
 	</pre>
 
 	<dl dfn-type=value dfn-for="width, height, inline-size, block-size, min-width, min-height, min-inline-size, min-block-size, max-width, max-height, max-inline-size, max-block-size">
@@ -1505,7 +1499,7 @@ New Column Sizing Values: the ''column-width/stretch'', ''column-width/min-conte
 
 	<pre class="propdef partial">
 	Name: column-width
-	New values: <<box-size>>
+	Value: auto | <<box-size>>
 	Computed value: as specified, with <<length-percentage>> values computed
 	Animation type: by computed value type
 	</pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/csswg-drafts/issues/13478#issuecomment-5536262067.

The resulting diff between before https://github.com/w3c/csswg-drafts/commit/ec88f459397006d69a896fd5b05d3f4a8f72a01e and after this PR, with expanded `<box-size>` and concatenated *New values*, and assuming CSS Sizing 4 takes precedence over CSS Sizing 3:

```diff
 column-width:

- auto | <length [0,∞]> | min-content | max-content | fit-content(<length-percentage>)
+ auto | <length-percentage [0,∞]> | contain | min-content | max-content | stretch | fit-content | fit-content(<length-percentage>) | <calc-size()>
```