### PR TITLE
[css-overflow-5] Added middle-truncation

### DIFF
--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -837,7 +837,7 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 
 		<dt><dfn id=overflow-ellipsis>ellipsis</dfn>
 		<dd>
-			Render an ellipsis character (U+2026)
+			Render an ellipsis character (U+2026) as [=overflow marker=]
 			to represent clipped inline content.
 			Implementations may substitute a more language, script, or writing-mode appropriate
 			ellipsis character,
@@ -845,7 +845,8 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 
 		<dt id=overflow-string><<string>>
 		<dd>
-			Render the given string to represent clipped inline content.
+			Render the given string as [=overflow marker=]
+			to represent clipped inline content.
 
 			All forced line breaks inside the specified string
 			(regardless of 'white-space' value)
@@ -857,7 +858,7 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 			Clip inline content that overflows its line box.
 			Characters may be only partially rendered.
 			In addition, the UA must apply a fade out effect
-			near the edge of the line box,
+			near the edge of the line box as [=overflow marker=],
 			reaching complete transparency at the edge.
 
 			Issue: Do we need to define the way

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -905,6 +905,10 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 			If no [=overflow marker anchor=] is specified,
 			''start'' is assumed.
 
+			The <<percentage>> is resolved against the width of the line box.
+			Values lower than 0 are clipped to 0.
+			Values greater than the width of the line box are clipped to the width of the line box.
+
 			Issue: Should ''start'' really be the default?
 
 		<dt><dfn>start</dfn>

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -1174,7 +1174,7 @@ ellipsis interaction with scrolling interfaces</h3>
 
 	When an element with non-clip text-overflow has overflow of scroll
 	in the inline progression dimension of the text,
-	and the browser provides a mechanism for scrolling
+	and the UA provides a mechanism for scrolling
 	(e.g. a scrollbar on the element,
 	or a touch interface to swipe-scroll, etc.),
 	there are additional implementation details that provide a better user experience:
@@ -1233,15 +1233,15 @@ ellipsis interaction with scrolling interfaces</h3>
 	that's doing the scrolling,
 	and the computed value of 'text-overflow' has two values, with
 	the value applying to the start edge being a non-clip value,
-	then implementations must render an ellipsis/string in place of
+	then implementations must render an [=overflow marker=] in place of
 	the clipped content,
 	with the same details as described in the value definition above,
-	except that the ellipsis/string is drawn in the <a>start</a>
+	except that the [=overflow marker=] is drawn in the <a>start</a>
 	(rather than <a>end</a>) of
 	the block's direction (per the direction property).
 
 	While the content is being scrolled,
-	implementations may adjust their rendering of ellipses/strings
+	implementations may adjust their rendering of the [=overflow marker=]
 	(e.g. align to the box edges rather than line edges).
 
 	<div class="example">
@@ -1255,8 +1255,8 @@ ellipsis interaction with scrolling interfaces</h3>
 	</div>
 
 	If there is insufficient space for both start
-	and end ellipses/strings,
-	then only the end ellipsis/string should be rendered.
+	and end [=overflow markers=],
+	then only the end [=overflow marker=] should be rendered.
 
 
 <h2 id="fragmentation" class=no-num>

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -898,6 +898,11 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 			Defines the position of the [=overflow marker=]
 			offset from the [=overflow marker anchor=].
 
+			If no [=overflow marker anchor=] is specified,
+			''start'' is assumed.
+
+			Issue: Should ''start'' really be the default?
+
 		<dt><dfn>start</dfn>
 		<dd>
 			Defines the [=overflow marker anchor=] to be the start edge of the line box.
@@ -920,7 +925,7 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 	for implementation purposes.
 
 	The <dfn>overflow marker</dfn> is the visual indicator used to represent truncated text.
-	The line edge used for offsets is specified via the <dfn>overflow marker anchor</dfn>.
+	The line edge used for offsets is specified by the <dfn>overflow marker anchor</dfn>.
 	It can either be ''text-overflow/start'' or ''text-overflow/end''.
 
 	If there is only one [=overflow marker=] with no [=overflow marker anchor=] specified,

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -1254,6 +1254,11 @@ ellipsis interaction with scrolling interfaces</h3>
 		</div>
 	</div>
 
