### PR TITLE
[animation-triggers-1] Introduce & Update TimelineTrigger interface

### DIFF
--- a/animation-triggers-1/Overview.bs
+++ b/animation-triggers-1/Overview.bs
@@ -663,18 +663,13 @@ urlPrefix: https://www.w3.org/TR/web-animations-1/; type: dfn
 
 # Programming interface # {#programming-interface}
 
-## The <code>AnimationTrigger</code> interface< ## {#the-animationtrigger-interface}
+## The <code>TimelineTrigger</code> interface ## {#the-timelinetrigger-interface}
 
 <pre class='idl'>
 [Exposed=Window]
-interface AnimationTrigger {
-	constructor(optional AnimationTriggerOptions options = {});
-	attribute AnimationTimeline timeline;
-	attribute AnimationTriggerBehavior behavior;
-	attribute any activationRangeStart;
-	attribute any activationRangeEnd;
-	attribute any activeRangeStart;
-	attribute any activeRangeEnd;
+interface TimelineTrigger {
+	constructor(optional sequence&lt;(TimelineTriggerRange or TimelineTriggerRangeInit)&gt; ranges = []);
+	attribute sequence&lt;TimelineTriggerRange&gt; ranges;
 };
 </pre>
 
@@ -682,32 +677,37 @@ interface AnimationTrigger {
 	interfaces/TimelineTrigger/constructor.html
 </wpt>
 
-<div dfn-type=constructor class=constructors dfn-for="AnimationTrigger">
-	: <dfn lt="AnimationTrigger(options)">AnimationTrigger(|options|)</dfn>
+<div dfn-type=constructor class=constructors dfn-for="TimelineTrigger">
+	: <dfn lt="TimelineTrigger(ranges)">TimelineTrigger(|ranges|)</dfn>
 	::
-		Creates a new {{AnimationTrigger}} object using the following procedure:
+		Creates a new {{TimelineTrigger}} object using the following procedure:
 
-		1. Create a new {{AnimationTrigger}} object, |trigger|.
+		1. Create a new {{TimelineTrigger}} object, |trigger|.
 
 		1. Set |trigger|.[=trigger/did trigger=] to false.
 
 		1. Set |trigger|.[=trigger state|state=] to [=trigger state/pending=].
 
-		1. Set [=activation range=] of |trigger| using |options|.{{AnimationTriggerOptions/activationRangeStart}} and |options|.{{AnimationTriggerOptions/activationRangeEnd}},
-			following the same rules as the {{KeyframeAnimationOptions}}
-			{{KeyframeAnimationOptions/rangeStart}} and {{KeyframeAnimationOptions/rangeEnd}} members respectively.
+		1. Let |trigger ranges| be an empty sequence of {{TimelineTriggerRange}} objects.
 
-		1. Set [=active range=] of |trigger| using |options|.{{AnimationTriggerOptions/activeRangeStart}} and |options|.{{AnimationTriggerOptions/activeRangeEnd}},
-			following the same rules above for [=activation range=], unless they are set to
-			"auto", in which case they are set to their corresponding side
-			of the [=activation range=].
+		1. For each |range| in |ranges|:
 
-		1. Set |trigger|.{{AnimationTrigger/timeline}} to |options|.{{AnimationTriggerOptions/timeline}}.
+			1. If |range| is a {{TimelineTriggerRange}} object:
+
+				1. Append |range| to |trigger ranges|.
+
+			1. Otherwise:
+
+				1. Let |range object| be the result of invoking the {{TimelineTriggerRange/TimelineTriggerRange(options)}} constructor with |range| as |options|.
+
+				1. Append |range object| to |trigger ranges|.
+
+		1. Set |trigger|.{{TimelineTrigger/ranges}} to |trigger ranges|.
 
 		<div dfn-type=argument class=parameters
-			dfn-for="AnimationTrigger/AnimationTrigger(options)">
+			dfn-for="TimelineTrigger/TimelineTrigger(ranges)">
 
-			: <dfn>options</dfn>
+			: <dfn>ranges</dfn>
 			::  Configuration parameters for the newly-created trigger.
 
 		</div>
@@ -715,70 +715,120 @@ interface AnimationTrigger {
 </div>
 
 <div dfn-type=attribute class=attributes
-	dfn-for="AnimationTrigger">
+	dfn-for="TimelineTrigger">
+
+	: <dfn>ranges</dfn>
+	::
+		Returns the list of {{TimelineTriggerRange}} objects for this trigger.
+
+</div>
+
+## The <code>TimelineTriggerRange</code> interface ## {#the-timelinetriggerrange-interface}
+
+<pre class='idl'>
+[Exposed=Window]
+interface TimelineTriggerRange {
+	constructor(optional TimelineTriggerRangeInit options = {});
+	attribute AnimationTimeline? timeline;
+	attribute any activationRangeStart;
+	attribute any activationRangeEnd;
+	attribute any activeRangeStart;
+	attribute any activeRangeEnd;
+};
+</pre>
+
+<div dfn-type=constructor class=constructors dfn-for="TimelineTriggerRange">
+	: <dfn lt="TimelineTriggerRange(options)">TimelineTriggerRange(|options|)</dfn>
+	::
+		Creates a new {{TimelineTriggerRange}} object using the following procedure:
+
+		1. Create a new {{TimelineTriggerRange}} object, |range|.
+
+		1. Set [=activation range=] of |range| using |options|.{{TimelineTriggerRangeInit/activationRangeStart}} and |options|.{{TimelineTriggerRangeInit/activationRangeEnd}},
+			following the same rules as the {{KeyframeAnimationOptions}}
+			{{KeyframeAnimationOptions/rangeStart}} and {{KeyframeAnimationOptions/rangeEnd}} members respectively.
+
+		1. Set [=active range=] of |range| using |options|.{{TimelineTriggerRangeInit/activeRangeStart}} and |options|.{{TimelineTriggerRangeInit/activeRangeEnd}},
+			following the same rules above for [=activation range=], unless they are set to
+			"auto", in which case they are set to their corresponding side
+			of the [=activation range=].
+
+		1. Set |range|.{{TimelineTriggerRange/timeline}} to |options|.{{TimelineTriggerRangeInit/timeline}}.
+
+		<div dfn-type=argument class=parameters
+			dfn-for="TimelineTriggerRange/TimelineTriggerRange(options)">
+
+			: <dfn>options</dfn>
+			::  Configuration parameters for the newly-created trigger range.
+
+		</div>
+
+</div>
+
+<div dfn-type=attribute class=attributes
+	dfn-for="TimelineTriggerRange">
 
 	: <dfn>timeline</dfn>
 	::
-		Returns the [=timeline=] for this trigger
+		Returns the [=timeline=] for this trigger range
 		or `null` if this timeline is [=inactive timeline|inactive=].
 
 	: <dfn>activationRangeStart</dfn>
 	::
-		Returns the [=activation range=]’s start of this trigger.
+		Returns the [=activation range=]’s start of this trigger range.
 
 	: <dfn>activationRangeEnd</dfn>
 	::
-		Returns the [=activation range=]’s end of this trigger.
+		Returns the [=activation range=]’s end of this trigger range.
 
 	: <dfn>activeRangeStart</dfn>
 	::
-		Returns the [=active range=]’s start of this trigger.
+		Returns the [=active range=]’s start of this trigger range.
 
 	: <dfn>activeRangeEnd</dfn>
 	::
-		Returns the [=active range=]’s end of this trigger.
+		Returns the [=active range=]’s end of this trigger range.
 
 </div>
 
-## The <code>AnimationTriggerOptions</code> dictionary ## {#the-animationtriggeroptions-dictionary}
+## The <code>TimelineTriggerRangeInit</code> dictionary ## {#the-timelinetriggerrangeinit-dictionary}
 
 <pre class='idl'>
-dictionary AnimationTriggerOptions {
+dictionary TimelineTriggerRangeInit {
 	AnimationTimeline? timeline;
-	AnimationTriggerBehavior? behavior = "once";
-	(TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) activationRangeStart = "normal";
-	(TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) activationRangeEnd = "normal";
-	(TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) activeRangeStart = "auto";
-	(TimelineRangeOffset or CSSNumericValue or CSSKeywordValue or DOMString) activeRangeEnd = "auto";
+	(DOMString or TimelineRangeOffset) activationRangeStart = "normal";
+	(DOMString or TimelineRangeOffset) activationRangeEnd = "normal";
+	(DOMString or TimelineRangeOffset) activeRangeStart = "auto";
+	(DOMString or TimelineRangeOffset) activeRangeEnd = "auto";
 };
 </pre>
 
 <div dfn-type=dict-member class=members
-		dfn-for="AnimationTriggerOptions">
+		dfn-for="TimelineTriggerRangeInit">
 
 	: <dfn>timeline</dfn>
 	::
-		The timeline to which the trigger is associated.
-		If not specified, the trigger is associated with [=default document timeline=].
+		The timeline to which the trigger range is associated.
+		If not specified, the trigger range is associated with [=default document timeline=].
 
 	: <dfn>activationRangeStart</dfn>
 	::
-		The start of the trigger’s [=activation range=].
+		The start of the trigger range’s [=activation range=].
 		If not specified, the [=activation range=]’s start is set to "normal".
 
 	: <dfn>activationRangeEnd</dfn>
 	::
-		The end of the trigger’s [=activation range=].
+		The end of the trigger range’s [=activation range=].
 		If not specified, the [=activation range=]’s end is set to "normal".
 
 	: <dfn>activeRangeStart</dfn>
 	::
-		The start of the trigger’s [=active range=].
+		The start of the trigger range’s [=active range=].
 		If not specified, the [=active range=]’s start is set to "auto".
 
 	: <dfn>activeRangeEnd</dfn>
 	::
-		The end of the trigger’s [=active range=].
+		The end of the trigger range’s [=active range=].
 		If not specified, the [=active range=]’s end is set to "auto".
 
 </div>


### PR DESCRIPTION
Update the TimelineTrigger interface to support multiple timelines in a top-level sequence of TimelineTriggerRange objects per the CSSWG resolution. Also update the constructor algorithm and define TimelineTriggerRangeInit.

WG resolution: https://github.com/w3c/csswg-drafts/issues/13175#issuecomment-3683974324

Fixes #13175.
