### PR TITLE
[css-color-5] Omit percentages from color-mix() serialization when all components have a known percentage, are all equal to each other and sum to greater than or equal to 100 (#14465)

### DIFF
--- a/css-color-5/Overview.bs
+++ b/css-color-5/Overview.bs
@@ -3248,8 +3248,8 @@ let its <dfn>effective percentage</dfn> be:
 		with omitted <<percentage>>s;
 	- otherwise, unknown.
 
-If all [=effective percentage=]s are known
-and equal to <code>100% / |N|</code>,
+If all [=effective percentage=]s are known,
+equal to each other, and greater than or equal to <code>100% / |N|</code>,
 no percentages are serialized.
 Otherwise, each argument's percentage is serialized as follows:
 	- If a <<percentage>> was explicitly specified,


### PR DESCRIPTION
Omit percentages from color-mix() serialization when all components:
  - have a known percentage
  - are all equal to each other
  - sum to greater than or equal to 100

This allows `color-mix(in srgb, red 75%, blue 75%)` to serialize as `color-mix(in srgb, red, blue)`.

If the values sum to less than 100, the percentages can't be omitted because it would change the meaning, removing the "leftover" component which gets multiplied as additional alpha.