+	If the [=overflow marker=] is offset from the edge of the line box
+	(either by a <<length-percentage>> or by ''center''),
+	then the smaller part of the visible content is fixed,
+	and only the larger part of the visible content is scrolled.
+
 	If there is insufficient space for both start
 	and end [=overflow markers=],
 	then only the end [=overflow marker=] should be rendered.

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -774,6 +774,482 @@ agent not to apply any axis locking when the specified element is scrolled.
 
 	</dl>
 
+
+<h2 id="auto-ellipsis">
+Automatic Ellipses</h2>
+
+<h3 id="text-overflow" caniuse="text-overflow">
+Inline Overflow Ellipsis: the 'text-overflow' property</h3>
+
+	<pre class="propdef">
+	Name: text-overflow
+	Value: [ clip | fade | <<fade()>> | <<general-overflow-marker>> ] && [ start | end ]? ]{1,2} |
+	Value: <nobr>[ <<general-overflow-marker>> && [ center | [ start | end ]? <<length-percentage [0,∞]>> ] ]</nobr>
+	Initial: clip
+	Applies to: block containers
+	Inherited: no
+	Percentages: refer to the width of the line box
+	Computed value: as specified, with lengths made absolute
+	Animation type: by computed value type
+	</pre>
+
+	<wpt>
+		line-clamp-auto-009.html
+		line-clamp-auto-010.html
+		webkit-line-clamp-036.html
+		webkit-line-clamp-037.html
+		line-clamp-with-text-overflow-string-003.html
+	</wpt>
+
+	ISSUE: This section might need to be re-synced against [[CSS-OVERFLOW-3]].
+
+	This property specifies rendering when inline content overflows
+	its line box edge
+	in the inline progression direction of its block container element ("the block")
+	that has 'overflow'
+	other than ''overflow/visible''.
+
+	<pre class=prod>
+	<dfn>&lt;general-overflow-marker></dfn> = ellipsis | <<string>>
+	</pre>
+
+	Even though this property is not inherited,
+	anonymous block container boxes generated to
+	establish the line box's <a>inline formatting context</a> (see [=block container=])
+	are ignored,
+	and the value of the property that applies is the one
+	on the non anonymous box.
+	<span class=note>This can be seen in the “nested paragraph” part of <a href="#example-a4ab7902"></a>:
+	even though the word “NESTED” is wrapped in an anonymous block container
+	whose 'text-overflow' property has the initial value,
+	it is ellipsed.</span>
+
+	Text can overflow for example when it is prevented from wrapping
+	(e.g. due to <code class="lang-css">white-space: nowrap</code>
+	or a single word is too long to fit).
+	Values have the following meanings:
+
+	<dl dfn-for="text-overflow" dfn-type=value>
+		<dt><dfn id=overflow-clip>clip</dfn>
+		<dd>
+			Clip inline content that overflows its block container element.
+			Characters may be only partially rendered.
+
+		<dt><dfn id=overflow-ellipsis>ellipsis</dfn>
+		<dd>
+			Render an ellipsis character (U+2026)
+			to represent clipped inline content.
+			Implementations may substitute a more language, script, or writing-mode appropriate
+			ellipsis character,
+			or three dots "..." if the ellipsis character is unavailable.
+
+		<dt id=overflow-string><<string>>
+		<dd>
+			Render the given string to represent clipped inline content.
+
+			All forced line breaks inside the specified string
+			(regardless of 'white-space' value)
+			must be collapsed,
+			as defined for collapsible segment breaks in [[css-text-3#line-break-transform]].
+
+		<dt dfn-type=function><dfn>fade( [ <<length-percentage>> ] )</dfn>
+		<dd>
+			Clip inline content that overflows its line box.
+			Characters may be only partially rendered.
+			In addition, the UA must apply a fade out effect
+			near the edge of the line box,
+			reaching complete transparency at the edge.
+
+			Issue: Do we need to define the way
+			the fade out is calculated
+			so that the fading is identical across browsers?
+			It should probably be something like
+			''mask-image: linear-gradient(to right, rgba(0,0,0,1), rgba(0,0,0,0))'',
+			except applied to the relevant portion of the line only.
+
+			The argument determines the distance
+			over which the fade effect is applied.
+			The <<percentage>> is resolved against the width of the line box.
+			Values lower than 0 are clipped to 0.
+			Values greater than the width of the line box are clipped to the width of the line box.
+
+			Issue: If the line box is too short
+			to display the fade effect at the desired length,
+			should we drop the effect,
+			or shrink the distance it is applied over until it fits,
+			or clip the end of the fade?
+
+			Issue: How should we deal with
+			things overflowing out of the line box,
+			or overlapping onto it?
+			Should fade apply to the logical content of the line,
+			or to the physical area of the line box,
+			or the intersection of both?
+
+		<dt><dfn>fade</dfn>
+		<dd>
+			Same as ''fade()'',
+			but the distance over which the fading effect is applied
+			is determined by the UA.
+			''1em'' is suggested as a reasonable value.
+
+		<dt><dfn><<length-percentage [0,∞]>></dfn>
+		<dd>
+			Defines the position of the [=overflow marker=]
+			offset from the [=overflow marker anchor=].
+
+		<dt><dfn>start</dfn>
+		<dd>
+			Defines the [=overflow marker anchor=] to be the start edge of the line box.
+
+		<dt><dfn>end</dfn>
+		<dd>
+			Defines the [=overflow marker anchor=] to be the end edge of the line box.
+
+		<dt><dfn>center</dfn>
+		<dd>
+			Defines that the [=overflow marker=] is placed in the middle of the line box.
+
+			By default, this means the same as placing it at 50% of the line box width from the start edge of the line box.
+			Though the UA may choose to place it at a different position,
+			for example to avoid hiding a file extension or URL ending.
+	</dl>
+
+	The term "character" is used in this property definition
+	for better readability and means "grapheme cluster" [[!UAX29]]
+	for implementation purposes.
+
+	The <dfn>overflow marker</dfn> is the visual indicator used to represent truncated text.
+	The line edge used for offsets is specified via the <dfn>overflow marker anchor</dfn>.
+	It can either be ''text-overflow/start'' or ''text-overflow/end''.
+
+	If there is only one [=overflow marker=] with no [=overflow marker anchor=] specified,
+	it applies only to the <a>end</a> line box edge.
+	If there are two overflow markers specified with no anchors,
+	the first value applies to the <a>line-left</a> edge,
+	and the second value applies to the <a>line-right</a> edge.
+	The terms <a>end</a>, <a>line-left</a> and <a>line-right</a> are defined in [[!CSS-WRITING-MODES-3]].
+
+	Note: the use of <a>line-left</a> and <a>line-right</a>
+	rather than <a>start</a> and <a>end</a>
+	when there are two values is intentional,
+	to facilitate the use of directional characters such as arrows.
+
+	For the ellipsis
+	and string values,
+	implementations must hide characters and
+	<a href="https://www.w3.org/TR/CSS2/visuren.html#inline-boxes">
+	atomic inline-level elements</a>
+	at the applicable edge(s) of the line as necessary to fit the ellipsis/string, and
+	place the ellipsis/string immediately adjacent
+	to the applicable edge(s) of the remaining inline content.
+
+	In order to avoid jitter in the position of the ellipsis
+	as scrolling reveals more content,
+	user agents may adjust the position of the ellipsis
+	to be adjacent to the end of the line,
+	or may fade/hide the ellipsis during scrolling.
+
+	The first character or
+	<a href="https://www.w3.org/TR/CSS2/visuren.html#inline-boxes">
+	atomic inline-level element</a>
+	on a line
+	must be clipped rather than ellipsed.
+
+	<div class=example>
+		<h3 id="bidi-ellipsis" class="no-num no-toc">Bidi ellipsis examples</h3>
+
+		These examples demonstrate which characters get hidden
+		to make room for the ellipsis in a bidi situation:
+		those visually at the edge of the line.
+
+		Sample CSS:
+		<pre><code highlight=css>
+		div {
+			font-family: monospace;
+			white-space: pre;
+			overflow: hidden;
+			width: 9ch;
+			text-overflow: ellipsis;
+		}
+		</code></pre>
+
+		Sample HTML fragments, renderings, and your browser:
+		<table class="awesome-table data">
+			<thead><tr><th>HTML<th>Reference rendering<th>Your Browser</thead>
+			<tr>
+			<td><code highlight=html>&lt;div>שלום 123456&lt;/div></code><td><div style="font-family:monospace">123456 ם…</div><td><div style="font-family: monospace; white-space: pre; overflow: hidden; width: 9ch; text-overflow: ellipsis">שלום 123456</div>
+			<tr><td><code highlight=html>&lt;div dir=rtl>שלום 123456&lt;/div></code><td><div style="font-family:monospace">…456 שלום</div><td><div style="font-family: monospace; white-space: pre; overflow: hidden; width: 9ch; text-overflow: ellipsis" dir=rtl>שלום 123456</div>
+		</table>
+	</div>
+
+
+<h3 id="ellipsing-details" class="no-num no-toc">
+ellipsing details</h3>
+
+	<ul>
+		<li>
+			Ellipsing only affects rendering and must not affect layout
+			nor dispatching of pointer events:
+			The UA should dispatch any pointer event on the ellipsis to the elided element,
+			as if 'text-overflow' had been ''text-overflow/none''.
+
+		<li>
+			The ellipsis is styled and baseline-aligned according to the block.
+
+		<li>
+			Ellipsing occurs after relative positioning and other graphical transformations.
+
+		<li>
+			If there is insufficient space for the ellipsis,
+			then clip the rendering of the ellipsis itself
+			(on the same side that neutral characters on the line
+			would have otherwise been clipped with the ''text-overflow:clip'' value).
+
+		<li>
+			For bidi purposes, the ellipsis and string values must be treated
+			as if they were wrapped in an anonymous inline
+			with ''unicode-bidi: isolate''
+			which inherits ''direction'' from the [=bidi paragraph=].
+
+			<wpt pathprefix="/css/css-ui/">
+				text-overflow-string-006.html
+				text-overflow-string-007.html
+				text-overflow-string-008.html
+			</wpt>
+	</ul>
+
+
+<h3 id="ellipsis-interaction" class="no-num no-toc">
+user interaction with ellipsis</h3>
+
+	<ul>
+		<li>
+			When the user is interacting with content
+			(e.g. editing, selecting, scrolling),
+			the user agent may treat ''text-overflow/ellipsis'', string values, ''overflow-text/fade'' or ''overflow-text/fade()'' as ''text-overflow:clip''.
+
+		<li>
+			Selecting the ellipsis should select the ellipsed text.
+			If all of the ellipsed text is selected,
+			UAs should show selection of the ellipsis.
+			Behavior of partially-selected ellipsed text is up to the UA.
+	</ul>
+
+	<div class="example">
+		<h3 id="text-overflow-examples" class="no-num no-toc">text-overflow examples</h3>
+
+		These examples demonstrate setting the text-overflow of a block container element
+		that has text which overflows its dimensions:
+
+		sample CSS for a div:
+		<pre><code class="lang-css">
+		div {
+			font-family: Helvetica, sans-serif;
+			line-height: 1.1;
+			width: 3.1em;
+			border: solid .1em black;
+			padding: 0.2em; margin:1em 0;
+		}
+		</code></pre>
+
+		sample HTML fragments, renderings, and your browser:
+		<table class="awesome-table"><tbody>
+		<tr>
+			<th>HTML
+			<th>sample rendering
+			<th>your browser
+
+		<tr>
+			<td>
+				<pre><code class="lang-markup">
+				&lt;div&gt;
+				CSS IS AWESOME, YES
+				&lt;/div&gt;
+				</code></pre>
+
+			<td>
+				<object type="image/png" data="images/cssisawesome.png">
+				First, a box with text drawing outside of it.
+				</object>
+
+			<td>
+				<div style="width:3.1em; border:solid .1em black; margin:1em 0; padding:.2em; font-family:Helvetica,sans-serif; line-height:1.1;">CSS IS AWESOME, YES</div>
+
+		<tr>
+			<td>
+				<pre><code class="lang-markup">
+				&lt;div style="<strong>text-overflow:clip;</strong> overflow:hidden"&gt;
+				CSS IS AWESOME, YES
+				&lt;/div&gt;
+				</code></pre>
+
+			<td>
+				<object type="image/png" data="images/cssisaweso.png">
+				Second, a similar box with the text clipped outside the box.
+				</object>
+
+			<td>
+				<div style="width:3.1em; border:solid .1em black; margin:1em 0; padding:.2em; font-family:Helvetica,sans-serif; line-height:1.1; overflow:hidden;text-overflow:clip;">CSS IS AWESOME, YES</div>
+
+		<tr>
+			<td>
+				<pre><code class="lang-markup">
+				&lt;div style="<strong>text-overflow:ellipsis;</strong> overflow:hidden"&gt;
+				CSS IS AWESOME, YES
+				&lt;/div&gt;
+				</code></pre>
+
+			<td>
+				<object type="image/png" data="images/cssisaw.png">
+				Third, a similar box with an ellipsis representing the clipped text.
+				</object>
+
+			<td>
+				<div style="width:3.1em; border:solid .1em black; margin:1em 0; padding:.2em;  font-family:Helvetica,sans-serif; line-height:1.1; overflow:hidden;text-overflow:ellipsis;">CSS IS AWESOME, YES</div>
+
+		<tr>
+			<td>
+				<pre><code class="lang-markup">
+				&lt;div style="<strong>text-overflow:ellipsis;</strong> overflow:hidden"&gt;
+				NESTED
+				 &lt;p&gt;PARAGRAPH&lt;/p&gt;
+				WON'T ELLIPSE.
+				&lt;/div&gt;
+				</code></pre>
+
+			<td>
+				<object type="image/png" data="images/nes.png">
+				Fourth, a box with a nested paragraph demonstrating anonymous block boxes equivalency and non-inheritance into a nested element.
+				</object>
+
+			<td>
+				<div style="width:3.1em; border:solid .1em black; margin:1em 0; padding:.2em;  font-family:Helvetica,sans-serif; line-height:1.1; overflow:hidden;text-overflow:ellipsis;">NESTED
+				 <p>PARAGRAPH</p>
+				WON'T ELLIPSE.</div>
+
+		<tr>
+			<td>
+				<pre><code class="lang-markup">
+				&lt;div style="<strong>text-overflow:fade;</strong> overflow:hidden"&gt;
+				CSS IS AWESOME, YES
+				&lt;/div&gt;
+				</code></pre>
+
+			<td>
+				<object type="image/png" data="images/cssisfade.png">
+				a box with the text fading out on overflow.
+				</object>
+
+			<td>
+				<div style="width:3.1em; border:solid .1em black; padding:.2em; font-family:Helvetica,sans-serif; line-height:1.1; overflow:hidden;text-overflow:clip;">CSS IS AWESOME, YES</div>
+		</tbody></table>
+	</div>
+
+	Note: the side of the line that the ellipsis is placed depends on the 'direction' of the block.
+	E.g. an overflow hidden right-to-left
+	(<code class="lang-css">direction: rtl</code>)
+	block clips inline content on the <a spec=css-writing-modes-3>left</a> side,
+	thus would place a text-overflow ellipsis on the <a spec=css-writing-modes-3>left</a>
+	to represent that clipped content.
+
+	Issue: insert RTL example diagram here to illustrate note.
+
+
+<h3 id="ellipsis-scrolling" class="no-num no-toc">
+ellipsis interaction with scrolling interfaces</h3>
+
+	This section applies to elements with text-overflow other than ''text-overflow:clip''
+	(non-clip text-overflow)
+	and overflow:scroll.
+
+	When an element with non-clip text-overflow has overflow of scroll
+	in the inline progression dimension of the text,
+	and the browser provides a mechanism for scrolling
+	(e.g. a scrollbar on the element,
+	or a touch interface to swipe-scroll, etc.),
+	there are additional implementation details that provide a better user experience:
+
+	When an element is scrolled (e.g. by the user, DOM manipulation),
+	more of the element's content is shown.
+	The value of text-overflow should not affect
+	whether more of the element's content is shown or not.
+	If a non-clip text-overflow is set,
+	then as more content is scrolled into view,
+	implementations should show whatever additional content fits,
+	only truncating content which would otherwise be clipped
+	(or is necessary to make room for the ellipsis/string),
+	until the element is scrolled far enough
+	to display the edge of the content
+	at which point that content should be displayed
+	rather than an ellipsis/string.
+
+	<div class="example">
+		This example uses text-overflow on an element with overflow scroll
+		to demonstrate the above described behavior.
+
+		sample CSS:
+		<pre><code class="lang-css">
+		div.crawlbar {
+			text-overflow: ellipsis;
+			height: 2em;
+			line-height: 1em;
+			overflow: scroll;
+			white-space: nowrap;
+			width: 15em;
+			border:1em solid black;
+		}
+		</code></pre>
+
+		sample HTML fragment:
+		<pre><code class="lang-markup">
+		&lt;div class="crawlbar"&gt;
+		CSS is awesome, especially when you can scroll
+		to see extra text instead of just
+		having it overlap other text by default.
+		&lt;/div&gt;
+		</code></pre>
+
+		demonstration of sample CSS and HTML:
+		<div style="text-overflow: ellipsis; height: 2em; line-height:1; overflow: scroll; white-space: nowrap; width: 15em; border:1em solid black;">
+		CSS is awesome, especially when you can scroll
+		to see extra text instead of just
+		having it overlap other text by default.
+		</div>
+	</div>
+
+	As some content is scrolled into view,
+	it is likely that other content may scroll out of view on the other side.
+	If that content's block container element is the same
+	that's doing the scrolling,
+	and the computed value of 'text-overflow' has two values, with
+	the value applying to the start edge being a non-clip value,
+	then implementations must render an ellipsis/string in place of
+	the clipped content,
+	with the same details as described in the value definition above,
+	except that the ellipsis/string is drawn in the <a>start</a>
+	(rather than <a>end</a>) of
+	the block's direction (per the direction property).
+
+	While the content is being scrolled,
+	implementations may adjust their rendering of ellipses/strings
+	(e.g. align to the box edges rather than line edges).
+
+	<div class="example">
+		Same as previous example except with <code>text-overflow: ellipsis ellipsis</code>, demonstrated:
+
+		<div style="text-overflow: ellipsis ellipsis; height: 2em; line-height: 1em; overflow: scroll; white-space: nowrap; width: 15em; border:1em solid black;">
+		CSS is awesome, especially when you can scroll
+		to see extra text instead of just
+		having it overlap other text by default.
+		</div>
+	</div>
+
+	If there is insufficient space for both start
+	and end ellipses/strings,
+	then only the end ellipsis/string should be rendered.
+
+
 <h2 id="fragmentation" class=no-num>
 Appendix A: Redirection of Overflow</h2>
 

--- a/css-overflow-5/Overview.bs
+++ b/css-overflow-5/Overview.bs
@@ -853,6 +853,9 @@ Inline Overflow Ellipsis: the 'text-overflow' property</h3>
 			must be collapsed,
 			as defined for collapsible segment breaks in [[css-text-3#line-break-transform]].
 
+			If used together with ''center'' as the [=overflow marker anchor=],
+			an empty string is treated as [=invalid at computed-value time=].
+
 		<dt dfn-type=function><dfn>fade( [ <<length-percentage>> ] )</dfn>
 		<dd>
 			Clip inline content that overflows its line box.


### PR DESCRIPTION
This change adds middle-truncation as resolved on in https://github.com/w3c/csswg-drafts/issues/3937#issuecomment-5203494437.

I made some changes regarding the [explainer](https://drafts.csswg.org/css-overflow-5/middle-truncation.md) based on the notes people had at the F2F, notably:

* Offset anchors to line-start by default with 100% referring to the line-end edge
* Renamed `middle` to `center` (though should be discussed, as UAs are allowed to place the overflow marker outside the exact center)
* Let `fade()` and `fade` _not_ apply to middle-truncation for now (needs further discussion how to handle them)
* Made empty string invalid for middle-truncation
* Let scrolling work on the _larger_ part instead of always the start part
* Let offset work with `start` and `end` keywords

The rest of the spec text is copied over from Overflow 4.

Once this PR is merged, I'll also open separate issues for all the things that still require some discussion.

Closes #3937

Thank you again @sharonhsl for all the help with this!

Sebastian