### PR TITLE
!Important is invalid and cause declaration to be invalid in function bodies and mixin arguments and private blocks

### DIFF
--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -1787,7 +1787,7 @@ In an ''@private'' rule, a [=custom property=] declaration
 with an ''!important'' annotation is invalid and ignored.
 
 <wpt>
-	mixins/mixin-private-important.html
+	mixins/important.html
 </wpt>
 
 When a [=style rule=] contains any ''@private'' rules

--- a/css-mixins-1/Overview.bs
+++ b/css-mixins-1/Overview.bs
@@ -233,6 +233,13 @@ then the [=default value=] must [=CSS/parse=] successfully
 according to that [=parameter type=]'s syntax.
 Otherwise, the ''@function'' rule is invalid.
 
+A <<declaration-value>> 
+cannot contain a top-level ''!important'' annotation. 
+This restriction applies to default values and to arguments 
+in <<dashed-function>>s, 
+including those used by ''@apply'' rules. 
+Mixin parameters use the same grammar as function parameters.
+
 <h4 id=function-prelude>
 The Function Prelude</h4>
 
@@ -295,6 +302,9 @@ Additionally, it accepts the following descriptors:
 
 Unknown descriptors are invalid and ignored,
 but do not make the ''@function'' rule itself invalid.
+
+In a [=function body=], a declaration 
+with an ''!important'' annotation is invalid and ignored.
 
 The '@function/result' Descriptor {#the-result-descriptor}
 ----------------------------------------------------------
@@ -1772,6 +1782,13 @@ and [=nested group rules=]
 (in which case it passes this same restriction to <em>their</em> contents).
 Any other contents are invalid and will be ignored,
 but do not invalidate the ''@private'' rule itself.
+
+In an ''@private'' rule, a [=custom property=] declaration 
+with an ''!important'' annotation is invalid and ignored.
+
+<wpt>
+	mixins/mixin-private-important.html
+</wpt>
 
 When a [=style rule=] contains any ''@private'' rules
 (including those nested in [=nested group rules=]),


### PR DESCRIPTION
[css-mixins-1] the CSSWG discussed whether !important is valid in functions and/or mixins. Issue #14212 was RESOLVED: in function bodies, function and mix in arguments, and all private blocks !important is invalid and causes declaration to be invalid.