### PR TITLE
[css-sizing-4] Fix syntax definition for `<box-size>`

### DIFF
--- a/css-sizing-4/Overview.bs
+++ b/css-sizing-4/Overview.bs
@@ -193,7 +193,7 @@ ISSUE: [[css-sizing-3#sizing-values]]
 	thus expanding the <<box-size>> production as follows:
 
 	<pre class=prod>
-		<dfn><<box-size>></dfn> = <<length-percentage>> | stretch | contain | min-content | max-content | fit-content | fit-content() | calc-size()
+		<dfn><<box-size>></dfn> = <<length-percentage>> | stretch | contain | min-content | max-content | fit-content | <fit-content()> | <calc-size()>
 	</pre>
 
 


### PR DESCRIPTION
`fit-content()` and `calc-size()` should reference their respective definitions in `<box-size>`